### PR TITLE
SERVER-5532 Write "db level locking enabled: %u" to stderr instead of stdout

### DIFF
--- a/src/mongo/db/d_concurrency.cpp
+++ b/src/mongo/db/d_concurrency.cpp
@@ -40,7 +40,7 @@ namespace mongo {
 
     struct atstartup { 
         atstartup() { 
-            cout << "db level locking enabled: " << ( DB_LEVEL_LOCKING_ENABLED ) << endl;
+            cerr << "db level locking enabled: " << ( DB_LEVEL_LOCKING_ENABLED ) << endl;
         }
     } atst;
 


### PR DESCRIPTION
Because it do malformed mongodump output files, if it write to stdout

https://jira.mongodb.org/browse/SERVER-5532

http://stackoverflow.com/a/10037024/328260
