### PR TITLE
Fixed the problem that the start script not working on some machine with numactl installed.

### DIFF
--- a/debian/init.d
+++ b/debian/init.d
@@ -68,7 +68,7 @@ fi
 NUMACTL_ARGS="--interleave=all"
 if which numactl >/dev/null 2>/dev/null && numactl $NUMACTL_ARGS ls / >/dev/null 2>/dev/null
 then
-    NUMACTL="numactl $NUMACTL_ARGS"
+    NUMACTL="numactl $NUMACTL_ARGS --"
 else
     NUMACTL=""
 fi
@@ -120,9 +120,9 @@ running() {
 
 start_server() {
 # Start the process using the wrapper
-            start-stop-daemon --background --start --quiet --pidfile $PIDFILE \
+            $NUMACTL start-stop-daemon --background --start --quiet --pidfile $PIDFILE \
                         --make-pidfile --chuid $DAEMONUSER \
-                        --exec $NUMACTL $DAEMON -- $DAEMON_OPTS
+                        --exec $DAEMON -- $DAEMON_OPTS
             errcode=$?
 	return $errcode
 }


### PR DESCRIPTION
The init script does not work on my server (Debian 6.0.1).

After I installed numactl, the init script says:

> Starting database: mongodb start-stop-daemon: unrecognized option '--interleave=all'
> Try 'start-stop-daemon --help' for more information.
> failed!

Seems that the --interleave option was passed to start-stop-daemon rather than numactl.

According the solution I found at: http://stackoverflow.com/questions/11161308/starting-mongodb-via-numactl-as-daemon
I moved the numactl command BEFORE the start-stop-daemon command.

Related jira issue: SERVER-3574
