### PR TITLE
SERVER-4084 -- spell 'during' correctly

### DIFF
--- a/shell/mongo_vstudio.cpp
+++ b/shell/mongo_vstudio.cpp
@@ -1198,7 +1198,7 @@ const StringData _jscode_raw_utils =
 "try {\n" 
 "__autocomplete__ = worker(prefix).sort();\n" 
 "}catch (e){\n" 
-"print(\"exception durring autocomplete: \" + tojson(e.message));\n" 
+"print(\"exception during autocomplete: \" + tojson(e.message));\n" 
 "__autocomplete__ = [];\n" 
 "}\n" 
 "}\n" 

--- a/shell/utils.js
+++ b/shell/utils.js
@@ -1193,7 +1193,7 @@ shellAutocomplete = function (/*prefix*/){ // outer scope function called on ini
         try {
             __autocomplete__ = worker(prefix).sort();
         }catch (e){
-            print("exception durring autocomplete: " + tojson(e.message));
+            print("exception during autocomplete: " + tojson(e.message));
             __autocomplete__ = [];
         }
     }


### PR DESCRIPTION
Change "durring" to "during" in an error message.
