### PR TITLE
SERVER-8535 Added exception logic to filesystem::exists call

### DIFF
--- a/src/mongo/db/initialize_server_global_state.cpp
+++ b/src/mongo/db/initialize_server_global_state.cpp
@@ -222,7 +222,15 @@ namespace mongo {
             std::string absoluteLogpath = boost::filesystem::absolute(
                     cmdLine.logpath, cmdLine.cwd).string();
 
-            const bool exists = boost::filesystem::exists(absoluteLogpath);
+            bool exists;
+
+            try{
+                exists = boost::filesystem::exists(absoluteLogpath);
+            } catch(boost::filesystem::filesystem_error& e) {
+                return Status(ErrorCodes::FileNotOpen, mongoutils::str::stream() <<
+                        "Failed probe for \"" << absoluteLogpath << "\": " <<
+                        e.code().message());
+            }
 
             if (exists) {
                 if (boost::filesystem::is_directory(absoluteLogpath)) {


### PR DESCRIPTION
Many of our calls to boost::filesystem::exists() do not treat it
as a function that throws exceptions. Adding logic to catch these
can stop various obscure permissions-related problems.
