### PR TITLE
Fixes SERVER-9491

### DIFF
--- a/src/mongo/s/balancer_policy.cpp
+++ b/src/mongo/s/balancer_policy.cpp
@@ -447,7 +447,7 @@ namespace mongo {
     string ChunkInfo::toString() const {
         StringBuilder buf;
         buf << " min: " << min;
-        buf << " max: " << min;
+        buf << " max: " << max;
         return buf.str();
     }
 

--- a/src/mongo/s/d_split.cpp
+++ b/src/mongo/s/d_split.cpp
@@ -474,7 +474,7 @@ namespace mongo {
 
     string ChunkInfo::toString() const {
         ostringstream os;
-        os << "lastmod: " << lastmod.toString() << " min: " << min << " max: " << endl;
+        os << "lastmod: " << lastmod.toString() << " min: " << min << " max: " << max << endl;
         return os.str();
     }
     // ** end temporary **


### PR DESCRIPTION
Upper chunk key was not written properly to the log in some places. See https://jira.mongodb.org/browse/SERVER-9491

This pull request fixes this.
