### PR TITLE
SERVER-3991 (reissue) -- don't index past end of string

### DIFF
--- a/shell/dbshell.cpp
+++ b/shell/dbshell.cpp
@@ -453,7 +453,10 @@ bool isBalanced( string code ) {
             }
             break;
         }
-
+        if (i>=code.size()) {
+            danglingOp = false;
+            break;
+        }
         if ( isOpSymbol( code[i] )) danglingOp = true;
         else if (! std::isspace( code[i] )) danglingOp = false;
     }


### PR DESCRIPTION
This is a reissue of my earlier fix. I'm trying to break them down into
bite-sized parts to make them easier to pull.

Break out of the for() loop once we've advanced the counter past the end.
Skip the test for dangling operator (no character to examine, we're inside
a quoted string) and set danglingOp = false.
