### PR TITLE
trivial fixes for scons compilation on ubuntu 6.06.2 LTS with scons 2.0.1

### DIFF
--- a/db/taskqueue.h
+++ b/db/taskqueue.h
@@ -71,6 +71,7 @@ namespace mongo {
             mutex::scoped_lock lk2(_invokeMutex);
             int toDrain;
             {
+				toDrain = 0;
                 // flip queueing to the other queue (we are double buffered)
                 readlocktry lk("", 5);
                 if( !lk.got() )

--- a/util/file_allocator.cpp
+++ b/util/file_allocator.cpp
@@ -209,6 +209,7 @@ namespace mongo {
                 string name;
                 long size;
                 {
+					size = 0;
                     scoped_lock lk( fa->_pendingMutex );
                     if ( fa->_pending.size() == 0 )
                         break;


### PR DESCRIPTION
commit b70638b3ce5348b7d8dd3c93980c03cea6af535c
Author: Michael Brenden mike@brenden.com
Date:   Sat Feb 12 01:11:39 2011 -0500

```
initialized vars "size" and "toDrain", to fix scons compile failures on Ubuntu 6.06.2 LTS with scons 2.0.1
```
