### PR TITLE
Fix for https://jira.mongodb.org/browse/SERVER-4166

### DIFF
--- a/client/dbclient.h
+++ b/client/dbclient.h
@@ -973,6 +973,10 @@ namespace mongo {
     BSONElement getErrField( const BSONObj& result );
     bool hasErrField( const BSONObj& result );
 
+    inline std::ostream& operator<<( std::ostream &s, const Query &q ) {
+        return s << q.toString();
+    }
+
 } // namespace mongo
 
 #include "dbclientcursor.h"


### PR DESCRIPTION
Implement operator<< for std::ostream output of mongo::Query objects
