### PR TITLE
SERVER-11679 add some missing query planner tests

### DIFF
--- a/src/mongo/db/query/canonical_query.cpp
+++ b/src/mongo/db/query/canonical_query.cpp
@@ -50,46 +50,34 @@ namespace mongo {
     // static
     Status CanonicalQuery::canonicalize(const string& ns, const BSONObj& query,
                                         CanonicalQuery** out) {
-        LiteParsedQuery* lpq;
-        // Pass empty sort and projection.
         BSONObj emptyObj;
-        Status parseStatus = LiteParsedQuery::make(ns, 0, 0, 0, query, emptyObj, emptyObj, &lpq);
-        if (!parseStatus.isOK()) { return parseStatus; }
-
-        auto_ptr<CanonicalQuery> cq(new CanonicalQuery());
-        Status initStatus = cq->init(lpq);
-        if (!initStatus.isOK()) { return initStatus; }
-
-        *out = cq.release();
-        return Status::OK();
+        return CanonicalQuery::canonicalize(ns, query, emptyObj, emptyObj, 0, 0, out);
     }
 
     // static
     Status CanonicalQuery::canonicalize(const string& ns, const BSONObj& query,
                                         long long skip, long long limit,
                                         CanonicalQuery** out) {
-        LiteParsedQuery* lpq;
-        // Pass empty sort and projection.
         BSONObj emptyObj;
-        Status parseStatus = LiteParsedQuery::make(ns, skip, limit, 0, query, emptyObj, emptyObj, &lpq);
-        if (!parseStatus.isOK()) { return parseStatus; }
-
-        auto_ptr<CanonicalQuery> cq(new CanonicalQuery());
-        Status initStatus = cq->init(lpq);
-        if (!initStatus.isOK()) { return initStatus; }
-
-        *out = cq.release();
-        return Status::OK();
+        return CanonicalQuery::canonicalize(ns, query, emptyObj, emptyObj, skip, limit, out);
     }
 
     // static
     Status CanonicalQuery::canonicalize(const string& ns, const BSONObj& query,
                                         const BSONObj& sort, const BSONObj& proj,
                                         CanonicalQuery** out) {
+        return CanonicalQuery::canonicalize(ns, query, sort, proj, 0, 0, out);
+    }
+
+    // static
+    Status CanonicalQuery::canonicalize(const string& ns, const BSONObj& query,
+                                        const BSONObj& sort, const BSONObj& proj,
+                                        long long skip, long long limit,
+                                        CanonicalQuery** out) {
         LiteParsedQuery* lpq;
         // Pass empty sort and projection.
         BSONObj emptyObj;
-        Status parseStatus = LiteParsedQuery::make(ns, 0, 0, 0, query, proj, sort, &lpq);
+        Status parseStatus = LiteParsedQuery::make(ns, skip, limit, 0, query, proj, sort, &lpq);
         if (!parseStatus.isOK()) { return parseStatus; }
 
         auto_ptr<CanonicalQuery> cq(new CanonicalQuery());

--- a/src/mongo/db/query/canonical_query.h
+++ b/src/mongo/db/query/canonical_query.h
@@ -52,6 +52,10 @@ namespace mongo {
         static Status canonicalize(const string& ns, const BSONObj& query, const BSONObj& sort,
                                    const BSONObj& proj, CanonicalQuery** out);
 
+        static Status canonicalize(const string& ns, const BSONObj& query, const BSONObj& sort,
+                                   const BSONObj& proj, long long skip, long long limit,
+                                   CanonicalQuery** out);
+
         // What namespace is this query over?
         const string& ns() const { return _pq->ns(); }
 


### PR DESCRIPTION
Adds additional test cases to query_planner_test.cpp. Also includes some cleanup of the query planner test framework methods / setup.
