### PR TITLE
fix exception raising in SConstruct

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -964,7 +964,7 @@ def doConfigure( myenv , needPcre=True , shell=False ):
                     found = True
                     break
             if not found:
-                raise "can't find a static %s" % l
+                raise RuntimeError("can't find a static %s" % l)
 
     # 'tcmalloc' needs to be the last library linked. Please, add new libraries before this 
     # point.


### PR DESCRIPTION
Python 2.6 prohibits string exceptions; fix one of these in SConstruct
