### PR TITLE
Fix precedence mismatch between stream/ternary operator.

### DIFF
--- a/src/mongo/util/version.cpp
+++ b/src/mongo/util/version.cpp
@@ -117,7 +117,7 @@ namespace mongo {
 #if( !defined(_MT) )
 #error _MT is not defined
 #endif
-        ss << (sizeof(char *) == 8) ? " 64bit" : " 32bit";
+        ss << (sizeof(char *) == 8 ? " 64bit" : " 32bit");
         return ss.str();
     }
 #else


### PR DESCRIPTION
Ternary operator has less precedence than stream operator.
