### PR TITLE
Allow "show databases" as alias for "show dbs".

### DIFF
--- a/src/mongo/shell/utils.js
+++ b/src/mongo/shell/utils.js
@@ -1471,7 +1471,7 @@ shellHelper.show = function (what) {
         return "";
     }
 
-    if (what == "dbs") {
+    if (what == "dbs" || what == "databases") {
         var dbs = db.getMongo().getDBs();
         var size = {};
         dbs.databases.forEach(function (x) { size[x.name] = x.sizeOnDisk; });


### PR DESCRIPTION
MySQL users are used to "databases". I often make the mistake myself, and have
seen various speakers and users wondering why "show databases" is actually
"show dbs".  The last time just in talk I am sitting in now.
