### PR TITLE
Changes to strcpy_s()

### DIFF
--- a/util/goodies.h
+++ b/util/goodies.h
@@ -354,9 +354,12 @@ namespace mongo {
     
 #if !defined(_WIN32)
     typedef int HANDLE;
+#if !defined(strcpy_s)
     inline void strcpy_s(char *dst, unsigned len, const char *src) {
-        strcpy(dst, src);
+        strncpy(dst, src, len-1);
+        dst[len-1] = '\0';
     }
+#endif
 #else
     typedef void *HANDLE;
 #endif


### PR DESCRIPTION
These changes are being submitted back on behalf of Cisco Systems, Inc. for compliance with the open source license requirements of mongodb.

Changes to strcpy_s() for v1.6:
1. Conditionalized the definition of Microsoft-based strcpy_s(),
   so as to avoid conflict with definitions of the same symbol
   in client applications.
2. Modified the strcpy_s() implementation to use strncpy() for
   safer string manipulations.
