### PR TITLE
SERVER-3771 -- part 1 (reissue 2) -- don't let 'prompt' become undefined

### DIFF
--- a/shell/dbshell.cpp
+++ b/shell/dbshell.cpp
@@ -811,15 +811,22 @@ int _main(int argc, char* argv[]) {
 //            shellMainScope->localConnect;
             //DBClientWithCommands *c = getConnection( JSContext *cx, JSObject *obj );
 
+            bool haveStringPrompt = false;
             promptType = scope->type("prompt");
-            if (promptType == String){
+            if( promptType == String ) {
                 prompt = scope->getString("prompt");
-            } else if (promptType  == Code) {
-                scope->exec("__prompt__ = prompt();", "", false, false, false, 0);
-                prompt = scope->getString("__prompt__");
-            } else {
-                prompt = sayReplSetMemberState()+"> ";
+                haveStringPrompt = true;
             }
+            else if( promptType == Code ) {
+                scope->exec("delete __prompt__;", "", false, false, false, 0);
+                scope->exec("__prompt__ = prompt();", "", false, false, false, 0);
+                if( scope->type("__prompt__") == String ) {
+                    prompt = scope->getString("__prompt__");
+                    haveStringPrompt = true;
+                }
+            }
+            if( !haveStringPrompt )
+                prompt = sayReplSetMemberState()+"> ";
 
             char * line = shellReadline( prompt.c_str() );
 


### PR DESCRIPTION
This is a reissue of my earlier fix.  I'm trying to break them down into
bite-sized parts to make them easier to pull.

Test the return value from a call to a function prompt (included regex)
and only use it if it is a string.  If we have no string prompt, display
the default prompt = sayReplSetMemberState()+"> "; .  Edited for style.
