### PR TITLE
SERVER-7831 reduce lock time with "nonAtomic" option.

### DIFF
--- a/src/mongo/db/commands/mr.cpp
+++ b/src/mongo/db/commands/mr.cpp
@@ -534,7 +534,6 @@ namespace mongo {
                 auto_ptr<DBClientCursor> cursor = _db.query( _config.tempLong , BSONObj() );
                 auto_ptr<Lock::GlobalWrite> globalWriteLock;
                 while ( cursor->more() ) {
-                    // nonAtomic option isset
                     // we can't use here separate locks between findOne() / upsert() / finalReduce()
                     if ( !_config.outNonAtomic ) {
                         globalWriteLock.reset( new Lock::GlobalWrite ); // TODO(erh) why global?


### PR DESCRIPTION
m/r: reduce post processing: patch for separate locks between findOne() / upsert() / finalReduce().

Merge too many documents, can take a long period of time,
and all of this time there is a global lock, we can avoid this,
with "{nonAtomic: true}" option.
This patch do this.
