### PR TITLE
Return error if try to call "fsyncLock" from "db.eval()"

### DIFF
--- a/src/mongo/db/commands/fsync.cpp
+++ b/src/mongo/db/commands/fsync.cpp
@@ -7,8 +7,6 @@
 #include "mongo/db/client.h"
 #include "mongo/util/background.h"
 
-#include "../curop.h"
-
 namespace mongo {
     
     class FSyncLockThread : public BackgroundJob {
@@ -66,7 +64,7 @@ namespace mongo {
 
                 SimpleMutex::scoped_lock lk(m);
                 err = "";
-
+                
                 (new FSyncLockThread())->go();
                 while ( ! locked && err.size() == 0 ) {
                     _threadSync.wait( m );


### PR DESCRIPTION
Add checking for context for current client, if it exist - runs from db.eval()
And for it: is not possible to call fsyncLock() - because it lock db.eval() at all

In some version (2.1 but not last) it gave an error, but db.eval() is not returned:

<pre>
Thu May 10 15:38:34 [conn3] CMD fsync: sync:1 lock:1
mongod: src/mongo/db/d_concurrency.cpp:272: static void mongo::Lock::ThreadSpanningOp::setWLockedNongreedy(): Assertion `threadState() == 0' failed.
Thu May 10 15:38:34 Got signal: 6 (Aborted).

Thu May 10 15:38:34 Backtrace:
0x59383f 0x589e20 0x7f9641c324f0 0x7f9641c32475 0x7f9641c356f0 0x7f9641c2b621 0x9508a7 0x8c88bd 0x5cbdbf 0x5cc57e 0x5cdaf0 0x98f17a 0x992cf5 0x6e6c99 0x6e8277 0x9b183d 0x94c478 0x6e04fc 0x70457d 0x87339c 
 /usr/bin/mongod(_ZN5mongo15printStackTraceERSo+0x1f) [0x59383f]
 /usr/bin/mongod(_ZN5mongo10abruptQuitEi+0x350) [0x589e20]
 /lib/x86_64-linux-gnu/libc.so.6(+0x324f0) [0x7f9641c324f0]
 /lib/x86_64-linux-gnu/libc.so.6(gsignal+0x35) [0x7f9641c32475]
 /lib/x86_64-linux-gnu/libc.so.6(abort+0x180) [0x7f9641c356f0]
 /lib/x86_64-linux-gnu/libc.so.6(__assert_fail+0xf1) [0x7f9641c2b621]
 /usr/bin/mongod() [0x9508a7]
 /usr/bin/mongod(_ZN5mongo12FSyncCommand3runERKSsRNS_7BSONObjEiRSsRNS_14BSONObjBuilderEb+0x21d) [0x8c88bd]
 /usr/bin/mongod(_ZN5mongo12_execCommandEPNS_7CommandERKSsRNS_7BSONObjEiRNS_14BSONObjBuilderEb+0x3f) [0x5cbdbf]
 /usr/bin/mongod(_ZN5mongo11execCommandEPNS_7CommandERNS_6ClientEiPKcRNS_7BSONObjERNS_14BSONObjBuilderEb+0x53e) [0x5cc57e]
 /usr/bin/mongod(_ZN5mongo12_runCommandsEPKcRNS_7BSONObjERNS_11_BufBuilderINS_16TrivialAllocatorEEERNS_14BSONObjBuilderEbi+0x280) [0x5cdaf0]
 /usr/bin/mongod(_ZN5mongo11runCommandsEPKcRNS_7BSONObjERNS_5CurOpERNS_11_BufBuilderINS_16TrivialAllocatorEEERNS_14BSONObjBuilderEbi+0x3a) [0x98f17a]
 /usr/bin/mongod(_ZN5mongo8runQueryERNS_7MessageERNS_12QueryMessageERNS_5CurOpES1_+0x525) [0x992cf5]
 /usr/bin/mongod(_ZN5mongo16assembleResponseERNS_7MessageERNS_10DbResponseERKNS_11HostAndPortE+0x839) [0x6e6c99]
 /usr/bin/mongod(_ZN5mongo14DBDirectClient4callERNS_7MessageES2_bPSs+0x67) [0x6e8277]
 /usr/bin/mongod(_ZN5mongo14DBClientCursor4initEv+0x8d) [0x9b183d]
 /usr/bin/mongod(_ZN5mongo12DBClientBase5queryERKSsNS_5QueryEiiPKNS_7BSONObjEii+0x258) [0x94c478]
 /usr/bin/mongod(_ZN5mongo14DBDirectClient5queryERKSsNS_5QueryEiiPKNS_7BSONObjEii+0x4c) [0x6e04fc]
 /usr/bin/mongod(_ZN5mongo10mongo_findEP9JSContextP8JSObjectjPlS4_+0x2cd) [0x70457d]
 /usr/bin/mongod(js_Invoke+0x4bc) [0x87339c]

Logstream::get called in uninitialized state
Thu May 10 15:38:34 ERROR: Client::~Client _context should be null but is not; client:conn
Logstream::get called in uninitialized state
Thu May 10 15:38:34 ERROR: Client::shutdown not called: conn
Logstream::get called in uninitialized state
Thu May 10 15:38:42 [initandlisten] connection accepted from 127.0.0.1:44277 #4 (2 connections now open)
</pre>


But in last it just lock db.eval() operations at all (current too)
