### PR TITLE
Keeping version number if present in rs.reconfig

### DIFF
--- a/shell/utils.js
+++ b/shell/utils.js
@@ -1688,7 +1688,8 @@ rs._runCmd = function (c) {
     return res;
 }
 rs.reconfig = function (cfg, options) {
-    cfg.version = rs.conf().version + 1;
+    if( cfg.version == undefined )
+        cfg.version = rs.conf().version + 1;
     cmd = { replSetReconfig: cfg };
     for (var i in options) {
         cmd[i] = options[i];


### PR DESCRIPTION
Details in https://jira.mongodb.org/browse/SERVER-4452

This change will respect the version in the replica set configuration object if passed in via rs.reconfig.

Tests:

*Correctly failed when passed in old version
*Correctly failed when passed in current version
*Correctly updated when passed in new version
*Correctly updated when no version passed in (still backwards compatible)
