### PR TITLE
[SERVER-9729]core/db/commands : remove unused vector variable

### DIFF
--- a/src/mongo/db/commands/mr.cpp
+++ b/src/mongo/db/commands/mr.cpp
@@ -1353,7 +1353,6 @@ namespace mongo {
                 ProgressMeterHolder pm(op->setMessage("m/r: merge sort and reduce",
                                                       "M/R Merge Sort and Reduce Progress"));
                 set<ServerAndQuery> servers;
-                vector< auto_ptr<DBClientCursor> > shardCursors;
 
                 {
                     // parse per shard results


### PR DESCRIPTION
This patch removes the unused vector variable from mr.cpp's run() method.
