### PR TITLE
change if position to speed up

### DIFF
--- a/src/mongo/client/dbclient_rs.cpp
+++ b/src/mongo/client/dbclient_rs.cpp
@@ -592,7 +592,7 @@ namespace mongo {
             }
 
             double state = member["state"].Number();
-            if (member["health"].Number() == 1 && (state == 1 || state == 2)) {
+            if ((state == 1 || state == 2) && member["health"].Number() == 1) {
                 LOG(1) << "dbclient_rs nodes["<<m<<"].ok = true " << host << endl;
                 scoped_lock lk( _lock );
                 _nodes[m].ok = true;


### PR DESCRIPTION
checking state == 1 || state == 2 is cheap operation compareing to member["health"].Number(), so changing if condition position is better
