### PR TITLE
SERVER-5684: Removing unnecessary cast from the profiling code.

### DIFF
--- a/src/mongo/db/ops/query.cpp
+++ b/src/mongo/db/ops/query.cpp
@@ -750,7 +750,7 @@ namespace mongo {
         int duration = curop.elapsedMillis();
         bool dbprofile = curop.shouldDBProfile( duration );
         if ( dbprofile || duration >= cmdLine.slowMS ) {
-            curop.debug().nscanned = (int)( cursor ? cursor->nscanned() : 0 );
+            curop.debug().nscanned = ( cursor ? cursor->nscanned() : 0LL );
             curop.debug().ntoskip = pq.getSkip();
         }
         curop.debug().nreturned = nReturned;


### PR DESCRIPTION
Since curop.debug().nscanned is a `long long`, and the return of the
`nscanned()` function is also a `long long`, casting is unnecessary here
as the false value `0` will correctly be coerced to a `long long`.
However, to improve readability, I have specifically marked the 0
constant as `0LL`.

https://jira.mongodb.org/browse/SERVER-5684
