### PR TITLE
[SERVER-9659] mongo-core/util: Remove atoll and use strtoll

### DIFF
--- a/src/mongo/util/processinfo_linux2.cpp
+++ b/src/mongo/util/processinfo_linux2.cpp
@@ -337,17 +337,12 @@ namespace mongo {
             if ( !meminfo.empty() && ( lineOff = meminfo.find( "MemTotal" ) ) != string::npos ) {
                 // found MemTotal line.  capture everything between 'MemTotal:' and ' kB'.
                 lineOff = meminfo.substr( lineOff ).find( ':' ) + 1;
-                meminfo = meminfo.substr( lineOff, meminfo.substr( lineOff ).find( "kB" ) - 1);
-                lineOff = 0;
-
-                // trim whitespace and append 000 to replace kB.
-                while ( isspace( meminfo.at( lineOff ) ) ) lineOff++;
                 meminfo = meminfo.substr( lineOff );
             }
             else {
                 meminfo = "";
             }
-            return atoll(meminfo.c_str()) * 1024;   // convert from kB to bytes
+            return strtoll(meminfo.c_str(), 0, 10) * 1024;   // convert from kB to bytes
         }
 
     };


### PR DESCRIPTION
This patch removes the deprecated atoll API and uses strtoll while returning the memory information for Linux based machines.

The JIRA is https://jira.mongodb.org/browse/SERVER-9659
