### PR TITLE
Added the --delay option for mongobridge.

### DIFF
--- a/src/mongo/tools/bridge.cpp
+++ b/src/mongo/tools/bridge.cpp
@@ -29,6 +29,7 @@ using namespace mongo;
 using namespace std;
 
 int port = 0;
+int delay = 0;
 string destUri;
 void cleanup( int sig );
 
@@ -50,6 +51,7 @@ public:
                     mp_.shutdown();
                     break;
                 }
+                sleepmillis( delay );
 
                 int oldId = m.header()->id;
                 if ( m.operation() == dbQuery || m.operation() == dbMsg || m.operation() == dbGetMore ) {
@@ -135,9 +137,10 @@ inline void setupSignals() {}
 #endif
 
 void helpExit() {
-    cout << "usage mongobridge --port <port> --dest <destUri>" << endl;
+    cout << "usage mongobridge --port <port> --dest <destUri> [ --delay <ms> ]" << endl;
     cout << "    port: port to listen for mongo messages" << endl;
     cout << "    destUri: uri of remote mongod instance" << endl;
+    cout << "    ms: transfer delay in milliseconds (default = 0)" << endl;
     ::_exit( -1 );
 }
 
@@ -151,15 +154,18 @@ int main( int argc, char **argv ) {
 
     setupSignals();
 
-    check( argc == 5 );
+    check( argc == 5 || argc == 7 );
 
-    for( int i = 1; i < 5; ++i ) {
+    for( int i = 1; i < argc; ++i ) {
         check( i % 2 != 0 );
         if ( strcmp( argv[ i ], "--port" ) == 0 ) {
             port = strtol( argv[ ++i ], 0, 10 );
         }
         else if ( strcmp( argv[ i ], "--dest" ) == 0 ) {
             destUri = argv[ ++i ];
+        }
+        else if ( strcmp( argv[ i ], "--delay" ) == 0 ) {
+            delay = strtol( argv[ ++i ], 0, 10 );
         }
         else {
             check( false );


### PR DESCRIPTION
This new argument adds an artificial delay after reading a message and before
passing it on. This is mostly useful when testing replicaset member selection
algorithms.
