### PR TITLE
SERVER-3470 (reissue 2) -- store multi-line commands in history

### DIFF
--- a/shell/dbshell.cpp
+++ b/shell/dbshell.cpp
@@ -114,7 +114,7 @@ static void edit(const string& var){
     const string js = shellMainScope->getString("__jsout__");
 
     if (strstr(js.c_str(), "[native code]")) {
-        cout << "Can't edit native functions" << endl;
+        cout << "can't edit native functions" << endl;
         return;
     }
 
@@ -899,7 +899,7 @@ int _main(int argc, char* argv[]) {
                 }
             }
 
-            shellHistoryAdd( line );
+            shellHistoryAdd( code.c_str() );
         }
 
         shellHistoryDone();

--- a/third_party/linenoise/linenoise.cpp
+++ b/third_party/linenoise/linenoise.cpp
@@ -774,6 +774,15 @@ int linenoiseHistoryAdd(const char *line) {
         memmove(history,history+1,sizeof(char*)*(history_max_len-1));
         history_len--;
     }
+
+    // convert newlines in multi-line code fragments to spaces before storing
+    char * p = linecopy;
+    while (*p) {
+        if ('\n' == *p) {
+            *p = ' ';
+        }
+        p++;
+    }
     history[history_len] = linecopy;
     history_len++;
     return 1;


### PR DESCRIPTION
This is a reissue of my earlier fix. I'm trying to break them down into
bite-sized parts to make them easier to pull.

Convert newlines to spaces and store the entire multi-line command instead
of just the line that began the command. Fix initial cap in error message.
