### PR TITLE
SERVER-2033: Adding support for skip and limits within the mongoexport tool

### DIFF
--- a/src/mongo/tools/export.cpp
+++ b/src/mongo/tools/export.cpp
@@ -45,6 +45,8 @@ public:
         ("jsonArray", "output to a json array rather than one object per line")
         ("slaveOk,k", po::value<bool>()->default_value(true) , "use secondaries for export if available, default true")
         ("forceTableScan", "force a table scan (do not use $snapshot)" )
+        ("skip", po::value<int>()->default_value(0), "documents to skip, default 0")
+        ("limit", po::value<int>()->default_value(0), "limit the numbers of documents returned, default all")
         ;
         _usesstdout = false;
     }
@@ -197,7 +199,7 @@ public:
 
         bool slaveOk = _params["slaveOk"].as<bool>();
 
-        auto_ptr<DBClientCursor> cursor = conn().query( ns.c_str() , q , 0 , 0 , fieldsToReturn , ( slaveOk ? QueryOption_SlaveOk : 0 ) | QueryOption_NoCursorTimeout );
+        auto_ptr<DBClientCursor> cursor = conn().query( ns.c_str() , q , getParam("limit", 0), getParam("skip", 0) , fieldsToReturn , ( slaveOk ? QueryOption_SlaveOk : 0 ) | QueryOption_NoCursorTimeout );
 
         if ( csv ) {
             for ( vector<string>::iterator i=_fields.begin(); i != _fields.end(); i++ ) {


### PR DESCRIPTION
I've added a couple of options to the mongoexport tool allowing the user to specify "--limit" and "--skip" parameters in order to grab a subset of results back from the database.

I didn't see a place to create/run tests, but I did compile a local copy with `scons tools` and played around with it for quite a bit. My team will be using this executable until these features are integrated. If there's something else needed before this can be integrated, let me know and I'll get it done. :wink:

https://jira.mongodb.org/browse/SERVER-2033
http://stackoverflow.com/questions/7631943/how-to-give-limit-in-mongoexport-in-mongodb
https://groups.google.com/forum/?fromgroups=#!topic/mongodb-user/idv5Cwpdmjk
