### PR TITLE
Fix alignment traps on ARMv7 take two

### DIFF
--- a/src/mongo/bson/bsonelement.h
+++ b/src/mongo/bson/bsonelement.h
@@ -184,7 +184,7 @@ namespace mongo {
         bool isNumber() const;
 
         /** Return double value for this field. MUST be NumberDouble type. */
-        double _numberDouble() const {return *reinterpret_cast< const double* >( value() ); }
+        double _numberDouble() const {return (reinterpret_cast< const PackedDouble* >( value() ))->d; }
         /** Return int value for this field. MUST be NumberInt type. */
         int _numberInt() const {return *reinterpret_cast< const int* >( value() ); }
         /** Return long long value for this field. MUST be NumberLong type. */
@@ -490,7 +490,7 @@ namespace mongo {
         case NumberLong:
             return *reinterpret_cast< const long long* >( value() ) != 0;
         case NumberDouble:
-            return *reinterpret_cast< const double* >( value() ) != 0;
+            return (reinterpret_cast < const PackedDouble* >(value ()))->d != 0;
         case NumberInt:
             return *reinterpret_cast< const int* >( value() ) != 0;
         case mongo::Bool:

--- a/src/mongo/bson/inline_decls.h
+++ b/src/mongo/bson/inline_decls.h
@@ -20,14 +20,17 @@
 #if defined(__GNUC__)
 
 #define NOINLINE_DECL __attribute__((noinline))
+#define PACKED_DECL __attribute__((packed))
 
 #elif defined(_MSC_VER)
 
 #define NOINLINE_DECL __declspec(noinline)
+#define PACKED_DECL
 
 #else
 
 #define NOINLINE_DECL
+#define PACKED_DECL
 
 #endif
 

--- a/src/mongo/db/key.cpp
+++ b/src/mongo/db/key.cpp
@@ -19,6 +19,7 @@
 #include "pch.h"
 #include "key.h"
 #include "mongo/util/startup_test.h"
+#include "../bson/util/builder.h"
 
 namespace mongo {
 
@@ -405,11 +406,11 @@ namespace mongo {
                     p += sizeof(double);
                     break;
                 case cint:
-                    b.append("", (int) ((double&) *p));
+                    b.append("", static_cast< int >((reinterpret_cast< const PackedDouble& >(*p)).d));
                     p += sizeof(double);
                     break;
                 case clong:
-                    b.append("", (long long) ((double&) *p));
+                    b.append("", static_cast< long long>((reinterpret_cast< const PackedDouble& >(*p)).d));
                     p += sizeof(double);
                     break;
                 default:
@@ -435,8 +436,8 @@ namespace mongo {
         switch( lt ) { 
         case cdouble:
             {
-                double L = *((double *) l);
-                double R = *((double *) r);
+                double L = (reinterpret_cast< const PackedDouble* >(l))->d;
+                double R = (reinterpret_cast< const PackedDouble* >(r))->d;
                 if( L < R )
                     return -1;
                 if( L != R )
@@ -624,7 +625,7 @@ namespace mongo {
                 l += 8; r += 8;
                 break;
             case cdouble:
-                if( *((double *) l) != *((double *) r) )
+                if( (reinterpret_cast< const PackedDouble* > (l))->d != (reinterpret_cast< const PackedDouble* >(r))->d )
                     return false;
                 l += 8; r += 8;
                 break;


### PR DESCRIPTION
Access doubles via a packed struct so the generated code
works with unaligned pointers too. The code generated by gcc for
i386 and amd64 for such an access is identical to the code
generated by a direct reference.
