### PR TITLE
[SERVER-8602] Update the handling of an already locked cursor.

### DIFF
--- a/src/mongo/db/clientcursor.h
+++ b/src/mongo/db/clientcursor.h
@@ -73,7 +73,7 @@ namespace mongo {
                 recursive_scoped_lock lock( ccmutex );
                 ClientCursor *cursor = ClientCursor::find_inlock( cursorid, true );
                 if ( cursor ) {
-                    uassert( 12051, "clientcursor already in use? driver problem?",
+                    uassert( 12051, "clientcursor already in use.",
                             cursor->_pinValue < 100 );
                     cursor->_pinValue += 100;
                     _cursorid = cursorid;

--- a/src/mongo/db/instance.cpp
+++ b/src/mongo/db/instance.cpp
@@ -641,6 +641,7 @@ namespace mongo {
     }
 
     QueryResult* emptyMoreResult(long long);
+    QueryResult* emptyMoreResultWithCursor(long long);
 
     void OpTime::waitForDifferent(unsigned millis){
         mutex::scoped_lock lk(m);
@@ -761,7 +762,12 @@ namespace mongo {
                 return ok;
             }
 
-            msgdata = emptyMoreResult(cursorid);
+            if (ex->getCode() == 12051 ) { // Cursor was already locked.
+            	msgdata = emptyMoreResultWithCursor(cursorid);
+            }
+            else {
+                msgdata = emptyMoreResult(cursorid);
+            }
         }
 
         Message *resp = new Message();

--- a/src/mongo/db/ops/query.cpp
+++ b/src/mongo/db/ops/query.cpp
@@ -68,12 +68,12 @@ namespace mongo {
 
     //int dump = 0;
 
-    /* empty result for error conditions */
-    QueryResult* emptyMoreResult(long long cursorid) {
+    /* empty result for error conditions but keeps the cursor alive. */
+    QueryResult* emptyMoreResultWithCursor(long long cursorid) {
         BufBuilder b(32768);
         b.skip(sizeof(QueryResult));
         QueryResult *qr = (QueryResult *) b.buf();
-        qr->cursorId = 0; // 0 indicates no more data to retrieve.
+        qr->cursorId = cursorid;
         qr->startingFrom = 0;
         qr->len = b.len();
         qr->setOperation(opReply);
@@ -81,6 +81,11 @@ namespace mongo {
         qr->nReturned = 0;
         b.decouple();
         return qr;
+    }
+
+    /* empty result for error conditions */
+    QueryResult* emptyMoreResult(long long cursorid) {
+        return emptyMoreResultWithCursor(0); // 0 indicates no more data to retrieve.
     }
 
     QueryResult* processGetMore(const char* ns,


### PR DESCRIPTION
Updates the response to an already locked cursor on the server to not respond with a zero cursor id so that the client does not think the cursor is exhausted.

https://jira.mongodb.org/browse/SERVER-8602
