### PR TITLE
[SERVER-9659] core/util: remove atoll and use parsenumberfromstring

### DIFF
--- a/src/mongo/util/processinfo_linux2.cpp
+++ b/src/mongo/util/processinfo_linux2.cpp
@@ -343,11 +343,15 @@ namespace mongo {
                 // trim whitespace and append 000 to replace kB.
                 while ( isspace( meminfo.at( lineOff ) ) ) lineOff++;
                 meminfo = meminfo.substr( lineOff );
+
+                unsigned long long systemMem = 0;
+                if ( mongo::parseNumberFromString( meminfo, &systemMem ).isOK() )	{
+                	return systemMem * 1024; // convert from kB to bytes
+                }
+                else
+                	log() << "Unable to collect system memory information" << endl;
             }
-            else {
-                meminfo = "";
-            }
-            return atoll(meminfo.c_str()) * 1024;   // convert from kB to bytes
+            return 0;
         }
 
     };


### PR DESCRIPTION
This patch replace atoll with stable parsenumberfromstring().
