### PR TITLE
$split function

### DIFF
--- a/jstests/aggregation/testall.js
+++ b/jstests/aggregation/testall.js
@@ -3,7 +3,7 @@
 */
 
 /* load the test documents */
-load('jstests/aggregation/data/articles.js');
+load('data/articles.js');
 
 // make sure we're using the right db; this is the same as "use mydb;" in shell
 db = db.getSiblingDB("aggdb");
@@ -1007,6 +1007,43 @@ var p17result = [
 ];
 
 assert.eq(p17.result, p17result, 'p17 failed');
+
+
+//split test 1
+
+var pSplit1 = db.runCommand( 
+{ aggregate: 'article', pipeline: [
+    { $match: { _id : 2 } },
+    {$project:{  
+        splited : { $split: [ "$title", "is" ]}
+}} ]});
+
+var pSplit1result = [
+    {
+        "_id" : 2,
+        "splited" : ["th", " is your title"]
+    }
+];
+
+assert.eq(pSplit1.result, pSplit1result, 'pSplit1 failed');
+
+//split test 2: split string must be smaller than splitable element "aa".split("aaa") => Not Good
+
+var pSplit1 = db.runCommand( 
+{ aggregate: 'article', pipeline: [
+    { $match: { _id : 2 } },
+    {$project:{  
+        splited : { $split: [ "$title", "Extremely large string to be found" ]}
+}} ]});
+
+var pSplit1result = [
+    {
+        "_id" : 2,
+        "splited" : ["this is your title"]
+    }
+];
+
+assert.eq(pSplit1.result, pSplit1result, 'pSplit2 failed');
 
 
 // strcasecmp test

--- a/src/mongo/db/pipeline/expression.h
+++ b/src/mongo/db/pipeline/expression.h
@@ -1009,6 +1009,23 @@ namespace mongo {
     };
 
 
+    /*-------- Expression Split ------*/
+
+    class ExpressionSplit :
+            public ExpressionNary {
+        public:
+            // virtuals from ExpressionNary
+            virtual ~ExpressionSplit();
+            virtual Value evaluate(const Document& pDocument) const;
+            virtual const char *getOpName() const;
+            virtual void addOperand(const intrusive_ptr<Expression> &pExpression);
+
+            static intrusive_ptr<ExpressionNary> create();
+
+        private:
+            ExpressionSplit();
+        };
+
     class ExpressionStrcasecmp :
         public ExpressionNary {
     public:


### PR DESCRIPTION
Aggregation framework is missing a $split string function. The result of a split operation over a string should be an array with the split result and should operate. A bit like jira https://jira.mongodb.org/browse/SERVER-6773 but with a slight difference where you can set the pattern on which to split the string on.

The overall operation should be as follows:

db.collection.aggregate( {$project:  {  splited:{    $split: [   "string to be splited", "pattern"   }     }   }
The string to be splited could be a document field as weel as the spliting pattern. 
db.collection.aggregate( {$project:  {  splited:{    $split: [   "$field1", "$field2"   }     }   }
