### PR TITLE
initialize ProcessInfo::SystemInfo at startup, add pageSize

### DIFF
--- a/src/mongo/SConscript
+++ b/src/mongo/SConscript
@@ -134,9 +134,13 @@ if not os.path.exists( str( processInfoPlatformFile ) ):
 
 processInfoFiles.append( processInfoPlatformFile )
 
-commonFiles += processInfoFiles
+env.StaticLibrary("processinfo",
+                  processInfoFiles,
+                  LIBDEPS=["foundation", "bson"])
 
-
+env.CppUnitTest("processinfo_test",
+                ["util/processinfo_test.cpp"],
+                LIBDEPS=["processinfo"])
 
 env.StaticLibrary("fail_point",
                   ["util/fail_point.cpp",
@@ -148,6 +152,7 @@ env.StaticLibrary('mongocommon', commonFiles,
                   LIBDEPS=['bson',
                            'foundation',
                            'md5',
+                           'processinfo',
                            'stacktrace',
                            'stringutils',
                            'fail_point',

--- a/src/mongo/util/processinfo.cpp
+++ b/src/mongo/util/processinfo.cpp
@@ -15,9 +15,10 @@
  *    limitations under the License.
  */
 
-#include "pch.h"
-#include "processinfo.h"
-#include "mmap.h"
+#include "mongo/pch.h"
+
+#include "mongo/base/init.h"
+#include "mongo/util/processinfo.h"
 
 #include <iostream>
 #include <fstream>
@@ -47,7 +48,17 @@ namespace mongo {
         pidFileWiper.write( path );
     }
 
-    // static lock for sysinfo initialization
-    mongo::mutex ProcessInfo::_sysInfoLock( "hostInfo" );
+    ProcessInfo::SystemInfo* ProcessInfo::systemInfo = NULL;
+
+    void ProcessInfo::initializeSystemInfo() {
+        if (systemInfo == NULL) {
+            systemInfo = new SystemInfo();
+        }
+    }
+
+    MONGO_INITIALIZER(SystemInfo)(InitializerContext* context) {
+        ProcessInfo::initializeSystemInfo();
+        return Status::OK();
+    }
 
 }

--- a/src/mongo/util/processinfo.h
+++ b/src/mongo/util/processinfo.h
@@ -77,6 +77,11 @@ namespace mongo {
         const unsigned getNumCores() const { return sysInfo().numCores; }
 
         /**
+         * Get the system page size in bytes.
+         */
+        static unsigned long long getPageSize() { return systemInfo->pageSize; }
+
+        /**
          * Get the CPU architecture (e.g. x86, x86_64)
          */
         const string& getArch() const { return sysInfo().cpuArch; }
@@ -116,6 +121,7 @@ namespace mongo {
             unsigned addrSize;
             unsigned long long memSize;
             unsigned numCores;
+            unsigned long long pageSize;
             string cpuArch;
             bool hasNuma;
             BSONObj _extraStats;
@@ -123,6 +129,7 @@ namespace mongo {
                     addrSize( 0 ),
                     memSize( 0 ),
                     numCores( 0 ),
+                    pageSize( 0 ),
                     hasNuma( false ) { 
                 // populate SystemInfo during construction
                 collectSystemInfo();
@@ -137,18 +144,14 @@ namespace mongo {
 
         static bool checkNumaEnabled();
 
-        const SystemInfo& sysInfo() const {
-            // initialize and collect sysInfo on first call
-            // TODO: SERVER-5112
-            static ProcessInfo::SystemInfo *initSysInfo = NULL;
-            if ( ! initSysInfo ) {
-                scoped_lock lk( _sysInfoLock );
-                if ( ! initSysInfo ) {
-                    initSysInfo = new SystemInfo();
-                }
-            }
-            return *initSysInfo;
+        static ProcessInfo::SystemInfo* systemInfo;
+
+        inline const SystemInfo& sysInfo() const {
+            return *systemInfo;
         }
+
+    public:
+        static void initializeSystemInfo();
 
     };
 

--- a/src/mongo/util/processinfo_darwin.cpp
+++ b/src/mongo/util/processinfo_darwin.cpp
@@ -158,6 +158,7 @@ namespace mongo {
         addrSize = (getSysctlByName< NumberVal >( "hw.cpu64bit_capable" ) ? 64 : 32);
         memSize = getSysctlByName< NumberVal >( "hw.memsize" );
         numCores = getSysctlByName< NumberVal >( "hw.ncpu" ); // includes hyperthreading cores
+        pageSize = static_cast<unsigned long long>(sysconf( _SC_PAGESIZE ));
         cpuArch = getSysctlByName< string >( "hw.machine" );
         hasNuma = checkNumaEnabled();
         

--- a/src/mongo/util/processinfo_freebsd.cpp
+++ b/src/mongo/util/processinfo_freebsd.cpp
@@ -136,6 +136,8 @@ namespace mongo {
             log() << "Unable to collect Number of CPUs. (errno: "
                   << errno << " msg: " << strerror(errno) << ")" << endl;
 
+        pageSize = static_cast<unsigned long long>(sysconf(_SC_PAGESIZE));
+
         hasNuma = checkNumaEnabled();
     }
 

--- a/src/mongo/util/processinfo_linux2.cpp
+++ b/src/mongo/util/processinfo_linux2.cpp
@@ -406,6 +406,7 @@ namespace mongo {
         memSize = LinuxSysHelper::getSystemMemorySize();
         addrSize = (string( unameData.machine ).find( "x86_64" ) != string::npos ? 64 : 32);
         numCores = cpuCount;
+        pageSize = static_cast<unsigned long long>(sysconf( _SC_PAGESIZE ));
         cpuArch = unameData.machine;
         hasNuma = checkNumaEnabled();
         
@@ -419,7 +420,7 @@ namespace mongo {
         bExtra.append( "kernelVersion", unameData.release );
         bExtra.append( "cpuFrequencyMHz", cpuFreq);
         bExtra.append( "cpuFeatures", cpuFeatures);
-        bExtra.append( "pageSize", static_cast< int >(sysconf( _SC_PAGESIZE ) ) );
+        bExtra.append( "pageSize", static_cast<long long>(pageSize) );
         bExtra.append( "numPages", static_cast< int >(sysconf( _SC_PHYS_PAGES ) ) );
         bExtra.append( "maxOpenFiles", static_cast< int >(sysconf( _SC_OPEN_MAX ) ) );
 

--- a/src/mongo/util/processinfo_test.cpp
+++ b/src/mongo/util/processinfo_test.cpp
@@ -1,0 +1,29 @@
+/**
+ *    Copyright (C) 2012 10gen Inc.
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under the terms of the GNU Affero General Public License, version 3,
+ *    as published by the Free Software Foundation.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "mongo/unittest/unittest.h"
+#include "mongo/util/processinfo.h"
+
+using mongo::ProcessInfo;
+
+namespace mongo_test {
+    TEST(ProcessInfo, SysInfoIsInitialized) {
+        ProcessInfo processInfo;
+        if (processInfo.supported()) {
+            ASSERT_FALSE(processInfo.getOsType().empty());
+        }
+    }
+}

--- a/src/mongo/util/processinfo_win32.cpp
+++ b/src/mongo/util/processinfo_win32.cpp
@@ -106,7 +106,8 @@ namespace mongo {
         GetNativeSystemInfo( &ntsysinfo );
         addrSize = (ntsysinfo.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64 ? 64 : 32);
         numCores = ntsysinfo.dwNumberOfProcessors;
-        bExtra.append( "pageSize", static_cast< int >(ntsysinfo.dwPageSize) );
+        pageSize = static_cast<unsigned long long>(ntsysinfo.dwPageSize);
+        bExtra.append("pageSize", static_cast<long long>(pageSize));
 
         // get memory info
         mse.dwLength = sizeof( mse );


### PR DESCRIPTION
Change how ProcessInfo is initialized in preparation for https://jira.mongodb.org/browse/SERVER-7570.

System-wide info in ProcessInfo is currently initialized lazily because there was no support for initialization at startup time. The new code leverages MONGO_INITIALIZER\* (https://jira.mongodb.org/browse/SERVER-5112) to create a single instance of ProcessInfo::SystemInfo at startup.
