### PR TITLE
Changed balancer_policy.cpp to move chunks more aggressively before the shards get big

### DIFF
--- a/s/balancer_policy.cpp
+++ b/s/balancer_policy.cpp
@@ -107,8 +107,11 @@ namespace mongo {
 
         // Solving imbalances takes a higher priority than draining shards. Many shards can
         // be draining at once but we choose only one of them to cater to per round.
+        // Important to start balanced, so when there are few chunks any imbalance must be fixed.
         const int imbalance = max.second - min.second;
-        const int threshold = balancedLastTime ? 2 : 8;
+        int threshold = 8;
+        if (balancedLastTime || max.second < 20) threshold = 2;
+        else if (max.second < 80) threshold = 4;
         string from, to;
         if ( imbalance >= threshold ) {
             from = max.first;


### PR DESCRIPTION
Designed to keep things in balance from the beginning and avoid overloading one shard. Eliot and I have both tested and found performance improvements when loading with random keys into sharded collections without pre-splitting.
