### PR TITLE
SERVER-7557 One obj key being $ref or $id shouldn't make the whole obj okForStorage.

### DIFF
--- a/src/mongo/db/jsobj.cpp
+++ b/src/mongo/db/jsobj.cpp
@@ -873,10 +873,9 @@ namespace mongo {
 
             if ( strchr( name , '.' ) ||
                     strchr( name , '$' ) ) {
-                return
-                    strcmp( name , "$ref" ) == 0 ||
-                    strcmp( name , "$id" ) == 0
-                    ;
+                if ( strcmp( name , "$ref" ) != 0 &&
+                     strcmp( name , "$id" ) != 0 )
+                  return false;
             }
 
             if ( e.mayEncapsulate() ) {

--- a/src/mongo/dbtests/jsobjtests.cpp
+++ b/src/mongo/dbtests/jsobjtests.cpp
@@ -2044,6 +2044,9 @@ namespace JsobjTests {
 
             good( "{x:{a:2}}" );
             bad( "{x:{'$a':2}}" );
+
+            good( "{$ref:1}" );
+            bad( "{$ref:1,$a:2}" );
         }
     };
 


### PR DESCRIPTION
I added a test for this and confirmed that `./test` passes.

Original bug was added in https://github.com/mongodb/mongo/commit/c9ed60974d3a795a25353f3790d6af6093bfad3d
