### PR TITLE
SERVER-10808 add __gcov_flush() call on exit

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -864,6 +864,7 @@ if nix:
 
     if linux and has_option( "gcov" ):
         env.Append( CXXFLAGS=" -fprofile-arcs -ftest-coverage " )
+        env.Append( CPPDEFINES=["MONGO_GCOV"] )
         env.Append( LINKFLAGS=" -fprofile-arcs -ftest-coverage " )
 
     if optBuild:

--- a/src/mongo/db/instance.cpp
+++ b/src/mongo/db/instance.cpp
@@ -75,6 +75,7 @@
 #include "mongo/s/stale_exception.h" // for SendStaleConfigException
 #include "mongo/util/fail_point_service.h"
 #include "mongo/util/file_allocator.h"
+#include "mongo/util/gcov.h"
 #include "mongo/util/goodies.h"
 #include "mongo/util/mongoutils/str.h"
 #include "mongo/util/time_support.h"
@@ -1156,6 +1157,8 @@ namespace mongo {
 
     /* not using log() herein in case we are already locked */
     NOINLINE_DECL void dbexit( ExitCode rc, const char *why ) {
+        
+        flushForGcov();
 
         Client * c = currentClient.get();
         {

--- a/src/mongo/dbtests/dbtests.cpp
+++ b/src/mongo/dbtests/dbtests.cpp
@@ -27,6 +27,7 @@
 #include "mongo/dbtests/dbtests.h"
 #include "mongo/dbtests/framework.h"
 #include "mongo/util/exception_filter_win32.h"
+#include "mongo/util/gcov.h"
 #include "mongo/util/startup_test.h"
 #include "mongo/util/text.h"
 
@@ -60,6 +61,7 @@ int wmain(int argc, wchar_t* argvW[], wchar_t* envpW[]) {
 #else
 int main(int argc, char* argv[], char** envp) {
     int exitCode = dbtestsMain(argc, argv, envp);
+    flushForGcov();
     ::_exit(exitCode);
 }
 #endif

--- a/src/mongo/s/server.cpp
+++ b/src/mongo/s/server.cpp
@@ -61,6 +61,7 @@
 #include "mongo/util/concurrency/task.h"
 #include "mongo/util/concurrency/thread_name.h"
 #include "mongo/util/exception_filter_win32.h"
+#include "mongo/util/gcov.h"
 #include "mongo/util/log.h"
 #include "mongo/util/net/message.h"
 #include "mongo/util/net/message_server.h"
@@ -657,5 +658,6 @@ void mongo::dbexit( ExitCode rc, const char *why ) {
           << " rc:" << rc
           << " " << ( why ? why : "" )
           << endl;
+    flushForGcov();
     ::_exit(rc);
 }

--- a/src/mongo/util/gcov.h
+++ b/src/mongo/util/gcov.h
@@ -1,0 +1,36 @@
+/**
+ *    Copyright (C) 2013 10gen Inc.
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under the terms of the GNU Affero General Public License, version 3,
+ *    as published by the Free Software Foundation.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *    As a special exception, the copyright holders give permission to link the
+ *    code of portions of this program with the OpenSSL library under certain
+ *    conditions as described in each individual source file and distribute
+ *    linked combinations including the program with the OpenSSL library. You
+ *    must comply with the GNU Affero General Public License in all respects
+ *    for all of the code used other than as permitted herein. If you modify
+ *    file(s) with this exception, you may extend this exception to your
+ *    version of the file(s), but you are not obligated to do so. If you do not
+ *    wish to do so, delete this exception statement from your version. If you
+ *    delete this exception statement from all source files in the program,
+ *    then also delete it in the license file.
+ */
+
+#pragma once
+
+#ifdef MONGO_GCOV
+extern "C" { void __gcov_flush(); }
+inline void flushForGcov() { __gcov_flush(); }
+#else
+inline void flushForGcov() {}
+#endif


### PR DESCRIPTION
Hi Matt - this is the pull request I talked to you about (allows code  coverage instrumentation stats to flush on exit from mongod, mongos and unit tests). Code review is linked in the SERVER ticket

Mike
