### PR TITLE
mongod.conf modiffied optlog deprecated.

### DIFF
--- a/rpm/mongod.conf
+++ b/rpm/mongod.conf
@@ -38,7 +38,7 @@ dbpath=/var/lib/mongo
 #   2=R
 #   3=both
 #   7=W+some reads
-#oplog = 0
+#diaglog = 0
 
 # Ignore query hints
 #nohints = true


### PR DESCRIPTION
mongod.conf modiffied. After uncomenting "#optlog = 0" mongo wouldn't start. Changed to "#diaglog = 0" and works fine.
