### PR TITLE
enhancements for the bsondump utility

### DIFF
--- a/tools/tool.h
+++ b/tools/tool.h
@@ -29,6 +29,7 @@
 #include "client/dbclient.h"
 #include "db/instance.h"
 #include "db/matcher.h"
+#include "db/projection.h"
 
 using std::string;
 
@@ -139,6 +140,7 @@ namespace mongo {
     class BSONTool : public Tool {
         bool _objcheck;
         auto_ptr<Matcher> _matcher;
+        auto_ptr<Projection> _projection;
 
     public:
         BSONTool( const char * name , DBAccess access=ALL, bool objcheck = false );


### PR DESCRIPTION
- add the ability to emit BSON, as well as JSON
- add support to apply a projection each object
- add support for reading stdin via '-'
- inhibit progress and summary output at log level 0

The modifications I've applied here make it possible to use bsondump to filter and transform streamed BSON data, and to chain together transformations by sending the output of one bsondump invocation to the input of another, making it possible to construct shell pipelines for manipulating BSON data.

Feedback/criticism/comments/reviews more than welcome. The only part of this that changes existing behavior is disabling the progress and summary output for BSONTool implementations at log level 0, so now you need to throw a -v on the command line to see that information. This was required to support BSON output, because if the summary data is emitted to std::cout then the resulting data stream is not valid BSON. When the output type is selected as BSON, attempts to raise the verbosity level result in an error to prevent this from happening.
