### PR TITLE
fix compile error with 'scons --ssl=SSL' SERVER-3893

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -744,7 +744,7 @@ if "uname" in dir(os):
 if has_option( "ssl" ):
     env.Append( CPPDEFINES=["MONGO_SSL"] )
     env.Append( LIBS=["ssl"] )
-    if darwin:
+    if darwin or linux:
         env.Append( LIBS=["crypto"] )
 
 try:


### PR DESCRIPTION
the error message is as follows:

/usr/bin/ld: util/net/sock.o: undefined reference to symbol 'ERR_load_crypto_strings'
/usr/bin/ld: note: 'ERR_load_crypto_strings' is defined in DSO
/lib/libcrypto.so.10 so try adding it to the linker command line
/lib/libcrypto.so.10: could not read symbols: Invalid operation

The platform is:
2.6.40.4-5.fc15.i686.debug #1 SMP Tue Aug 30 14:29:53 UTC 2011 i686 i686 i386 GNU/Linux

Fedora Core 15.
