### PR TITLE
SERVER-5378 out {} parameters position independence

### DIFF
--- a/jstests/mr_parampositions.js
+++ b/jstests/mr_parampositions.js
@@ -1,0 +1,37 @@
+
+t = db.mr_replace;
+t.drop();
+
+t.insert( { a : [ 1 , 2 ] } )
+t.insert( { a : [ 2 , 3 ] } )
+t.insert( { a : [ 3 , 4 ] } )
+
+outCollStr = "mr_replace_col";
+outDbStr = "mr_db";
+
+m = function(){ for (i=0; i<this.a.length; i++ ) emit( this.a[i] , 1 ); } 
+r = function(k,vs){ return Array.sum( vs ); }
+
+function tos( o ){
+    var s = "";
+    for ( var i=0; i<100; i++ ){
+        if ( o[i] )
+            s += i + "_" + o[i];
+    }
+    return s;
+}
+
+positions = [{ replace: outCollStr, db: outDbStr },  {db: outDbStr, replace: outCollStr}];
+
+for ( i= 0 ; i < 2; i++ ) {
+  print("Testing mr replace into other DB")
+  res = t.mapReduce( m , r , { out : positions[i] }); 
+  printjson( res );
+  expected = { "1" : 1 , "2" : 2 , "3" : 2 , "4" : 1 };
+  outDb = db.getMongo().getDB(outDbStr);
+  outColl = outDb[outCollStr];
+  str = tos( outColl.convertToSingleObject("value") )
+  print("Received result: " + str);
+  assert.eq( tos( expected ) , str , "A Received wrong result " + str );
+}
+

--- a/src/mongo/db/commands/mr.cpp
+++ b/src/mongo/db/commands/mr.cpp
@@ -244,23 +244,27 @@ namespace mongo {
                 BSONElement e = o.firstElement();
                 string t = e.fieldName();
 
-                if ( t == "normal" || t == "replace" ) {
+                if ( o.hasElement("normal") ) {
                     outType = REPLACE;
-                    finalShort = e.String();
+                    finalShort = o["normal"].String();
+                } 
+                else if ( o.hasElement("replace") ) { 
+                    outType = REPLACE;
+                    finalShort = o["replace"].String();
                 }
-                else if ( t == "merge" ) {
+                else if ( o.hasElement("merge") ) { 
                     outType = MERGE;
-                    finalShort = e.String();
+                    finalShort = o["merge"].String();
                 }
-                else if ( t == "reduce" ) {
+                else if ( o.hasElement("reduce") ) {
                     outType = REDUCE;
-                    finalShort = e.String();
+                    finalShort = o["reduce"].String();
                 }
-                else if ( t == "inline" ) {
+                else if ( o.hasElement("inline") ) {
                     outType = INMEMORY;
                 }
                 else {
-                    uasserted( 13522 , str::stream() << "unknown out specifier [" << t << "]" );
+                    uasserted( 13522 , str::stream() << "please specify one of [replace|merge|reduce|inline] in 'out' object");
                 }
 
                 if (o.hasElement("db")) {


### PR DESCRIPTION
Where we put replace, db, inline, etc within the map-reduce "out" BSON object shouldn't matter, this fixes.  
