### PR TITLE
Update src/mongo/scripting/engine_v8.cpp

### DIFF
--- a/src/mongo/scripting/engine_v8.cpp
+++ b/src/mongo/scripting/engine_v8.cpp
@@ -1453,7 +1453,7 @@ namespace mongo {
     void V8Scope::v8ToMongoInternal(BSONObjBuilder& b,
                                     const string& elementName,
                                     v8::Handle<v8::Object> obj) {
-        uint32_t bsonType = obj->GetInternalField( 0 )->ToUint32()->Value();
+        int32_t bsonType = obj->GetInternalField( 0 )->ToInt32()->Value();
         switch(bsonType) {
         case Timestamp:
             b.appendTimestamp(elementName,


### PR DESCRIPTION
I got a build error on line 1463 with clang++ -std=c++11.
If I'm not mistaken, MinKey's value is -1, which clang refuses to
compare with an uint32_t
