### PR TITLE
Implementation of BSONObj::getDoubleField

### DIFF
--- a/bson/bsonobj.h
+++ b/bson/bsonobj.h
@@ -165,6 +165,9 @@ namespace mongo {
 
         /** @return INT_MIN if not present - does some type conversions */
         int getIntField(const char *name) const;
+        
+        /** @return DBL_MIN if not present - does some type conversions */
+        double getDoubleField(const char *name) const;
 
         /** @return false if not present */
         bool getBoolField(const char *name) const;

--- a/db/jsobj.cpp
+++ b/db/jsobj.cpp
@@ -24,6 +24,7 @@
 #include "../util/base64.h"
 #include "../util/md5.hpp"
 #include <limits>
+#include <float.h>
 #include "../util/unittest.h"
 #include "../util/embedded_builder.h"
 #include "json.h"
@@ -818,6 +819,11 @@ namespace mongo {
     int BSONObj::getIntField(const char *name) const {
         BSONElement e = getField(name);
         return e.isNumber() ? (int) e.number() : INT_MIN;
+    }
+
+    double BSONObj::getDoubleField(const char *name) const {
+        BSONElement e = getField(name);
+        return e.isNumber() ? (double) e.number() : DBL_MIN;
     }
 
     bool BSONObj::getBoolField(const char *name) const {


### PR DESCRIPTION
Hello,
I noticed that the C++ driver didn't have any method to get back any double pushed in the database. So I added it, mostly copy/pasted from getIntField.
