### PR TITLE
SERVER-5348: fix incorrect usage of macro BOOST_CHECK_EXCEPTION

### DIFF
--- a/src/mongo/client/redef_macros.h
+++ b/src/mongo/client/redef_macros.h
@@ -34,7 +34,6 @@
 #define wassert MONGO_wassert
 #define massert MONGO_massert
 #define uassert MONGO_uassert
-#define BOOST_CHECK_EXCEPTION MONGO_BOOST_CHECK_EXCEPTION
 #define DESTRUCTOR_GUARD MONGO_DESTRUCTOR_GUARD
 
 // util/goodies.h

--- a/src/mongo/client/undef_macros.h
+++ b/src/mongo/client/undef_macros.h
@@ -35,7 +35,6 @@
 #undef wassert
 #undef massert
 #undef uassert
-#undef BOOST_CHECK_EXCEPTION
 #undef DESTRUCTOR_GUARD
 
 // util/goodies.h

--- a/src/mongo/db/db.cpp
+++ b/src/mongo/db/db.cpp
@@ -481,7 +481,7 @@ namespace mongo {
 
         FileAllocator::get()->start();
 
-        MONGO_BOOST_CHECK_EXCEPTION_WITH_MSG( clearTmpFiles(), "clear tmp files" );
+        MONGO_ASSERT_ON_EXCEPTION_WITH_MSG( clearTmpFiles(), "clear tmp files" );
 
         dur::startup();
 

--- a/src/mongo/db/namespace_details.cpp
+++ b/src/mongo/db/namespace_details.cpp
@@ -90,7 +90,7 @@ namespace mongo {
         boost::filesystem::path dir( dir_ );
         dir /= database_;
         if ( !boost::filesystem::exists( dir ) )
-            MONGO_BOOST_CHECK_EXCEPTION_WITH_MSG( boost::filesystem::create_directory( dir ), "create dir for db " );
+            MONGO_ASSERT_ON_EXCEPTION_WITH_MSG( boost::filesystem::create_directory( dir ), "create dir for db " );
     }
 
     unsigned lenForNewNsFiles = 16 * 1024 * 1024;

--- a/src/mongo/db/pdfile.cpp
+++ b/src/mongo/db/pdfile.cpp
@@ -201,7 +201,7 @@ namespace mongo {
     void _deleteDataFiles(const char *database) {
         if ( directoryperdb ) {
             FileAllocator::get()->waitUntilFinished();
-            MONGO_BOOST_CHECK_EXCEPTION_WITH_MSG( boost::filesystem::remove_all( boost::filesystem::path( dbpath ) / database ), "delete data files with a directoryperdb" );
+            MONGO_ASSERT_ON_EXCEPTION_WITH_MSG( boost::filesystem::remove_all( boost::filesystem::path( dbpath ) / database ), "delete data files with a directoryperdb" );
             return;
         }
         class : public FileOp {
@@ -2252,7 +2252,7 @@ namespace mongo {
             stringstream ss;
             ss << prefix << "_repairDatabase_" << i++;
             reservedPath = repairPath / ss.str();
-            BOOST_CHECK_EXCEPTION( exists = boost::filesystem::exists( reservedPath ) );
+            MONGO_ASSERT_ON_EXCEPTION( exists = boost::filesystem::exists( reservedPath ) );
         }
         while ( exists );
         return reservedPath;
@@ -2314,7 +2314,7 @@ namespace mongo {
         Path reservedPath =
             uniqueReservedPath( ( preserveClonedFilesOnFailure || backupOriginalFiles ) ?
                                 "backup" : "_tmp" );
-        BOOST_CHECK_EXCEPTION( boost::filesystem::create_directory( reservedPath ) );
+        MONGO_ASSERT_ON_EXCEPTION( boost::filesystem::create_directory( reservedPath ) );
         string reservedPathString = reservedPath.native_directory_string();
 
         bool res;
@@ -2334,7 +2334,7 @@ namespace mongo {
             problem() << errmsg << endl;
 
             if ( !preserveClonedFilesOnFailure )
-                BOOST_CHECK_EXCEPTION( boost::filesystem::remove_all( reservedPath ) );
+                MONGO_ASSERT_ON_EXCEPTION( boost::filesystem::remove_all( reservedPath ) );
 
             getDur().syncDataAndTruncateJournal(); // Must be done before and after repair
 
@@ -2351,13 +2351,13 @@ namespace mongo {
         }
         else {
             _deleteDataFiles( dbName );
-            BOOST_CHECK_EXCEPTION( boost::filesystem::create_directory( Path( dbpath ) / dbName ) );
+            MONGO_ASSERT_ON_EXCEPTION( boost::filesystem::create_directory( Path( dbpath ) / dbName ) );
         }
 
         _replaceWithRecovered( dbName, reservedPathString.c_str() );
 
         if ( !backupOriginalFiles )
-            BOOST_CHECK_EXCEPTION( boost::filesystem::remove_all( reservedPath ) );
+            MONGO_ASSERT_ON_EXCEPTION( boost::filesystem::remove_all( reservedPath ) );
 
         getDur().syncDataAndTruncateJournal(); // Must be done before and after repair
 
@@ -2375,7 +2375,7 @@ namespace mongo {
         boost::filesystem::path q;
         q = p / (c+"ns");
         bool ok = false;
-        BOOST_CHECK_EXCEPTION( ok = fo.apply( q ) );
+        MONGO_ASSERT_ON_EXCEPTION( ok = fo.apply( q ) );
         if ( ok )
             log(2) << fo.op() << " file " << q.string() << endl;
         int i = 0;
@@ -2385,7 +2385,7 @@ namespace mongo {
             stringstream ss;
             ss << c << i;
             q = p / ss.str();
-            BOOST_CHECK_EXCEPTION( ok = fo.apply(q) );
+            MONGO_ASSERT_ON_EXCEPTION( ok = fo.apply(q) );
             if ( ok ) {
                 if ( extra != 10 ) {
                     log(1) << fo.op() << " file " << q.string() << endl;

--- a/src/mongo/util/assert_util.h
+++ b/src/mongo/util/assert_util.h
@@ -235,27 +235,26 @@ namespace mongo {
 
 } // namespace mongo
 
-#define BOOST_CHECK_EXCEPTION MONGO_BOOST_CHECK_EXCEPTION
-#define MONGO_BOOST_CHECK_EXCEPTION( expression ) \
+#define MONGO_ASSERT_ON_EXCEPTION( expression ) \
     try { \
         expression; \
     } catch ( const std::exception &e ) { \
         stringstream ss; \
-        ss << "caught boost exception: " << e.what() << ' ' << __FILE__ << ' ' << __LINE__; \
+        ss << "caught exception: " << e.what() << ' ' << __FILE__ << ' ' << __LINE__; \
         msgasserted( 13294 , ss.str() ); \
     } catch ( ... ) { \
-        massert( 10437 ,  "unknown boost failed" , false ); \
+        massert( 10437 ,  "unknown exception" , false ); \
     }
 
-#define MONGO_BOOST_CHECK_EXCEPTION_WITH_MSG( expression, msg ) \
+#define MONGO_ASSERT_ON_EXCEPTION_WITH_MSG( expression, msg ) \
     try { \
         expression; \
     } catch ( const std::exception &e ) { \
         stringstream ss; \
-        ss << msg << " caught boost exception: " << e.what();   \
+        ss << msg << " caught exception exception: " << e.what();   \
         msgasserted( 14043 , ss.str() );        \
     } catch ( ... ) { \
-        msgasserted( 14044 , std::string("unknown boost failed ") + msg );   \
+        msgasserted( 14044 , std::string("unknown exception") + msg );   \
     }
 
 #define DESTRUCTOR_GUARD MONGO_DESTRUCTOR_GUARD

--- a/src/mongo/util/file_allocator.cpp
+++ b/src/mongo/util/file_allocator.cpp
@@ -325,8 +325,8 @@ namespace mongo {
                     log() << "    will try again in 10 seconds" << endl; // not going to warning logs
                     try {
                         if ( tmp.size() )
-                            BOOST_CHECK_EXCEPTION( boost::filesystem::remove( tmp ) );
-                        BOOST_CHECK_EXCEPTION( boost::filesystem::remove( name ) );
+                            MONGO_ASSERT_ON_EXCEPTION( boost::filesystem::remove( tmp ) );
+                        MONGO_ASSERT_ON_EXCEPTION( boost::filesystem::remove( name ) );
                     }
                     catch ( ... ) {
                     }


### PR DESCRIPTION
macro BOOST_CHECK_EXCEPTION is to be used only with the boost unit
test framework, not as a general tool to catch exceptions.
