### PR TITLE
fix start when numactl is installed

### DIFF
--- a/debian/init.d
+++ b/debian/init.d
@@ -68,7 +68,7 @@ fi
 NUMACTL_ARGS="--interleave=all"
 if which numactl >/dev/null 2>/dev/null && numactl $NUMACTL_ARGS ls / >/dev/null 2>/dev/null
 then
-    NUMACTL="numactl $NUMACTL_ARGS"
+    NUMACTL="`which numactl` $NUMACTL_ARGS"
 else
     NUMACTL=""
 fi
@@ -120,9 +120,9 @@ running() {
 
 start_server() {
 # Start the process using the wrapper
-            start-stop-daemon --background --start --quiet --pidfile $PIDFILE \
+            $NUMACTL start-stop-daemon --background --start --quiet --pidfile $PIDFILE \
                         --make-pidfile --chuid $DAEMONUSER \
-                        --exec $NUMACTL $DAEMON -- $DAEMON_OPTS
+                        --exec $DAEMON -- $DAEMON_OPTS
             errcode=$?
 	return $errcode
 }


### PR DESCRIPTION
root@billy4:~# /etc/init.d/mongodb restart
Restarting database: mongodbstart-stop-daemon: unrecognized option
'--interleave=all'
Try 'start-stop-daemon --help' for more information.
 failed!
root@billy4:~#
