### PR TITLE
Update connpool.cpp

### DIFF
--- a/src/mongo/client/connpool.cpp
+++ b/src/mongo/client/connpool.cpp
@@ -257,6 +257,10 @@ namespace mongo {
 
     DBConnectionPool::~DBConnectionPool() {
         // connection closing is handled by ~PoolForHost
+        if ( _hooks ) {
+            delete _hooks;
+            _hooks = NULL;
+        }
     }
 
     void DBConnectionPool::flush() {


### PR DESCRIPTION
The DBConnectionPool constructor new the object _hooks,but the destrctor no delete the _hooks will be occur a global memory leak.(when i used valgrind checking my app memleak)
