### PR TITLE
SERVER-9501: initial sync exception: 10083

### DIFF
--- a/src/mongo/db/pdfile.cpp
+++ b/src/mongo/db/pdfile.cpp
@@ -211,7 +211,7 @@ namespace mongo {
             BSONElement e = options.getField("size");
             if ( e.isNumber() ) {
                 size = e.numberLong();
-                uassert( 10083 , "create collection invalid size spec", size > 0 );
+                uassert( 10083 , "create collection invalid size spec", size >= 0 );
 
                 size += 0xff;
                 size &= 0xffffffffffffff00LL;


### PR DESCRIPTION
Changed validation to allow explicit creation of size 0 collections. Should be backported to 2.4.X
