### PR TITLE
SERVER-4012 (reissue) -- make ctrl-T work like bash and emacs

### DIFF
--- a/third_party/linenoise/linenoise.cpp
+++ b/third_party/linenoise/linenoise.cpp
@@ -601,11 +601,12 @@ static int linenoisePrompt(int fd, char *buf, size_t buflen, const char *prompt)
             }
             break;
         case 20:    /* ctrl-t */
-            if (pos > 0 && pos < len) {
-                int aux = buf[pos-1];
-                buf[pos-1] = buf[pos];
-                buf[pos] = aux;
-                if (pos != len-1) pos++;
+            if (pos > 0 && len > 1) {
+                size_t leftCharPos = (pos == len) ? pos - 2 : pos - 1;
+                char aux = buf[leftCharPos];
+                buf[leftCharPos] = buf[leftCharPos+1];
+                buf[leftCharPos+1] = aux;
+                if (pos != len) pos++;
                 refreshLine(fd,prompt,buf,len,pos,cols);
             }
             break;


### PR DESCRIPTION
This is a reissue of my earlier fix. I'm trying to break them down into
bite-sized parts to make them easier to pull.

Small changes to logic to do what bash does when ctrl-T is hit at or
next to the end of a line.
