### PR TITLE
fix test for ProcessInfo::blockInMemory/pagesInMemory to avoid failures on older *nixes

### DIFF
--- a/src/mongo/util/processinfo_none.cpp
+++ b/src/mongo/util/processinfo_none.cpp
@@ -61,7 +61,7 @@ namespace mongo {
         verify(0);
     }
 
-    bool ProcessInfo::pagesInMemory(const void* start, size_t numPages, vector<bool>* out) {
+    bool ProcessInfo::pagesInMemory(const void* start, size_t numPages, vector<char>* out) {
         verify(0);
     }
 


### PR DESCRIPTION
Also, fix build in Solaris.
