### PR TITLE
quick explain without cursor full scan

### DIFF
--- a/src/mongo/db/ops/query.cpp
+++ b/src/mongo/db/ops/query.cpp
@@ -731,6 +731,10 @@ namespace mongo {
                 queryResponseBuilder->noteYield();
             }
             
+            if ( pq.isExplain() == (char)2 ) {
+                break;
+            }
+            
             if ( pq.getMaxScan() && cursor->nscanned() > pq.getMaxScan() ) {
                 break;
             }
@@ -974,7 +978,7 @@ namespace mongo {
             return "";
         }
 
-        bool explain = pq.isExplain();
+        char explain = pq.isExplain();
         BSONObj order = pq.getOrder();
         BSONObj query = pq.getFilter();
 

--- a/src/mongo/db/parsed_query.cpp
+++ b/src/mongo/db/parsed_query.cpp
@@ -108,7 +108,7 @@ namespace mongo {
 
     void ParsedQuery::_reset() {
         _wantMore = true;
-        _explain = false;
+        _explain = 0;
         _snapshot = false;
         _returnKey = false;
         _showDiskLoc = false;
@@ -161,7 +161,7 @@ namespace mongo {
             if( *name == '$' ) {
                 name++;
                 if ( strcmp( "explain" , name ) == 0 )
-                    _explain = e.trueValue();
+                    _explain = e.isNumber() ? (char)e.numberInt() : e.trueValue();
                 else if ( strcmp( "snapshot" , name ) == 0 )
                     _snapshot = e.trueValue();
                 else if ( strcmp( "min" , name ) == 0 )

--- a/src/mongo/db/parsed_query.h
+++ b/src/mongo/db/parsed_query.h
@@ -55,7 +55,7 @@ namespace mongo {
         bool hasOption( int x ) const { return ( x & _options ) != 0; }
         bool hasReadPref() const { return _hasReadPref; }
         
-        bool isExplain() const { return _explain; }
+        char isExplain() const { return _explain; }
         bool isSnapshot() const { return _snapshot; }
         bool returnKey() const { return _returnKey; }
         bool showDiskLoc() const { return _showDiskLoc; }
@@ -100,7 +100,7 @@ namespace mongo {
         const int _options;
         shared_ptr<Projection> _fields;
         bool _wantMore;
-        bool _explain;
+        char _explain;
         bool _snapshot;
         bool _returnKey;
         bool _showDiskLoc;


### PR DESCRIPTION
use 

db.test.find({$query:{a:6},$explain:2})

can do an explain without  cursor full scan.
it may save a lot of time and resource on a query which has a big nscanned
