### PR TITLE
SERVER-5008 SERVER-6013 (v2.0) avoid overwriting customized /etc/sysconfig/mongod when upgrading

### DIFF
--- a/rpm/mongo.spec
+++ b/rpm/mongo.spec
@@ -127,7 +127,7 @@ fi
 #%{_mandir}/man1/mongod.1*
 %{_mandir}/man1/mongos.1*
 /etc/rc.d/init.d/mongod
-/etc/sysconfig/mongod
+%config(noreplace) /etc/sysconfig/mongod
 #/etc/rc.d/init.d/mongos
 %attr(0755,mongod,mongod) %dir /var/lib/mongo
 %attr(0755,mongod,mongod) %dir /var/log/mongo


### PR DESCRIPTION
avoid overwriting customized /etc/sysconfig/mongod when upgrading
