### PR TITLE
SERVER-2379

### DIFF
--- a/tools/import.cpp
+++ b/tools/import.cpp
@@ -109,7 +109,7 @@ class Import : public Tool {
                     }
                     else {
                         data.append(line, end-line);
-                        line = end+2; //skip '"' and ','
+                        line = end+(end[1] == ',' ? 2 : 1); //skip '"', and ',' if present
                         break;
                     }
                 }


### PR DESCRIPTION
Currently, the CSV parser blindly skips two characters after handling a quoted string (the closing `"` and the `,`). However, when the value is the last one in the record, there is no comma and it ends up skipping the `\0` and heading into unknown memory (which happens to contain the _previous_ line of the CSV).

Fix this by testing to see if the next character is indeed a `,`.
