### PR TITLE
Always use the 32-bit Microsoft toolchain when building with --32 on Windows

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -241,15 +241,17 @@ windows = False
 freebsd = False
 openbsd = False
 solaris = False
+force32 = has_option( "force32" ) 
 force64 = has_option( "force64" )
-if not force64 and os.getcwd().endswith( "mongo-64" ):
+if not force64 and not force32 and os.getcwd().endswith( "mongo-64" ):
     force64 = True
     print( "*** assuming you want a 64-bit build b/c of directory *** " )
 msarch = None
-if force64:
+if force32:
+    msarch = "x86"
+elif force64:
     msarch = "amd64"
 
-force32 = has_option( "force32" ) 
 release = has_option( "release" )
 static = has_option( "static" )
 
@@ -268,6 +270,7 @@ justClientLib = (COMMAND_LINE_TARGETS == ['mongoclient'])
 
 env = Environment( BUILD_DIR=variantDir,
                    MSVS_ARCH=msarch ,
+                   TARGET_ARCH=msarch ,
                    tools=["default", "gch", "jsheader", "mergelib" ],
                    PYSYSPLATFORM=os.sys.platform,
 


### PR DESCRIPTION
For some reason on my 64-bit Windows 7 system, I can’t build a 32-bit Mongo (with `scons --32 -j8`) because SCons 2.1.0 insists on using the 64-bit toolchain. This happens even if I try to build in an x86 Visual Studio Command Prompt – SCons is still picking up a 64-bit toolchain from somewhere.

I’m not entirely sure why this is, but I suspect that SCons distinguishes between the toolchain that comes with Visual Studio, and otherwise identical copies of the same toolchain from other sources, such as from the Windows 7 SDK.

The SCons documentation is very vague about what `MSVS_ARCH` actually does. OTOH, it is quite clear that `TARGET_ARCH` should be set to the architecture that we are building for, and currently Mongo’s `SConstruct` makes no effort to do that.

Therefore, the attached commit changes `SConstruct` so that, when building with `--32` or `--64`, `TARGET_ARCH` and `MSVS_ARCH` are set to `x86` or `x64` as appropriate. This fixes the problem for me so that SCons now picks up the correct toolchain.

While I was there I also changed the logic that defaults to 64-bit if the current directory is named `mongo-64`, so that it has no effect if the build is run with `--32`. It doesn’t make much sense to me to make a 64-bit build when the user has explicitly asked for 32-bit.

(This is a resubmission of pull request #167, which erroneously requested a pull from my `master` branch – sorry about that).
