### PR TITLE
SERVER-9985 mongodb.upstart: chown dirs potentially created by pre-start stanza

### DIFF
--- a/debian/mongodb.upstart
+++ b/debian/mongodb.upstart
@@ -5,8 +5,15 @@ limit nofile 20000 20000
 kill timeout 300 # wait 300s between SIGTERM and SIGKILL.
 
 pre-start script
-    mkdir -p /var/lib/mongodb/
-    mkdir -p /var/log/mongodb/
+    if ! [ -d /var/lib/mongodb/ ]; then
+        mkdir -p /var/lib/mongodb/
+        chown -R mongodb:mongodb /var/lib/mongodb/
+    fi
+
+    if ! [ -d /var/log/mongodb/ ]; then
+        mkdir -p /var/log/mongodb/
+        chown -R mongodb:mongodb /var/log/mongodb/
+    fi
 end script
 
 start on runlevel [2345]


### PR DESCRIPTION
Usually these are created by the the post-install script that runs after installing the package, but if those were rm'ed later on and then created by this script, their permission would be most likely set to root, causing mongod to fail starting.
