### PR TITLE
SERVER-8159: Write backtrace error to log() instead of std::ostream.

### DIFF
--- a/src/mongo/util/stacktrace.cpp
+++ b/src/mongo/util/stacktrace.cpp
@@ -46,7 +46,7 @@ namespace mongo {
         strings = ::backtrace_symbols( b, size );
         if (strings == NULL) {
             const int err = errno;
-            os << "Unable to collect backtrace symbols (" << errnoWithDescription(err) << ")"
+            log() << "Unable to collect backtrace symbols (" << errnoWithDescription(err) << ")"
                << std::endl;
             return;
         }


### PR DESCRIPTION
For OS where backtrace_symbols is exist.
Like in win32 version of "printStackTrace()"
