### PR TITLE
Fix scons option "use-system-sm" does not work correctly

### DIFF
--- a/src/mongo/SConscript
+++ b/src/mongo/SConscript
@@ -175,7 +175,7 @@ env.CppUnitTest('bson_template_evaluator_test', ['scripting/bson_template_evalua
 
 if usesm:
     env.StaticLibrary('scripting', scripting_common_files + ['scripting/engine_spidermonkey.cpp'],
-                      LIBDEPS=['$BUILD_DIR/third_party/js-1.7/js', 'bson_template_evaluator'])
+                      LIBDEPS=['$BUILD_DIR/third_party/shim_spidermonkey', 'bson_template_evaluator'])
 elif usev8:
     env.StaticLibrary('scripting', scripting_common_files + ['scripting/engine_v8.cpp',
                                                              'scripting/v8_db.cpp',

--- a/src/third_party/SConscript
+++ b/src/third_party/SConscript
@@ -32,13 +32,14 @@ else:
     env.SConscript('snappy/SConscript')
     env.StaticLibrary('shim_snappy', ['shim_snappy.cpp'], LIBDEPS=['snappy/snappy'])
 
+if windows:
+    env.Append(CPPDEFINES=['XP_WIN'])
+else:
+    env.Append(CPPDEFINES=['XP_UNIX'])
+
 if use_system_version_of_library("sm"):
     env.StaticLibrary("shim_spidermonkey", ['shim_spidermonkey.cpp'], SYSLIBDEPS=['js'])
 else:
-    if windows:
-        env.Append(CPPDEFINES=['XP_WIN'])
-    else:
-        env.Append(CPPDEFINES=['XP_UNIX'])
     env.Append(CPPPATH='$BUILD_DIR/third_party/js-1.7')
     env.SConscript('js-1.7/SConscript')
     env.StaticLibrary('shim_spidermonkey', ['shim_spidermonkey.cpp'], LIBDEPS=['js-1.7/js'])


### PR DESCRIPTION
1. XP_UNIX, ... should be defined for both of use-system-sm and not (src/third_party/SConscript)
2. scripting engine should link to shim_spidermonkey, not libjs.a (src/mongo/SConscript)

error messages:
1. XP_UNIX, ... should be defined for both of use-system-sm and not (src/third_party/SConscript)
   
   ```
   $ scons --use-system-sm --extralib=js
     :
   ar rc build/darwin/cpppath__opt_local_include_js/extralib_js/use-system-sm/m
   ongo/libmongodandmongos.a build/darwin/cpppath__opt_local_include_js/extrali
   b_js/use-system-sm/mongo/db/connection_factory.o build/darwin/cpppath__opt_l
   ocal_include_js/extralib_js/use-system-sm/mongo/util/net/message_server_port
   .o
   in file included from src/third_party/js-1.7/jspubtd.h:45,
                    from src/third_party/js-1.7/jsapi.h:47,
                    from src/mongo/scripting/engine_spidermonkey.h:32,
                    from src/mongo/scripting/engine_spidermonkey.cpp:20:
   src/third_party/js-1.7/jstypes.h:248:6: error: #error "must define one of xp
   _beos, xp_os2, xp_win or xp_unix"
   src/third_party/js-1.7/jstypes.h:264:2: error: #error no suitable type for j
   sint8/jsuint8
   src/third_party/js-1.7/jstypes.h:277:2: error: #error no suitable type for j
   sint16/jsuint16
     :
   scons: *** [build/darwin/cpppath__opt_local_include_js/extralib_js/use-syste
   m-sm/mongo/scripting/engine_spidermonkey.o] error 1
   scons: building terminated because of errors.
   ```
2. scripting engine should link to shim_spidermonkey, not libjs.a (src/mongo/SConscript)
   
   ```
   $ scons --use-system-sm --extralib=js
     :
   scons: *** [build/darwin/cpppath__opt_local_include_js/extralib_js/use-syste
   m-sm/mongo/mongod] Implicit dependency `src/third_party/js-1.7/libjs.a' not 
   found, needed by target `build/darwin/cpppath__opt_local_include_js/extralib
   _js/use-system-sm/mongo/mongod'.
   scons: building terminated because of errors.
   ```
