### PR TITLE
SERVER-340 - add $iset modifier for upsert.

### DIFF
--- a/db/ops/update.h
+++ b/db/ops/update.h
@@ -64,8 +64,8 @@ namespace mongo {
      */
     struct Mod {
         // See opFromStr below
-        //        0    1    2     3         4     5          6    7      8       9       10    11        12           13
-        enum Op { INC, SET, PUSH, PUSH_ALL, PULL, PULL_ALL , POP, UNSET, BITAND, BITOR , BIT , ADDTOSET, RENAME_FROM, RENAME_TO } op;
+        //        0    1    2     3     4         5     6          7    8      9       10      11    12        13           14
+        enum Op { INC, SET, ISET, PUSH, PUSH_ALL, PULL, PULL_ALL , POP, UNSET, BITAND, BITOR , BIT , ADDTOSET, RENAME_FROM, RENAME_TO } op;
 
         static const char* modNames[];
         static unsigned modNamesNum;
@@ -314,6 +314,8 @@ namespace mongo {
             case 'i': {
                 if ( fn[2] == 'n' && fn[3] == 'c' && fn[4] == 0 )
                     return Mod::INC;
+                if ( fn[2] == 's' && fn[3] == 'e' && fn[4] == 't' && fn[5] == 0 )
+                    return Mod::ISET;
                 break;
             }
             case 's': {
@@ -623,7 +625,7 @@ namespace mongo {
                 // no-op b/c unset/pull of nothing does nothing
                 break;
 
-            case Mod::INC:
+            case Mod::INC: case Mod::ISET:
                 ms.fixedOpName = "$set";
             case Mod::SET: {
                 m._checkForAppending( m.elt );

--- a/dbtests/updatetests.cpp
+++ b/dbtests/updatetests.cpp
@@ -230,6 +230,50 @@ namespace UpdateTests {
         }
     };
 
+    class ISetExists : public SetBase {
+    public:
+        void run() {
+            client().insert( ns(), fromjson( "{ a: 'b' }" ) );
+            client().update( ns(), Query(), fromjson( "{ $iset: { a: 5 } }" ) );
+            ASSERT( client().findOne( ns(), fromjson( "{ a: 5 }" ) ).isEmpty() );
+            ASSERT( !client().findOne( ns(), fromjson( "{ a: 'b' }" ) ).isEmpty() );
+        }
+    };
+
+    class ISetNotExists : public SetBase {
+    public:
+        void run() {
+            client().insert( ns(), fromjson( "{ a: 'b' }" ) );
+            client().update( ns(), Query(), fromjson( "{ $iset: { c: 5 } }" ) );
+            ASSERT( !client().findOne( ns(), fromjson( "{ a: 'b', c: 5 }" ) ).isEmpty() );
+        }
+    };
+
+    class ISetUpsert : public SetBase {
+    public:
+        void run() {
+            client().update( ns(), fromjson( "{ a: 'b' }" ), fromjson( "{ $iset: { c: 5 } }" ), true );
+            ASSERT( !client().findOne( ns(), fromjson( "{ a: 'b', c: 5 }" ) ).isEmpty() );
+        }
+    };
+
+    class ISetIdExistingUpsert : public SetBase {
+    public:
+        void run() {
+            client().insert( ns(), fromjson( "{ a: 'b' }" ) );
+            client().update( ns(), fromjson( "{ a: 'b' }" ), fromjson( "{ $iset: { _id: 5 } }" ), true );
+            ASSERT( client().findOne( ns(), fromjson( "{ _id: 5 }" ) ).isEmpty() );
+        }
+    };
+
+    class ISetIdNewUpsert : public SetBase {
+    public:
+        void run() {
+            client().update( ns(), fromjson( "{ a: 'b' }" ), fromjson( "{ $iset: { _id: 5 } }" ), true );
+            ASSERT( client().findOne( ns(), fromjson( "{ _id: 5 }" ) ).woCompare( fromjson( "{ _id:5, a: 'b' }" ) ) == 0 );
+        }
+    };
+
     class IncMissing : public SetBase {
     public:
         void run() {
@@ -825,6 +869,11 @@ namespace UpdateTests {
             add< SetRecreateDotted >();
             add< SetMissingDotted >();
             add< SetAdjacentDotted >();
+            add< ISetExists >();
+            add< ISetNotExists >();
+            add< ISetUpsert >();
+            add< ISetIdExistingUpsert >();
+            add< ISetIdNewUpsert >();
             add< IncMissing >();
             add< MultiInc >();
             add< UnorderedNewSet >();

--- a/jstests/update3.js
+++ b/jstests/update3.js
@@ -21,3 +21,23 @@ f.drop();
 f.save( {'_id':0} );
 f.update( {}, {$set:{'_id':5}} );
 assert.eq( 0, f.findOne()._id , "D" );
+
+f.drop();
+f.save( { a:1 } );
+f.update( {}, {$iset:{ a:2 }} );
+assert.eq( 1, f.findOne().a , "E" );
+f.update( {}, {$iset:{ b:2 }} );
+assert.eq( 2, f.findOne().b , "F" );
+
+f.drop();
+f.update( {a:1}, {$iset:{ b:2 }}, true );
+assert.eq( 1, f.findOne().a , "G" );
+assert.eq( 2, f.findOne().b , "H" );
+
+f.drop();
+f.update( {a:1}, {$iset:{ _id:0 }}, true );
+assert.eq( 0, f.findOne()._id , "I" );
+assert.eq( 1, f.findOne().a , "J" );
+f.update( {a:1}, {$iset:{ _id:9 }}, true );
+assert.eq( 0, f.findOne()._id , "K" );
+assert.eq( 1, f.findOne().a , "L" );


### PR DESCRIPTION
Sets values only if they're not already set.
Allows setting _id in upserts.
