### PR TITLE
fix MVar's link info in the comment

### DIFF
--- a/util/concurrency/README
+++ b/util/concurrency/README
@@ -7,7 +7,7 @@ task.h - an abstraction around threads
 mutex.h - small enhancements that wrap boost::mutex
 mvar.h
  This is based on haskell's MVar synchronization primitive:
- http://www.haskell.org/ghc/docs/latest/html/libraries/base-4.2.0.0/Control-Concurrent-MVar.html
+ http://www.haskell.org/ghc/docs/latest/html/libraries/base/Control-Concurrent-MVar.html
  It is a thread-safe queue that can hold at most one object.
  You can also think of it as a box that can be either full or empty.
 value.h

--- a/util/concurrency/mvar.h
+++ b/util/concurrency/mvar.h
@@ -18,7 +18,7 @@
 namespace mongo {
 
     /* This is based on haskell's MVar synchronization primitive:
-     * http://www.haskell.org/ghc/docs/latest/html/libraries/base-4.2.0.0/Control-Concurrent-MVar.html
+     * http://www.haskell.org/ghc/docs/latest/html/libraries/base/Control-Concurrent-MVar.html
      *
      * It is a thread-safe queue that can hold at most one object.
      * You can also think of it as a box that can be either full or empty.


### PR DESCRIPTION
The original link doesn't exist any more. Use the latest one instead.

It's a trivial fix, hope it can be accepted.
