### PR TITLE
ctrl-c cancels multiline not mongo  SERVER-3484

### DIFF
--- a/shell/dbshell.cpp
+++ b/shell/dbshell.cpp
@@ -308,6 +308,9 @@ char * shellReadline( const char * prompt , int handlesigint = 0 ) {
 #endif
 
     char * ret = linenoise( prompt );
+	if ( inMultiLine && !ret && errno == EAGAIN ) {
+		gotInterrupted = 1;
+	}
     signal( SIGINT , quitNicely );
     atPrompt = false;
     return ret;

--- a/third_party/linenoise/linenoise.cpp
+++ b/third_party/linenoise/linenoise.cpp
@@ -560,6 +560,8 @@ static int linenoisePrompt(int fd, char *buf, size_t buflen, const char *prompt)
             if (c == 0) continue;
         }
 
+        errno = 0;
+
         switch(c) {
         case 13:    /* enter */
             history_len--;


### PR DESCRIPTION
This fixes part of the issue in SERVER-3484

could this be accepted?
