### PR TITLE
SERVER-7485 Allow ranges in the delay argument in mongobridge

### DIFF
--- a/src/mongo/tools/bridge.cpp
+++ b/src/mongo/tools/bridge.cpp
@@ -31,6 +31,8 @@ using namespace std;
 
 int port = 0;
 int delay = 0;
+int delayBegin = 0;
+int delayEnd = 0;
 string destUri;
 void cleanup( int sig );
 
@@ -52,7 +54,13 @@ public:
                     mp_.shutdown();
                     break;
                 }
-                sleepmillis( delay );
+
+                if ( delayBegin && delayEnd ) {
+                    sleepmillis( delayBegin + ( rand() % ( delayEnd - delayBegin ) ) );
+                }
+                else if ( delay ) {
+                    sleepmillis( delay );
+                }
 
                 int oldId = m.header()->id;
                 if ( m.operation() == dbQuery || m.operation() == dbMsg || m.operation() == dbGetMore ) {
@@ -168,7 +176,14 @@ int main( int argc, char **argv, char** envp ) {
             destUri = argv[ ++i ];
         }
         else if ( strcmp( argv[ i ], "--delay" ) == 0 ) {
-            delay = strtol( argv[ ++i ], 0, 10 );
+            i++;
+            if ( strchr( argv[ i ], '-' ) != NULL ) {
+               delayBegin = strtol( argv[ i ], 0, 10 );
+               delayEnd = strtol( strchr( argv[ i ], '-' ) + 1, 0, 10 );
+            }
+            else {
+               delay = strtol( argv[ i ], 0, 10 );
+            }
         }
         else {
             check( false );


### PR DESCRIPTION
Each query passing through will be delayed by a random value between
the start and end delay value. This extends the functionality that was added
in https://github.com/mongodb/mongo/pull/257 and extends --delay 30
to --delay 10-40.
