### PR TITLE
fix checkAndSet in Already class

### DIFF
--- a/db/dur_commitjob.h
+++ b/db/dur_commitjob.h
@@ -89,7 +89,7 @@ namespace mongo {
             */
             bool checkAndSet(void* p, int len) {
                 unsigned x = mongoutils::hashPointer(p);
-                pair<void*, int> nd = nodes[x % N];
+                pair<void*, int>& nd = nodes[x % N];
                 if( nd.first == p ) {
                     if( nd.second < len ) {
                         nd.second = len;


### PR DESCRIPTION
In the original code, one node is retrieved by value, therefore, the
corresponding value is never changed in following code, we should use
"reference" instead in order to get what we expect.
