### PR TITLE
fix bad error message when attempting to subtract date

### DIFF
--- a/jstests/aggregation/bugs/server6239.js
+++ b/jstests/aggregation/bugs/server6239.js
@@ -32,3 +32,11 @@ test({$add: ['$num', '$date']}, new Date(millis + num));
 // addition supports any number of arguments
 test({$add: ['$date']}, new Date(millis));
 test({$add: ['$num', '$date', '$num']}, new Date(millis + num + num));
+
+// test error message
+var errmsg = db.runCommand({aggregate: "s6239", pipeline: [
+  {$project: {error:
+    {$subtract: ['$num', '$date']}
+  }}
+]}).errmsg;
+assert.eq(errmsg, "exception: cant $subtract a Date from a NumberDouble")

--- a/src/mongo/db/pipeline/expression.cpp
+++ b/src/mongo/db/pipeline/expression.cpp
@@ -2507,7 +2507,7 @@ namespace mongo {
         else {
             if (rhs.getType()) {
                 uasserted(16614, str::stream() << "cant $subtract a Date from a "
-                                               << typeName(rhs.getType()));
+                                               << typeName(lhs.getType()));
             }
 
             uasserted(16556, "$subtract only supports numeric or Date types");


### PR DESCRIPTION
Currently, when you try to subtract a date from a number using the aggregation framework you get the confusing error message "exception: cant $subtract a Date from a Date".

Here's an example:

```
bigbrock(mongod-2.3.2-pre-) test> db.s6239.aggregate({
    $project: {out: {$subtract: [1, '$date']}}
});
Error: Printing Stack Trace
    at printStackTrace (src/mongo/shell/utils.js:37:7)
    at DBCollection.aggregate (src/mongo/shell/collection.js:866:1)
    at (shell):1:10
Tue Jan  8 17:29:36.095 javascript execution failed src/mongo/shell/collection.js:867 aggregate failed: {
  "errmsg": "exception: cant $subtract a Date from a Date",
  "code": 16614,
  "ok": 0
}
```

The error message was constructed using the wrong side of the subtraction. I've provided a fix and a test to confirm it works correctly.
