### PR TITLE
SERVER-2634

### DIFF
--- a/db/jsobj.cpp
+++ b/db/jsobj.cpp
@@ -1318,7 +1318,7 @@ namespace mongo {
     bool BSONObjBuilder::numStrsReady = (numStrs[0].size() > 0);
 
     bool BSONObjBuilder::appendAsNumber( const StringData& fieldName , const string& data ) {
-        if ( data.size() == 0 || data == "-")
+        if ( data.size() == 0 || data == "-" || data == "." )
             return false;
 
         unsigned int pos=0;


### PR DESCRIPTION
BSONObjBuilder treats the string "." as a numeric value (zero). This can cause unexpected behavior, as evidenced by the fact that there's a bug on it.
