### PR TITLE
SERVER-12110 Using the safe strcpy_s. The 'num' parameter is the size of the 'buf' array.

### DIFF
--- a/src/mongo/util/net/sock.cpp
+++ b/src/mongo/util/net/sock.cpp
@@ -406,7 +406,7 @@ namespace mongo {
     int SSLManager::password_cb(char *buf,int num, int rwflag,void *userdata){
         SSLManager* sm = (SSLManager*)userdata;
         string pass = sm->_password;
-        strcpy(buf,pass.c_str());
+        strcpy_s(buf, num, pass.c_str());
         return(pass.size());
     }
 


### PR DESCRIPTION
This will help protect against buffer overflow and/or heap corruption.
