### PR TITLE
SERVER-3470: Multiline Command handling in History

### DIFF
--- a/shell/dbshell.cpp
+++ b/shell/dbshell.cpp
@@ -746,15 +746,15 @@ int _main(int argc, char* argv[]) {
             bool wascmd = false;
             {
                 string cmd = line;
-		//FIX: in case space not found find will return string::npos
+                //FIX: in case space not found find will return string::npos
                 if ( cmd.find( " " ) != string::npos ) {
                     cmd = cmd.substr( 0 , cmd.find( " " ) );
-		}
-		else {
-		    //in case of space is not found, look for new line to split command with arguments
+                }
+                else {
+                    //in case of space is not found, look for new line to split command with arguments
                     if ( cmd.find( "\n" ) != string::npos )
-                    	cmd = cmd.substr( 0 , cmd.find( "\n" ) );
-		}
+                       cmd = cmd.substr( 0 , cmd.find( "\n" ) );
+                }
 
                 if ( cmd.find( "\"" ) == string::npos ) {
                     try {
@@ -782,7 +782,7 @@ int _main(int argc, char* argv[]) {
                 }
             }
 
-	    //code has complete command which needs to be persisted in history
+            //code has complete command which needs to be persisted in history
             shellHistoryAdd( code.c_str() );
         }
 


### PR DESCRIPTION
Hi,

The changes are related to multi-line command handling in history. Also it has one minor change in the way currently space is being searching in command string. 

Please review it and let me know your comments.

Thanks,
Swapnil
