### PR TITLE
SERVER-10204 exported records uses cout instead of cerr

### DIFF
--- a/src/mongo/tools/export.cpp
+++ b/src/mongo/tools/export.cpp
@@ -241,7 +241,9 @@ public:
         if (jsonArray)
             out << ']' << endl;
 
-        cerr << "exported " << num << " records" << endl;
+        if (!_quiet) {
+            (_usesstdout ? cout : cerr ) << "exported " << num << " records" << endl;
+        }   
 
         return 0;
     }


### PR DESCRIPTION
Motivation:
Adding to Shaun, successfully exporting does not imply the use of cerr. 
