### PR TITLE
SERVER-9191 fix oplog page for dbs that require admin login

### DIFF
--- a/src/mongo/db/repl/oplogreader.cpp
+++ b/src/mongo/db/repl/oplogreader.cpp
@@ -198,6 +198,16 @@ namespace mongo {
         return conn()->runCommand("admin", cmd.obj(), res);
     }
 
+    void OplogReader::query(const char *ns,
+                            Query query,
+                            int nToReturn,
+                            int nToSkip,
+                            const BSONObj* fields) {
+        cursor.reset(
+            _conn->query(ns, query, nToReturn, nToSkip, fields, QueryOption_SlaveOk).release()
+        );
+    }
+
     void OplogReader::tailingQuery(const char *ns, const BSONObj& query, const BSONObj* fields ) {
         verify( !haveCursor() );
         LOG(2) << "repl: " << ns << ".find(" << query.toString() << ')' << endl;

--- a/src/mongo/db/repl/oplogreader.h
+++ b/src/mongo/db/repl/oplogreader.h
@@ -86,6 +86,12 @@ namespace mongo {
         }
         */
 
+        void query(const char *ns,
+                   Query query,
+                   int nToReturn,
+                   int nToSkip,
+                   const BSONObj* fields=0);
+
         void tailingQuery(const char *ns, const BSONObj& query, const BSONObj* fields=0);
 
         void tailingQueryGTE(const char *ns, OpTime t, const BSONObj* fields=0);


### PR DESCRIPTION
In oplog page on rest interface, use oplogreader (which had authentication) instead of dbclient (w/o auth) to query oplogs. This fixes the broken oplog page for dbs having a admin account.

https://jira.mongodb.org/browse/SERVER-9191
