### PR TITLE
SERVER-6217 SERVER-7217 background jobs cannot be run multiple times (rejected)

### DIFF
--- a/src/mongo/dbtests/background_job_test.cpp
+++ b/src/mongo/dbtests/background_job_test.cpp
@@ -96,26 +96,26 @@ namespace BackgroundJobTests {
     class GoStateCase {
     public:
         void run() {
-	    for ( unsigned int i = 0; i < 100; i++ ) { // race
-		IncTester tester( 0 /* inc without wait */ );
-		tester.go();
-		ASSERT_NOT_EQUALS( tester.getState(), BackgroundJob::NotStarted ); // Running or Done
-		tester.wait(); // cleanup
-	    }
+            for ( unsigned int i = 0; i < 100; i++ ) { // race
+                IncTester tester( 0 /* inc without wait */ );
+                tester.go();
+                ASSERT_NOT_EQUALS( tester.getState(), BackgroundJob::NotStarted ); // Running or Done
+                tester.wait(); // cleanup
+            }
         }
     };
 
     class RunTwiceCase {
     public:
         void run() {
-	    for ( unsigned int i = 0; i < 100; i++ ) { // race
-		IncTester tester( 0 /* inc without wait */ );
-		tester.go();
-		tester.wait();
-		tester.go();
-		tester.wait();
-		ASSERT_EQUALS( tester.getVal() , 2 );
-	    }
+            for ( unsigned int i = 0; i < 100; i++ ) { // race
+                IncTester tester( 0 /* inc without wait */ );
+                tester.go();
+                tester.wait();
+                tester.go();
+                tester.wait();
+                ASSERT_EQUALS( tester.getVal() , 2 );
+            }
         }
     };
 

--- a/src/mongo/util/background.cpp
+++ b/src/mongo/util/background.cpp
@@ -50,7 +50,7 @@ namespace mongo {
     // Background object can be only be destroyed after jobBody() ran
     void BackgroundJob::jobBody( boost::shared_ptr<JobStatus> status ) {
         LOG(1) << "BackgroundJob starting: " << name() << endl;
-	verify( status->state == Running );
+        verify( status->state == Running );
 
         const string threadName = name();
         if( ! threadName.empty() )
@@ -77,9 +77,9 @@ namespace mongo {
     }
 
     BackgroundJob& BackgroundJob::go() {
-	scoped_lock l( _status->m );
-	massert( 13643 , mongoutils::str::stream() << "backgroundjob already started: " << name() , _status->state != Running );
-	_status->state = Running;
+        scoped_lock l( _status->m );
+        massert( 13643 , mongoutils::str::stream() << "backgroundjob already started: " << name() , _status->state != Running );
+        _status->state = Running;
         boost::thread t( boost::bind( &BackgroundJob::jobBody , this, _status ) );
         return *this;
     }


### PR DESCRIPTION
"status = Running" was moved from jobBody() to go() because otherwise go() could return and getState() still return NotRunning (or Done from a previous go()). It was a race condition. That's tested in GoStateCase().
