### PR TITLE
SERVER-11776 Replication 'isself' check should allow mapped ports

### DIFF
--- a/src/mongo/db/commands/isself.cpp
+++ b/src/mongo/db/commands/isself.cpp
@@ -207,11 +207,6 @@ namespace mongo {
         int _p = port();
         int p = _p == -1 ? ServerGlobalParams::DefaultDBPort : _p;
 
-        if (p != serverGlobalParams.port) {
-            // shortcut - ports have to match at the very least
-            return false;
-        }
-
         string host = str::stream() << this->host() << ":" << p;
 
         {
@@ -234,8 +229,10 @@ namespace mongo {
                 string a = *i;
                 string b = *j;
 
-                if ( a == b ||
-                        ( str::startsWith( a , "127." ) && str::startsWith( b , "127." ) )  // 127. is all loopback
+                // check if the ports match as well
+                if ( (p == serverGlobalParams.port) && 
+                        (a == b || ( str::startsWith( a , "127." ) && str::startsWith( b , "127." ) ))  // 127. is all loopback
+                        
                    ) {
 
                     // add to cache


### PR DESCRIPTION
'isself' should match the ports only if the hosts are being string matched. In cases where an instance is being addressed through a proxy port, port matching is an incorrect check - it invalidates a genuine match.

e.g. a mongod instance listening on port 27017 may be get redirected traffic from another port through IPtables routing. Such instances would fail to get added to a replica set for no good reason. Port proxies maybe required in multi-tenant cloud based systems where bind-able IPs/ports are NAT'ed.
