### PR TITLE
SERVER-11236 changed logprocessdetails.js to check entire log

### DIFF
--- a/jstests/logprocessdetails.js
+++ b/jstests/logprocessdetails.js
@@ -2,7 +2,21 @@
  * SERVER-7140 test. Checks that process info is re-logged on log rotation
  */
 
-doTest = function(){
+/**
+ * Checks an array for match against regex.
+ * Returns true if regex matches a string in the array
+ */
+doesLogMatchRegex = function(logArray, regex) {
+   for (var i = (logArray.length - 1); i >= 0; i--){
+        var regexInLine = regex.exec(logArray[i]);
+        if (regexInLine != null){
+            return true;
+        }
+    }
+    return false;
+}
+
+doTest = function() {
     var log = db.adminCommand({ getLog: 'global'});
     //this regex will need to change if output changes
     var re = new RegExp(".*conn.*options.*");
@@ -18,8 +32,8 @@ doTest = function(){
     assert.neq(null, log2);
     assert.gte(log2.totalLinesWritten, lineCount);
 
-    var lastLineFound = re.exec(log2.log.pop());
-    assert.neq(null, lastLineFound);
+    var informationIsLogged = doesLogMatchRegex(log2.log, re);
+    assert.eq(informationIsLogged, true, "Process details not present in RAM log");
 }
 
 doTest();


### PR DESCRIPTION
The .js test for logging process details on log rotations now checks the entire RAM log instead of just the most recent log entry, which should end unpredictable test failures.
