### PR TITLE
SERVER-4007 (reissue) -- use .c_str() instead of .data()

### DIFF
--- a/shell/dbshell.cpp
+++ b/shell/dbshell.cpp
@@ -101,7 +101,7 @@ static void edit(const string& var){
         return;
     }
 
-    for (const char* p=var.data(); *p ; p++){
+    for (const char* p=var.c_str(); *p ; p++){
         if (! (isalnum(*p) || *p == '_' || *p == '.')){
             cout << "can only edit variable or property" << endl;
             return;


### PR DESCRIPTION
This is a reissue of my earlier fix. I'm trying to break them down into
bite-sized parts to make them easier to pull.

Use .c_str() instead of .data() if the loop is checking for 0 as terminator.
