### PR TITLE
SERVER-10517: do not add command such as db.auth() to shell history whe...

### DIFF
--- a/src/mongo/shell/dbshell.cpp
+++ b/src/mongo/shell/dbshell.cpp
@@ -133,7 +133,7 @@ void shellHistoryAdd( const char * line ) {
     // be able to add things like `.author`, so be smart about how this is
     // detected by using regular expresions.
     static pcrecpp::RE hiddenHelpers(
-            "\\.(auth|addUser|updateUser|changeUserPassword)\\s*\\(");
+            "\\.\\s*(auth|addUser|updateUser|changeUserPassword)\\s*\\(");
     // Also don't want the raw user management commands to show in the shell when run directly
     // via runCommand.
     static pcrecpp::RE hiddenCommands(


### PR DESCRIPTION
auth commands added to history when there are spaces after 'dot'
example:
db. auth(USERNAME, PASSWORD)
