### PR TITLE
CXX-104 add --cxx and --ldflags to c++ client build

### DIFF
--- a/distsrc/client/SConstruct
+++ b/distsrc/client/SConstruct
@@ -6,6 +6,21 @@ import os
 import sys
 
 # options
+
+AddOption( "--cxx", 
+          dest="cxx", 
+          type="string", 
+          nargs=1, 
+          action="store",
+          default="g++",help="use an alternate C++ compiler" )
+
+AddOption( "--ldflags", 
+          dest="ldflags", 
+          type="string", 
+          nargs=1, 
+          action="store",
+          default="",help="add some ld flags like --ldflags=/usr/lib --> -L/usr/lib" )
+
 AddOption("--extrapath",
           dest="extrapath",
           type="string",
@@ -68,6 +83,15 @@ if linux:
 
 boostLibs = ["thread", "filesystem", "system"]
 conf = Configure(env)
+
+if GetOption( "cxx" ) is not None:
+        conf.env.Replace(CXX = GetOption( "cxx" ) )
+        print(">> Using CXX compiler " + GetOption( "cxx" ))
+
+if GetOption( "ldflags" ) is not None:
+        conf.env.Append(LINKFLAGS = GetOption( "ldflags" ))
+        print(">> Using LDFLAGS = " + GetOption( "ldflags" ))
+
 for lib in boostLibs:
     if not conf.CheckLib(["boost_%s-mt" % lib, "boost_%s" % lib],
                          language="C++"):


### PR DESCRIPTION
(using command line params as requested)

use --cxx=alt compiler --ldflags=/usr/lib (--> -L/usr/lib)
env LINKFLAGS = ldflags - before boost lib check

Note: AddExtraLibs function does not appear to add lib path for boost lib check routine "scons conf.CheckLib" (for example please see config.log after running scons, no libs are specified during boost lib check routine when using --extrapath.)
