### PR TITLE
remove unused allocTemp

### DIFF
--- a/db/btree.cpp
+++ b/db/btree.cpp
@@ -1244,13 +1244,6 @@ namespace mongo {
     }
 
     template< class V >
-    BtreeBucket<V> * BtreeBucket<V>::allocTemp() {
-      BtreeBucket *b = (BtreeBucket*) malloc(V::BucketSize);
-        b->init();
-        return b;
-    }
-
-    template< class V >
     inline void BtreeBucket<V>::fix(const DiskLoc thisLoc, const DiskLoc child) {
         if ( !child.isNull() ) {
             if ( insert_debug )

--- a/db/btree.h
+++ b/db/btree.h
@@ -899,12 +899,6 @@ namespace mongo {
     protected:
 
         /**
-         * Allocate a temporary btree bucket in ram rather than in memory mapped
-         * storage.  The caller must release this bucket with free().
-         */
-        static BtreeBucket<V> * allocTemp();
-
-        /**
          * Preconditions:
          *  - This bucket is packed.
          *  - Cannot add a key of size KeyMax to this bucket.


### PR DESCRIPTION
allocTemp is not used anymore, so we can delete it safely.
