### PR TITLE
Fix SERVER-4806 

### DIFF
--- a/src/mongo/bson/util/builder.h
+++ b/src/mongo/bson/util/builder.h
@@ -208,7 +208,9 @@ namespace mongo {
                 ss << "BufBuilder attempted to grow() to " << a << " bytes, past the 64MB limit.";
                 msgasserted(13548, ss.str().c_str());
             }
-            data = (char *) al.Realloc(data, a);
+            void* newData = al.Realloc(data, a);
+            if (newData == 0) msgasserted(16062, "out of memory BufBuilder::grow_reallocate");
+            data = (char*) newData;
             size= a;
         }
 


### PR DESCRIPTION
Check realloc calls in BufBuilder for memory allocation failure.
