### PR TITLE
Fixing typo directly -> directory in help string for option --directoryperdb

### DIFF
--- a/src/mongo/tools/tool_options.cpp
+++ b/src/mongo/tools/tool_options.cpp
@@ -146,7 +146,7 @@ namespace mongo {
             return ret;
         }
         ret = options->addOption(OD("directoryperdb", "directoryperdb", moe::Switch,
-                    "each db is in a separate directly "
+                    "each db is in a separate directory "
                     "(relevant only if dbpath specified)", true));
         if(!ret.isOK()) {
             return ret;


### PR DESCRIPTION
This typo appears in both `mongodump --help` and `mongoexport --help`.
