### PR TITLE
Add $setIfAbsent modifier

### DIFF
--- a/src/mongo/db/ops/update_internal.cpp
+++ b/src/mongo/db/ops/update_internal.cpp
@@ -29,8 +29,9 @@
 
 namespace mongo {
 
-    const char* Mod::modNames[] = { "$inc", "$set", "$push", "$pushAll", "$pull", "$pullAll" , "$pop", "$unset" ,
-                                    "$bitand" , "$bitor" , "$bit" , "$addToSet", "$rename", "$rename"
+    const char* Mod::modNames[] = { "$inc", "$set", "$setIfAbsent", "$push", "$pushAll", "$pull", "$pullAll" ,
+    								"$pop", "$unset", "$bitand" , "$bitor" , "$bit" , "$addToSet", "$rename",
+    								"$rename"
                                   };
     unsigned Mod::modNamesNum = sizeof(Mod::modNames)/sizeof(char*);
 
@@ -101,6 +102,7 @@ namespace mongo {
             break;
         }
 
+        case SET_IF_ABSENT:
         case SET: {
             _checkForAppending( elt );
             builder.appendAs( elt , shortFieldName );
@@ -413,6 +415,13 @@ namespace mongo {
                     }
                 }
                 break;
+
+            case Mod::SET_IF_ABSENT:
+            	// Can only stay in place if the previous value was null (i.e. no-op)
+            	mss->amIInPlacePossible( !e.isNull() );
+            	if (!e.isNull())
+            		ms.dontApply=true;
+            	break;
 
             case Mod::SET:
                 mss->amIInPlacePossible( m.elt.type() == e.type() &&

--- a/src/mongo/db/ops/update_internal.h
+++ b/src/mongo/db/ops/update_internal.h
@@ -36,8 +36,8 @@ namespace mongo {
      */
     struct Mod {
         // See opFromStr below
-        //        0    1    2     3         4     5          6    7      8       9       10    11        12           13
-        enum Op { INC, SET, PUSH, PUSH_ALL, PULL, PULL_ALL , POP, UNSET, BITAND, BITOR , BIT , ADDTOSET, RENAME_FROM, RENAME_TO } op;
+        //        0    1    2     3         4     5          6    7      8       9       10    11        12           13         14
+        enum Op { INC, SET, PUSH, PUSH_ALL, PULL, PULL_ALL , POP, UNSET, BITAND, BITOR , BIT , ADDTOSET, RENAME_FROM, RENAME_TO, SET_IF_ABSENT } op;
 
         static const char* modNames[];
         static unsigned modNamesNum;
@@ -258,8 +258,14 @@ namespace mongo {
                 break;
             }
             case 's': {
-                if ( fn[2] == 'e' && fn[3] == 't' && fn[4] == 0 )
-                    return Mod::SET;
+                if ( fn[2] == 'e' && fn[3] == 't') {
+                	if (fn[4] == 0 )
+                		return Mod::SET;
+                	else if (fn[4] == 'I' && fn[5] == 'f' && fn[6] == 'A'
+                			&& fn[7] == 'b' && fn[8] == 's' && fn[9] == 'e'
+                			&& fn[10] == 'n' && fn[11] == 't' && fn[12] == 0)
+                		return Mod::SET_IF_ABSENT;
+                }
                 break;
             }
             case 'p': {
@@ -563,6 +569,7 @@ namespace mongo {
                 // no-op b/c unset/pull of nothing does nothing
                 break;
 
+            case Mod::SET_IF_ABSENT:
             case Mod::INC:
                 ms.fixedOpName = "$set";
             case Mod::SET: {


### PR DESCRIPTION
Found myself wanting to set an initial value on _insert only_ and/or later if a particular value was not present.  I had some trouble identifying how to do it atomically without a couple steps, trips to the server or weird edge cases to handle in-between.

I've implemented a $setIfAbsent modifier for project consideration that works well on update as well findAndModify operations.  See simple example below for atomic creation/modified timestamps:

> db.steve.update({"_id" : 17}, { $set : { "modified" : new Date()}, $inc : { "counter" : 1 }, $setIfAbsent : {"created" : new Date()}}, true);

{ "_id" : 17, "counter" : 1, "created" : ISODate("2012-09-04T00:39:54.103Z"), "modified" : ISODate("2012-09-04T00:39:54.103Z") }

> db.steve.update({"_id" : 17}, { $set : { "modified" : new Date()}, $inc : { "counter" : 1 }, $setIfAbsent : {"created" : new Date()}}, true);

{ "_id" : 17, "counter" : 2, "created" : ISODate("2012-09-04T00:39:54.103Z"), "modified" : ISODate("2012-09-04T00:40:41.569Z") }
