### PR TITLE
Update src/mongo/db/ops/update_internal.cpp

### DIFF
--- a/src/mongo/db/ops/update_internal.cpp
+++ b/src/mongo/db/ops/update_internal.cpp
@@ -1215,7 +1215,7 @@ namespace mongo {
                          fieldName[0] != '$' || op == Mod::UNSET );
                 uassert( 10148,
                          "Mod on _id not allowed",
-                         strcmp( fieldName, "_id" ) != 0 );
+                         strcmp( fieldName, "_id" ) != 0 && op != Mod::SET_ON_INSERT);
                 uassert( 10149,
                          "Invalid mod field name, may not end in a period",
                          fieldName[ strlen( fieldName ) - 1 ] != '.' );


### PR DESCRIPTION
If a document does not have an _id, then it should be legal to write to that field in an update.  The need for this ability is documented in these two threads:

https://jira.mongodb.org/browse/SERVER-4175
https://jira.mongodb.org/browse/SERVER-340
