### PR TITLE
Fix sysv init script for numactl

### DIFF
--- a/debian/init.d
+++ b/debian/init.d
@@ -56,7 +56,6 @@ CONF=/etc/mongodb.conf
 DATA=/var/lib/mongodb
 LOGDIR=/var/log/mongodb
 PIDFILE=$DATA/$NAME.pid
-LOCKFILE=$DATA/mongod.lock
 LOGFILE=$LOGDIR/$NAME.log  # Server logfile
 ENABLE_MONGODB=yes
 


### PR DESCRIPTION
Because numactl, if use it in such way - it not start
because of argument "--interleave=all", it must be after "--"

But even if we fix this, numactl goes to background and not return child pid
and from "start-stop-daemon" we have pid of numactl, that already not exist

So we need to use lock file, that create mongodb
