### PR TITLE
bug fix: trailing comma in json when query hits limit in rest api

### DIFF
--- a/src/mongo/db/restapi.cpp
+++ b/src/mongo/db/restapi.cpp
@@ -184,16 +184,16 @@ namespace mongo {
                     out << " ,\n";
                 BSONObj obj = cursor->next();
                 if( html ) {
+                    out << obj.jsonString(Strict, html?1:0) << "\n\n";
                     if( out.tellp() > 4 * 1024 * 1024 ) {
                         out << "Stopping output: more than 4MB returned and in html mode\n";
                         break;
                     }
-                    out << obj.jsonString(Strict, html?1:0) << "\n\n";
                 }
                 else {
+                    out << "    " << obj.jsonString();
                     if( out.tellp() > 50 * 1024 * 1024 ) // 50MB limit - we are using ram
                         break;
-                    out << "    " << obj.jsonString();
                 }
             }
 


### PR DESCRIPTION
When a query hits the memory limit, there is a trailing comma because the while loop aborts early. This leads to invalid JSON, and things like the `json` python package will reject it.

The commit here just flips the order when breaking to output the next obj first, so that the final output avoids the trailing comma. Technically this will go even more over the memory limit - an alternative is to check earlier in the loop, before outputting the comma, but this seemed cleaner.

Let me know what you think?
