### PR TITLE
SERVER-9751 Force S2 geometry library to use Mongo's LOG instead of stderr

### DIFF
--- a/src/third_party/s2/base/logging.cc
+++ b/src/third_party/s2/base/logging.cc
@@ -15,24 +15,3 @@
 #include "time.h"
 
 #include "logging.h"
-
-namespace google_base {
-DateLogger::DateLogger() {
-#if defined(_MSC_VER)
-  _tzset();
-#endif
-}
-
-char* const DateLogger::HumanDate() {
-#if defined(_MSC_VER)
-  _strtime_s(buffer_, sizeof(buffer_));
-#else
-  time_t time_value = time(NULL);
-  struct tm now;
-  localtime_r(&time_value, &now);
-  snprintf(buffer_, sizeof(buffer_), "%02d:%02d:%02d",
-           now.tm_hour, now.tm_min, now.tm_sec);
-#endif
-  return buffer_;
-}
-}  // namespace google_base

--- a/src/third_party/s2/base/logging.h
+++ b/src/third_party/s2/base/logging.h
@@ -17,14 +17,20 @@
 #include <stdlib.h>
 #include <stdlib.h>
 #include <iostream>
-using std::ostream;
-using std::cout;
-using std::endl;
 
 #include "macros.h"
+#include "util/log.h"
+
+#define INFO 1
+#define FATAL 0
+#define DFATAL 0
+
+#define S2LOG(x) LOG(x)
+#define VLOG(x) LOG(x)
+
 
 // Always-on checking
-#define CHECK(x)	if(x){}else LogMessageFatal(__FILE__, __LINE__).stream() << "Check failed: " #x
+#define CHECK(x)	if(x){}else VLOG(2) << __FILE__ << ":" << __LINE__ << ": Check failed: " #x
 #define CHECK_LT(x, y)	CHECK((x) < (y))
 #define CHECK_GT(x, y)	CHECK((x) > (y))
 #define CHECK_LE(x, y)	CHECK((x) <= (y))
@@ -53,47 +59,6 @@ using std::endl;
 #endif
 
 #include "base/port.h"
-#define INFO std::cout
-#define FATAL std::cerr
-#define DFATAL std::cerr
 
-#define S2LOG(x) x
-#define VLOG(x) if (x>0) {} else S2LOG(INFO)
-
-namespace google_base {
-class DateLogger {
- public:
-  DateLogger();
-  char* const HumanDate();
- private:
-  char buffer_[9];
-};
-}  // namespace google_base
-
-class LogMessage {
- public:
-  LogMessage(const char* file, int line) {
-    std::cerr << "[" << pretty_date_.HumanDate() << "] "
-              << file << ":" << line << ": ";
-  }
-  ~LogMessage() { std::cerr << "\n"; }
-  std::ostream& stream() { return std::cerr; }
-
- private:
-  google_base::DateLogger pretty_date_;
-  DISALLOW_COPY_AND_ASSIGN(LogMessage);
-};
-
-class LogMessageFatal : public LogMessage {
- public:
-  LogMessageFatal(const char* file, int line)
-    : LogMessage(file, line) { }
-  ~LogMessageFatal() {
-    std::cerr << "\n";
-    ::abort();
-  }
- private:
-  DISALLOW_COPY_AND_ASSIGN(LogMessageFatal);
-};
 
 #endif  // BASE_LOGGING_H

--- a/src/third_party/s2/r1interval.h
+++ b/src/third_party/s2/r1interval.h
@@ -42,6 +42,12 @@ class R1Interval {
   //   lat_bounds_ = R1Interval(lat_lo, lat_hi);
   R1Interval() : bounds_(1, 0) {}
 
+  inline std::string toString() const{
+    std::stringstream out;
+    out << this;
+    return out.str();
+  }
+
   // Returns an empty interval.
   static inline R1Interval Empty() { return R1Interval(); }
 

--- a/src/third_party/s2/s1interval.h
+++ b/src/third_party/s2/s1interval.h
@@ -52,6 +52,12 @@ class S1Interval {
   //   lng_bounds_ = S1Interval(lng_lo, lng_hi);
   inline S1Interval();
 
+  inline std::string toString() const{
+    std::stringstream out;
+    out << this;
+    return out.str();
+  }
+
   // Returns the empty interval.
   static inline S1Interval Empty();
 


### PR DESCRIPTION
Right now S2 library just writes any debugging output and errors
to std::cerr. This patch changes S2's logger to use Mongo's LOG macros.

That way it is much easier to find errors in geometry primitives.
