### PR TITLE
Remove "LOG" Macro

### DIFF
--- a/src/mongo/client/parallel.cpp
+++ b/src/mongo/client/parallel.cpp
@@ -110,7 +110,7 @@ namespace mongo {
                 throw RecvStaleConfigException( _ns , "ClusteredCursor::query" , true );
             }
             
-            LOG(5) << "ClusteredCursor::query (" << type() << ") server:" << server
+            MONGO_LOG(5) << "ClusteredCursor::query (" << type() << ") server:" << server
                    << " ns:" << _ns << " query:" << q << " num:" << num
                    << " _fields:" << _fields << " options: " << _options << endl;
         
@@ -1201,7 +1201,7 @@ namespace mongo {
                     break;
                 }
 
-                LOG(5) << "ParallelSortClusteredCursor::init server:" << sq._server << " ns:" << _ns
+                MONGO_LOG(5) << "ParallelSortClusteredCursor::init server:" << sq._server << " ns:" << _ns
                        << " query:" << q << " _fields:" << _fields << " options: " << _options  << endl;
 
                 if( ! _cursors[i].raw() )
@@ -1519,7 +1519,7 @@ namespace mongo {
 
                 versionManager.checkShardVersionCB( _conn, e.getns(), false, 1 );
 
-                LOG( i > 1 ? 0 : 1 ) << "retrying lazy command" << causedBy( e ) << endl;
+                MONGO_LOG( i > 1 ? 0 : 1 ) << "retrying lazy command" << causedBy( e ) << endl;
 
                 assert( _conn->lazySupported() );
                 _done = false;

--- a/src/mongo/client/redef_macros.h
+++ b/src/mongo/client/redef_macros.h
@@ -53,9 +53,6 @@
 #define RARELY MONGO_RARELY
 #define ONCE MONGO_ONCE
 
-// util/log.h
-#define LOG MONGO_LOG
-
 #undef MONGO_MACROS_CLEANED
 #endif
 

--- a/src/mongo/client/undef_macros.h
+++ b/src/mongo/client/undef_macros.h
@@ -54,8 +54,5 @@
 #undef RARELY
 #undef ONCE
 
-// util/log.h
-#undef LOG
-
 #define MONGO_MACROS_CLEANED
 #endif

--- a/src/mongo/db/clientcursor.cpp
+++ b/src/mongo/db/clientcursor.cpp
@@ -179,7 +179,7 @@ namespace mongo {
                 ClientCursor *cc = i.current();
                 if( cc->shouldTimeout(0) ) {
                     numberTimedOut++;
-                    LOG(1) << "killing old cursor " << cc->_cursorid << ' ' << cc->_ns
+                    MONGO_LOG(1) << "killing old cursor " << cc->_cursorid << ' ' << cc->_ns
                            << " idle:" << cc->idleTime() << "ms\n";
                     i.deleteAndAdvance();
                 }

--- a/src/mongo/db/commands/isself.cpp
+++ b/src/mongo/db/commands/isself.cpp
@@ -158,7 +158,7 @@ namespace mongo {
     bool HostAndPort::isSelf() const {
 
         if( dyn() ) { 
-            LOG(2) << "isSelf " << _dynName << ' ' << dynHostMyName() << endl;
+            MONGO_LOG(2) << "isSelf " << _dynName << ' ' << dynHostMyName() << endl;
             return dynHostMyName() == _dynName;
         }
 

--- a/src/mongo/db/d_concurrency.cpp
+++ b/src/mongo/db/d_concurrency.cpp
@@ -118,7 +118,7 @@ namespace mongo {
         lk(cc().lockStatus.excluder, d.writeExcluder), 
         gslk()
     {
-        LOG(3) << "ExcludeAllWrites" << endl;
+        MONGO_LOG(3) << "ExcludeAllWrites" << endl;
         wassert( !d.dbMutex.isWriteLocked() );
     };
     ExcludeAllWrites::~ExcludeAllWrites() {

--- a/src/mongo/db/database.cpp
+++ b/src/mongo/db/database.cpp
@@ -334,7 +334,7 @@ namespace mongo {
             fromFreeList = false;
             e = suitableFile( ns, size, !capped, enforceQuota )->createExtent( ns, size, capped );
         }
-        LOG(1) << "allocExtent " << ns << " size " << size << ' ' << fromFreeList << endl; 
+        MONGO_LOG(1) << "allocExtent " << ns << " size " << size << ' ' << fromFreeList << endl; 
         return e;
     }
 

--- a/src/mongo/db/dur_journal.cpp
+++ b/src/mongo/db/dur_journal.cpp
@@ -563,7 +563,7 @@ namespace mongo {
                     log() << "warning: open of lsn file failed" << endl;
                     return;
                 }
-                LOG(1) << "lsn set " << _lastFlushTime << endl;
+                MONGO_LOG(1) << "lsn set " << _lastFlushTime << endl;
                 LSNFile lsnf;
                 lsnf.set(_lastFlushTime);
                 f.write(0, (char*)&lsnf, sizeof(lsnf));

--- a/src/mongo/db/dur_writetodatafiles.cpp
+++ b/src/mongo/db/dur_writetodatafiles.cpp
@@ -29,9 +29,9 @@ namespace mongo {
 
         static void WRITETODATAFILES_Impl1(const JSectHeader& h, AlignedBuilder& uncompressed) {
             LockMongoFilesShared lk;
-            LOG(3) << "journal WRITETODATAFILES 1" << endl;
+            MONGO_LOG(3) << "journal WRITETODATAFILES 1" << endl;
             RecoveryJob::get().processSection(&h, uncompressed.buf(), uncompressed.len(), 0);
-            LOG(3) << "journal WRITETODATAFILES 2" << endl;
+            MONGO_LOG(3) << "journal WRITETODATAFILES 2" << endl;
         }
 
 #if 0
@@ -87,7 +87,7 @@ namespace mongo {
             WRITETODATAFILES_Impl1(h, uncompressed);
             unsigned long long m = t.micros();
             stats.curr->_writeToDataFilesMicros += m;
-            LOG(2) << "journal WRITETODATAFILES " << m / 1000.0 << "ms" << endl;
+            MONGO_LOG(2) << "journal WRITETODATAFILES " << m / 1000.0 << "ms" << endl;
         }
 
     }

--- a/src/mongo/db/geo/2d.cpp
+++ b/src/mongo/db/geo/2d.cpp
@@ -934,12 +934,12 @@ namespace mongo {
                     break;
                 }
                 else{
-                    LOG( CDEBUG + 1 ) << "Key doesn't match : " << cursor->current()["_id"] << " saved : " << _id << endl;
+                    MONGO_LOG( CDEBUG + 1 ) << "Key doesn't match : " << cursor->current()["_id"] << " saved : " << _id << endl;
                 }
                 cursor->advance();
             }
 
-            if( ! count ) { LOG( CDEBUG ) << "No key found for " << _key << endl; }
+            if( ! count ) { MONGO_LOG( CDEBUG ) << "No key found for " << _key << endl; }
 
             _dirty = false;
 
@@ -1311,7 +1311,7 @@ namespace mongo {
 
             bool filled = false;
 
-            LOG( CDEBUG ) << "Checking cursor, in state " << (int) _state << ", first call " << _firstCall <<
+            MONGO_LOG( CDEBUG ) << "Checking cursor, in state " << (int) _state << ", first call " << _firstCall <<
                              ", empty : " << _cur.isEmpty() << ", dirty : " << _cur.isDirty() << ", stack : " << _stack.size() << endl;
 
             bool first = _firstCall;
@@ -1331,7 +1331,7 @@ namespace mongo {
 
             while ( moreToDo() ) {
 
-                LOG( CDEBUG ) << "Refilling stack..." << endl;
+                MONGO_LOG( CDEBUG ) << "Refilling stack..." << endl;
 
                 fillStack( maxPointsHeuristic );
                 filled = true;
@@ -1376,7 +1376,7 @@ namespace mongo {
         virtual void noteLocation() {
             _noted = true;
 
-            LOG( CDEBUG ) << "Noting location with " << _stack.size() << ( _cur.isEmpty() ? "" : " + 1 " ) << " points " << endl;
+            MONGO_LOG( CDEBUG ) << "Noting location with " << _stack.size() << ( _cur.isEmpty() ? "" : " + 1 " ) << " points " << endl;
 
             // Make sure we advance past the point we're at now,
             // since the current location may move on an update/delete
@@ -1389,13 +1389,13 @@ namespace mongo {
             _min.save();
             _max.save();
 
-            LOG( CDEBUG ) << "Min " << _min.toString() << endl;
-            LOG( CDEBUG ) << "Max " << _max.toString() << endl;
+            MONGO_LOG( CDEBUG ) << "Min " << _min.toString() << endl;
+            MONGO_LOG( CDEBUG ) << "Max " << _max.toString() << endl;
 
             // Dirty all our queued stuff
             for( list<GeoPoint>::iterator i = _stack.begin(); i != _stack.end(); i++ ){
 
-                LOG( CDEBUG ) << "Undirtying stack point with id " << i->_id << endl;
+                MONGO_LOG( CDEBUG ) << "Undirtying stack point with id " << i->_id << endl;
 
                 if( i->makeDirty() ) _nDirtied++;
                 assert( i->isDirty() );
@@ -1422,7 +1422,7 @@ namespace mongo {
         /* called before query getmore block is iterated */
         virtual void checkLocation() {
 
-            LOG( CDEBUG ) << "Restoring location with " << _stack.size() << ( ! _cur.isDirty() ? "" : " + 1 " ) << " points " << endl;
+            MONGO_LOG( CDEBUG ) << "Restoring location with " << _stack.size() << ( ! _cur.isDirty() ? "" : " + 1 " ) << " points " << endl;
 
             // We can assume an error was thrown earlier if this database somehow disappears
 
@@ -1430,8 +1430,8 @@ namespace mongo {
             _min.restore();
             _max.restore();
 
-            LOG( CDEBUG ) << "Min " << _min.toString() << endl;
-            LOG( CDEBUG ) << "Max " << _max.toString() << endl;
+            MONGO_LOG( CDEBUG ) << "Min " << _min.toString() << endl;
+            MONGO_LOG( CDEBUG ) << "Max " << _max.toString() << endl;
 
             // If the current key moved, we may have been advanced past the current point - need to check this
             // if( _state == DOING_EXPAND ){
@@ -1444,19 +1444,19 @@ namespace mongo {
             list<GeoPoint>::iterator i = _stack.begin();
             while( i != _stack.end() ){
 
-                LOG( CDEBUG ) << "Undirtying stack point with id " << i->_id << endl;
+                MONGO_LOG( CDEBUG ) << "Undirtying stack point with id " << i->_id << endl;
 
                 DiskLoc oldLoc;
                 if( i->unDirty( _spec, oldLoc ) ){
                     // Document is in same location
-                    LOG( CDEBUG ) << "Undirtied " << oldLoc << endl;
+                    MONGO_LOG( CDEBUG ) << "Undirtied " << oldLoc << endl;
 
                     i++;
                 }
                 else if( ! i->loc().isNull() ){
 
                     // Re-found document somewhere else
-                    LOG( CDEBUG ) << "Changed location of " << i->_id << " : " << i->loc() << " vs " << oldLoc << endl;
+                    MONGO_LOG( CDEBUG ) << "Changed location of " << i->_id << " : " << i->loc() << " vs " << oldLoc << endl;
 
                     _nChangedOnYield++;
                     fixMatches( oldLoc, i->loc() );
@@ -1465,7 +1465,7 @@ namespace mongo {
                 else {
 
                     // Can't re-find document
-                    LOG( CDEBUG ) << "Removing document " << i->_id << endl;
+                    MONGO_LOG( CDEBUG ) << "Removing document " << i->_id << endl;
 
                     _nRemovedOnYield++;
                     _found--;
@@ -1477,7 +1477,7 @@ namespace mongo {
             }
 
             if( _cur.isDirty() ){
-                LOG( CDEBUG ) << "Undirtying cur point with id : " << _cur._id << endl;
+                MONGO_LOG( CDEBUG ) << "Undirtying cur point with id : " << _cur._id << endl;
             }
 
             // Check current item
@@ -1486,7 +1486,7 @@ namespace mongo {
                 if( _cur.loc().isNull() ){
 
                     // Document disappeared!
-                    LOG( CDEBUG ) << "Removing cur point " << _cur._id << endl;
+                    MONGO_LOG( CDEBUG ) << "Removing cur point " << _cur._id << endl;
 
                     _nRemovedOnYield++;
                     advance();
@@ -1494,7 +1494,7 @@ namespace mongo {
                 else{
 
                     // Document moved
-                    LOG( CDEBUG ) << "Changed location of cur point " << _cur._id << " : " << _cur.loc() << " vs " << oldLoc << endl;
+                    MONGO_LOG( CDEBUG ) << "Changed location of cur point " << _cur._id << " : " << _cur.loc() << " vs " << oldLoc << endl;
 
                     _nChangedOnYield++;
                     fixMatches( oldLoc, _cur.loc() );
@@ -1504,9 +1504,9 @@ namespace mongo {
             _noted = false;
         }
 
-        virtual Record* _current() { assert(ok()); LOG( CDEBUG + 1 ) << "_current " << _cur._loc.obj()["_id"] << endl; return _cur._loc.rec(); }
-        virtual BSONObj current() { assert(ok()); LOG( CDEBUG + 1 ) << "current " << _cur._o << endl; return _cur._o; }
-        virtual DiskLoc currLoc() { assert(ok()); LOG( CDEBUG + 1 ) << "currLoc " << _cur._loc << endl; return _cur._loc; }
+        virtual Record* _current() { assert(ok()); MONGO_LOG( CDEBUG + 1 ) << "_current " << _cur._loc.obj()["_id"] << endl; return _cur._loc.rec(); }
+        virtual BSONObj current() { assert(ok()); MONGO_LOG( CDEBUG + 1 ) << "current " << _cur._o << endl; return _cur._o; }
+        virtual DiskLoc currLoc() { assert(ok()); MONGO_LOG( CDEBUG + 1 ) << "currLoc " << _cur._loc << endl; return _cur._loc; }
         virtual BSONObj currKey() const { return _cur._key; }
 
         virtual CoveredIndexMatcher* matcher() const {
@@ -1768,12 +1768,12 @@ namespace mongo {
         bool remembered( BSONObj o ){
             BSONObj seenId = o["_id"].wrap("").getOwned();
             if( _seenIds.find( seenId ) != _seenIds.end() ){
-                LOG( CDEBUG + 1 ) << "Object " << o["_id"] << " already seen." << endl;
+                MONGO_LOG( CDEBUG + 1 ) << "Object " << o["_id"] << " already seen." << endl;
                 return true;
             }
             else{
                 _seenIds.insert( seenId );
-                LOG( CDEBUG + 1 ) << "Object " << o["_id"] << " remembered." << endl;
+                MONGO_LOG( CDEBUG + 1 ) << "Object " << o["_id"] << " remembered." << endl;
                 return false;
             }
         }

--- a/src/mongo/db/matcher.cpp
+++ b/src/mongo/db/matcher.cpp
@@ -821,7 +821,7 @@ namespace mongo {
     /* See if an object matches the query.
     */
     bool Matcher::matches(const BSONObj& jsobj , MatchDetails * details ) const {
-        LOG(5) << "Matcher::matches() " << jsobj.toString() << endl;
+        MONGO_LOG(5) << "Matcher::matches() " << jsobj.toString() << endl;
 
         /* assuming there is usually only one thing to match.  if more this
            could be slow sometimes. */

--- a/src/mongo/db/matcher_covered.cpp
+++ b/src/mongo/db/matcher_covered.cpp
@@ -59,7 +59,7 @@ namespace mongo {
 
     bool CoveredIndexMatcher::matches(const BSONObj &key, const DiskLoc &recLoc , MatchDetails * details , bool keyUsable ) {
 
-        LOG(5) << "CoveredIndexMatcher::matches() " << key.toString() << ' ' << recLoc.toString() << ' ' << keyUsable << endl;
+        MONGO_LOG(5) << "CoveredIndexMatcher::matches() " << key.toString() << ' ' << recLoc.toString() << ' ' << keyUsable << endl;
 
         dassert( key.isValid() );
 
@@ -79,7 +79,7 @@ namespace mongo {
             details->_loadedObject = true;
 
         bool res = _docMatcher->matches(recLoc.obj() , details );
-        LOG(5) << "CoveredIndexMatcher _docMatcher->matches() returns " << res << endl;
+        MONGO_LOG(5) << "CoveredIndexMatcher _docMatcher->matches() returns " << res << endl;
         return res;
     }
 

--- a/src/mongo/db/mongommf.cpp
+++ b/src/mongo/db/mongommf.cpp
@@ -273,21 +273,21 @@ namespace mongo {
     }
 
     bool MongoMMF::open(string fname, bool sequentialHint) {
-        LOG(3) << "mmf open " << fname << endl;
+        MONGO_LOG(3) << "mmf open " << fname << endl;
         setPath(fname);
         _view_write = mapWithOptions(fname.c_str(), sequentialHint ? SEQUENTIAL : 0);
         return finishOpening();
     }
 
     bool MongoMMF::create(string fname, unsigned long long& len, bool sequentialHint) {
-        LOG(3) << "mmf create " << fname << endl;
+        MONGO_LOG(3) << "mmf create " << fname << endl;
         setPath(fname);
         _view_write = map(fname.c_str(), len, sequentialHint ? SEQUENTIAL : 0);
         return finishOpening();
     }
 
     bool MongoMMF::finishOpening() {
-        LOG(3) << "mmf finishOpening " << (void*) _view_write << ' ' << filename() << " len:" << length() << endl;
+        MONGO_LOG(3) << "mmf finishOpening " << (void*) _view_write << ' ' << filename() << " len:" << length() << endl;
         if( _view_write ) {
             if( cmdLine.dur ) {
                 _view_private = createPrivateMap();
@@ -320,7 +320,7 @@ namespace mongo {
     }
 
     /*virtual*/ void MongoMMF::close() {
-        LOG(3) << "mmf close " << filename() << endl;
+        MONGO_LOG(3) << "mmf close " << filename() << endl;
 
         if( view_write() /*actually was opened*/ ) {
             if( cmdLine.dur ) {

--- a/src/mongo/db/namespace.cpp
+++ b/src/mongo/db/namespace.cpp
@@ -684,7 +684,7 @@ namespace mongo {
        options: { capped : ..., size : ... }
     */
     void addNewNamespaceToCatalog(const char *ns, const BSONObj *options = 0) {
-        LOG(1) << "New namespace: " << ns << endl;
+        MONGO_LOG(1) << "New namespace: " << ns << endl;
         if ( strstr(ns, "system.namespaces") ) {
             // system.namespaces holds all the others, so it is not explicitly listed in the catalog.
             // TODO: fix above should not be strstr!

--- a/src/mongo/db/oplog.cpp
+++ b/src/mongo/db/oplog.cpp
@@ -680,7 +680,7 @@ namespace mongo {
      */
     bool applyOperation_inlock(const BSONObj& op , bool fromRepl ) {
         assertInWriteLock();
-        LOG(6) << "applying op: " << op << endl;
+        MONGO_LOG(6) << "applying op: " << op << endl;
         bool failedUpdate = false;
 
         OpCounters * opCounters = fromRepl ? &replOpCounters : &globalOpCounters;

--- a/src/mongo/db/ops/query.cpp
+++ b/src/mongo/db/ops/query.cpp
@@ -162,7 +162,7 @@ namespace mongo {
                 if ( c->matcher() && !c->matcher()->matchesCurrent( c ) ) {
                 }
                 else if ( manager && ! manager->belongsToMe( cc ) ){
-                    LOG(2) << "cursor skipping document in un-owned chunk: " << c->current() << endl;
+                    MONGO_LOG(2) << "cursor skipping document in un-owned chunk: " << c->current() << endl;
                 }
                 else {
                     if( c->getsetdup(c->currLoc()) ) {

--- a/src/mongo/db/pdfile.cpp
+++ b/src/mongo/db/pdfile.cpp
@@ -642,7 +642,7 @@ namespace mongo {
     }
 
     DiskLoc Extent::_reuse(const char *nsname, bool capped) {
-        LOG(3) << "reset extent was:" << nsDiagnostic.toString() << " now:" << nsname << '\n';
+        MONGO_LOG(3) << "reset extent was:" << nsDiagnostic.toString() << " now:" << nsname << '\n';
         massert( 10360 ,  "Extent::reset bad magic value", magic == 0x41424344 );
         nsDiagnostic = nsname;
         markEmpty();

--- a/src/mongo/db/queryutil.cpp
+++ b/src/mongo/db/queryutil.cpp
@@ -1249,7 +1249,7 @@ namespace mongo {
             }
         }
 
-        LOG(5) << "FieldRangeVector::matches() returns " << ok << endl;
+        MONGO_LOG(5) << "FieldRangeVector::matches() returns " << ok << endl;
 
         return ok;
     }

--- a/src/mongo/db/repl/consensus.cpp
+++ b/src/mongo/db/repl/consensus.cpp
@@ -153,7 +153,7 @@ namespace mongo {
         LastYea &L = this->ly.ref(lk);
         time_t now = time(0);
         if( L.when + LeaseTime >= now && L.who != memberId ) {
-            LOG(1) << "replSet not voting yea for " << memberId <<
+            MONGO_LOG(1) << "replSet not voting yea for " << memberId <<
                    " voted for " << L.who << ' ' << now-L.when << " secs ago" << rsLog;
             throw VoteException();
         }
@@ -177,7 +177,7 @@ namespace mongo {
     void Consensus::electCmdReceived(BSONObj cmd, BSONObjBuilder* _b) {
         BSONObjBuilder& b = *_b;
         DEV log() << "replSet received elect msg " << cmd.toString() << rsLog;
-        else LOG(2) << "replSet received elect msg " << cmd.toString() << rsLog;
+        else MONGO_LOG(2) << "replSet received elect msg " << cmd.toString() << rsLog;
         string set = cmd["set"].String();
         unsigned whoid = cmd["whoid"].Int();
         int cfgver = cmd["cfgver"].Int();
@@ -310,7 +310,7 @@ namespace mongo {
                 allUp = false;
             }
         }
-        LOG(1) << "replSet dev we are freshest of up nodes, nok:" << nok << " nTies:" << nTies << rsLog;
+        MONGO_LOG(1) << "replSet dev we are freshest of up nodes, nok:" << nok << " nTies:" << nTies << rsLog;
         assert( ord <= theReplSet->lastOpTimeWritten ); // <= as this may change while we are working...
         return true;
     }

--- a/src/mongo/db/repl/heartbeat.cpp
+++ b/src/mongo/db/repl/heartbeat.cpp
@@ -179,7 +179,7 @@ namespace mongo {
         string name() const { return "rsHealthPoll"; }
         void doWork() {
             if ( !theReplSet ) {
-                LOG(2) << "replSet not initialized yet, skipping health poll this round" << rsLog;
+                MONGO_LOG(2) << "replSet not initialized yet, skipping health poll this round" << rsLog;
                 return;
             }
 

--- a/src/mongo/db/repl/rs.cpp
+++ b/src/mongo/db/repl/rs.cpp
@@ -69,7 +69,7 @@ namespace mongo {
     }
 
     void ReplSetImpl::assumePrimary() {
-        LOG(2) << "replSet assuming primary" << endl;
+        MONGO_LOG(2) << "replSet assuming primary" << endl;
         assert( iAmPotentiallyHot() );
         writelock lk("admin."); // so we are synchronized with _logOp()
 
@@ -125,7 +125,7 @@ namespace mongo {
     const bool closeOnRelinquish = true;
 
     void ReplSetImpl::relinquish() {
-        LOG(2) << "replSet attempting to relinquish" << endl;
+        MONGO_LOG(2) << "replSet attempting to relinquish" << endl;
         if( box.getState().primary() ) {
             {
                 writelock lk("admin."); // so we are synchronized with _logOp()
@@ -350,7 +350,7 @@ namespace mongo {
 
         _seeds = &replSetCmdline.seeds;
 
-        LOG(1) << "replSet beginning startup..." << rsLog;
+        MONGO_LOG(1) << "replSet beginning startup..." << rsLog;
 
         loadConfig();
 
@@ -361,7 +361,7 @@ namespace mongo {
         for( set<HostAndPort>::iterator i = replSetCmdline.seedSet.begin(); i != replSetCmdline.seedSet.end(); i++ ) {
             if( i->isSelf() ) {
                 if( sss == 1 ) {
-                    LOG(1) << "replSet warning self is listed in the seed list and there are no other seeds listed did you intend that?" << rsLog;
+                    MONGO_LOG(1) << "replSet warning self is listed in the seed list and there are no other seeds listed did you intend that?" << rsLog;
                 }
             }
             else {
@@ -597,7 +597,7 @@ namespace mongo {
         while( 1 ) {
             startupStatus = LOADINGCONFIG;
             startupStatusMsg.set("loading " + rsConfigNs + " config (LOADINGCONFIG)");
-            LOG(1) << "loadConfig() " << rsConfigNs << endl;
+            MONGO_LOG(1) << "loadConfig() " << rsConfigNs << endl;
             try {
                 vector<ReplSetConfig> configs;
                 try {
@@ -660,7 +660,7 @@ namespace mongo {
                             log() << "replSet info you may need to run replSetInitiate -- rs.initiate() in the shell -- if that is not already done" << rsLog;
                         }
                         if( _seeds->size() == 0 ) {
-                            LOG(1) << "replSet info no seed hosts were specified on the --replSet command line" << rsLog;
+                            MONGO_LOG(1) << "replSet info no seed hosts were specified on the --replSet command line" << rsLog;
                         }
                     }
                     else {

--- a/src/mongo/db/repl/rs_config.cpp
+++ b/src/mongo/db/repl/rs_config.cpp
@@ -443,7 +443,7 @@ namespace mongo {
             }
 
             // if we got here, this is a valid rule
-            LOG(1) << "replSet new rule " << rule.fieldName() << ": " << r->toString() << rsLog;
+            MONGO_LOG(1) << "replSet new rule " << rule.fieldName() << ": " << r->toString() << rsLog;
             rules[rule.fieldName()] = r;
         }
     }
@@ -582,7 +582,7 @@ namespace mongo {
     ReplSetConfig::ReplSetConfig(const HostAndPort& h) :
       _ok(false),_majority(-1)
     {
-        LOG(2) << "ReplSetConfig load " << h.toStringLong() << rsLog;
+        MONGO_LOG(2) << "ReplSetConfig load " << h.toStringLong() << rsLog;
 
         _constructed = false;
         clear();

--- a/src/mongo/db/repl/rs_initialsync.cpp
+++ b/src/mongo/db/repl/rs_initialsync.cpp
@@ -75,7 +75,7 @@ namespace mongo {
         if( d && d->stats.nrecords == 0 )
             return; // already empty, ok.
 
-        LOG(1) << "replSet empty oplog" << rsLog;
+        MONGO_LOG(1) << "replSet empty oplog" << rsLog;
         d->emptyCappedCollection(rsoplog);
     }
 

--- a/src/mongo/db/repl/rs_rollback.cpp
+++ b/src/mongo/db/repl/rs_rollback.cpp
@@ -568,7 +568,7 @@ namespace mongo {
         sethbmsg("rollback 6");
 
         // clean up oplog
-        LOG(2) << "replSet rollback truncate oplog after " << h.commonPoint.toStringPretty() << rsLog;
+        MONGO_LOG(2) << "replSet rollback truncate oplog after " << h.commonPoint.toStringPretty() << rsLog;
         // todo: fatal error if this throws?
         oplogDetails->cappedTruncateAfter(rsoplog, h.commonPointOurDiskloc, false);
 

--- a/src/mongo/db/repl/rs_sync.cpp
+++ b/src/mongo/db/repl/rs_sync.cpp
@@ -265,7 +265,7 @@ namespace mongo {
         remoteOldestOp = r.findOne(rsoplog, Query());
         OpTime remoteTs = remoteOldestOp["ts"]._opTime();
         DEV log() << "replSet remoteOldestOp:    " << remoteTs.toStringLong() << rsLog;
-        else LOG(3) << "replSet remoteOldestOp: " << remoteTs.toStringLong() << rsLog;
+        else MONGO_LOG(3) << "replSet remoteOldestOp: " << remoteTs.toStringLong() << rsLog;
         DEV {
             log() << "replSet lastOpTimeWritten: " << lastOpTimeWritten.toStringLong() << rsLog;
             log() << "replSet our state: " << state().toString() << rsLog;
@@ -495,7 +495,7 @@ namespace mongo {
 
             r.tailCheck();
             if( !r.haveCursor() ) {
-                LOG(1) << "replSet end syncTail pass with " << hn << rsLog;
+                MONGO_LOG(1) << "replSet end syncTail pass with " << hn << rsLog;
                 // TODO : reuse our connection to the primary.
                 return;
             }
@@ -604,7 +604,7 @@ namespace mongo {
         }
         GhostSlave &slave = *g;
         if (slave.init) {
-            LOG(1) << "tracking " << slave.slave->h().toString() << " as " << rid << rsLog;
+            MONGO_LOG(1) << "tracking " << slave.slave->h().toString() << " as " << rid << rsLog;
             return;
         }
 
@@ -662,7 +662,7 @@ namespace mongo {
             // the target might end up with a new Member, but s.slave never
             // changes so we'll compare the names
             || target == slave->slave || target->fullName() == slave->slave->fullName()) {
-            LOG(1) << "replica set ghost target no good" << endl;
+            MONGO_LOG(1) << "replica set ghost target no good" << endl;
             return;
         }
 
@@ -675,7 +675,7 @@ namespace mongo {
                 slave->reader.ghostQueryGTE(rsoplog, last);
             }
 
-            LOG(1) << "replSet last: " << slave->last.toString() << " to " << last.toString() << rsLog;
+            MONGO_LOG(1) << "replSet last: " << slave->last.toString() << " to " << last.toString() << rsLog;
             if (slave->last > last) {
                 return;
             }
@@ -689,11 +689,11 @@ namespace mongo {
                 BSONObj o = slave->reader.nextSafe();
                 slave->last = o["ts"]._opTime();
             }
-            LOG(2) << "now last is " << slave->last.toString() << rsLog;
+            MONGO_LOG(2) << "now last is " << slave->last.toString() << rsLog;
         }
         catch (DBException& e) {
             // we'll be back
-            LOG(2) << "replSet ghost sync error: " << e.what() << " for "
+            MONGO_LOG(2) << "replSet ghost sync error: " << e.what() << " for "
                    << slave->slave->fullName() << rsLog;
             slave->reader.resetConnection();
         }

--- a/src/mongo/s/balance.cpp
+++ b/src/mongo/s/balance.cpp
@@ -162,7 +162,7 @@ namespace mongo {
         cursor.reset();
 
         if ( collections.empty() ) {
-            LOG(1) << "no collections to balance" << endl;
+            MONGO_LOG(1) << "no collections to balance" << endl;
             return;
         }
 
@@ -177,7 +177,7 @@ namespace mongo {
         vector<Shard> allShards;
         Shard::getAllShards( allShards );
         if ( allShards.size() < 2) {
-            LOG(1) << "can't balance without more active shards" << endl;
+            MONGO_LOG(1) << "can't balance without more active shards" << endl;
             return;
         }
 
@@ -214,7 +214,7 @@ namespace mongo {
             cursor.reset();
 
             if (shardToChunksMap.empty()) {
-                LOG(1) << "skipping empty collection (" << ns << ")";
+                MONGO_LOG(1) << "skipping empty collection (" << ns << ")";
                 continue;
             }
 
@@ -290,7 +290,7 @@ namespace mongo {
 
                 // now make sure we should even be running
                 if ( ! grid.shouldBalance() ) {
-                    LOG(1) << "skipping balancing round because balancing is disabled" << endl;
+                    MONGO_LOG(1) << "skipping balancing round because balancing is disabled" << endl;
 
                     // Ping again so scripts can determine if we're active without waiting
                     _ping( conn.conn(), true );
@@ -312,7 +312,7 @@ namespace mongo {
                 {
                     dist_lock_try lk( &balanceLock , "doing balance round" );
                     if ( ! lk.got() ) {
-                        LOG(1) << "skipping balancing round because another balancer is active" << endl;
+                        MONGO_LOG(1) << "skipping balancing round because another balancer is active" << endl;
 
                         // Ping again so scripts can determine if we're active without waiting
                         _ping( conn.conn(), true );
@@ -323,18 +323,18 @@ namespace mongo {
                         continue;
                     }
                     
-                    LOG(1) << "*** start balancing round" << endl;
+                    MONGO_LOG(1) << "*** start balancing round" << endl;
 
                     vector<CandidateChunkPtr> candidateChunks;
                     _doBalanceRound( conn.conn() , &candidateChunks );
                     if ( candidateChunks.size() == 0 ) {
-                        LOG(1) << "no need to move any chunk" << endl;
+                        MONGO_LOG(1) << "no need to move any chunk" << endl;
                     }
                     else {
                         _balancedLastTime = _moveChunks( &candidateChunks );
                     }
                     
-                    LOG(1) << "*** end of balancing round" << endl;
+                    MONGO_LOG(1) << "*** end of balancing round" << endl;
                 }
 
                 // Ping again so scripts can determine if we're active without waiting
@@ -348,7 +348,7 @@ namespace mongo {
                 log() << "caught exception while doing balance: " << e.what() << endl;
 
                 // Just to match the opening statement if in log level 1
-                LOG(1) << "*** End of balancing round" << endl;
+                MONGO_LOG(1) << "*** End of balancing round" << endl;
 
                 sleepsecs( 30 ); // sleep a fair amount b/c of error
                 continue;

--- a/src/mongo/s/balancer_policy.cpp
+++ b/src/mongo/s/balancer_policy.cpp
@@ -66,10 +66,10 @@ namespace mongo {
                 }
             }
             else if ( opsQueued ) {
-                LOG(1) << "won't send a chunk to: " << shard << " because it has ops queued" << endl;
+                MONGO_LOG(1) << "won't send a chunk to: " << shard << " because it has ops queued" << endl;
             }
             else if ( maxedOut ) {
-                LOG(1) << "won't send a chunk to: " << shard << " because it is maxedOut" << endl;
+                MONGO_LOG(1) << "won't send a chunk to: " << shard << " because it is maxedOut" << endl;
             }
 
 
@@ -96,13 +96,13 @@ namespace mongo {
             return NULL;
         }
 
-        LOG(1) << "collection : " << ns << endl;
-        LOG(1) << "donor      : " << max.second << " chunks on " << max.first << endl;
-        LOG(1) << "receiver   : " << min.second << " chunks on " << min.first << endl;
+        MONGO_LOG(1) << "collection : " << ns << endl;
+        MONGO_LOG(1) << "donor      : " << max.second << " chunks on " << max.first << endl;
+        MONGO_LOG(1) << "receiver   : " << min.second << " chunks on " << min.first << endl;
         if ( ! drainingShards.empty() ) {
             string drainingStr;
             joinStringDelim( drainingShards, &drainingStr, ',' );
-            LOG(1) << "draining           : " << ! drainingShards.empty() << "(" << drainingShards.size() << ")" << endl;
+            MONGO_LOG(1) << "draining           : " << ! drainingShards.empty() << "(" << drainingShards.size() << ")" << endl;
         }
 
         // Solving imbalances takes a higher priority than draining shards. Many shards can

--- a/src/mongo/s/client.cpp
+++ b/src/mongo/s/client.cpp
@@ -121,7 +121,7 @@ namespace mongo {
             return res;
         
         if ( fromWriteBackListener ) {
-            LOG(1) << "not doing recursive writeback" << endl;
+            MONGO_LOG(1) << "not doing recursive writeback" << endl;
             return res;
         }
         

--- a/src/mongo/s/commands_public.cpp
+++ b/src/mongo/s/commands_public.cpp
@@ -116,7 +116,7 @@ namespace mongo {
 
             // don't override
             virtual bool run(const string& dbName , BSONObj& cmdObj, int, string& errmsg, BSONObjBuilder& output, bool) {
-                LOG(1) << "RunOnAllShardsCommand db: " << dbName << " cmd:" << cmdObj << endl;
+                MONGO_LOG(1) << "RunOnAllShardsCommand db: " << dbName << " cmd:" << cmdObj << endl;
                 set<Shard> shards;
                 getShards(dbName, cmdObj, shards);
 
@@ -1008,7 +1008,7 @@ namespace mongo {
                 // note here, the MR output process requires no splitting / migration during process, hence StaleConfigException should not happen
                 Strategy* s = SHARDED;
                 ChunkPtr c = manager->findChunk( o );
-                LOG(4) << "  server:" << c->getShard().toString() << " " << o << endl;
+                MONGO_LOG(4) << "  server:" << c->getShard().toString() << " " << o << endl;
                 s->insert( c->getShard() , ns , o , flags, safe);
                 return c;
             }
@@ -1082,7 +1082,7 @@ namespace mongo {
                 BSONObj shardedCommand = fixForShards( cmdObj , shardResultCollection , badShardedField, static_cast<int>(maxChunkSizeBytes) );
 
                 if ( ! shardedInput && ! shardedOutput && ! customOutDB ) {
-                    LOG(1) << "simple MR, just passthrough" << endl;
+                    MONGO_LOG(1) << "simple MR, just passthrough" << endl;
                     return passthrough( confIn , cmdObj , result );
                 }
 
@@ -1191,7 +1191,7 @@ namespace mongo {
                 BSONObjBuilder postCountsB;
 
                 if (!shardedOutput) {
-                    LOG(1) << "MR with single shard output, NS=" << finalColLong << " primary=" << confOut->getPrimary() << endl;
+                    MONGO_LOG(1) << "MR with single shard output, NS=" << finalColLong << " primary=" << confOut->getPrimary() << endl;
                     ShardConnection conn( confOut->getPrimary() , finalColLong );
                     ok = conn->runCommand( outDB , finalCmd.obj() , singleResult );
 
@@ -1203,7 +1203,7 @@ namespace mongo {
                     conn.done();
                 } else {
 
-                    LOG(1) << "MR with sharded output, NS=" << finalColLong << endl;
+                    MONGO_LOG(1) << "MR with sharded output, NS=" << finalColLong << endl;
 
                     // create the sharded collection if needed
                     if (!confOut->isSharded(finalColLong)) {

--- a/src/mongo/s/config.cpp
+++ b/src/mongo/s/config.cpp
@@ -340,7 +340,7 @@ namespace mongo {
     }
 
     void DBConfig::unserialize(const BSONObj& from) {
-        LOG(1) << "DBConfig unserialize: " << _name << " " << from << endl;
+        MONGO_LOG(1) << "DBConfig unserialize: " << _name << " " << from << endl;
         assert( _name == from["_id"].String() );
 
         _shardingEnabled = from.getBoolField("partitioned");
@@ -442,7 +442,7 @@ namespace mongo {
 
         // 1
         if ( ! configServer.allUp( errmsg ) ) {
-            LOG(1) << "\t DBConfig::dropDatabase not all up" << endl;
+            MONGO_LOG(1) << "\t DBConfig::dropDatabase not all up" << endl;
             return 0;
         }
 
@@ -465,7 +465,7 @@ namespace mongo {
             log() << "error removing from config server even after checking!" << endl;
             return 0;
         }
-        LOG(1) << "\t removed entry from config server for: " << _name << endl;
+        MONGO_LOG(1) << "\t removed entry from config server for: " << _name << endl;
 
         set<Shard> allServers;
 
@@ -501,7 +501,7 @@ namespace mongo {
             conn.done();
         }
 
-        LOG(1) << "\t dropped primary db for: " << _name << endl;
+        MONGO_LOG(1) << "\t dropped primary db for: " << _name << endl;
 
         configServer.logChange( "dropDatabase" , _name , BSONObj() );
         return true;
@@ -527,7 +527,7 @@ namespace mongo {
             }
 
             seen.insert( i->first );
-            LOG(1) << "\t dropping sharded collection: " << i->first << endl;
+            MONGO_LOG(1) << "\t dropping sharded collection: " << i->first << endl;
 
             i->second.getCM()->getAllShards( allServers );
             i->second.getCM()->drop( i->second.getCM() );
@@ -535,7 +535,7 @@ namespace mongo {
 
             num++;
             uassert( 10184 ,  "_dropShardedCollections too many collections - bailing" , num < 100000 );
-            LOG(2) << "\t\t dropped " << num << " so far" << endl;
+            MONGO_LOG(2) << "\t\t dropped " << num << " so far" << endl;
         }
 
         return true;
@@ -603,7 +603,7 @@ namespace mongo {
         string fullString;
         joinStringDelim( configHosts, &fullString, ',' );
         _primary.setAddress( ConnectionString( fullString , ConnectionString::SYNC ) );
-        LOG(1) << " config string : " << fullString << endl;
+        MONGO_LOG(1) << " config string : " << fullString << endl;
 
         return true;
     }
@@ -764,7 +764,7 @@ namespace mongo {
                     got.erase(name);
                     log() << "warning: invalid chunksize (" << csize << ") ignored" << endl;
                 } else {
-                    LOG(1) << "MaxChunkSize: " << csize << endl;
+                    MONGO_LOG(1) << "MaxChunkSize: " << csize << endl;
                     Chunk::MaxChunkSize = csize * 1024 * 1024;
                 }
             }
@@ -839,7 +839,7 @@ namespace mongo {
                     conn->createCollection( "config.changelog" , 1024 * 1024 * 10 , true );
                 }
                 catch ( UserException& e ) {
-                    LOG(1) << "couldn't create changelog (like race condition): " << e << endl;
+                    MONGO_LOG(1) << "couldn't create changelog (like race condition): " << e << endl;
                     // don't care
                 }
                 createdCapped = true;

--- a/src/mongo/s/cursors.cpp
+++ b/src/mongo/s/cursors.cpp
@@ -108,7 +108,7 @@ namespace mongo {
         }
 
         bool hasMore = sendMore && _cursor->more();
-        LOG(5) << "\t hasMore: " << hasMore << " sendMore: " << sendMore << " cursorMore: " << _cursor->more() << " ntoreturn: " << ntoreturn
+        MONGO_LOG(5) << "\t hasMore: " << hasMore << " sendMore: " << sendMore << " cursorMore: " << _cursor->more() << " ntoreturn: " << ntoreturn
                << " num: " << num << " wouldSendMoreIfHad: " << sendMore << " id:" << getId() << " totalSent: " << _totalSent << endl;
 
         replyToQuery( 0 , r.p() , r.m() , b.buf() , b.len() , num , _totalSent , hasMore ? getId() : 0 );
@@ -140,7 +140,7 @@ namespace mongo {
     }
 
     ShardedClientCursorPtr CursorCache::get( long long id ) const {
-        LOG(_myLogLevel) << "CursorCache::get id: " << id << endl;
+        MONGO_LOG(_myLogLevel) << "CursorCache::get id: " << id << endl;
         scoped_lock lk( _mutex );
         MapSharded::const_iterator i = _cursors.find( id );
         if ( i == _cursors.end() ) {
@@ -152,7 +152,7 @@ namespace mongo {
     }
 
     void CursorCache::store( ShardedClientCursorPtr cursor ) {
-        LOG(_myLogLevel) << "CursorCache::store cursor " << " id: " << cursor->getId() << endl;
+        MONGO_LOG(_myLogLevel) << "CursorCache::store cursor " << " id: " << cursor->getId() << endl;
         assert( cursor->getId() );
         scoped_lock lk( _mutex );
         _cursors[cursor->getId()] = cursor;
@@ -165,14 +165,14 @@ namespace mongo {
     }
     
     void CursorCache::storeRef( const string& server , long long id ) {
-        LOG(_myLogLevel) << "CursorCache::storeRef server: " << server << " id: " << id << endl;
+        MONGO_LOG(_myLogLevel) << "CursorCache::storeRef server: " << server << " id: " << id << endl;
         assert( id );
         scoped_lock lk( _mutex );
         _refs[id] = server;
     }
 
     string CursorCache::getRef( long long id ) const {
-        LOG(_myLogLevel) << "CursorCache::getRef id: " << id << endl;
+        MONGO_LOG(_myLogLevel) << "CursorCache::getRef id: " << id << endl;
         assert( id );
         scoped_lock lk( _mutex );
         MapNormal::const_iterator i = _refs.find( id );
@@ -219,7 +219,7 @@ namespace mongo {
         long long * cursors = (long long *)x;
         for ( int i=0; i<n; i++ ) {
             long long id = cursors[i];
-            LOG(_myLogLevel) << "CursorCache::gotKillCursors id: " << id << endl;
+            MONGO_LOG(_myLogLevel) << "CursorCache::gotKillCursors id: " << id << endl;
 
             if ( ! id ) {
                 log( LL_WARNING ) << " got cursor id of 0 to kill" << endl;
@@ -245,7 +245,7 @@ namespace mongo {
                 _refs.erase( j );
             }
 
-            LOG(_myLogLevel) << "CursorCache::found gotKillCursors id: " << id << " server: " << server << endl;
+            MONGO_LOG(_myLogLevel) << "CursorCache::found gotKillCursors id: " << id << " server: " << server << endl;
 
             assert( server.size() );
             ScopedDbConnection conn( server );

--- a/src/mongo/s/d_logic.cpp
+++ b/src/mongo/s/d_logic.cpp
@@ -60,7 +60,7 @@ namespace mongo {
             return false;
         }
 
-        LOG(1) << "connection meta data too old - will retry ns:(" << ns << ") op:(" << opToString(op) << ") " << errmsg << endl;
+        MONGO_LOG(1) << "connection meta data too old - will retry ns:(" << ns << ") op:(" << opToString(op) << ") " << errmsg << endl;
 
         if ( doesOpGetAResponse( op ) ) {
             assert( dbresponse );
@@ -97,8 +97,8 @@ namespace mongo {
         const OID& clientID = ShardedConnectionInfo::get(false)->getID();
         massert( 10422 ,  "write with bad shard config and no server id!" , clientID.isSet() );
 
-        LOG(1) << "got write with an old config - writing back ns: " << ns << endl;
-        LOG(1) << m.toString() << endl;
+        MONGO_LOG(1) << "got write with an old config - writing back ns: " << ns << endl;
+        MONGO_LOG(1) << m.toString() << endl;
 
         BSONObjBuilder b;
         b.appendBool( "writeBack" , true );
@@ -112,7 +112,7 @@ namespace mongo {
         b.appendTimestamp( "yourVersion" , info ? info->getVersion(ns) : (ConfigVersion)0 );
 
         b.appendBinData( "msg" , m.header()->len , bdtCustom , (char*)(m.singleData()) );
-        LOG(2) << "writing back msg with len: " << m.header()->len << " op: " << m.operation() << endl;
+        MONGO_LOG(2) << "writing back msg with len: " << m.header()->len << " op: " << m.operation() << endl;
         writeBackManager.queueWriteBack( clientID.str() , b.obj() );
 
         return true;

--- a/src/mongo/s/d_migrate.cpp
+++ b/src/mongo/s/d_migrate.cpp
@@ -171,7 +171,7 @@ namespace mongo {
             Timer t;
             for ( int i=0; i<3600; i++ ) {
                 if ( opReplicatedEnough( lastOpApplied , ( getSlaveCount() / 2 ) + 1 ) ) {
-                    LOG(t.seconds() < 30 ? 1 : 0) << "moveChunk repl sync took " << t.seconds() << " seconds" << migrateLog;
+                    MONGO_LOG(t.seconds() < 30 ? 1 : 0) << "moveChunk repl sync took " << t.seconds() << " seconds" << migrateLog;
                     return;
                 }
                 sleepsecs(1);
@@ -1122,7 +1122,7 @@ namespace mongo {
                 preCond.done();
 
                 BSONObj cmd = cmdBuilder.obj();
-                LOG(7) << "moveChunk update: " << cmd << migrateLog;
+                MONGO_LOG(7) << "moveChunk update: " << cmd << migrateLog;
 
                 bool ok = false;
                 BSONObj cmdResult;
@@ -1722,7 +1722,7 @@ namespace mongo {
             assert( ! isInRange( BSON( "x" << 5 ) , min , max ) );
             assert( ! isInRange( BSON( "x" << 6 ) , min , max ) );
 
-            LOG(1) << "isInRangeTest passed" << migrateLog;
+            MONGO_LOG(1) << "isInRangeTest passed" << migrateLog;
         }
     } isInRangeTest;
 }

--- a/src/mongo/s/d_split.cpp
+++ b/src/mongo/s/d_split.cpp
@@ -410,7 +410,7 @@ namespace mongo {
                                 currCount = 0;
                                 numChunks++;
                                 
-                                LOG(4) << "picked a split key: " << bc->prettyKey( currKey ) << endl;
+                                MONGO_LOG(4) << "picked a split key: " << bc->prettyKey( currKey ) << endl;
                             }
                             
                         }
@@ -692,7 +692,7 @@ namespace mongo {
 
             BSONObjBuilder logDetail;
             origChunk.appendShortVersion( "before" , logDetail );
-            LOG(1) << "before split on " << origChunk << endl;
+            MONGO_LOG(1) << "before split on " << origChunk << endl;
             vector<ChunkInfo> newChunks;
 
             ShardChunkVersion myVersion = maxVersion;
@@ -760,7 +760,7 @@ namespace mongo {
 
             BSONObj cmd = cmdBuilder.obj();
 
-            LOG(1) << "splitChunk update: " << cmd << endl;
+            MONGO_LOG(1) << "splitChunk update: " << cmd << endl;
 
             bool ok;
             BSONObj cmdResult;

--- a/src/mongo/s/d_state.cpp
+++ b/src/mongo/s/d_state.cpp
@@ -288,7 +288,7 @@ namespace mongo {
     ShardedConnectionInfo* ShardedConnectionInfo::get( bool create ) {
         ShardedConnectionInfo* info = _tl.get();
         if ( ! info && create ) {
-            LOG(1) << "entering shard mode for connection" << endl;
+            MONGO_LOG(1) << "entering shard mode for connection" << endl;
             info = new ShardedConnectionInfo();
             _tl.reset( info );
         }
@@ -316,7 +316,7 @@ namespace mongo {
     void ShardedConnectionInfo::addHook() {
         static bool done = false;
         if (!done) {
-            LOG(1) << "adding sharding hook" << endl;
+            MONGO_LOG(1) << "adding sharding hook" << endl;
             pool.addHook(new ShardingConnectionHook(false));
             shardConnectionPool.addHook(new ShardingConnectionHook(true));
             done = true;

--- a/src/mongo/s/d_writeback.cpp
+++ b/src/mongo/s/d_writeback.cpp
@@ -144,7 +144,7 @@ namespace mongo {
             // we want to do return at least at every 5 minutes so sockets don't timeout
             BSONObj z;
             if ( writeBackManager.getWritebackQueue(id.str())->queue.blockingPop( z, 5 * 60 /* 5 minutes */ ) ) {
-                LOG(1) << "WriteBackCommand got : " << z << endl;
+                MONGO_LOG(1) << "WriteBackCommand got : " << z << endl;
                 result.append( "data" , z );
             }
             else {

--- a/src/mongo/s/grid.cpp
+++ b/src/mongo/s/grid.cpp
@@ -524,7 +524,7 @@ namespace mongo {
             assert( Grid::_inBalancingWindow( w8 , now ) );
             assert( Grid::_inBalancingWindow( w9 , now ) );
 
-            LOG(1) << "BalancingWidowObjTest passed" << endl;
+            MONGO_LOG(1) << "BalancingWidowObjTest passed" << endl;
         }
     } BalancingWindowObjTest;
 

--- a/src/mongo/s/request.cpp
+++ b/src/mongo/s/request.cpp
@@ -110,7 +110,7 @@ namespace mongo {
         }
 
 
-        LOG(3) << "Request::process ns: " << getns() << " msg id:" << (int)(_m.header()->id) << " attempt: " << attempt << endl;
+        MONGO_LOG(3) << "Request::process ns: " << getns() << " msg id:" << (int)(_m.header()->id) << " attempt: " << attempt << endl;
 
         Strategy * s = SHARDED;
         _counter = &opsNonSharded;

--- a/src/mongo/s/shard.cpp
+++ b/src/mongo/s/shard.cpp
@@ -366,7 +366,7 @@ namespace mongo {
                 best = t;
         }
 
-        LOG(1) << "best shard for new allocation is " << best << endl;
+        MONGO_LOG(1) << "best shard for new allocation is " << best << endl;
         return best.shard();
     }
 
@@ -380,7 +380,7 @@ namespace mongo {
     void ShardingConnectionHook::onCreate( DBClientBase * conn ) {
         if( !noauth ) {
             string err;
-            LOG(2) << "calling onCreate auth for " << conn->toString() << endl;
+            MONGO_LOG(2) << "calling onCreate auth for " << conn->toString() << endl;
             uassert( 15847, "can't authenticate to shard server",
                     conn->auth("local", internalSecurity.user, internalSecurity.pwd, err, false));
         }

--- a/src/mongo/s/shard_version.cpp
+++ b/src/mongo/s/shard_version.cpp
@@ -114,8 +114,8 @@ namespace mongo {
 
         BSONObj cmd = cmdBuilder.obj();
 
-        LOG(1) << "initializing shard connection to " << conn->toString() << endl;
-        LOG(2) << "initial sharding settings : " << cmd << endl;
+        MONGO_LOG(1) << "initializing shard connection to " << conn->toString() << endl;
+        MONGO_LOG(2) << "initial sharding settings : " << cmd << endl;
 
         bool ok = conn->runCommand( "admin" , cmd , result );
 
@@ -127,7 +127,7 @@ namespace mongo {
             ok = true;
         }
 
-        LOG(3) << "initial sharding result : " << result << endl;
+        MONGO_LOG(3) << "initial sharding result : " << result << endl;
 
         return ok;
 
@@ -202,14 +202,14 @@ namespace mongo {
         }
 
         if( version == 0 ){
-            LOG(0) << "resetting shard version of " << ns << " on " << conn->getServerAddress() << ", " <<
+            MONGO_LOG(0) << "resetting shard version of " << ns << " on " << conn->getServerAddress() << ", " <<
                       ( ! isSharded ? "no longer sharded" :
                       ( ! manager ? "no chunk manager found" :
                                     "version is zero" ) ) << endl;
         }
 
 
-        LOG(2) << " have to set shard version for conn: " << conn << " ns:" << ns
+        MONGO_LOG(2) << " have to set shard version for conn: " << conn << " ns:" << ns
                << " my last seq: " << sequenceNumber << "  current: " << officialSequenceNumber
                << " version: " << version << " manager: " << manager.get()
                << endl;
@@ -217,12 +217,12 @@ namespace mongo {
         BSONObj result;
         if ( setShardVersion( *conn , ns , version , authoritative , result ) ) {
             // success!
-            LOG(1) << "      setShardVersion success: " << result << endl;
+            MONGO_LOG(1) << "      setShardVersion success: " << result << endl;
             connectionShardStatus.setSequence( conn , ns , officialSequenceNumber );
             return true;
         }
 
-        LOG(1) << "       setShardVersion failed!\n" << result << endl;
+        MONGO_LOG(1) << "       setShardVersion failed!\n" << result << endl;
 
         if ( result["need_authoritative"].trueValue() )
             massert( 10428 ,  "need_authoritative set but in authoritative mode already" , ! authoritative );
@@ -245,7 +245,7 @@ namespace mongo {
 
         const int maxNumTries = 7;
         if ( tryNumber < maxNumTries ) {
-            LOG( tryNumber < ( maxNumTries / 2 ) ? 1 : 0 ) 
+            MONGO_LOG( tryNumber < ( maxNumTries / 2 ) ? 1 : 0 ) 
                 << "going to retry checkShardVersion host: " << conn->getServerAddress() << " " << result << endl;
             sleepmillis( 10 * tryNumber );
             checkShardVersion( conn , ns , refManager, true , tryNumber + 1 );

--- a/src/mongo/s/shardkey.cpp
+++ b/src/mongo/s/shardkey.cpp
@@ -266,7 +266,7 @@ namespace mongo {
                 moveToFrontBenchmark(100);
             }
 
-            LOG(1) << "shardKeyTest passed" << endl;
+            MONGO_LOG(1) << "shardKeyTest passed" << endl;
         }
     } shardKeyTest;
 

--- a/src/mongo/s/strategy_shard.cpp
+++ b/src/mongo/s/strategy_shard.cpp
@@ -44,7 +44,7 @@ namespace mongo {
 
             r.checkAuth( Auth::READ );
 
-            LOG(3) << "shard query: " << q.ns << "  " << q.query << endl;
+            MONGO_LOG(3) << "shard query: " << q.ns << "  " << q.query << endl;
 
             if ( q.ntoreturn == 1 && strstr(q.ns, ".$cmd") )
                 throw UserException( 8010 , "something is wrong, shouldn't see a command here" );
@@ -60,7 +60,7 @@ namespace mongo {
                 if ( qSpec.isExplain() ) start_millis = curTimeMillis64();
                 cursor->init();
 
-                LOG(5) << "   cursor type: " << cursor->type() << endl;
+                MONGO_LOG(5) << "   cursor type: " << cursor->type() << endl;
                 shardedCursorTypes.hit( cursor->type() );
 
                 if ( qSpec.isExplain() ) {
@@ -88,7 +88,7 @@ namespace mongo {
                     return;
                 }
 
-                LOG(5) << "storing cursor : " << cc->getId() << endl;
+                MONGO_LOG(5) << "storing cursor : " << cc->getId() << endl;
                 cursorCache.store( cc );
             }
             else{
@@ -134,11 +134,11 @@ namespace mongo {
                 int ntoreturn = r.d().pullInt();
                 long long id = r.d().pullInt64();
 
-                LOG(6) << "want cursor : " << id << endl;
+                MONGO_LOG(6) << "want cursor : " << id << endl;
 
                 ShardedClientCursorPtr cursor = cursorCache.get( id );
                 if ( ! cursor ) {
-                    LOG(6) << "\t invalid cursor :(" << endl;
+                    MONGO_LOG(6) << "\t invalid cursor :(" << endl;
                     replyToQuery( ResultFlag_CursorNotFound , r.p() , r.m() , 0 , 0 , 0 );
                     return;
                 }
@@ -220,7 +220,7 @@ namespace mongo {
 
                 try {
 
-                    LOG(4) << "  server:" << c->getShard().toString() << " bulk insert " << objs.size() << " documents" << endl;
+                    MONGO_LOG(4) << "  server:" << c->getShard().toString() << " bulk insert " << objs.size() << " documents" << endl;
 
                     // Taken from single-shard bulk insert, should not need multiple methods in future
                     // insert( c->getShard() , r.getns() , objs , flags);
@@ -252,7 +252,7 @@ namespace mongo {
                     // Assume the inserts did *not* succeed, so we don't want to erase them
 
                     int logLevel = retries < 2;
-                    LOG( logLevel ) << "retrying bulk insert of " << objs.size() << " documents to chunk " << c << " because of StaleConfigException: " << e << endl;
+                    MONGO_LOG( logLevel ) << "retrying bulk insert of " << objs.size() << " documents to chunk " << c << " because of StaleConfigException: " << e << endl;
 
                     if( retries > 2 ){
                         versionManager.forceRemoteCheckShardVersionCB( e.getns() );
@@ -420,7 +420,7 @@ namespace mongo {
             while ( true ) {
                 try {
                     manager->getShardsForQuery( shards , pattern );
-                    LOG(2) << "delete : " << pattern << " \t " << shards.size() << " justOne: " << justOne << endl;
+                    MONGO_LOG(2) << "delete : " << pattern << " \t " << shards.size() << " justOne: " << justOne << endl;
                     if ( shards.size() == 1 ) {
                         doWrite( dbDelete , r , *shards.begin() );
                         return;
@@ -462,7 +462,7 @@ namespace mongo {
             }
             else{
                 const char *ns = r.getns();
-                LOG(3) << "write: " << ns << endl;
+                MONGO_LOG(3) << "write: " << ns << endl;
 
                 DbMessage& d = r.d();
 

--- a/src/mongo/s/strategy_single.cpp
+++ b/src/mongo/s/strategy_single.cpp
@@ -36,7 +36,7 @@ namespace mongo {
         virtual void queryOp( Request& r ) {
             QueryMessage q( r.d() );
 
-            LOG(3) << "single query: " << q.ns << "  " << q.query << "  ntoreturn: " << q.ntoreturn << " options : " << q.queryOptions << endl;
+            MONGO_LOG(3) << "single query: " << q.ns << "  " << q.query << "  ntoreturn: " << q.ntoreturn << " options : " << q.queryOptions << endl;
 
             if ( r.isCommand() ) {
 
@@ -93,7 +93,7 @@ namespace mongo {
         virtual void getMore( Request& r ) {
             const char *ns = r.getns();
 
-            LOG(3) << "single getmore: " << ns << endl;
+            MONGO_LOG(3) << "single getmore: " << ns << endl;
 
             long long id = r.d().getInt64( 4 );
             
@@ -162,12 +162,12 @@ namespace mongo {
             if ( r.isShardingEnabled() &&
                     strstr( ns , ".system.indexes" ) == strchr( ns , '.' ) &&
                     strchr( ns , '.' ) ) {
-                LOG(1) << " .system.indexes write for: " << ns << endl;
+                MONGO_LOG(1) << " .system.indexes write for: " << ns << endl;
                 handleIndexWrite( op , r );
                 return;
             }
 
-            LOG(3) << "single write: " << ns << endl;
+            MONGO_LOG(3) << "single write: " << ns << endl;
             doWrite( op , r , r.primaryShard() );
             r.gotInsert(); // Won't handle mulit-insert correctly. Not worth parsing the request.
         }

--- a/src/mongo/s/writeback_listener.cpp
+++ b/src/mongo/s/writeback_listener.cpp
@@ -117,7 +117,7 @@ namespace mongo {
         while ( ! inShutdown() ) {
             
             if ( ! Shard::isAShardNode( _addr ) ) {
-                LOG(1) << _addr << " is not a shard node" << endl;
+                MONGO_LOG(1) << _addr << " is not a shard node" << endl;
                 sleepsecs( 60 );
                 continue;
             }
@@ -139,7 +139,7 @@ namespace mongo {
 
                 }
 
-                LOG(1) << "writebacklisten result: " << result << endl;
+                MONGO_LOG(1) << "writebacklisten result: " << result << endl;
 
                 BSONObj data = result.getObjectField( "data" );
                 if ( data.getBoolField( "writeBack" ) ) {
@@ -168,11 +168,11 @@ namespace mongo {
                     // TODO: The logic here could be refactored, but keeping to the original codepath for safety for now
                     ChunkManagerPtr manager = db->getChunkManagerIfExists( ns );
 
-                    LOG(1) << "connectionId: " << cid << " writebackId: " << wid << " needVersion : " << needVersion.toString()
+                    MONGO_LOG(1) << "connectionId: " << cid << " writebackId: " << wid << " needVersion : " << needVersion.toString()
                            << " mine : " << ( manager ? manager->getVersion().toString() : "(unknown)" )
                            << endl;
 
-                    LOG(1) << m.toString() << endl;
+                    MONGO_LOG(1) << m.toString() << endl;
 
                     if ( needVersion.isSet() && manager && needVersion <= manager->getVersion() ) {
                         // this means when the write went originally, the version was old

--- a/src/mongo/tools/dump.cpp
+++ b/src/mongo/tools/dump.cpp
@@ -293,7 +293,7 @@ public:
             try {
                 obj = loc.obj();
                 assert( obj.valid() );
-                LOG(1) << obj << endl;
+                MONGO_LOG(1) << obj << endl;
                 w( obj );
             }
             catch ( std::exception& e ) {

--- a/src/mongo/util/assert_util.cpp
+++ b/src/mongo/util/assert_util.cpp
@@ -166,7 +166,7 @@ namespace mongo {
 
     NOINLINE_DECL void uasserted(int msgid, const char *msg) {
         assertionCount.condrollover( ++assertionCount.user );
-        LOG(1) << "User Assertion: " << msgid << ":" << msg << endl;
+        MONGO_LOG(1) << "User Assertion: " << msgid << ":" << msg << endl;
         raiseError(msgid,msg);
         throw UserException(msgid, msg);
     }

--- a/src/mongo/util/background.cpp
+++ b/src/mongo/util/background.cpp
@@ -46,7 +46,7 @@ namespace mongo {
 
     // Background object can be only be destroyed after jobBody() ran
     void BackgroundJob::jobBody( boost::shared_ptr<JobStatus> status ) {
-        LOG(1) << "BackgroundJob starting: " << name() << endl;
+        MONGO_LOG(1) << "BackgroundJob starting: " << name() << endl;
         {
             scoped_lock l( status->m );
             massert( 13643 , mongoutils::str::stream() << "backgroundjob already started: " << name() , status->state == NotStarted );
@@ -180,7 +180,7 @@ namespace mongo {
                 }
                 
                 int ms = timer.millis();
-                LOG( ms <= 3 ? 1 : 0 ) << "task: " << t->taskName() << " took: " << ms << "ms" << endl;
+                MONGO_LOG( ms <= 3 ? 1 : 0 ) << "task: " << t->taskName() << " took: " << ms << "ms" << endl;
             }
         }
     }

--- a/src/mongo/util/log.h
+++ b/src/mongo/util/log.h
@@ -385,7 +385,6 @@ namespace mongo {
     }
 
 #define MONGO_LOG(level) if ( MONGO_likely(logLevel < (level)) ) { } else log( level )
-#define LOG MONGO_LOG
 
     inline Nullstream& log( LogLevel l ) {
         return Logstream::get().prolog().setLogLevel( l );


### PR DESCRIPTION
The macro "LOG" should be removed because the name "LOG" is too common and conflicts with
some other products.
For example, current mongodb is not work with [google-glog](http://code.google.com/p/google-glog/).
It also uses "LOG" macro for logging.
Here is a sample code:

```
#include <glog/logging.h>
#include <client/dbclient.h> // <- undefs LOG macro

int main() {
  LOG(ERROR) << "hoge"; // compile error
}
```
