### PR TITLE
SERVER-7862 Added configurable socketTimeout option to mongos.

### DIFF
--- a/src/mongo/db/cmdline.h
+++ b/src/mongo/db/cmdline.h
@@ -142,6 +142,7 @@ namespace mongo {
 
         SSLManager* sslServerManager; // currently leaks on close
 #endif
+        double defaultSocketTimeout;  // --socketTimeout in seconds
 
         /**
          * Switches to enable experimental (unsupported) features.
@@ -195,7 +196,7 @@ namespace mongo {
         durOptions(0), objcheck(false), oplogSize(0), defaultProfile(0),
         slowMS(100), defaultLocalThresholdMillis(15), pretouch(0), moveParanoia( true ),
         syncdelay(60), noUnixSocket(false), doFork(0), socket("/tmp"), maxConns(DEFAULT_MAX_CONN),
-        logAppend(false), logWithSyslog(false)
+        logAppend(false), logWithSyslog(false), defaultSocketTimeout(0)
     {
         started = time(0);
 

--- a/src/mongo/s/server.cpp
+++ b/src/mongo/s/server.cpp
@@ -324,6 +324,7 @@ static void processCommandLineOptions(const std::vector<std::string>& argv) {
     ( "configdb" , po::value<string>() , "1 or 3 comma separated config servers" )
     ( "localThreshold", po::value <int>(), "ping time (in ms) for a node to be "
                                            "considered local (default 15ms)" )
+    ( "socketTimeout", po::value <double>(), "default socket timeout (in seconds)" )
     ( "test" , "just run unit tests" )
     ( "upgrade" , "upgrade meta data version" )
     ( "chunkSize" , po::value<int>(), "maximum amount of data per chunk" )
@@ -382,6 +383,10 @@ static void processCommandLineOptions(const std::vector<std::string>& argv) {
 
     if ( params.count( "localThreshold" ) ) {
         cmdLine.defaultLocalThresholdMillis = params["localThreshold"].as<int>();
+    }
+
+    if ( params.count( "socketTimeout" ) ) {
+        cmdLine.defaultSocketTimeout = params["socketTimeout"].as<double>();
     }
 
     if ( params.count( "ipv6" ) ) {

--- a/src/mongo/s/shardconnection.cpp
+++ b/src/mongo/s/shardconnection.cpp
@@ -81,7 +81,7 @@ namespace mongo {
                 shardConnectionPool.onHandedOut( c.get() ); // May throw an exception
             } else {
                 s->created++;
-                c.reset( shardConnectionPool.get( addr ) );
+                c.reset( shardConnectionPool.get( addr, cmdLine.defaultSocketTimeout ) );
             }
             if ( !noauth ) {
                 c->setAuthenticationTable( ClientBasic::getCurrent()->getAuthenticationInfo()->
@@ -160,7 +160,7 @@ namespace mongo {
                     }
 
                     if( ! s->avail )
-                        s->avail = shardConnectionPool.get( sconnString );
+                        s->avail = shardConnectionPool.get( sconnString, cmdLine.defaultSocketTimeout );
 
                     versionManager.checkShardVersionCB( s->avail, ns, false, 1 );
                 } catch(...) { 


### PR DESCRIPTION
Although DBClient\* family classes support custom socket timeouts, mongos does not specify any. This can lead to hung queries in cases if mongos is running locally but mongod is running on remote host and a major networking issue takes place.

(associated Jira ticket: https://jira.mongodb.org/browse/SERVER-7862)

This patch adds a `--socketTimeout` opiton to mongos in a manner like `--localThreshold` option is handled.
