### PR TITLE
MongoDB 1.8.x and 2.0.x support for mongooplog tool

### DIFF
--- a/src/mongo/tools/oplog.cpp
+++ b/src/mongo/tools/oplog.cpp
@@ -19,6 +19,7 @@
 #include "pch.h"
 #include "db/json.h"
 #include "db/oplogreader.h"
+#include "util/version.h"
 
 #include "tool.h"
 
@@ -69,6 +70,8 @@ public:
         string ns = getParam( "oplogns" );
         r.tailingQueryGTE( ns.c_str() , start );
 
+        bool legacyApplyOps = (versionCmp(mongodVersion(), "2.2.0") < 0);
+
         int num = 0;
         while ( r.more() ) {
             BSONObj o = r.next();
@@ -88,6 +91,8 @@ public:
             if ( o["op"].String() == "n" )
                 continue;
 
+            string dbname = legacyApplyOps? nsToDatabase(o["ns"].String()) : "admin";
+
             BSONObjBuilder b( o.objsize() + 32 );
             BSONArrayBuilder updates( b.subarrayStart( "applyOps" ) );
             updates.append( o );
@@ -96,7 +101,7 @@ public:
             BSONObj c = b.obj();
             
             BSONObj res;
-            bool ok = conn().runCommand( "admin" , c , res );
+            bool ok = conn().runCommand( dbname , c , res );
             if ( print || ! ok )
                 log() << res << endl;
         }


### PR DESCRIPTION
Thanks for making this great utility. We've found mongooplog extremely useful. However, before we can switch on 2.2,  we still need to use it on older instances.

So, we started use this patched mongooplog, which was tested on 1.8.5, 2.0.7, and 2.2.0 mongodb versions. Hopefully, you'll find the patch useful.

Thank you!
