### PR TITLE
SERVER-2459 add --excludeCollection to mongodump

### DIFF
--- a/debian/mongodump.1
+++ b/debian/mongodump.1
@@ -33,8 +33,11 @@ specify password of user (notice there is no space)
 .B \-d, \-\-db DATABASE
 database to use
 .TP
-.B \-c, \-\-c COLLECTION
+.B \-c, \-\-collection COLLECTION
 collection to use
+.TP
+.B \-\-excludeCollection COLLECTION
+exclude a certain collection from dump
 .TP
 .B \-o, \-\-out DIRECTORY
 output directory or - for stdout.

--- a/src/mongo/tools/dump.cpp
+++ b/src/mongo/tools/dump.cpp
@@ -41,9 +41,12 @@ class Dump : public Tool {
     private:
         FILE* _f;
     };
+protected:
+	string _excludeCollection;
 public:
     Dump() : Tool( "dump" , ALL , "" , "" , true ) {
         add_options()
+        ("excludeCollection", po::value<string>(), "exclude a certain collection from dump")
         ("out,o", po::value<string>()->default_value("dump"), "output directory or \"-\" for stdout")
         ("query,q", po::value<string>() , "json query" )
         ("oplog", "Use oplog for point-in-time snapshotting" )
@@ -208,6 +211,12 @@ public:
             //if a particular collections is specified, and it's not this one, skip it
             if ( _coll != "" && db + "." + _coll != name && _coll != name )
                 continue;
+
+            // if a particular collection is excluded, and it's this one, skip it
+            if ( _excludeCollection != "" && (db + "." + _excludeCollection == name || _excludeCollection == name ) ) {
+                log() << "\tskipping collection " << name << endl;
+                continue;
+            }
 
             // raise error before writing collection with non-permitted filename chars in the name
             size_t hasBadChars = name.find_first_of("/\0");
@@ -472,6 +481,8 @@ public:
         }
 
         _usingMongos = isMongos();
+
+        _excludeCollection = getParam("excludeCollection");
 
         boost::filesystem::path root( out );
         string db = _db;


### PR DESCRIPTION
I wanted to resolve SERVER-2459, so I patched /src/mongo/tools/dump.cpp to add a new command line option, --excludeCollection.  I also updated the man file debian/mongodump.1 to reflect this.  I think I have made these changes following the style of the existing code.  This is my first contribution to Mongo and if you see issues with my code, I would appreciate any feedback.  Thanks for considering my patch.
