### PR TITLE
SERVER-10626 $add projection supports arrays of numbers

### DIFF
--- a/jstests/aggregation/bugs/arrayadd.js
+++ b/jstests/aggregation/bugs/arrayadd.js
@@ -1,0 +1,19 @@
+c = db.arrayadd;
+
+// Test array add with implicit array creation
+c.drop();
+c.save({a:[{b: 1}, {b: 2}, {b: 3}]});
+
+assert.eq(c.aggregate({$project: {total: {$add: "$a.b"}}}).result[0].total, 6);
+
+// Test nested array add
+c.drop();
+c.save({a: [1, 2, [1, 1, 1]]});
+
+assert.eq(c.aggregate({$project: {total: {$add: "$a"}}}).result[0].total, 6);
+
+// Test null aborts sum (SERVER-7932)
+c.drop();
+c.save({a:[{b: 1}, {b: 2}, {b: null}]});
+
+assert.eq(c.aggregate({$project: {total: {$add: "$a.b"}}}).result[0].total, null);

--- a/src/mongo/db/pipeline/expression.h
+++ b/src/mongo/db/pipeline/expression.h
@@ -325,7 +325,11 @@ namespace mongo {
           @returns addition expression
          */
         static intrusive_ptr<ExpressionNary> create();
-    };
+
+    private:
+        boost::optional<Value> addToRunningTotal(const Value& val, BSONType& totalType,
+                double& doubleTotal, long long & longTotal, bool& haveDate) const;
+};
 
 
     class ExpressionAnd :


### PR DESCRIPTION
Adds nested arrays if provided. Retains nullish behavior if null is part of input.
