### PR TITLE
SERVER-6736 Changed size calculation to represent MBs as 1024*1024

### DIFF
--- a/src/mongo/db/oplog.cpp
+++ b/src/mongo/db/oplog.cpp
@@ -367,13 +367,13 @@ namespace mongo {
             sz = (double)cmdLine.oplogSize;
         else {
             /* not specified. pick a default size */
-            sz = 50.0 * 1000 * 1000;
+            sz = 50.0 * 1024 * 1024;
             if ( sizeof(int *) >= 8 ) {
 #if defined(__APPLE__)
                 // typically these are desktops (dev machines), so keep it smallish
-                sz = (256-64) * 1000 * 1000;
+                sz = (256-64) * 1024 * 1024;
 #else
-                sz = 990.0 * 1000 * 1000;
+                sz = 990.0 * 1024 * 1024;
                 boost::intmax_t free = File::freeSpace(dbpath); //-1 if call not supported.
                 double fivePct = free * 0.05;
                 if ( fivePct > sz )


### PR DESCRIPTION
SERVER-6736, a quick change to make size calculations use 1024 instead of 1000
