### PR TITLE
Bug fix: when mongodump outputs to stdout, log and progress meter should output to stderr.

### DIFF
--- a/src/mongo/tools/dump.cpp
+++ b/src/mongo/tools/dump.cpp
@@ -32,6 +32,8 @@ using namespace mongo;
 
 namespace po = boost::program_options;
 
+extern bool mongo::progress_meter_use_stdout;
+
 class Dump : public Tool {
     class FilePtr : boost::noncopyable {
     public:
@@ -58,6 +60,10 @@ public:
                 // write output to standard error to avoid mangling output
                 // must happen early to avoid sending junk to stdout
                 useStandardOutput(false);
+		if(Logstream::getLogDesc() == 1) { // If log goes to stdout
+			Logstream::setLogFile(stderr);
+		}
+		progress_meter_use_stdout = false; // ProgressMeter output to stderr
         }
     }
 

--- a/src/mongo/util/goodies.h
+++ b/src/mongo/util/goodies.h
@@ -157,13 +157,16 @@ namespace mongo {
     typedef void *HANDLE;
 #endif
 
+    extern bool progress_meter_use_stdout;
     class ProgressMeter : boost::noncopyable {
     public:
-        ProgressMeter( unsigned long long total , int secondsBetween = 3 , int checkInterval = 100 , string units = "" ) : _units(units) {
+        ProgressMeter( unsigned long long total , int secondsBetween = 3 , int checkInterval = 100 , string units = "" ) : 
+	    _units(units)
+	   ,_useStdout(progress_meter_use_stdout) {
             reset( total , secondsBetween , checkInterval );
         }
 
-        ProgressMeter() {
+        ProgressMeter(): _useStdout(progress_meter_use_stdout) {
             _active = 0;
             _units = "";
         }
@@ -195,7 +198,7 @@ namespace mongo {
          */
         bool hit( int n = 1 ) {
             if ( ! _active ) {
-                cout << "warning: hit an inactive ProgressMeter" << endl;
+                _useStdout?cout:cerr << "warning: hit an inactive ProgressMeter" << endl;
                 return false;
             }
 
@@ -210,10 +213,10 @@ namespace mongo {
 
             if ( _total > 0 ) {
                 int per = (int)( ( (double)_done * 100.0 ) / (double)_total );
-                cout << "\t\t" << _done << "/" << _total << "\t" << per << "%";
+                _useStdout?cout:cerr << "\t\t" << _done << "/" << _total << "\t" << per << "%";
 
                 if ( ! _units.empty() ) {
-                    cout << "\t(" << _units << ")" << endl;
+                    _useStdout?cout:cerr << "\t(" << _units << ")" << endl;
                 }
                 else {
                     cout << endl;
@@ -266,6 +269,7 @@ namespace mongo {
         int _lastTime;
 
         string _units;
+	bool _useStdout;
     };
 
     // e.g.: 

--- a/src/mongo/util/log.cpp
+++ b/src/mongo/util/log.cpp
@@ -38,6 +38,7 @@ using namespace std;
 
 namespace mongo {
 
+    bool progress_meter_use_stdout = true; // Move this to ProgressMeter if there is a .cpp file for it.
     Nullstream nullstream;
     vector<Tee*>* Logstream::globalTees = 0;
 


### PR DESCRIPTION
I am working on a project on foursquare that uses the mongodump and output to stdout. There is a bug in the tool that both the log and the progress meter(used during the server shut down, not during the dump) outputs to stdout and corrupt the mongodump data. This commit is to fix that problem.
