### PR TITLE
SERVER-7017 - Fix for overrun when copy collection

### DIFF
--- a/src/mongo/db/namespace_details.cpp
+++ b/src/mongo/db/namespace_details.cpp
@@ -862,7 +862,7 @@ namespace mongo {
                         }
                     }
                 else
-                     newIndexSpecB << "ns" << to;
+                    newIndexSpecB << "ns" << to;
             }
             BSONObj newIndexSpec = newIndexSpecB.done();
             DiskLoc newIndexSpecLoc = theDataFileMgr.insert( s.c_str(), newIndexSpec.objdata(), newIndexSpec.objsize(), true, false );


### PR DESCRIPTION
Fix for the overrun of a namespace when copying collection. 

Check that the new total length of a namespace will be less than 119.

119 is 128 chars, -6 for $extra, -2 for $. and -1 for terminator 
