### PR TITLE
Defaulting the connection to localhost in case connected without any par...

### DIFF
--- a/src/mongo/client/dbclientinterface.h
+++ b/src/mongo/client/dbclientinterface.h
@@ -1116,8 +1116,9 @@ namespace mongo {
            false was returned -- it will try to connect again.
 
            @param serverHostname host to connect to.  can include port number ( 127.0.0.1 , 127.0.0.1:5555 )
+	   default to localhost.
         */
-        void connect(const string& serverHostname) {
+        void connect(const string& serverHostname = "localhost") {
             string errmsg;
             if( !connect(HostAndPort(serverHostname), errmsg) )
                 throw ConnectException(string("can't connect ") + errmsg);

--- a/src/mongo/client/examples/insert_demo.cpp
+++ b/src/mongo/client/examples/insert_demo.cpp
@@ -34,7 +34,7 @@ int main() {
     try {
         cout << "connecting to localhost..." << endl;
         DBClientConnection c;
-        c.connect("localhost");
+        c.connect();
         cout << "connected ok" << endl;
 
         bo o = BSON( "hello" << "world" );


### PR DESCRIPTION
This is done so that client doesnt have to explicitly specify localhost string or loopback IP.
