### PR TITLE
SERVER-1201 SERVER-3153 Showing UUID binary types better

### DIFF
--- a/shell/utils.js
+++ b/shell/utils.js
@@ -567,7 +567,9 @@ else {
 
 if ( typeof( BinData ) != "undefined" ){
     BinData.prototype.tojson = function () {
-        //return "BinData type: " + this.type + " len: " + this.len;
+        if (this.type == 3) {
+             return "UUID('" + this.hex() + "')"
+        }
         return this.toString();
     }
     


### PR DESCRIPTION
UUIDs can already be created easily by using:
  UUID('hex-string')

However, they were still printed as BinData(3, 'base64') which
makes it difficult to debug.

This patch will print UUID objects in the same way as they
can be created, i.e. using the UUID('hex-string') format.

Fixes SERVER-1201
