### PR TITLE
added quit as a synonym for exit

### DIFF
--- a/src/mongo/shell/dbshell.cpp
+++ b/src/mongo/shell/dbshell.cpp
@@ -857,16 +857,12 @@ int _main( int argc, char* argv[] ) {
                     linePtr[--lineLen] = 0;
             }
 
-            if ( ! linePtr || ( strlen( linePtr ) == 4 && strstr( linePtr , "exit" ) ) ) {
+            string code = linePtr;
+            if ( ! linePtr || 
+                code == "exit" || code == "exit;"  || 
+                code == "quit" || code == "quit;") {
                 if ( ! mongo::cmdLine.quiet )
                     cout << "bye" << endl;
-                if ( line )
-                    free( line );
-                break;
-            }
-
-            string code = linePtr;
-            if ( code == "exit" || code == "exit;" ) {
                 free( line );
                 break;
             }


### PR DESCRIPTION
Added quit and quit; as synonyms for exit in the shell.

Removed some seemingly redundant code, might be overlooking something?
