### PR TITLE
Update connpool.cpp

### DIFF
--- a/src/mongo/client/connpool.cpp
+++ b/src/mongo/client/connpool.cpp
@@ -257,6 +257,10 @@ namespace mongo {
 
     DBConnectionPool::~DBConnectionPool() {
         // connection closing is handled by ~PoolForHost
+        if (_hooks) {
+            delete _hooks;
+            hooks = NULL;
+        }
     }
 
     void DBConnectionPool::flush() {


### PR DESCRIPTION
_hooks constructor new the object,but destructor don't delete,will be a global memory leak.
