### PR TITLE
SERVER-10486 mongofiles collection and chunk size

### DIFF
--- a/src/mongo/tools/files.cpp
+++ b/src/mongo/tools/files.cpp
@@ -150,7 +150,7 @@ public:
 
             if (hasParam("replace")){
                 auto_ptr<DBClientCursor> cursor =
-                  conn().query(_db + "." _coll + ".files",
+                  conn().query(_db + "." + _coll + ".files",
                                BSON("filename" << filename << "_id" << NE << file["_id"] ));
                 while (cursor->more()){
                     BSONObj o = cursor->nextSafe();
@@ -192,29 +192,29 @@ public:
                     return -3;
                 } else if (chunk_size > 0) {
                     g.setChunkSize(chunk_size);
-		}
+                }
             }
 
-	    if ((unsigned int)f.getChunkSize() != g.getChunkSize()) {
-              string out = getParam("local", tempnam(NULL, f.getFilename().c_str()));
-              f.write( out );
+            if ((unsigned int)f.getChunkSize() != g.getChunkSize()) {
+                string out = getParam("local", tempnam(NULL, f.getFilename().c_str()));
+                f.write( out );
 
-              BSONObj file = g.storeFile(out, filename, type);
-              remove(out.c_str());
+                BSONObj file = g.storeFile(out, filename, type);
+                remove(out.c_str());
 
-              auto_ptr<DBClientCursor> cursor =
-              conn().query(_db+"."+_coll+".files",
-                           BSON("filename" << filename << "_id" << NE << file["_id"] ));
-              while (cursor->more()) {
-                  BSONObj o = cursor->nextSafe();
-                  conn().remove(_db+"."+_coll+".files", BSON("_id" << o["_id"]));
-                  conn().remove(_db+"."+_coll+".chunks", BSON("files_id" << o["_id"]));
-              }
+                auto_ptr<DBClientCursor> cursor =
+                conn().query(_db+"."+_coll+".files",
+                             BSON("filename" << filename << "_id" << NE << file["_id"] ));
+                while (cursor->more()) {
+                    BSONObj o = cursor->nextSafe();
+                    conn().remove(_db+"."+_coll+".files", BSON("_id" << o["_id"]));
+                    conn().remove(_db+"."+_coll+".chunks", BSON("files_id" << o["_id"]));
+                }
 
-              conn().getLastError();
+                conn().getLastError();
             } else {
-	      cout << "Skipping file " << filename << " (already desired chunk size)" << endl;
-	    }
+                cout << "Skipping file " << filename << " (already desired chunk size)" << endl;
+            }
             return 0;
         }
 


### PR DESCRIPTION
### Summary

This small patch adds support for
- setting an arbitrary collection name (help suggested that this was supported but the tool silently ignored it)
- setting the GridFS chunk size for a file during put
- a new command "re-chunk" that allows for changing the chunk size of existing files
### Ticket

The ticket for this pull request is at https://jira.mongodb.org/browse/SERVER-10486

This pull request supersedes/fixes/invalidates:
https://jira.mongodb.org/browse/SERVER-4931
https://jira.mongodb.org/browse/SERVER-2334
https://jira.mongodb.org/browse/SERVER-6874
https://jira.mongodb.org/browse/SERVER-2335
https://jira.mongodb.org/browse/SERVER-2469
### lint check output

```
# python buildscripts/lint.py src/mongo/tools/files.cpp 
Total errors found: 0
```

I'd appreciate if this could be merged for a future version of MongoDB.
