### PR TITLE
SERVER-4042 convert HashTable::iterAll() to use boost::bind instead of function callback

### DIFF
--- a/db/namespace.cpp
+++ b/db/namespace.cpp
@@ -204,17 +204,13 @@ namespace mongo {
             ht->iterAll(namespaceOnLoadCallback);
     }
 
-    static void namespaceGetNamespacesCallback( const Namespace& k , NamespaceDetails& v , void * extra ) {
-        list<string> * l = (list<string>*)extra;
+    static void namespaceGetNamespacesCallback( const Namespace& k , NamespaceDetails& v , list<string> * l ) {
         if ( ! k.hasDollarSign() )
             l->push_back( (string)k );
     }
-    void NamespaceIndex::getNamespaces( list<string>& tofill , bool onlyCollections ) const {
-        assert( onlyCollections ); // TODO: need to implement this
-        //                                  need boost::bind or something to make this less ugly
-
+    void NamespaceIndex::getNamespaces( list<string>& tofill ) const {
         if ( ht )
-            ht->iterAll( namespaceGetNamespacesCallback , (void*)&tofill );
+            ht->iterAll( boost::bind(namespaceGetNamespacesCallback , _1, _2, &tofill) );
     }
 
     void NamespaceDetails::addDeletedRec(DeletedRecord *d, DiskLoc dloc) {

--- a/db/namespace.h
+++ b/db/namespace.h
@@ -641,7 +641,7 @@ namespace mongo {
             return ht != 0;
         }
 
-        void getNamespaces( list<string>& tofill , bool onlyCollections = true ) const;
+        void getNamespaces( list<string>& tofill ) const;
 
         NamespaceDetails::Extra* newExtra(const char *ns, int n, NamespaceDetails *d);
 

--- a/util/hashtab.h
+++ b/util/hashtab.h
@@ -153,21 +153,11 @@ namespace mongo {
             return true;
         }
 
-        typedef void (*IteratorCallback)( const Key& k , Type& v );
+        typedef boost::function< void ( const Key& k , Type& v ) > IteratorCallback;
         void iterAll( IteratorCallback callback ) {
             for ( int i=0; i<n; i++ ) {
                 if ( nodes(i).inUse() ) {
                     callback( nodes(i).k , nodes(i).value );
-                }
-            }
-        }
-
-        // TODO: should probably use boost::bind for this, but didn't want to look at it
-        typedef void (*IteratorCallback2)( const Key& k , Type& v , void * extra );
-        void iterAll( IteratorCallback2 callback , void * extra ) {
-            for ( int i=0; i<n; i++ ) {
-                if ( nodes(i).inUse() ) {
-                    callback( nodes(i).k , nodes(i).value , extra );
                 }
             }
         }


### PR DESCRIPTION
fix TODO in util/hashtab.h - use boost::bind instead of function callback
