### PR TITLE
Update src/mongo/tools/tool.cpp

### DIFF
--- a/src/mongo/tools/tool.cpp
+++ b/src/mongo/tools/tool.cpp
@@ -241,8 +241,8 @@ namespace mongo {
                 cerr << endl << "If you are running a mongod on the same "
                      "path you should connect to that instead of direct data "
                      "file access" << endl << endl;
-                dbexit( EXIT_CLEAN );
-                ::_exit(-1);
+                dbexit( EXIT_FS );
+                ::_exit(EXIT_FAILURE);
             }
 
             FileAllocator::get()->start();


### PR DESCRIPTION
SERVER-1994: Change the exit code from 0 when the tools are given a bad dbpath.  

EXIT_FAILURE could not be passed to dbexit, but EXIT_FS should be acceptable.

Tested on mongodump and mongorestore successfully.
