### PR TITLE
Fixed typo after SERVER-10871

### DIFF
--- a/debian/init.d
+++ b/debian/init.d
@@ -56,7 +56,7 @@ NAME=mongod
 # http://dochub.mongodb.org/core/configurationoptions
 CONF=/etc/mongod.conf
 PIDFILE=/var/run/$NAME.pid
-ENABLE_MONGODB=yes
+ENABLE_MONGOD=yes
 
 # Include mongodb defaults if available
 if [ -f /etc/default/$NAME ] ; then


### PR DESCRIPTION
In SERVER-10871, https://github.com/mongodb/mongo/commit/09ffdcc9274e20b879710cdb5d1271a65e6c6470,  @ehershey changed `ENABLE_MONGODB` to `ENABLE_MONGOD`. And here is the missing one.
