### PR TITLE
SERVER-9327 Allow cross-site requests

### DIFF
--- a/db/cmdline.h
+++ b/db/cmdline.h
@@ -50,6 +50,7 @@ namespace mongo {
 
         string bind_ip;        // --bind_ip
         bool rest;             // --rest
+        bool xorigin;          // --xorigin
         bool jsonp;            // --jsonp
 
         string _replSet;       // --replSet[/<seedlist>]
@@ -132,7 +133,7 @@ namespace mongo {
     };
 
     inline CmdLine::CmdLine() :
-        port(DefaultDBPort), rest(false), jsonp(false), quiet(false), noTableScan(false), prealloc(true), smallfiles(sizeof(int*) == 4),
+        port(DefaultDBPort), rest(false), xorigin(false), jsonp(false), quiet(false), noTableScan(false), prealloc(true), smallfiles(sizeof(int*) == 4),
         configsvr(false),
         quota(false), quotaFiles(8), cpu(false), durOptions(0), objcheck(false), oplogSize(0), defaultProfile(0), slowMS(100), pretouch(0), moveParanoia( true ),
         syncdelay(60), noUnixSocket(false), socket("/tmp") 

--- a/db/db.cpp
+++ b/db/db.cpp
@@ -578,6 +578,7 @@ int main(int argc, char* argv[]) {
     ("quota", "limits each database to a certain number of files (8 default)")
     ("quotaFiles", po::value<int>(), "number of files allower per db, requires --quota")
     ("rest","turn on simple rest api")
+    ("xorigin","allow cross-site requests via rest api, requires --rest")
     ("repair", "run repair on all dbs")
     ("repairpath", po::value<string>() , "root directory for repair files - defaults to dbpath" )
     ("slowms",po::value<int>(&cmdLine.slowMS)->default_value(100), "value of slow for profile and console log" )
@@ -757,6 +758,9 @@ int main(int argc, char* argv[]) {
         }
         if (params.count("rest")) {
             cmdLine.rest = true;
+        }
+        if (params.count("xorigin")) {
+            cmdLine.xorigin = true;
         }
         if (params.count("jsonp")) {
             cmdLine.jsonp = true;

--- a/db/restapi.cpp
+++ b/db/restapi.cpp
@@ -82,6 +82,10 @@ namespace mongo {
 
             headers.push_back( (string)"x-action: " + action );
             headers.push_back( (string)"x-ns: " + fullns );
+            
+            if ( cmdLine.xorigin ) {
+                headers.push_back( "Access-Control-Allow-Origin: *" );
+            }
 
             bool html = false;
 


### PR DESCRIPTION
Added cmd line option --xorigin to send "Access-Control-Allow-Origin: *" header to allow AJAX requests from other domains.
