### PR TITLE
Fix timing bug in Mongodb replicaset configuration (init.d)

### DIFF
--- a/debian/init.d
+++ b/debian/init.d
@@ -115,6 +115,11 @@ running() {
     [ ! -f "$PIDFILE" ] && return 1
     pid=`cat $PIDFILE`
     running_pid $pid $DAEMON || return 1
+    for i in `seq 1 20`; do
+      nc -z localhost <%= node['mongodb']['port'] %> && return 0
+      echo -n "."
+      sleep 15
+    done
     return 0
 }
 


### PR DESCRIPTION
Since start_server() and restart_server() do not actually verify whether the
port is open and receiving connections (even though mongo starts up,
pre-alloc/other setup takes a few minutes), the replicaset recipe was failing to
establish a connection with the db. The change to the initd file waits for the
port to be open before proceeding, ensuring that the replicaset recipe will
work.

Fixes: https://github.com/edelight/chef-mongodb/issues/17
References: https://github.com/edelight/chef-mongodb/pull/43
