### PR TITLE
mongod config file fix

### DIFF
--- a/db/cmdline.cpp
+++ b/db/cmdline.cpp
@@ -155,6 +155,9 @@ namespace mongo {
                         }
                     }
                     boost::to_upper(test);
+                    if ( test.find( "FASTSYNC" ) != string::npos )
+                        cout << "warning \fastsync\" should not be put in your configuration file" << endl;
+
                     if ( test[0] == '#' ) {
                     } else if ( test.find( "=FALSE" ) == string::npos ) {
                         ss << line << endl;


### PR DESCRIPTION
ignores lines that begin with # and ignores and displays warning for lines in config files containing =false
stops flag=false from setting the flag (to true)
displays warning for lines containing fastsync
