### PR TITLE
SERVER-6013 (for v2.0) Update rpm/mongo.spec

### DIFF
--- a/rpm/mongo.spec
+++ b/rpm/mongo.spec
@@ -126,8 +126,8 @@ fi
 %{_bindir}/mongos
 #%{_mandir}/man1/mongod.1*
 %{_mandir}/man1/mongos.1*
-/etc/rc.d/init.d/mongod
-/etc/sysconfig/mongod
+%config(noreplace) /etc/rc.d/init.d/mongod
+%config(noreplace) /etc/sysconfig/mongod
 #/etc/rc.d/init.d/mongos
 %attr(0755,mongod,mongod) %dir /var/lib/mongo
 %attr(0755,mongod,mongod) %dir /var/log/mongo


### PR DESCRIPTION
avoid overwriting customized files in /etc when updating
