### PR TITLE
SERVER-3280: Fixing the RPM init.d file to work on Centos/Redhat

### DIFF
--- a/rpm/init.d-mongod
+++ b/rpm/init.d-mongod
@@ -36,7 +36,14 @@ start()
 stop()
 {
   echo -n $"Stopping mongod: "
-  killproc -p /var/lib/mongo/mongod.lock -t30 -TERM /usr/bin/mongod
+
+  # Redhat/Centos uses a different version of killproc
+  if [ -f /etc/redhat-release ]; then
+    killproc -d 30 /usr/bin/mongod -TERM
+  else
+    killproc -p /var/lib/mongo/mongod.lock -t30 -TERM /usr/bin/mongod
+  fi
+
   RETVAL=$?
   echo
   [ $RETVAL -eq 0 ] && rm -f /var/lock/subsys/mongod


### PR DESCRIPTION
The killproc macro on these distrobutions does not support the given
parameters. Instead it supports a different set of parameters. Also
the lock file specified does not include a pid so it will not work
when killing the process anyway. Have not tested the original on
another OS so cannot verify it works on any other distro.
