### PR TITLE
SERVER-11817 use enum instead of bool for exact/inexact index bounds

### DIFF
--- a/src/mongo/db/query/index_bounds_builder.h
+++ b/src/mongo/db/query/index_bounds_builder.h
@@ -40,6 +40,14 @@ namespace mongo {
      */
     class IndexBoundsBuilder {
     public:
+
+        enum BoundsTightness {
+            // Index bounds are exact.
+            EXACT,
+            // Index bounds are inexact, and a fetch is required.
+            INEXACT_FETCH
+        };
+
         /**
          * Populate the provided O.I.L. with one interval goes from MinKey to MaxKey (or vice-versa
          * depending on the index direction).
@@ -56,21 +64,21 @@ namespace mongo {
          * expr->isArray() must be true, and expr->isLogical() must be false.  
          */
         static void translate(const MatchExpression* expr, const BSONElement& elt,
-                              OrderedIntervalList* oilOut, bool* exactOut);
+                              OrderedIntervalList* oilOut, BoundsTightness* tightnessOut);
 
         /**
          * Creates bounds for 'expr' (indexed according to 'elt').  Intersects those bounds
          * with the bounds in oilOut, which is an in/out parameter.
          */
         static void translateAndIntersect(const MatchExpression* expr, const BSONElement& elt,
-                                          OrderedIntervalList* oilOut, bool* exactOut);
+                                          OrderedIntervalList* oilOut, BoundsTightness* tightnessOut);
 
         /**
          * Creates bounds for 'expr' (indexed according to 'elt').  Unions those bounds
          * with the bounds in oilOut, which is an in/out parameter.
          */
         static void translateAndUnion(const MatchExpression* expr, const BSONElement& elt,
-                                      OrderedIntervalList* oilOut, bool* exactOut);
+                                      OrderedIntervalList* oilOut, BoundsTightness* tightnessOut);
 
         /**
          * Make a range interval from the provided object.
@@ -111,15 +119,15 @@ namespace mongo {
          *
          *  used to optimize queries in some simple regex cases that start with '^'
          */
-        static string simpleRegex(const char* regex, const char* flags, bool* exact);
+        static string simpleRegex(const char* regex, const char* flags, BoundsTightness* tightnessOut);
 
         static Interval allValues();
 
         static void translateRegex(const RegexMatchExpression* rme, OrderedIntervalList* oil,
-                                   bool* exact);
+                                   BoundsTightness* tightnessOut);
 
         static void translateEquality(const BSONElement& data, bool isHashed,
-                                      OrderedIntervalList* oil, bool* exact);
+                                      OrderedIntervalList* oil, BoundsTightness* tightnessOut);
 
         static void unionize(OrderedIntervalList* oilOut);
         static void intersectize(const OrderedIntervalList& arg, OrderedIntervalList* oilOut);

--- a/src/mongo/db/query/index_bounds_builder_test.cpp
+++ b/src/mongo/db/query/index_bounds_builder_test.cpp
@@ -64,13 +64,13 @@ namespace {
         auto_ptr<MatchExpression> expr(parseMatchExpression(obj));
         BSONElement elt = obj.firstElement();
         OrderedIntervalList oil;
-        bool exact;
-        IndexBoundsBuilder::translate(expr.get(), elt, &oil, &exact);
+        IndexBoundsBuilder::BoundsTightness tightness;
+        IndexBoundsBuilder::translate(expr.get(), elt, &oil, &tightness);
         ASSERT_EQUALS(oil.name, "a");
         ASSERT_EQUALS(oil.intervals.size(), 1U);
         ASSERT_EQUALS(Interval::INTERVAL_EQUALS, oil.intervals[0].compare(
             Interval(fromjson("{'': -Infinity, '': 1}"), true, true)));
-        ASSERT(exact);
+        ASSERT(tightness == IndexBoundsBuilder::EXACT);
     }
 
     TEST(IndexBoundsBuilderTest, TranslateLteNumberMin) {
@@ -78,13 +78,13 @@ namespace {
         auto_ptr<MatchExpression> expr(parseMatchExpression(obj));
         BSONElement elt = obj.firstElement();
         OrderedIntervalList oil;
-        bool exact;
-        IndexBoundsBuilder::translate(expr.get(), elt, &oil, &exact);
+        IndexBoundsBuilder::BoundsTightness tightness;
+        IndexBoundsBuilder::translate(expr.get(), elt, &oil, &tightness);
         ASSERT_EQUALS(oil.name, "a");
         ASSERT_EQUALS(oil.intervals.size(), 1U);
         ASSERT_EQUALS(Interval::INTERVAL_EQUALS, oil.intervals[0].compare(
             Interval(BSON("" << negativeInfinity << "" << numberMin), true, true)));
-        ASSERT(exact);
+        ASSERT(tightness == IndexBoundsBuilder::EXACT);
     }
 
     TEST(IndexBoundsBuilderTest, TranslateLteNegativeInfinity) {
@@ -92,13 +92,13 @@ namespace {
         auto_ptr<MatchExpression> expr(parseMatchExpression(obj));
         BSONElement elt = obj.firstElement();
         OrderedIntervalList oil;
-        bool exact;
-        IndexBoundsBuilder::translate(expr.get(), elt, &oil, &exact);
+        IndexBoundsBuilder::BoundsTightness tightness;
+        IndexBoundsBuilder::translate(expr.get(), elt, &oil, &tightness);
         ASSERT_EQUALS(oil.name, "a");
         ASSERT_EQUALS(oil.intervals.size(), 1U);
         ASSERT_EQUALS(Interval::INTERVAL_EQUALS, oil.intervals[0].compare(
             Interval(fromjson("{'': -Infinity, '': -Infinity}"), true, true)));
-        ASSERT(exact);
+        ASSERT(tightness == IndexBoundsBuilder::EXACT);
     }
 
     TEST(IndexBoundsBuilderTest, TranslateLtNumber) {
@@ -106,13 +106,13 @@ namespace {
         auto_ptr<MatchExpression> expr(parseMatchExpression(obj));
         BSONElement elt = obj.firstElement();
         OrderedIntervalList oil;
-        bool exact;
-        IndexBoundsBuilder::translate(expr.get(), elt, &oil, &exact);
+        IndexBoundsBuilder::BoundsTightness tightness;
+        IndexBoundsBuilder::translate(expr.get(), elt, &oil, &tightness);
         ASSERT_EQUALS(oil.name, "a");
         ASSERT_EQUALS(oil.intervals.size(), 1U);
         ASSERT_EQUALS(Interval::INTERVAL_EQUALS, oil.intervals[0].compare(
             Interval(fromjson("{'': -Infinity, '': 1}"), true, false)));
-        ASSERT(exact);
+        ASSERT(tightness == IndexBoundsBuilder::EXACT);
     }
 
     TEST(IndexBoundsBuilderTest, TranslateLtNumberMin) {
@@ -120,13 +120,13 @@ namespace {
         auto_ptr<MatchExpression> expr(parseMatchExpression(obj));
         BSONElement elt = obj.firstElement();
         OrderedIntervalList oil;
-        bool exact;
-        IndexBoundsBuilder::translate(expr.get(), elt, &oil, &exact);
+        IndexBoundsBuilder::BoundsTightness tightness;
+        IndexBoundsBuilder::translate(expr.get(), elt, &oil, &tightness);
         ASSERT_EQUALS(oil.name, "a");
         ASSERT_EQUALS(oil.intervals.size(), 1U);
         ASSERT_EQUALS(Interval::INTERVAL_EQUALS, oil.intervals[0].compare(
             Interval(BSON("" << negativeInfinity << "" << numberMin), true, false)));
-        ASSERT(exact);
+        ASSERT(tightness == IndexBoundsBuilder::EXACT);
     }
 
     TEST(IndexBoundsBuilderTest, TranslateLtNegativeInfinity) {
@@ -134,11 +134,11 @@ namespace {
         auto_ptr<MatchExpression> expr(parseMatchExpression(obj));
         BSONElement elt = obj.firstElement();
         OrderedIntervalList oil;
-        bool exact;
-        IndexBoundsBuilder::translate(expr.get(), elt, &oil, &exact);
+        IndexBoundsBuilder::BoundsTightness tightness;
+        IndexBoundsBuilder::translate(expr.get(), elt, &oil, &tightness);
         ASSERT_EQUALS(oil.name, "a");
         ASSERT_EQUALS(oil.intervals.size(), 0U);
-        ASSERT(exact);
+        ASSERT(tightness == IndexBoundsBuilder::EXACT);
     }
 
     TEST(IndexBoundsBuilderTest, TranslateGtNumber) {
@@ -146,13 +146,13 @@ namespace {
         auto_ptr<MatchExpression> expr(parseMatchExpression(obj));
         BSONElement elt = obj.firstElement();
         OrderedIntervalList oil;
-        bool exact;
-        IndexBoundsBuilder::translate(expr.get(), elt, &oil, &exact);
+        IndexBoundsBuilder::BoundsTightness tightness;
+        IndexBoundsBuilder::translate(expr.get(), elt, &oil, &tightness);
         ASSERT_EQUALS(oil.name, "a");
         ASSERT_EQUALS(oil.intervals.size(), 1U);
         ASSERT_EQUALS(Interval::INTERVAL_EQUALS, oil.intervals[0].compare(
             Interval(fromjson("{'': 1, '': Infinity}"), false, true)));
-        ASSERT(exact);
+        ASSERT(tightness == IndexBoundsBuilder::EXACT);
     }
 
     TEST(IndexBoundsBuilderTest, TranslateGtNumberMax) {
@@ -160,13 +160,13 @@ namespace {
         auto_ptr<MatchExpression> expr(parseMatchExpression(obj));
         BSONElement elt = obj.firstElement();
         OrderedIntervalList oil;
-        bool exact;
-        IndexBoundsBuilder::translate(expr.get(), elt, &oil, &exact);
+        IndexBoundsBuilder::BoundsTightness tightness;
+        IndexBoundsBuilder::translate(expr.get(), elt, &oil, &tightness);
         ASSERT_EQUALS(oil.name, "a");
         ASSERT_EQUALS(oil.intervals.size(), 1U);
         ASSERT_EQUALS(Interval::INTERVAL_EQUALS, oil.intervals[0].compare(
             Interval(BSON("" << numberMax << "" << positiveInfinity), false, true)));
-        ASSERT(exact);
+        ASSERT(tightness == IndexBoundsBuilder::EXACT);
     }
 
     TEST(IndexBoundsBuilderTest, TranslateGtPositiveInfinity) {
@@ -174,11 +174,11 @@ namespace {
         auto_ptr<MatchExpression> expr(parseMatchExpression(obj));
         BSONElement elt = obj.firstElement();
         OrderedIntervalList oil;
-        bool exact;
-        IndexBoundsBuilder::translate(expr.get(), elt, &oil, &exact);
+        IndexBoundsBuilder::BoundsTightness tightness;
+        IndexBoundsBuilder::translate(expr.get(), elt, &oil, &tightness);
         ASSERT_EQUALS(oil.name, "a");
         ASSERT_EQUALS(oil.intervals.size(), 0U);
-        ASSERT(exact);
+        ASSERT(tightness == IndexBoundsBuilder::EXACT);
     }
 
     TEST(IndexBoundsBuilderTest, TranslateGteNumber) {
@@ -186,13 +186,13 @@ namespace {
         auto_ptr<MatchExpression> expr(parseMatchExpression(obj));
         BSONElement elt = obj.firstElement();
         OrderedIntervalList oil;
-        bool exact;
-        IndexBoundsBuilder::translate(expr.get(), elt, &oil, &exact);
+        IndexBoundsBuilder::BoundsTightness tightness;
+        IndexBoundsBuilder::translate(expr.get(), elt, &oil, &tightness);
         ASSERT_EQUALS(oil.name, "a");
         ASSERT_EQUALS(oil.intervals.size(), 1U);
         ASSERT_EQUALS(Interval::INTERVAL_EQUALS, oil.intervals[0].compare(
             Interval(fromjson("{'': 1, '': Infinity}"), true, true)));
-        ASSERT(exact);
+        ASSERT(tightness == IndexBoundsBuilder::EXACT);
     }
 
     TEST(IndexBoundsBuilderTest, TranslateGteNumberMax) {
@@ -200,13 +200,13 @@ namespace {
         auto_ptr<MatchExpression> expr(parseMatchExpression(obj));
         BSONElement elt = obj.firstElement();
         OrderedIntervalList oil;
-        bool exact;
-        IndexBoundsBuilder::translate(expr.get(), elt, &oil, &exact);
+        IndexBoundsBuilder::BoundsTightness tightness;
+        IndexBoundsBuilder::translate(expr.get(), elt, &oil, &tightness);
         ASSERT_EQUALS(oil.name, "a");
         ASSERT_EQUALS(oil.intervals.size(), 1U);
         ASSERT_EQUALS(Interval::INTERVAL_EQUALS, oil.intervals[0].compare(
             Interval(BSON("" << numberMax << "" << positiveInfinity), true, true)));
-        ASSERT(exact);
+        ASSERT(tightness == IndexBoundsBuilder::EXACT);
     }
 
     TEST(IndexBoundsBuilderTest, TranslateGtePositiveInfinity) {
@@ -214,13 +214,13 @@ namespace {
         auto_ptr<MatchExpression> expr(parseMatchExpression(obj));
         BSONElement elt = obj.firstElement();
         OrderedIntervalList oil;
-        bool exact;
-        IndexBoundsBuilder::translate(expr.get(), elt, &oil, &exact);
+        IndexBoundsBuilder::BoundsTightness tightness;
+        IndexBoundsBuilder::translate(expr.get(), elt, &oil, &tightness);
         ASSERT_EQUALS(oil.name, "a");
         ASSERT_EQUALS(oil.intervals.size(), 1U);
         ASSERT_EQUALS(Interval::INTERVAL_EQUALS, oil.intervals[0].compare(
             Interval(fromjson("{'': Infinity, '': Infinity}"), true, true)));
-        ASSERT(exact);
+        ASSERT(tightness == IndexBoundsBuilder::EXACT);
     }
 
 }  // namespace

--- a/src/mongo/db/query/planner_access.h
+++ b/src/mongo/db/query/planner_access.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include "mongo/db/query/canonical_query.h"
+#include "mongo/db/query/index_bounds_builder.h"
 #include "mongo/db/query/query_planner_params.h"
 #include "mongo/db/query/query_solution.h"
 
@@ -128,7 +129,7 @@ namespace mongo {
          */
         static QuerySolutionNode* makeLeafNode(const IndexEntry& index,
                                                MatchExpression* expr,
-                                               bool* exact);
+                                               IndexBoundsBuilder::BoundsTightness* tightnessOut);
 
         /**
          * Merge the predicate 'expr' with the leaf node 'node'.
@@ -136,7 +137,7 @@ namespace mongo {
         static void mergeWithLeafNode(MatchExpression* expr,
                                       const IndexEntry& index,
                                       size_t pos,
-                                      bool* exactOut,
+                                      IndexBoundsBuilder::BoundsTightness* tightnessOut,
                                       QuerySolutionNode* node,
                                       MatchExpression::MatchType mergeType);
 


### PR DESCRIPTION
This is purely a refactor, existing behavior should be unaffected. The enum is needed because in a forthcoming change we will add a third value, INEXACT_COVERED. Some regex queries have inexact bounds but are nevertheless covered by the index and therefore do not require a fetch.
