### PR TITLE
SERVER-8158: Fix erasing "\t" and " " from config file strings.

### DIFF
--- a/src/mongo/db/cmdline.cpp
+++ b/src/mongo/db/cmdline.cpp
@@ -143,8 +143,8 @@ namespace {
         while ( f ) {
             f.getline(line, MAX_LINE_LENGTH);
             s = line;
-            std::remove(s.begin(), s.end(), ' ');
-            std::remove(s.begin(), s.end(), '\t');
+            boost::algorithm::erase_all(s, " ");
+            boost::algorithm::erase_all(s, "\t");
             boost::to_upper(s);
 
             if ( s.find( "FASTSYNC" ) != string::npos )


### PR DESCRIPTION
std::remove doesn't actually delete elements from the container, it
only shunts non-deleted elements forwards on top of deleted elements
