### PR TITLE
SERVER-7570 changed ProcessInfo::blockInMemory to leverage getPageSize, added pagesInMemory

### DIFF
--- a/src/mongo/db/record.cpp
+++ b/src/mongo/db/record.cpp
@@ -461,7 +461,7 @@ namespace mongo {
         if (seen || ps::rolling[ps::bigHash(region)].access( region , offset , false ) ) {
         
 #ifdef _DEBUG
-            if ( blockSupported && ! ProcessInfo::blockInMemory( const_cast<char*>(data) ) ) {
+            if ( blockSupported && ! ProcessInfo::blockInMemory(data) ) {
                 warning() << "we think data is in ram but system says no"  << endl;
             }
 #endif

--- a/src/mongo/util/processinfo.h
+++ b/src/mongo/util/processinfo.h
@@ -107,7 +107,27 @@ namespace mongo {
 
         static bool blockCheckSupported();
 
-        static bool blockInMemory( char * start );
+        static bool blockInMemory(const void* start);
+
+        /**
+         * @return a pointer aligned to the start of the page the provided pointer belongs to.
+         *
+         * NOTE requires blockCheckSupported() == true
+         */
+        inline static const void* alignToStartOfPage(const void* ptr) {
+            return reinterpret_cast<const void*>(
+                    reinterpret_cast<unsigned long long>(ptr) & ~(getPageSize() - 1));
+        }
+
+        /**
+         * Sets i-th element of 'out' to non-zero if the i-th page starting from the one containing
+         * 'start' is in memory.
+         * The 'out' vector will be resized to fit the requested number of pages.
+         * @return true on success, false otherwise
+         *
+         * NOTE: requires blockCheckSupported() == true
+         */
+        static bool pagesInMemory(const void* start, size_t numPages, vector<char>* out);
 
     private:
         /**

--- a/src/mongo/util/processinfo_linux2.cpp
+++ b/src/mongo/util/processinfo_linux2.cpp
@@ -451,19 +451,26 @@ namespace mongo {
         return true;
     }
 
-    bool ProcessInfo::blockInMemory( char * start ) {
-        static long pageSize = 0;
-        if ( pageSize == 0 ) {
-            pageSize = sysconf( _SC_PAGESIZE );
-        }
-        start = start - ( (unsigned long long)start % pageSize );
+    bool ProcessInfo::blockInMemory(const void* start) {
         unsigned char x = 0;
-        if ( mincore( start , 128 , &x ) ) {
+        if (mincore(const_cast<void*>(alignToStartOfPage(start)), getPageSize(), &x)) {
             log() << "mincore failed: " << errnoWithDescription() << endl;
             return 1;
         }
         return x & 0x1;
     }
 
+    bool ProcessInfo::pagesInMemory(const void* start, size_t numPages, vector<char>* out) {
+        out->resize(numPages);
+        if (mincore(const_cast<void*>(alignToStartOfPage(start)), numPages * getPageSize(),
+                    reinterpret_cast<unsigned char*>(&out->front()))) {
+            log() << "mincore failed: " << errnoWithDescription() << endl;
+            return false;
+        }
+        for (size_t i = 0; i < numPages; ++i) {
+            (*out)[i] &= 0x1; 
+        }
+        return true;
+    }
 
 }

--- a/src/mongo/util/processinfo_none.cpp
+++ b/src/mongo/util/processinfo_none.cpp
@@ -57,9 +57,12 @@ namespace mongo {
         
     }
 
-    bool ProcessInfo::blockInMemory( char * start ) {
+    bool ProcessInfo::blockInMemory(const void* start) {
         verify(0);
-        return true;
+    }
+
+    bool ProcessInfo::pagesInMemory(const void* start, size_t numPages, vector<bool>* out) {
+        verify(0);
     }
 
 }

--- a/src/mongo/util/processinfo_test.cpp
+++ b/src/mongo/util/processinfo_test.cpp
@@ -14,6 +14,10 @@
  *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <vector>
+
+#include "boost/scoped_array.hpp"
+
 #include "mongo/unittest/unittest.h"
 #include "mongo/util/processinfo.h"
 
@@ -24,6 +28,40 @@ namespace mongo_test {
         ProcessInfo processInfo;
         if (processInfo.supported()) {
             ASSERT_FALSE(processInfo.getOsType().empty());
+        }
+    }
+
+    TEST(ProcessInfo, NonZeroPageSize) {
+        if (ProcessInfo::blockCheckSupported()) {
+            ASSERT_GREATER_THAN(ProcessInfo::getPageSize(), 0u);
+        }
+    }
+
+    const size_t PAGES = 10;
+
+    TEST(ProcessInfo, BlockInMemoryDoesNotThrowIfSupported) {
+        if (ProcessInfo::blockCheckSupported()) {
+            boost::scoped_array<char> ptr(new char[ProcessInfo::getPageSize() * PAGES]);
+            ProcessInfo::blockInMemory(ptr.get() + ProcessInfo::getPageSize() * 2);
+        }
+    }
+
+    TEST(ProcessInfo, PagesInMemoryIsSensible) {
+        if (ProcessInfo::blockCheckSupported()) {
+            static volatile char ptr[4096 * PAGES];
+            ptr[1] = 'a';
+            std::vector<char> result;
+            ASSERT_TRUE(ProcessInfo::pagesInMemory(const_cast<char*>(ptr), PAGES, &result));
+            ASSERT_TRUE(result[0]);
+            ASSERT_FALSE(result[1]);
+            ASSERT_FALSE(result[2]);
+            ASSERT_FALSE(result[3]);
+            ASSERT_FALSE(result[4]);
+            ASSERT_FALSE(result[5]);
+            ASSERT_FALSE(result[6]);
+            ASSERT_FALSE(result[7]);
+            ASSERT_FALSE(result[8]);
+            ASSERT_FALSE(result[9]);
         }
     }
 }

--- a/src/mongo/util/processinfo_win32.cpp
+++ b/src/mongo/util/processinfo_win32.cpp
@@ -200,7 +200,7 @@ namespace mongo {
         return psapiGlobal.supported;
     }
 
-    bool ProcessInfo::blockInMemory( char * start ) {
+    bool ProcessInfo::blockInMemory(const void* start) {
 #if 0
         // code for printing out page fault addresses and pc's --
         // this could be useful for targetting heavy pagefault locations in the code
@@ -216,12 +216,34 @@ namespace mongo {
         }
 #endif
         PSAPI_WORKING_SET_EX_INFORMATION wsinfo;
-        wsinfo.VirtualAddress = start;
+        wsinfo.VirtualAddress = const_cast<void*>(start);
         BOOL result = psapiGlobal.QueryWSEx( GetCurrentProcess(), &wsinfo, sizeof(wsinfo) );
         if ( result )
             if ( wsinfo.VirtualAttributes.Valid )
                 return true;
         return false;
+    }
+
+    bool ProcessInfo::pagesInMemory(const void* start, size_t numPages, vector<char>* out) {
+        out->resize(numPages);
+        scoped_array<PSAPI_WORKING_SET_EX_INFORMATION> wsinfo(
+                new PSAPI_WORKING_SET_EX_INFORMATION[numPages]);
+
+        const void* startOfFirstPage = alignToStartOfPage(start);
+        for (size_t i = 0; i < numPages; i++) {
+            wsinfo[i].VirtualAddress = reinterpret_cast<void*>(
+                    reinterpret_cast<unsigned long long>(startOfFirstPage) + i * getPageSize());
+        }
+
+        BOOL result = psapiGlobal.QueryWSEx(GetCurrentProcess(),
+                                            wsinfo.get(),
+                                            sizeof(PSAPI_WORKING_SET_EX_INFORMATION) * numPages);
+
+        if (!result) return false;
+        for (size_t i = 0; i < numPages; ++i) {
+            (*out)[i] = wsinfo[i].VirtualAttributes.Valid ? 1 : 0;
+        }
+        return true;
     }
 
 }


### PR DESCRIPTION
Fixes https://jira.mongodb.org/browse/SERVER-7570.

smokeCppUnittests pass on Linux, Darwin and Windows.
