### PR TITLE
Use libstemmer when using system libraries.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -798,7 +798,9 @@ if not use_system_version_of_library("boost"):
                 CPPDEFINES=['BOOST_ALL_NO_LIB'])
 
 env.Prepend(CPPPATH=['$BUILD_DIR/third_party/s2'])
-env.Prepend(CPPPATH=['$BUILD_DIR/third_party/libstemmer_c/include'])
+
+if not use_system_version_of_library("stemmer"):
+    env.Prepend(CPPPATH=['$BUILD_DIR/third_party/libstemmer_c/include'])
 
 env.Append( CPPPATH=['$EXTRACPPPATH'],
             LIBPATH=['$EXTRALIBPATH'] )


### PR DESCRIPTION
Hi.

This allows the use of a system-provided libstemmer, instead of using the convenience copy.

Regards,
Rogério Brito.
