### PR TITLE
Fix for SERVER-2371

### DIFF
--- a/db/index.cpp
+++ b/db/index.cpp
@@ -59,13 +59,13 @@ namespace mongo {
             for( vector<BSONObj*>::iterator i = addedKeys.begin(); i != addedKeys.end(); i++ ) {
                 KeyOwned k(**i);
                 bool dup = h->wouldCreateDup(idx, head, k, ordering, self);
-				if (dup) {
-					stringstream ss;
-			        ss << "E11001 duplicate key on update error ";
-			        ss << "index: " << idx.indexNamespace() << "  ";
-			        ss << "dup key: " << k.toString();
-			        uasserted(11001, ss.str());
-				}
+                if (dup) {
+                    stringstream ss;
+                    ss << "E11001 duplicate key on update error ";
+                    ss << "index: " << idx.indexNamespace() << "  ";
+                    ss << "dup key: " << k.toString();
+                    uasserted(11001, ss.str());
+                }
             }
         }
     };


### PR DESCRIPTION
Duplicate Key exception on update does not provide enough context to enable easy recovery.  Built and tested the change on Mac OS X Snow Leopard.  Would greatly appreciate this being included, as this is not the first time or project on which this has caused me real pain.

Chris
