### PR TITLE
SERVER-9612 Fixes mongos to parse correctly IPV6

### DIFF
--- a/src/mongo/s/config.cpp
+++ b/src/mongo/s/config.cpp
@@ -981,7 +981,7 @@ namespace mongo {
         if ( name.find( ":" ) != string::npos ) {
             if ( withPort )
                 return name;
-            return name.substr( 0 , name.find( ":" ) );
+            return name.substr( 0 , name.find_last_of( ":" ) );
         }
 
         if ( withPort ) {


### PR DESCRIPTION
https://jira.mongodb.org/browse/SERVER-9612
