### PR TITLE
Bugfix for mongoexport which was truncating long strings (> ~160 chars) in CSV mode

### DIFF
--- a/src/mongo/tools/export.cpp
+++ b/src/mongo/tools/export.cpp
@@ -91,7 +91,7 @@ public:
             return object.toString(false);
         case String:
         case Symbol:
-            return csvEscape(object.toString(false), true);
+            return csvEscape(object.toString(false, true), true);
         case Object:
             return csvEscape(object.jsonString(Strict, false));
         case Array:


### PR DESCRIPTION
See discussion here: https://groups.google.com/forum/?fromgroups#!topic/mongodb-user/ngu9U1lKMfk
