### PR TITLE
remove unused declaration of NamespaceCursor

### DIFF
--- a/db/namespace.h
+++ b/db/namespace.h
@@ -582,8 +582,6 @@ namespace mongo {
        if you will: at least the core parts.  (Additional info in system.* collections.)
     */
     class NamespaceIndex {
-        friend class NamespaceCursor;
-
     public:
         NamespaceIndex(const string &dir, const string &database) :
             ht( 0 ), dir_( dir ), database_( database ) {}


### PR DESCRIPTION
Class NamespaceCursor was deleted in commit 10d993452beda41f4b3cef765e2c2222f474de0f.
We should get rid of this last declaration as well.
