### PR TITLE
Server 8477 Remove extra return statement in DBException::toString()

### DIFF
--- a/src/mongo/util/assert_util.cpp
+++ b/src/mongo/util/assert_util.cpp
@@ -55,8 +55,8 @@ namespace mongo {
     bool DBException::traceExceptions = false;
 
     string DBException::toString() const {
-        stringstream ss; 
-	ss << getCode() << " " << what();
+        stringstream ss;
+        ss << getCode() << " " << what();
         return ss.str();
     }
 


### PR DESCRIPTION
A patch for jira ticket Server 8477
