### PR TITLE
Add "field" option to geoNear for manually specifying geo field.

### DIFF
--- a/db/geo/2d.cpp
+++ b/db/geo/2d.cpp
@@ -2575,10 +2575,11 @@ namespace mongo {
 
             int geoIdx = -1;
             if ( cmdObj.hasField("field") ) {
-              geoIdx = d->findIndexByName( (cmdObj["field"].str() + "_").c_str() );
+              BSONObj fieldKeyPattern = BSON( cmdObj["field"].str() << GEO2DNAME );
+              geoIdx = d->findIndexByKeyPattern( fieldKeyPattern );
 
               if ( geoIdx == -1 ) {
-                errmsg = "couldn't find geo index by name :(";
+                errmsg = "couldn't find geo index by key '" + cmdObj["field"].str() + "' :(";
                 return false;
               }
             } else {


### PR DESCRIPTION
This eliminates the need to guess the name of the field based on which
is a geo field, although I left that capability in there so as to not
break backwards compatibility.

All geo js tests still green.
