### PR TITLE
Padding Fix

### DIFF
--- a/db/pdfile.cpp
+++ b/db/pdfile.cpp
@@ -1540,6 +1540,9 @@ namespace mongo {
         DiskLoc extentLoc;
         int lenWHdr = len + Record::HeaderSize;
         lenWHdr = (int) (lenWHdr * d->paddingFactor);
+		if ( lenWHdr > BSONObjMaxInternalSize ) {
+			lenWHdr = BSONObjMaxInternalSize;
+		}
         if ( lenWHdr == 0 ) {
             // old datafiles, backward compatible here.
             assert( d->paddingFactor == 0 );


### PR DESCRIPTION
On IRC this evening, zmbmartin reported a larger than 4MB document size in a test collection in which he was doing multiple $push operations into a single document to test size limits.  The size for a single document was reported as 5981004 bytes by stats(), whereas the bsonsize() for that document showed 4194062 bytes.

There was no maximum size check for a document plus padding, and allocating an extant larger than the maximum possible document size is wasteful.  I've added a check to cap the maximum value at BSONObjMaxInternalSize, which appears to include space for any possible headers and such.
