### PR TITLE
db/stats/counters code causes SIGBUS on ARM

### DIFF
--- a/src/mongo/db/stats/counters.h
+++ b/src/mongo/db/stats/counters.h
@@ -33,37 +33,36 @@ namespace mongo {
     public:
 
         OpCounters();
-
+/*
         AtomicUInt * getInsert() { return _insert; }
         AtomicUInt * getQuery() { return _query; }
         AtomicUInt * getUpdate() { return _update; }
         AtomicUInt * getDelete() { return _delete; }
         AtomicUInt * getGetMore() { return _getmore; }
         AtomicUInt * getCommand() { return _command; }
-
-        void incInsertInWriteLock(int n) { _insert->x += n; }
-        void gotInsert() { _insert[0]++; }
-        void gotQuery() { _query[0]++; }
-        void gotUpdate() { _update[0]++; }
-        void gotDelete() { _delete[0]++; }
-        void gotGetMore() { _getmore[0]++; }
-        void gotCommand() { _command[0]++; }
+*/
+        void incInsertInWriteLock(int n) { _insert.x += n; }
+        void gotInsert() { _insert++; }
+        void gotQuery() { _query++; }
+        void gotUpdate() { _update++; }
+        void gotDelete() { _delete++; }
+        void gotGetMore() { _getmore++; }
+        void gotCommand() { _command++; }
 
         void gotOp( int op , bool isCommand );
 
-        BSONObj& getObj();
+        BSONObj getObj();
 
     private:
-        BSONObj _obj;
 
         // todo: there will be a lot of cache line contention on these.  need to do something 
         //       else eventually.
-        AtomicUInt * _insert;
-        AtomicUInt * _query;
-        AtomicUInt * _update;
-        AtomicUInt * _delete;
-        AtomicUInt * _getmore;
-        AtomicUInt * _command;
+        AtomicUInt _insert;
+        AtomicUInt _query;
+        AtomicUInt _update;
+        AtomicUInt _delete;
+        AtomicUInt _getmore;
+        AtomicUInt _command;
     };
 
     extern OpCounters globalOpCounters;


### PR DESCRIPTION
On ARM accessing unaligned words via atomic load and store instructions
causes alignment faults and crashes the application. This is an issue
for the statistics counters which are AtomicUInts and can be in BSON
data, thus unaligned. This change introduces CounterUInt which is an
alias for AtomicUInt but can be made a simple UInt on ARM or other
architectures with such constraints.

If this looks ok (I ws not sure whether to use a #define instead of typedef and for the latter make it private or not) a simple #ifdef can make the ARM code use an unsigned int. Not thread safe but as the comments in the same file notes that is not a prio for counters. AtomicUInt definitely needs to remain used in all other places on ARM (pointers outside BSON data)
