### PR TITLE
Added spacing to an error message.

### DIFF
--- a/s/strategy_shard.cpp
+++ b/s/strategy_shard.cpp
@@ -294,7 +294,7 @@ namespace mongo {
                         while(fields.more()) {
                             const string field = fields.next().fieldName();
                             uassert(13123,
-                                    str::stream() << "Can't modify shard key's value field" << field
+                                    str::stream() << "Can't modify shard key's value field: " << field
                                     << " for collection: " << manager->getns(),
                                     ! manager->getShardKey().partOfShardKey(field));
                         }


### PR DESCRIPTION
This fixes the "Can't modify shard key's value field" message where the word "field" would be adjacent to the actual field name.
