### PR TITLE
Increase log level on authentication

### DIFF
--- a/src/mongo/db/security_commands.cpp
+++ b/src/mongo/db/security_commands.cpp
@@ -69,7 +69,7 @@ namespace mongo {
     CmdLogout cmdLogout;
 
     bool CmdAuthenticate::run(const string& dbname , BSONObj& cmdObj, int, string& errmsg, BSONObjBuilder& result, bool fromRepl) {
-        log() << " authenticate: " << cmdObj << endl;
+        log(2) << " authenticate: " << cmdObj << endl;
 
         string user = cmdObj.getStringField("user");
         string key = cmdObj.getStringField("key");


### PR DESCRIPTION
In our deploy we end up authenticating to the database alot.  It's not desirable but it isn't something we can architect around quickly.  We just upgraded from 1.8.2 to 2.0.2 and now have many of these entries in our log file:

Tue Jan 24 17:29:56 [conn53354]  authenticate: { authenticate: 1, nonce: "<nonce>", user: "<user>", key: "<key>" }

Since this message is being logged at DEBUG we can't disable it.  I've moved the log level for that call up to notify so users can still see it if they want but they also have the ability to disable it.
