### PR TITLE
SERVER-5511: `help` is not a log, and shouldn't be given `migrateLog`

### DIFF
--- a/src/mongo/s/d_migrate.cpp
+++ b/src/mongo/s/d_migrate.cpp
@@ -201,7 +201,7 @@ namespace mongo {
         }
 
         virtual void help( stringstream& help ) const {
-            help << "internal - should not be called directly" << migrateLog;
+            help << "internal - should not be called directly";
         }
         virtual bool slaveOk() const { return false; }
         virtual bool adminOnly() const { return true; }
@@ -714,7 +714,7 @@ namespace mongo {
     public:
         MoveChunkCommand() : Command( "moveChunk" ) {}
         virtual void help( stringstream& help ) const {
-            help << "should not be calling this directly" << migrateLog;
+            help << "should not be calling this directly";
         }
 
         virtual bool slaveOk() const { return false; }


### PR DESCRIPTION
This corrects an issue where `migrateLog` was being passed into a string
stream.  For a log() object, this would have altered its behavior
normally, but for a regular stringstream, just displayed the pointer
value

https://jira.mongodb.org/browse/SERVER-5511
