### PR TITLE
SERVER-5616 Any shell command containing the string ".auth" is not added to shell history

### DIFF
--- a/src/mongo/shell/dbshell.cpp
+++ b/src/mongo/shell/dbshell.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "pch.h"
+#include <pcrecpp.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -112,8 +113,11 @@ void shellHistoryAdd( const char * line ) {
         return;
     lastLine = line;
 
-    if ( strstr( line, ".auth") == NULL &&
-         strstr( line, ".addUser") == NULL )
+    // We don't want any .auth() or .addUser() commands added, but we want to
+    // be able to add things like `.author`, so be smart about how this is
+    // detected by using regular expresions.
+    static pcrecpp::RE hiddenCommands("\\.(auth|addUser)\\s*\\(");
+    if (!hiddenCommands.PartialMatch(line))
     {
         linenoiseHistoryAdd( line );
     }


### PR DESCRIPTION
https://jira.mongodb.org/browse/SERVER-5616

In the case where items such as `db.author` are used, these would
normally be omitted--which isn't what's needed.  Furthermore, items like
`db.auth   ()` are also permitted, and should not be displayed.  This
replaces the existing `strstr` check with a regular expression using
PCRE.
