### PR TITLE
SERVER-7800 Fix "db.printSlaveReplicationInfo()" command in mongo shell, for replica sets.

### DIFF
--- a/src/mongo/shell/db.js
+++ b/src/mongo/shell/db.js
@@ -789,14 +789,30 @@ DB.prototype.printReplicationInfo = function() {
 }
 
 DB.prototype.printSlaveReplicationInfo = function() {
+    var startOptimeDate = null;
+
     function getReplLag(st) {
-        var now = new Date();
+        assert( startOptimeDate , "how could this be null (getReplLag startOptimeDate)" );
         print("\t syncedTo: " + st.toString() );
-        var ago = (now-st)/1000;
+        var ago = (startOptimeDate-st)/1000;
         var hrs = Math.round(ago/36)/100;
         print("\t\t = " + Math.round(ago) + " secs ago (" + hrs + "hrs)");
     };
-    
+
+    function getMaster(members) {
+        var found;
+        members.forEach(function(row) {
+            if (row.self) {
+                found = row;
+                return false;
+            }
+        });
+
+        if (found) {
+            return found;
+        }
+    };
+
     function g(x) {
         assert( x , "how could this be null (printSlaveReplicationInfo gx)" )
         print("source:   " + x.host);
@@ -828,9 +844,11 @@ DB.prototype.printSlaveReplicationInfo = function() {
 
     if (L.system.replset.count() != 0) {
         var status = this.adminCommand({'replSetGetStatus' : 1});
+        startOptimeDate = getMaster(status.members).optimeDate; 
         status.members.forEach(r);
     }
     else if( L.sources.count() != 0 ) {
+        startOptimeDate = new Date();
         L.sources.find().forEach(g);
     }
     else {


### PR DESCRIPTION
It is wrong to compare current slave optime with time at this moment,
because some databases don't changes during some period of time.

Value which we must use to compare with current slave optime is -
master optime.
