### PR TITLE
SERVER-6726 Add configuration to "mongos" to allow finer-grained control of the connection pool

### DIFF
--- a/src/mongo/client/connpool.cpp
+++ b/src/mongo/client/connpool.cpp
@@ -130,7 +130,7 @@ namespace mongo {
             StoredConnection c = _pool.top();
             _pool.pop();
             
-            if ( c.ok( now ) && all.size() < PoolForHost::_maxSpareConnPools)
+            if ( c.ok( now ) )
                 all.push_back( c );
             else
                 stale.push_back( c.conn );
@@ -167,7 +167,6 @@ namespace mongo {
   
     // if connection has been idle for 30 minutes, kill it
     unsigned PoolForHost::_connPoolTimeout = 1800; 
-    unsigned PoolForHost::_maxSpareConnPools = 50;
 
     // ------ DBConnectionPool ------
 

--- a/src/mongo/client/connpool.h
+++ b/src/mongo/client/connpool.h
@@ -90,9 +90,6 @@ namespace mongo {
         static void setConnPoolTimeout( unsigned timeout ) { _connPoolTimeout = timeout; }
         static unsigned getConnPoolTimeout() { return _connPoolTimeout; }
 
-        static void setMaxSpareConnPools( unsigned max ) { _maxSpareConnPools = max; }
-        static unsigned getMaxSpareConnPools() { return _maxSpareConnPools; }
-
     private:
 
         struct StoredConnection {

--- a/src/mongo/s/server.cpp
+++ b/src/mongo/s/server.cpp
@@ -335,8 +335,8 @@ static void processCommandLineOptions(const std::vector<std::string>& argv) {
     ( "ipv6", "enable IPv6 support (disabled by default)" )
     ( "jsonp","allow JSONP access via http (has security implications)" )
     ( "noscripting", "disable scripting engine" )
-    ( "maxSpareConnPools" , po::value<int>(), "maximum number of DB connection pools" )
-    ( "connPoolTimeout"   , po::value<int>(), "Limit of the idling time for DB connection pools" )
+    ( "connPoolMaxPerHost" , po::value<int>(), "maximum number of DB connection per host in pool" )
+    ( "connPoolTimeout"   , po::value<int>(), "Limit of the idling time for DB connections in pool" )
     ;
 
     visible_options.add(general_options);
@@ -381,10 +381,10 @@ static void processCommandLineOptions(const std::vector<std::string>& argv) {
           PoolForHost::setConnPoolTimeout(cpooltimeout);
         }
     }
-    if ( params.count( "maxSpareConnPools" ) ) {
-        int maxsparecpools = params["maxSpareConnPools"].as<int>();
-        if ( maxsparecpools > 0 ) {
-          PoolForHost::setMaxSpareConnPools(maxsparecpools);
+    if ( params.count( "connPoolMaxPerHost" ) ) {
+        int maxperhost = params["connPoolMaxPerHost"].as<int>();
+        if ( maxperhost > 0 ) {
+          PoolForHost::setMaxPerHost(maxperhost);
         }
     }
 


### PR DESCRIPTION
I merged my previous patch to current master and confirmed its effect.

Sincerely,

=== origin ===
https://github.com/mongodb/mongo/pull/278

I'm Hiroaki Kubota from rakuten.co.jp. (hiroaki.kubota@mail.rakuten.com)

We are using the MongoDB with sharding structure.
And connect to the Mongo-Sharding from approximates 100 web servers
(that have 50 httpd process per server).
We also run the "mongos" on each web server.

Normally the number of the connections between "mongs" and "mongod" is approximates 55.
It's the good form !
But sometimes, the number of the connections raise to 300-350 on every web server.
And the "mongod" would refuse to connect from "mongos" more than 20000 as the limit of the mongod.

So we want to control the connection pool in the "mongos".

You already provide us the "maxConns" configuration.
However "maxConns" affects client side of the "mongos".

It's useless for us.

So we added some configurations to control "mongos" more minutely.

maxSpareConnPools
50 is default.
It's used in PoolForHost::getStaleConnections()

connPoolTimeout
1800 is default.
It's used in PoolForHost::StoredConnection::ok()
It's hard coded now.

Please review it and accept this pull-request.

Regards,

To be related to https://jira.mongodb.org/browse/SERVER-6726
