### PR TITLE
Use a signed char to store BSONType enumerations

### DIFF
--- a/src/mongo/bson/bson_validate.cpp
+++ b/src/mongo/bson/bson_validate.cpp
@@ -130,8 +130,8 @@ namespace mongo {
         Status validateElementInfo(Buffer* buffer, ValidationState::State* nextState) {
             Status status = Status::OK();
 
-            char type;
-            if ( !buffer->readNumber<char>(&type) )
+            signed char type;
+            if ( !buffer->readNumber<signed char>(&type) )
                 return Status( ErrorCodes::InvalidBSON, "invalid bson" );
 
             if ( type == EOO ) {


### PR DESCRIPTION
MinKey is defined as -1, so a signed char must be used to store BSONType
enumerations. Using a char to store a negative value results in
undefined behaviour. On i386 and amd64 architectures it happens to work
because on these platforms a char is generally signed, but this is not
guaranteed.

This fixes a build failure on ARM, where chars are unsigned by default,
and using MinKey (defined as -1) results in a compiler error.
