### PR TITLE
SERVER-10471 fix OR with inexact bounds

### DIFF
--- a/src/mongo/db/query/query_planner_test.cpp
+++ b/src/mongo/db/query/query_planner_test.cpp
@@ -813,8 +813,10 @@ namespace {
         runQuery(fromjson("{$or: [ {a: {$geoIntersects: {$geometry: {type: 'Point', coordinates: [10.0, 10.0]}}}},"
                                  " {b: {$geoWithin: { $centerSphere: [[ 10, 20 ], 0.01 ] } }} ]}"));
 
+        ASSERT_EQUALS(getNumSolutions(), 2U);
         assertSolutionExists("{cscan: 1}");
-        // TODO investigate why no indexed solution exists
+        assertSolutionExists("{or: {nodes: [{fetch: {ixscan: {a: '2dsphere'}}},"
+                                           "{fetch: {ixscan: {b: '2dsphere'}}}]}}");
     }
 
 


### PR DESCRIPTION
Adds a fix in QueryPlanner::processIndexScans. The existing behavior can cause the query planner to generate no indexed solution for some OR queries. A specific case is $or with a geo query on a '2dsphere' index. In general, this is an issue for $or queries with inexact index bounds.

The filters for OR branches with inexact index bounds are currently left hanging, violating a precondition of QueryPlanner::buildIndexedOr. This patch adds logic to ensure that the proper FETCH -> IXSCAN is returned after properly clipping off the children of the $or. Doing so ensures that filters are applied only to the appropriate OR branch, as opposed to handling like an AND where filters can be brought above the AND node in the solution tree.
