### PR TITLE
SERVER-1970 mongofiles should allow the GridFS namespace to be set

### DIFF
--- a/src/mongo/tools/tool.cpp
+++ b/src/mongo/tools/tool.cpp
@@ -82,6 +82,12 @@ namespace mongo {
             ("collection,c",po::value<string>(), "collection to use (some commands)" )
             ;
 
+        if ( access & SPECIFY_GRIDFSNS )
+            _options->add_options()
+            ("db,d",po::value<string>(), "database to use" )
+            ("gridfsnamespace",po::value<string>(), "collection namespace prefix to use for GridFS operations")
+            ;
+
         _hidden_options = new po::options_description( name + " hidden options" );
 
         /* support for -vv -vvvv etc. */

--- a/src/mongo/tools/tool.h
+++ b/src/mongo/tools/tool.h
@@ -41,6 +41,7 @@ namespace mongo {
             REMOTE_SERVER = 1 << 1 ,
             LOCAL_SERVER = 1 << 2 ,
             SPECIFY_DBCOL = 1 << 3 ,
+            SPECIFY_GRIDFSNS = 1 << 4 ,
             ALL = REMOTE_SERVER | LOCAL_SERVER | SPECIFY_DBCOL
         };
 


### PR DESCRIPTION
Added a new DBAccess role for Tools to allow specifying the GridFS database and namespace.
