### PR TITLE
SERVER-10343 Fix $regex query when given both a RegEx and options.

### DIFF
--- a/jstests/regex_options.js
+++ b/jstests/regex_options.js
@@ -1,0 +1,7 @@
+t = db.jstests_regex_options;
+
+t.drop();
+t.save( { a: "foo" } );
+assert.eq( 1, t.count( { a: { "$regex": /O/i } } ) );
+assert.eq( 1, t.count( { a: /O/i } ) );
+assert.eq( 1, t.count( { a: { "$regex": "O", "$options": "i" } } ) );

--- a/src/mongo/db/matcher/expression_parser.cpp
+++ b/src/mongo/db/matcher/expression_parser.cpp
@@ -416,6 +416,7 @@ namespace mongo {
                 }
                 else if ( e.type() == RegEx ) {
                     regex = e.regex();
+                    regexOptions = e.regexFlags();
                 }
                 else {
                     return StatusWithMatchExpression( ErrorCodes::BadValue,


### PR DESCRIPTION
MatchExpressionParser::_parseRegexDocument() now makes use of options embedded in a provided RegEx.
