### PR TITLE
SERVER-9237 put a warning message to log if 'rest' option is overridden by 'nohttpinterface'

### DIFF
--- a/src/mongo/db/db.cpp
+++ b/src/mongo/db/db.cpp
@@ -278,7 +278,11 @@ namespace mongo {
 
         logStartup();
         startReplication();
-        if ( !noHttpInterface )
+        if ( noHttpInterface ) {
+            if (cmdLine.rest)
+                log() << "note: 'rest' option is overridden by 'nohttpinterface', REST interface will not be enabled" << endl;
+        }
+        else
             boost::thread web( boost::bind(&webServerThread, new RestAdminAccess() /* takes ownership */));
 
 #if(TESTEXHAUST)


### PR DESCRIPTION
It cost me ~30min to find out why since the option override is silenced.

https://jira.mongodb.org/browse/SERVER-9237
