### PR TITLE
SERVER-5399 Essentially aliasing quit, exit, and function call variations. (+ misc cleanup)

### DIFF
--- a/src/mongo/shell/dbshell.cpp
+++ b/src/mongo/shell/dbshell.cpp
@@ -842,12 +842,22 @@ int _main( int argc, char* argv[] ) {
             free(lineCStr);
             lineCStr = NULL;
 
+            // First, check to see if this code needs to be finished.  If it
+            // does, we'll need to do some parsing before we look at commands.
+            gotInterrupted = false;
+            line = finishCode( line );
+
             if ( line == "quit" || line == "exit" ) {
               // Replace this with the real command that the shell expects
               line += "(0)";
             }
 
-            if ( line == "cls" ) {
+            if ( gotInterrupted ) {
+                // If we got interrupted in multiline editing, just print a new
+                // line so that the next command will be entered (correctly) on
+                // the next line.
+                cout << endl;
+            } else if ( line == "cls" ) {
                 linenoiseClearScreen();
             } else if( boost::algorithm::starts_with( line, "edit " ) ) {
                 string s = line.c_str() + 5; // skip "edit "

--- a/src/mongo/shell/dbshell.cpp
+++ b/src/mongo/shell/dbshell.cpp
@@ -824,35 +824,31 @@ int _main( int argc, char* argv[] ) {
                 prompt = "> ";
             }
 
-            char * line = shellReadline( prompt.c_str() );
-            char * linePtr = line;  // can't clobber 'line', we need to free() it later
+            char * lineCStr = shellReadline( prompt.c_str() );
 
-            if ( line ) {
-                // Strips out leading whitespace.
-                while ( linePtr[0] == ' ' )
-                    ++linePtr;
-                int lineLen = strlen( linePtr );
-
-                // Strip out trailing whitespace and semicolons; semicolons
-                // have no bearing on commands in the shell.  This also allows
-                // for "bad" commands like `exit ;`.  This will help habitual
-                // C++ programmers. :)
-                while ( lineLen > 0 && ( linePtr[lineLen - 1] == ' ' 
-                                      || linePtr[lineLen - 1] == ';' ) )
-                    --lineLen;
-                linePtr[lineLen] = 0;
-            } else {
+            if ( !lineCStr ) {
                 // User must have hit ^C; treat this like an exit.
                 if( !mongo::cmdLine.quiet )
                     cout << "User interrupt detected; exiting..." << endl;
                 break;
             }
 
-            string code = linePtr;
+            // Strips out leading whitespace.
+            while ( lineCStr[0] == ' ' )
+                ++lineCStr;
+            int lineLen = strlen( lineCStr );
+
+            // Strip out trailing whitespace
+            while ( lineLen > 0 && ( lineCStr[lineLen - 1] == ' ' 
+                                  || lineCStr[lineLen - 1] == ';' ) )
+                --lineLen;
+            lineCStr[lineLen] = 0;
+
+            string code = lineCStr;
 
             // Free line before we forget.
-            free(line);
-            line = linePtr = NULL;
+            free(lineCStr);
+            lineCStr = NULL;
 
             if ( code == "quit" || code == "exit" ) {
               // Replace this with the real command that the shell expects

--- a/src/mongo/shell/dbshell.cpp
+++ b/src/mongo/shell/dbshell.cpp
@@ -854,11 +854,9 @@ int _main( int argc, char* argv[] ) {
             free(line);
             line = linePtr = NULL;
 
-            if ( code == "exit" )
-            {
-                if ( ! mongo::cmdLine.quiet )
-                    cout << "bye" << endl;
-                break;
+            if ( code == "quit" || code == "exit" ) {
+              // Replace this with the real command that the shell expects
+              code += "(0)";
             }
 
             if ( code == "cls" ) {

--- a/src/mongo/shell/dbshell.cpp
+++ b/src/mongo/shell/dbshell.cpp
@@ -835,32 +835,32 @@ int _main( int argc, char* argv[] ) {
                 break;
             }
 
-            string code = lineCStr;
-            boost::algorithm::trim(code);
+            string line = lineCStr;
+            boost::algorithm::trim(line);
 
             // Free line before we forget.
             free(lineCStr);
             lineCStr = NULL;
 
-            if ( code == "quit" || code == "exit" ) {
+            if ( line == "quit" || line == "exit" ) {
               // Replace this with the real command that the shell expects
-              code += "(0)";
+              line += "(0)";
             }
 
-            if ( code == "cls" ) {
+            if ( line == "cls" ) {
                 linenoiseClearScreen();
-            } else if( boost::algorithm::starts_with( code, "edit " ) ) {
-                string s = code.c_str() + 5; // skip "edit "
+            } else if( boost::algorithm::starts_with( line, "edit " ) ) {
+                string s = line.c_str() + 5; // skip "edit "
                 boost::algorithm::trim_left(s);
                 edit( s );
-            } else if ( !code.empty() ) {
+            } else if ( !line.empty() ) {
                 // Whatever we have now will be in the form:
                 //   CMD ARGS
                 bool wasCmd = false;
                 string cmd;
-                size_t strPos = code.find(' ');
+                size_t strPos = line.find(' ');
                 if ( strPos != string::npos )
-                    cmd = code.substr( 0, strPos );
+                    cmd = line.substr( 0, strPos );
 
                 if ( cmd.find("\"") == string::npos ) {
                     try {
@@ -869,7 +869,7 @@ int _main( int argc, char* argv[] ) {
                                 "(shellhelp1)" , false , true , true );
                         if ( scope->getBoolean( "__iscmd__" )  ) {
                             scope->exec(
-                                    (string) "shellHelper( \"" + cmd + "\" , \"" + code.substr( cmd.size() ) + "\");",
+                                    (string) "shellHelper( \"" + cmd + "\" , \"" + line.substr( cmd.size() ) + "\");",
                                     "(shellhelp2)" , false , true , false );
                             wasCmd = true;
                         }
@@ -881,7 +881,7 @@ int _main( int argc, char* argv[] ) {
 
                 if ( !wasCmd ) {
                     try {
-                        if ( scope->exec( code.c_str() , "(shell)" , false , true , false ) )
+                        if ( scope->exec( line.c_str() , "(shell)" , false , true , false ) )
                             scope->exec( "shellPrintHelper( __lastres__ );" , "(shell2)" , true , true , false );
                     }
                     catch ( std::exception& exc ) {
@@ -890,9 +890,9 @@ int _main( int argc, char* argv[] ) {
                 }
             }
 
-            // If the code contained anything, add it to the history.
-            if(!code.empty())
-                shellHistoryAdd( code.c_str() );
+            // If the line contained anything, add it to the history.
+            if(!line.empty())
+                shellHistoryAdd( line.c_str() );
         }
 
         shellHistoryDone();

--- a/src/mongo/shell/dbshell.cpp
+++ b/src/mongo/shell/dbshell.cpp
@@ -858,8 +858,8 @@ int _main( int argc, char* argv[] ) {
                 //   CMD ARGS
                 bool wasCmd = false;
                 string cmd;
-                size_t strPos = code.find(" ");
-                if ( strPos > 0 )
+                size_t strPos = code.find(' ');
+                if ( strPos != string::npos )
                     cmd = code.substr( 0, strPos );
 
                 if ( cmd.find("\"") == string::npos ) {

--- a/src/mongo/shell/dbshell.cpp
+++ b/src/mongo/shell/dbshell.cpp
@@ -20,6 +20,8 @@
 #include <string.h>
 
 #include <boost/filesystem/operations.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/algorithm/string/trim.hpp>
 
 #include "mongo/client/dbclientinterface.h"
 #include "mongo/db/cmdline.h"
@@ -833,18 +835,8 @@ int _main( int argc, char* argv[] ) {
                 break;
             }
 
-            // Strips out leading whitespace.
-            while ( lineCStr[0] == ' ' )
-                ++lineCStr;
-            int lineLen = strlen( lineCStr );
-
-            // Strip out trailing whitespace
-            while ( lineLen > 0 && ( lineCStr[lineLen - 1] == ' ' 
-                                  || lineCStr[lineLen - 1] == ';' ) )
-                --lineLen;
-            lineCStr[lineLen] = 0;
-
             string code = lineCStr;
+            boost::algorithm::trim(code);
 
             // Free line before we forget.
             free(lineCStr);
@@ -857,11 +849,9 @@ int _main( int argc, char* argv[] ) {
 
             if ( code == "cls" ) {
                 linenoiseClearScreen();
-            } else if( startsWith( code, "edit " ) ) {
-                const char* s = code.c_str() + 5; // skip "edit "
-                while( *s && isspace( *s ) )
-                    s++;
-
+            } else if( boost::algorithm::starts_with( code, "edit " ) ) {
+                string s = code.c_str() + 5; // skip "edit "
+                boost::algorithm::trim_left(s);
                 edit( s );
             } else if ( !code.empty() ) {
                 // Whatever we have now will be in the form:

--- a/src/mongo/shell/shell_utils.cpp
+++ b/src/mongo/shell/shell_utils.cpp
@@ -126,6 +126,8 @@ namespace mongo {
 
         void installShellUtils( Scope& scope ) {
             scope.injectNative( "quit", Quit );
+            // SERVER-5399: Set `exit` as well, so that quit/exit both resolve.
+            scope.injectNative( "exit", Quit );
             scope.injectNative( "getMemInfo" , JSGetMemInfo );
             scope.injectNative( "_srand" , JSSrand );
             scope.injectNative( "_rand" , JSRand );


### PR DESCRIPTION
Previously, `exit` was being implemented as a code in the DB shell, while 
`quit` was being implemented as a shell function.  This meant that both were 
doing different things, and were called differently--i.e., `exit` could be run 
as is, whereas `quit()` had to be called as a function. 