### PR TITLE
Fix stripping of binaries during install

### DIFF
--- a/src/mongo/SConscript
+++ b/src/mongo/SConscript
@@ -465,10 +465,12 @@ def installBinary( e, name ):
     name = add_exe( name )
 
     inst = e.Install( "$INSTALL_DIR/bin", name )[0]
-
+    
+    target = "$INSTALL_DIR/bin/" + name
+    
     allBinaries += [ name ]
     if (solaris or linux) and (not has_option("nostrip")):
-        e.AddPostAction( inst, e.Action( 'strip $TARGET' ) )
+        e.AddPostAction( inst, e.Action( 'strip ' + target ) )
 
     if not has_option( "no-glibc-check" ) and linux and len( COMMAND_LINE_TARGETS ) == 1 and str( COMMAND_LINE_TARGETS[0] ) == "s3dist":
         e.AddPostAction( inst, checkGlibc )


### PR DESCRIPTION
Not sure why $TARGET is used here.  Hopefully this is useful for others =)
