### PR TITLE
Use signed char so it works on ARM and PPC

### DIFF
--- a/src/mongo/bson/bsonelement.h
+++ b/src/mongo/bson/bsonelement.h
@@ -105,7 +105,7 @@ namespace mongo {
         operator std::string() const { return toString(); }
 
         /** Returns the type of the element */
-        BSONType type() const { return (BSONType) *data; }
+        BSONType type() const { return (BSONType) *reinterpret_cast< const signed char * >(data); }
 
         /** retrieve a field within this element
             throws exception if *this is not an embedded object


### PR DESCRIPTION
On ARM and PowerPC char is unsigned by default. This breaks
BSONtype() because the latter needs to represent -1 as well.

The bug can also be reproduced on x86 if passing -funsigned-char to gcc. The smoketest fails due to a SIGTRAP.
