### PR TITLE
[SERVER-9631] Client example changes

### DIFF
--- a/src/mongo/client/examples/first.cpp
+++ b/src/mongo/client/examples/first.cpp
@@ -67,7 +67,7 @@ int main( int argc, const char **argv ) {
 
     {
         mongo::BSONObjBuilder query;
-        auto_ptr<mongo::DBClientCursor> cursor = conn.query( "test.people" , query.obj() );
+        std::auto_ptr<mongo::DBClientCursor> cursor = conn.query( "test.people" , query.obj() );
         if (!cursor.get()) {
             cout << "query failure" << endl;
             return EXIT_FAILURE;
@@ -95,4 +95,5 @@ int main( int argc, const char **argv ) {
         cout << res.isEmpty() << "\t" << res.jsonString() << endl;
     }
 
+    return EXIT_SUCCESS;
 }

--- a/src/mongo/client/examples/httpClientTest.cpp
+++ b/src/mongo/client/examples/httpClientTest.cpp
@@ -60,5 +60,6 @@ int main( int argc, const char **argv ) {
 #ifdef MONGO_SSL
     play( "https://www.10gen.com/" );
 #endif
-    
+
+    return EXIT_SUCCESS;
 }

--- a/src/mongo/client/examples/insert_demo.cpp
+++ b/src/mongo/client/examples/insert_demo.cpp
@@ -55,8 +55,8 @@ int main() {
     } 
     catch(DBException& e) { 
         cout << "caught DBException " << e.toString() << endl;
-        return 1;
+        return EXIT_FAILURE;
     }
 
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/src/mongo/client/examples/rs.cpp
+++ b/src/mongo/client/examples/rs.cpp
@@ -122,4 +122,5 @@ int main( int argc , const char ** argv ) {
         threads[i]->join();
     }
 
+    return EXIT_SUCCESS;
 }

--- a/src/mongo/client/examples/second.cpp
+++ b/src/mongo/client/examples/second.cpp
@@ -43,6 +43,12 @@ int main( int argc, const char **argv ) {
     conn->insert( ns , BSON( "name" << "sara" << "num" << 24 ) );
 
     std::auto_ptr<DBClientCursor> cursor = conn->query( ns , BSONObj() );
+
+    if (!cursor.get()) {
+        cout << "query failure" << endl;
+        return EXIT_FAILURE;
+    }
+
     cout << "using cursor" << endl;
     while ( cursor->more() ) {
         BSONObj obj = cursor->next();
@@ -52,4 +58,6 @@ int main( int argc, const char **argv ) {
     conn->ensureIndex( ns , BSON( "name" << 1 << "num" << -1 ) );
 
     conn.done();
+
+    return EXIT_SUCCESS;
 }

--- a/src/mongo/client/examples/tutorial.cpp
+++ b/src/mongo/client/examples/tutorial.cpp
@@ -23,15 +23,21 @@
 
 using namespace mongo;
 
-void printIfAge(DBClientConnection& c, int age) {
-    auto_ptr<DBClientCursor> cursor = c.query("tutorial.persons", QUERY( "age" << age ).sort("name") );
+int printIfAge(DBClientConnection& c, int age) {
+    std::auto_ptr<DBClientCursor> cursor = c.query("tutorial.persons", QUERY( "age" << age ).sort("name") );
+    if (!cursor.get()) {
+        cout << "query failure" << endl;
+        return EXIT_FAILURE;
+    }
+
     while( cursor->more() ) {
         BSONObj p = cursor->next();
         cout << p.getStringField("name") << endl;
     }
+    return EXIT_SUCCESS;
 }
 
-void run() {
+int run() {
     DBClientConnection c;
     c.connect("localhost"); //"192.168.58.1");
     cout << "connected ok" << endl;
@@ -50,21 +56,28 @@ void run() {
 
     cout << "count:" << c.count("tutorial.persons") << endl;
 
-    auto_ptr<DBClientCursor> cursor = c.query("tutorial.persons", BSONObj());
+    std::auto_ptr<DBClientCursor> cursor = c.query("tutorial.persons", BSONObj());
+    if (!cursor.get()) {
+        cout << "query failure" << endl;
+        return EXIT_FAILURE;
+    }
+
     while( cursor->more() ) {
         cout << cursor->next().toString() << endl;
     }
 
     cout << "\nprintifage:\n";
-    printIfAge(c, 33);
+    return printIfAge(c, 33);
 }
 
 int main() {
+	int ret = EXIT_SUCCESS;
     try {
-        run();
+        ret = run();
     }
     catch( DBException &e ) {
         cout << "caught " << e.what() << endl;
+        ret = EXIT_FAILURE;
     }
-    return 0;
+    return ret;
 }

--- a/src/mongo/client/examples/whereExample.cpp
+++ b/src/mongo/client/examples/whereExample.cpp
@@ -52,7 +52,11 @@ int main( int argc, const char **argv ) {
     conn.insert( ns , BSON( "name" << "eliot" << "num" << 17 ) );
     conn.insert( ns , BSON( "name" << "sara" << "num" << 24 ) );
 
-    auto_ptr<DBClientCursor> cursor = conn.query( ns , BSONObj() );
+    std::auto_ptr<DBClientCursor> cursor = conn.query( ns , BSONObj() );
+    if (!cursor.get()) {
+        cout << "query failure" << endl;
+        return EXIT_FAILURE;
+    }
 
     while ( cursor->more() ) {
         BSONObj obj = cursor->next();
@@ -64,6 +68,10 @@ int main( int argc, const char **argv ) {
     Query q = Query("{}").where("this.name == name" , BSON( "name" << "sara" ));
 
     cursor = conn.query( ns , q );
+    if (!cursor.get()) {
+        cout << "query failure" << endl;
+        return EXIT_FAILURE;
+    }
 
     int num = 0;
     while ( cursor->more() ) {
@@ -72,4 +80,6 @@ int main( int argc, const char **argv ) {
         num++;
     }
     verify( num == 1 );
+
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
[PATCH 1/3] client/example: Port number parameter message

Added check to provide the error message if the port number parameter is not provided.

[PATCH 2/3] client/example: use uniform coding style for verify macro

This patch changes the MONGO_verify macro usage to verify so as to make the examples make use of the uniform coding style

[PATCH 3/3] client/example: cursor check and return values

This patch add the check for the valid cursor before moving forward and add the correct return values for the application exit.
