### PR TITLE
[mongorestore] A space is missing between "file" and the filename

### DIFF
--- a/tools/restore.cpp
+++ b/tools/restore.cpp
@@ -256,7 +256,7 @@ public:
             if ( ! ( err["err"].isNull() ) ) {
                 cerr << "Error creating index " << o["ns"].String();
                 cerr << ": " << err["code"].Int() << " " << err["err"].String() << endl;
-                cerr << "To resume index restoration, run " << _name << " on file" << _fileName << " manually." << endl;
+                cerr << "To resume index restoration, run " << _name << " on file " << _fileName << " manually." << endl;
                 ::abort();
             }
         }


### PR DESCRIPTION
Actual result :

```
   Error creating index .espace: 13075 db name can't be empty
   To resume index restoration, run mongorestore on file./system.indexes.bson manually.
   Abandon
```

Expected result : 

```
   Error creating index .espace: 13075 db name can't be empty
   To resume index restoration, run mongorestore on file ./system.indexes.bson manually.
   Abandon
```
