### PR TITLE
SERVER-9253 `rpm/init.d-mongod stop` unnecessarily sleeps for 5mn

### DIFF
--- a/rpm/init.d-mongod
+++ b/rpm/init.d-mongod
@@ -54,16 +54,36 @@ start()
 
 stop()
 {
-  echo -n $"Stopping mongod: "
-  killproc -p "$PIDFILE" -d 300 /usr/bin/mongod
-  RETVAL=$?
+  echo $"Stopping mongod: "
+  mongo_killproc
+  RETVAL=$((! $?))
+  if [ $RETVAL -eq 0 ] ; then
+    success "$mongod shutdown"
+    rm -f /var/lock/subsys/mongod $PIDFILE
+  else
+    failure "$mongod shutdown"
+  fi
   echo
-  [ $RETVAL -eq 0 ] && rm -f /var/lock/subsys/mongod
+  return $RETVAL
 }
 
 restart () {
 	stop
 	start
+}
+
+mongo_killproc()
+{
+  pid=`pidofproc -p "$PIDFILE" $mongod`
+
+  killproc -p "$PIDFILE" $mongod -TERM >/dev/null 2>&1
+  x=0
+  while [ $x -le 30 ] && checkpid $pid ; do
+    sleep 10
+    x=$(( $x + 1))
+  done
+  killproc -p "$PIDFILE" $mongod -KILL >/dev/null 2>&1
+  checkpid $pid
 }
 
 ulimit -n 12000


### PR DESCRIPTION
`/etc/init.d/mongod stop` uses killproc with a 5mn delay between TERM and KILL.
In most cases this 5mn sleep is too long and the stop command hangs unnecessarily even though the process has exited successfully.

This ticket is to re-implement the same 5mn delay but with a busy-wait loop that would return as early as possible.

https://jira.mongodb.org/browse/SERVER-9253
