### PR TITLE
SERVER-6514 Fix mongoclient shared library build

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -708,9 +708,6 @@ if nix:
         except KeyError:
             pass
 
-    if linux and has_option( "sharedclient" ):
-        env.Append( LINKFLAGS=" -Wl,--as-needed -Wl,-zdefs " )
-
     if linux and has_option( "gcov" ):
         env.Append( CXXFLAGS=" -fprofile-arcs -ftest-coverage " )
         env.Append( LINKFLAGS=" -fprofile-arcs -ftest-coverage " )

--- a/debian/files
+++ b/debian/files
@@ -1,1 +1,0 @@
-mongodb_0.9.7_amd64.deb devel optional

--- a/debian/rules
+++ b/debian/rules
@@ -24,7 +24,7 @@ build-stamp: configure-stamp
 	dh_testdir
 
         # Add here commands to compile the package.
-	scons 
+	scons --sharedclient
         #docbook-to-man debian/mongodb.sgml > mongodb.1
 	ls debian/*.1 > debian/mongodb.manpages
 
@@ -64,7 +64,7 @@ install: build
 	dh_prep
 	dh_installdirs
 
-	scons --prefix=$(CURDIR)/debian/mongodb/usr install
+	scons --sharedclient --prefix=$(CURDIR)/debian/mongodb/usr install
 	mkdir -p $(CURDIR)/debian/mongodb/etc
 	cp $(CURDIR)/debian/mongodb.conf $(CURDIR)/debian/mongodb/etc/mongodb.conf 
 

--- a/src/SConscript.client
+++ b/src/SConscript.client
@@ -4,6 +4,7 @@
 # programs.
 
 Import('env clientEnv')
+Import("has_option")
 
 env.Command(['mongo/base/error_codes.h', 'mongo/base/error_codes.cpp',],
             ['mongo/base/generate_error_codes.py', 'mongo/base/error_codes.err'],
@@ -134,7 +135,13 @@ for path in clientHeaderDirectories:
     clientHeaders.extend(Glob('mongo/%s/*.h' % path))
     clientHeaders.extend(Glob('mongo/%s/*.hpp' % path))
 
-mongoclient_lib = env.Library('mongoclient', clientSource),
+if has_option( "sharedclient" ):
+    mongoclient_lib = env.SharedLibrary( "mongoclient", clientSource,
+            CPPFLAGS="-fPIC", LINKFLAGS=" -Wl,--as-needed -Wl,-zdefs -shared ")
+else:
+    mongoclient_lib = env.Library('mongoclient', clientSource),
+
+
 mongoclient_install = env.Install('#/', [
         mongoclient_lib,
         #env.SharedLibrary('mongoclient', clientSource),

--- a/src/mongo/SConscript
+++ b/src/mongo/SConscript
@@ -655,9 +655,6 @@ env.Library("clientandshell", ["client/clientAndShell.cpp"],
                                        "notmongodormongos"])
 env.Library("allclient", "client/clientOnly.cpp", LIBDEPS=["clientandshell"])
 
-if has_option( "sharedclient" ):
-    sharedClientLibName = str( env.SharedLibrary( "mongoclient", [], LIBDEPS=["allclient"] )[0] )
-
 # dbtests test binary
 env.StaticLibrary('testframework', ['dbtests/framework.cpp'], LIBDEPS=['unittest/unittest'])
 
@@ -804,9 +801,10 @@ if installSetup.headers:
 
 #lib
 if installSetup.libraries:
-    env.Install('$INSTALL_DIR/$NIX_LIB_DIR', '#${LIBPREFIX}mongoclient${LIBSUFFIX}')
     if has_option( "sharedclient" ):
         env.Install( "$INSTALL_DIR/$NIX_LIB_DIR",  '#${SHLIBPREFIX}mongoclient${SHLIBSUFFIX}')
+    else:
+        env.Install('$INSTALL_DIR/$NIX_LIB_DIR', '#${LIBPREFIX}mongoclient${LIBSUFFIX}')
 
 # Stage the top-level mongodb banners
 distsrc = env.Dir('#distsrc')


### PR DESCRIPTION
fixing and relocating mongoclient shared library build target, such that both, static and shared are declared at the same location. The command:

  scons --sharedclient mongoclient

now builds again a shared mongoclient version instead of always building the static one.
