### PR TITLE
get accessors for bsonSize and topSize in btree BucketBasics

### DIFF
--- a/src/mongo/db/btree.h
+++ b/src/mongo/db/btree.h
@@ -377,6 +377,14 @@ namespace mongo {
         int nKeys() const { return this->n; }
         const DiskLoc getNextChild() const { return this->nextChild; }
 
+        // for tree inspection and statistical analysis
+        // NOTE: topSize and emptySize have different types in BtreeData_V0 and BtreeData_V1
+
+        /** Size used for bson storage, including storage of old keys. */
+        unsigned int getTopSize() const { return static_cast<unsigned int>(this->topSize); }
+        /** Size of the empty region. */
+        unsigned int getEmptySize() const { return static_cast<unsigned int>(this->emptySize); }
+
     protected:
         char * dataAt(short ofs) { return this->data + ofs; }
 


### PR DESCRIPTION
This fixes https://jira.mongodb.org/browse/SERVER-7571.
