### PR TITLE
Fixing typo introduced in b3f4d6c4b7aab682376a4503d6f76d698d08d799

### DIFF
--- a/rpm/mongo.spec
+++ b/rpm/mongo.spec
@@ -51,7 +51,7 @@ to develop mongo client software.
 %setup
 
 %build
-scons -%{?_smp_mflags} -prefix=$RPM_BUILD_ROOT/usr all
+scons -%{?_smp_mflags} --prefix=$RPM_BUILD_ROOT/usr all
 # XXX really should have shared library here
 
 %install


### PR DESCRIPTION
The command should use --prefix not -prefix.

Using -prefix fails because it is trying to use the flags p r e f i x instead of setting the prefix.
