### PR TITLE
SERVER-11035 fix count10.js MCI failures

### DIFF
--- a/jstests/count10.js
+++ b/jstests/count10.js
@@ -9,27 +9,27 @@ for ( i=0; i<100; i++ ){
 // make sure data is written
 db.getLastError();
 
-var thr = new Thread(function () {
+s = startParallelShell(
+    'sleep(1000); ' +
+    'current = db.currentOp({"ns": db.count10.getFullName(), "query.count": db.count10.getName()}); ' +
+    'assert(current); ' +
+    'countOp = current.inprog[0]; ' +
+    'assert(countOp); ' +
+    'db.killOp(countOp.opid); '
+);
+
+function getKilledCount() {
     try {
-        db.getSisterDB("admin").auth("admin", "password");
         db.count10.find("sleep(1000)").count();
-    }
-    catch (e) {
+    } catch (e) {
         return e;
     }
-});
+}
 
-thr.start();
-sleep(1000);
-
-current = db.currentOp({"ns": t.getFullName(), "query.count": t.getName()});
-assert(current);
-countOp = current.inprog[0];
-assert(countOp);
-
-db.killOp(countOp.opid);
-res = thr.returnData();
-
+var res = getKilledCount();
 assert(res);
 assert(res.match(/count failed/) !== null);
 assert(res.match(/\"code\"/) !== null);
+
+s();
+


### PR DESCRIPTION
This test was failing due to an authorization failure. In order to run the count command when running against a mongod with --auth, the test needs to log in as the admin user.

Original code review:
http://codereview.10gen.com/11598025/
