### PR TITLE
[SERVER-9586] Demangle C++ stack trace symbols for more readable stack traces.

### DIFF
--- a/src/mongo/util/stacktrace.cpp
+++ b/src/mongo/util/stacktrace.cpp
@@ -22,10 +22,10 @@
 
 #ifdef MONGO_HAVE_EXECINFO_BACKTRACE
 
-#include <execinfo.h>	/* For backtrace() and backtrace_symbols() */
-#include <dlfcn.h>	/* For dladdr() */
+#include <execinfo.h>   /* For backtrace() and backtrace_symbols() */
+#include <dlfcn.h>      /* For dladdr() */
 #ifdef __GNUC__
-#include <cxxabi.h>	/* For __cxa_demangle() */
+#include <cxxabi.h>     /* For __cxa_demangle() */
 #endif
 
 namespace mongo {
@@ -52,34 +52,34 @@ namespace mongo {
                << std::endl;
         }
         for ( int i = 0; i < size; i++ ) {
-	    char buf[1024];
-	    Dl_info info;
-	    if (dladdr(callstack[i], &info) && info.dli_sname) {
-		char *demangled = NULL;
-		int status = -1;
+            char buf[1024];
+            Dl_info info;
+            if (dladdr(callstack[i], &info) && info.dli_sname) {
+                char *demangled = NULL;
+                int status = -1;
 #ifdef __GNUC__
-		if (info.dli_sname[0] == '_')
-		    demangled = abi::__cxa_demangle(info.dli_sname, NULL, 0, &status);
+                if (info.dli_sname[0] == '_')
+                    demangled = abi::__cxa_demangle(info.dli_sname, NULL, 0, &status);
 #endif
-		const char *symbol = (status == 0) ? demangled : info.dli_sname;
-		snprintf(buf, sizeof(buf), " %-3d %*p %s + %zd\n",
-			 i, int(2 + sizeof(void*) * 2), callstack[i], symbol,
-			(char *)callstack[i] - (char *)info.dli_saddr);
-		free(demangled);
-	    } else {
-		const char *symbol = (symbols != NULL) ? strstr(symbols[i], "0x") : NULL;
-		if (symbol) {
-		    /* Skip over the address and get the mangled name. */
-		    while (!isspace(*symbol++))
-			;
-		} else {
-		    symbol = "???";
-		}
-		snprintf(buf, sizeof(buf), " %-3d %*p %s\n",
-			 i, int(2 + sizeof(void*) * 2), callstack[i], symbol);
-	    }
-	    os << buf;
-	}
+                const char *symbol = (status == 0) ? demangled : info.dli_sname;
+                snprintf(buf, sizeof(buf), " %-3d %*p %s + %zd\n",
+                         i, int(2 + sizeof(void*) * 2), callstack[i], symbol,
+                        (char *)callstack[i] - (char *)info.dli_saddr);
+                free(demangled);
+            } else {
+                const char *symbol = (symbols != NULL) ? strstr(symbols[i], "0x") : NULL;
+                if (symbol) {
+                    /* Skip over the address and get the mangled name. */
+                    while (!isspace(*symbol++))
+                        ;
+                } else {
+                    symbol = "???";
+                }
+                snprintf(buf, sizeof(buf), " %-3d %*p %s\n",
+                         i, int(2 + sizeof(void*) * 2), callstack[i], symbol);
+            }
+            os << buf;
+        }
         os.flush();
         ::free( symbols );
     }


### PR DESCRIPTION
This pull request will demangle C++ names and makes stack traces far more readable.

Example before:

```
Sat May  4 14:04:52.352   Assertion failure isABSONObj() src/mongo/db/../bson/bson-inl.h 183
0x10017116b 0x100135396 0x10001bbde 0x100001e21 0x7fff8d4af94a 0 0x10015f232 0x10015fdad 0x100160095 0x10007104d 0x1000a2581 0x1000627bf 0x10007e3eb 0x100127a85 0x10010f92f 0x3258efc4c4db
 0   mongo                               0x000000010017116b _ZN5mongo15printStackTraceERSo + 43
 1   mongo                               0x0000000100135396 _ZN5mongo12verifyFailedEPKcS1_j + 310
 2   mongo                               0x000000010001bbde _ZNK5mongo11shell_utils18ConnectionRegistry30killOperationsOnAllConnectionsEb + 1342
 3   mongo                               0x0000000100001e21 _Z10quitNicelyi + 145
 4   libsystem_c.dylib                   0x00007fff8d4af94a _sigtramp + 26
 5   ???                                 0x0000000000000000 0x0 + 0
 6   mongo                               0x000000010015f232 _ZN5mongo13MessagingPort4recvERNS_7MessageE + 130
 7   mongo                               0x000000010015fdad _ZN5mongo13MessagingPort4recvERKNS_7MessageERS1_ + 45
 8   mongo                               0x0000000100160095 _ZN5mongo13MessagingPort4callERNS_7MessageES2_ + 53
 9   mongo                               0x000000010007104d _ZN5mongo18DBClientConnection4callERNS_7MessageES2_bPSs + 77
 10  mongo                               0x00000001000a2581 _ZN5mongo14DBClientCursor4initEv + 161
 11  mongo                               0x00000001000627bf _ZN5mongo12DBClientBase5queryERKSsNS_5QueryEiiPKNS_7BSONObjEii + 191
 12  mongo                               0x000000010007e3eb _ZN5mongo18DBClientConnection5queryERKSsNS_5QueryEiiPKNS_7BSONObjEii + 139
 13  mongo                               0x0000000100127a85 _ZN5mongo9mongoFindEPNS_7V8ScopeERKN2v89ArgumentsE + 965
 14  mongo                               0x000000010010f92f _ZN5mongo7V8Scope10v8CallbackERKN2v89ArgumentsE + 175
 15  ???                                 0x00003258efc4c4db 0x0 + 55357561160923
Sat May  4 14:04:52.354 terminate() called in shell, printing stack:
0x10017116b 0x100001d33 0x7fff862703c9 0x7fff86270424 0x7fff8627158b 0x10013556c 0x10001bbde 0x100001e21 0x7fff8d4af94a 0 0x10015f232 0x10015fdad 0x100160095 0x10007104d 0x1000a2581 0x1000627bf 0x10007e3eb 0x100127a85 0x10010f92f 0x3258efc4c4db
 0   mongo                               0x000000010017116b _ZN5mongo15printStackTraceERSo + 43
 1   mongo                               0x0000000100001d33 _Z11myterminatev + 67
 2   libc++abi.dylib                     0x00007fff862703c9 _ZL19safe_handler_callerPFvvE + 8
 3   libc++abi.dylib                     0x00007fff86270424 __cxa_bad_typeid + 0
 4   libc++abi.dylib                     0x00007fff8627158b _ZL23__gxx_exception_cleanup19_Unwind_Reason_CodeP17_Unwind_Exception + 0
 5   mongo                               0x000000010013556c _ZN5mongo12verifyFailedEPKcS1_j + 780
 6   mongo                               0x000000010001bbde _ZNK5mongo11shell_utils18ConnectionRegistry30killOperationsOnAllConnectionsEb + 1342
 7   mongo                               0x0000000100001e21 _Z10quitNicelyi + 145
 8   libsystem_c.dylib                   0x00007fff8d4af94a _sigtramp + 26
 9   ???                                 0x0000000000000000 0x0 + 0
 10  mongo                               0x000000010015f232 _ZN5mongo13MessagingPort4recvERNS_7MessageE + 130
 11  mongo                               0x000000010015fdad _ZN5mongo13MessagingPort4recvERKNS_7MessageERS1_ + 45
 12  mongo                               0x0000000100160095 _ZN5mongo13MessagingPort4callERNS_7MessageES2_ + 53
 13  mongo                               0x000000010007104d _ZN5mongo18DBClientConnection4callERNS_7MessageES2_bPSs + 77
 14  mongo                               0x00000001000a2581 _ZN5mongo14DBClientCursor4initEv + 161
 15  mongo                               0x00000001000627bf _ZN5mongo12DBClientBase5queryERKSsNS_5QueryEiiPKNS_7BSONObjEii + 191
 16  mongo                               0x000000010007e3eb _ZN5mongo18DBClientConnection5queryERKSsNS_5QueryEiiPKNS_7BSONObjEii + 139
 17  mongo                               0x0000000100127a85 _ZN5mongo9mongoFindEPNS_7V8ScopeERKN2v89ArgumentsE + 965
 18  mongo                               0x000000010010f92f _ZN5mongo7V8Scope10v8CallbackERKN2v89ArgumentsE + 175
 19  ???                                 0x00003258efc4c4db 0x0 + 55357561160923
```

Example after:

```
Sat May  4 14:06:17.138   Assertion failure isABSONObj() src/mongo/bson/bson-inl.h 183
0x10c7c1d4d 0x10c79ffcc 0x10c757351 0x10c6e3e0a 0x10c6d5cd5 0x7fff8d4af94a 0x10d5f20a0 0x10c7b6c4c 0x10c7b7291 0x10c7b7628 0x10c71b0ae 0x10c71b2fd 0x10c73e39a 0x10c718b70 0x10c724532 0x10c79a637 0x10c783882 0x23cf5ea4ce17
 0          0x10c7c1d4d mongo::printStackTrace(std::ostream&) + 61
 1          0x10c79ffcc mongo::verifyFailed(char const*, char const*, unsigned int) + 284
 2          0x10c757351 mongo::BSONElement::embeddedObject() const + 193
 3          0x10c6e3e0a mongo::shell_utils::ConnectionRegistry::killOperationsOnAllConnections(bool) const + 524
 4          0x10c6d5cd5 quitNicely(int) + 85
 5       0x7fff8d4af94a _sigtramp + 26
 6          0x10d5f20a0 0x0 + 4519305376
 7          0x10c7b6c4c mongo::MessagingPort::recv(mongo::Message&) + 112
 8          0x10c7b7291 mongo::MessagingPort::recv(mongo::Message const&, mongo::Message&) + 33
 9          0x10c7b7628 mongo::MessagingPort::call(mongo::Message&, mongo::Message&) + 52
 10         0x10c71b0ae mongo::DBClientConnection::call(mongo::Message&, mongo::Message&, bool, std::string*) + 88
 11         0x10c71b2fd non-virtual thunk to mongo::DBClientConnection::call(mongo::Message&, mongo::Message&, bool, std::string*) + 13
 12         0x10c73e39a mongo::DBClientCursor::init() + 304
 13         0x10c718b70 mongo::DBClientBase::query(std::string const&, mongo::Query, int, int, mongo::BSONObj const*, int, int) + 180
 14         0x10c724532 mongo::DBClientConnection::query(std::string const&, mongo::Query, int, int, mongo::BSONObj const*, int, int) + 130
 15         0x10c79a637 mongo::mongoFind(mongo::V8Scope*, v8::Arguments const&) + 1031
 16         0x10c783882 mongo::V8Scope::v8Callback(v8::Arguments const&) + 116
 17      0x23cf5ea4ce17 0x0 + 39373553061399
Sat May  4 14:06:17.141 terminate() called in shell, printing stack:
0x10c7c1d4d 0x10c6d5eaf 0x7fff862703c9 0x7fff86270424 0x7fff8627158b 0x10c7a0113 0x10c757351 0x10c6e3e0a 0x10c6d5cd5 0x7fff8d4af94a 0x10d5f20a0 0x10c7b6c4c 0x10c7b7291 0x10c7b7628 0x10c71b0ae 0x10c71b2fd 0x10c73e39a 0x10c718b70 0x10c724532 0x10c79a637
 0          0x10c7c1d4d mongo::printStackTrace(std::ostream&) + 61
 1          0x10c6d5eaf myterminate() + 79
 2       0x7fff862703c9 safe_handler_caller(void (*)()) + 8
 3       0x7fff86270424 __cxa_bad_typeid + 0
 4       0x7fff8627158b __gxx_exception_cleanup(_Unwind_Reason_Code, _Unwind_Exception*) + 0
 5          0x10c7a0113 mongo::verifyFailed(char const*, char const*, unsigned int) + 611
 6          0x10c757351 mongo::BSONElement::embeddedObject() const + 193
 7          0x10c6e3e0a mongo::shell_utils::ConnectionRegistry::killOperationsOnAllConnections(bool) const + 524
 8          0x10c6d5cd5 quitNicely(int) + 85
 9       0x7fff8d4af94a _sigtramp + 26
 10         0x10d5f20a0 0x0 + 4519305376
 11         0x10c7b6c4c mongo::MessagingPort::recv(mongo::Message&) + 112
 12         0x10c7b7291 mongo::MessagingPort::recv(mongo::Message const&, mongo::Message&) + 33
 13         0x10c7b7628 mongo::MessagingPort::call(mongo::Message&, mongo::Message&) + 52
 14         0x10c71b0ae mongo::DBClientConnection::call(mongo::Message&, mongo::Message&, bool, std::string*) + 88
 15         0x10c71b2fd non-virtual thunk to mongo::DBClientConnection::call(mongo::Message&, mongo::Message&, bool, std::string*) + 13
 16         0x10c73e39a mongo::DBClientCursor::init() + 304
 17         0x10c718b70 mongo::DBClientBase::query(std::string const&, mongo::Query, int, int, mongo::BSONObj const*, int, int) + 180
 18         0x10c724532 mongo::DBClientConnection::query(std::string const&, mongo::Query, int, int, mongo::BSONObj const*, int, int) + 130
 19         0x10c79a637 mongo::mongoFind(mongo::V8Scope*, v8::Arguments const&) + 1031
```
