### PR TITLE
Fix rpm/init.d-mongod DBPATH variable to allow for whitespace in config files

### DIFF
--- a/rpm/init.d-mongod
+++ b/rpm/init.d-mongod
@@ -22,7 +22,7 @@ SYSCONFIG="/etc/sysconfig/mongod"
 # FIXME: 1.9.x has a --shutdown flag that parses the config file and
 # shuts down the correct running pid, but that's unavailable in 1.8
 # for now.  This can go away when this script stops supporting 1.8.
-DBPATH=`awk -F= '/^dbpath=/{print $2}' "$CONFIGFILE"`
+DBPATH=`awk -F= '/^dbpath[ \t]*=/{print $2}' "$CONFIGFILE"`
 mongod=${MONGOD-/usr/bin/mongod}
 
 MONGO_USER=mongod


### PR DESCRIPTION
Without this, if dbpath has been specified as 'dbpath = …' in the
config file the script will fail to properly execute $0 stop
