### PR TITLE
SERVER-10026 tighten index bounds for some array equality queries

### DIFF
--- a/src/mongo/db/query/index_bounds_builder_test.cpp
+++ b/src/mongo/db/query/index_bounds_builder_test.cpp
@@ -84,7 +84,7 @@ namespace {
         ASSERT_EQUALS(oil.intervals.size(), 1U);
         ASSERT_EQUALS(Interval::INTERVAL_EQUALS, oil.intervals[0].compare(
             Interval(BSON("" << negativeInfinity << "" << numberMin), true, true)));
-        ASSERT(tightness == IndexBoundsBuilder::EXACT);
+        ASSERT_EQUALS(tightness, IndexBoundsBuilder::EXACT);
     }
 
     TEST(IndexBoundsBuilderTest, TranslateLteNegativeInfinity) {
@@ -98,7 +98,7 @@ namespace {
         ASSERT_EQUALS(oil.intervals.size(), 1U);
         ASSERT_EQUALS(Interval::INTERVAL_EQUALS, oil.intervals[0].compare(
             Interval(fromjson("{'': -Infinity, '': -Infinity}"), true, true)));
-        ASSERT(tightness == IndexBoundsBuilder::EXACT);
+        ASSERT_EQUALS(tightness, IndexBoundsBuilder::EXACT);
     }
 
     TEST(IndexBoundsBuilderTest, TranslateLtNumber) {
@@ -112,7 +112,7 @@ namespace {
         ASSERT_EQUALS(oil.intervals.size(), 1U);
         ASSERT_EQUALS(Interval::INTERVAL_EQUALS, oil.intervals[0].compare(
             Interval(fromjson("{'': -Infinity, '': 1}"), true, false)));
-        ASSERT(tightness == IndexBoundsBuilder::EXACT);
+        ASSERT_EQUALS(tightness, IndexBoundsBuilder::EXACT);
     }
 
     TEST(IndexBoundsBuilderTest, TranslateLtNumberMin) {
@@ -126,7 +126,7 @@ namespace {
         ASSERT_EQUALS(oil.intervals.size(), 1U);
         ASSERT_EQUALS(Interval::INTERVAL_EQUALS, oil.intervals[0].compare(
             Interval(BSON("" << negativeInfinity << "" << numberMin), true, false)));
-        ASSERT(tightness == IndexBoundsBuilder::EXACT);
+        ASSERT_EQUALS(tightness, IndexBoundsBuilder::EXACT);
     }
 
     TEST(IndexBoundsBuilderTest, TranslateLtNegativeInfinity) {
@@ -138,7 +138,7 @@ namespace {
         IndexBoundsBuilder::translate(expr.get(), elt, &oil, &tightness);
         ASSERT_EQUALS(oil.name, "a");
         ASSERT_EQUALS(oil.intervals.size(), 0U);
-        ASSERT(tightness == IndexBoundsBuilder::EXACT);
+        ASSERT_EQUALS(tightness, IndexBoundsBuilder::EXACT);
     }
 
     TEST(IndexBoundsBuilderTest, TranslateGtNumber) {
@@ -152,7 +152,7 @@ namespace {
         ASSERT_EQUALS(oil.intervals.size(), 1U);
         ASSERT_EQUALS(Interval::INTERVAL_EQUALS, oil.intervals[0].compare(
             Interval(fromjson("{'': 1, '': Infinity}"), false, true)));
-        ASSERT(tightness == IndexBoundsBuilder::EXACT);
+        ASSERT_EQUALS(tightness, IndexBoundsBuilder::EXACT);
     }
 
     TEST(IndexBoundsBuilderTest, TranslateGtNumberMax) {
@@ -166,7 +166,7 @@ namespace {
         ASSERT_EQUALS(oil.intervals.size(), 1U);
         ASSERT_EQUALS(Interval::INTERVAL_EQUALS, oil.intervals[0].compare(
             Interval(BSON("" << numberMax << "" << positiveInfinity), false, true)));
-        ASSERT(tightness == IndexBoundsBuilder::EXACT);
+        ASSERT_EQUALS(tightness, IndexBoundsBuilder::EXACT);
     }
 
     TEST(IndexBoundsBuilderTest, TranslateGtPositiveInfinity) {
@@ -178,7 +178,7 @@ namespace {
         IndexBoundsBuilder::translate(expr.get(), elt, &oil, &tightness);
         ASSERT_EQUALS(oil.name, "a");
         ASSERT_EQUALS(oil.intervals.size(), 0U);
-        ASSERT(tightness == IndexBoundsBuilder::EXACT);
+        ASSERT_EQUALS(tightness, IndexBoundsBuilder::EXACT);
     }
 
     TEST(IndexBoundsBuilderTest, TranslateGteNumber) {
@@ -192,7 +192,7 @@ namespace {
         ASSERT_EQUALS(oil.intervals.size(), 1U);
         ASSERT_EQUALS(Interval::INTERVAL_EQUALS, oil.intervals[0].compare(
             Interval(fromjson("{'': 1, '': Infinity}"), true, true)));
-        ASSERT(tightness == IndexBoundsBuilder::EXACT);
+        ASSERT_EQUALS(tightness, IndexBoundsBuilder::EXACT);
     }
 
     TEST(IndexBoundsBuilderTest, TranslateGteNumberMax) {
@@ -206,7 +206,7 @@ namespace {
         ASSERT_EQUALS(oil.intervals.size(), 1U);
         ASSERT_EQUALS(Interval::INTERVAL_EQUALS, oil.intervals[0].compare(
             Interval(BSON("" << numberMax << "" << positiveInfinity), true, true)));
-        ASSERT(tightness == IndexBoundsBuilder::EXACT);
+        ASSERT_EQUALS(tightness, IndexBoundsBuilder::EXACT);
     }
 
     TEST(IndexBoundsBuilderTest, TranslateGtePositiveInfinity) {
@@ -220,7 +220,23 @@ namespace {
         ASSERT_EQUALS(oil.intervals.size(), 1U);
         ASSERT_EQUALS(Interval::INTERVAL_EQUALS, oil.intervals[0].compare(
             Interval(fromjson("{'': Infinity, '': Infinity}"), true, true)));
-        ASSERT(tightness == IndexBoundsBuilder::EXACT);
+        ASSERT_EQUALS(tightness, IndexBoundsBuilder::EXACT);
+    }
+
+    TEST(IndexBoundsBuilderTest, TranslateArrayEqualBasic) {
+        BSONObj obj = fromjson("{a: [1, 2, 3]}");
+        auto_ptr<MatchExpression> expr(parseMatchExpression(obj));
+        BSONElement elt = obj.firstElement();
+        OrderedIntervalList oil;
+        IndexBoundsBuilder::BoundsTightness tightness;
+        IndexBoundsBuilder::translate(expr.get(), elt, &oil, &tightness);
+        ASSERT_EQUALS(oil.name, "a");
+        ASSERT_EQUALS(oil.intervals.size(), 2U);
+        ASSERT_EQUALS(Interval::INTERVAL_EQUALS, oil.intervals[0].compare(
+            Interval(fromjson("{'': 1, '': 1}"), true, true)));
+        ASSERT_EQUALS(Interval::INTERVAL_EQUALS, oil.intervals[1].compare(
+            Interval(fromjson("{'': [1, 2, 3], '': [1, 2, 3]}"), true, true)));
+        ASSERT_EQUALS(tightness, IndexBoundsBuilder::INEXACT_FETCH);
     }
 
 }  // namespace

--- a/src/mongo/db/query/query_planner_test.cpp
+++ b/src/mongo/db/query/query_planner_test.cpp
@@ -760,6 +760,15 @@ namespace {
         assertSolutionExists("{fetch: {ixscan: {'a.b': 1, 'a.c': 1}}}");
     }
 
+    TEST_F(IndexAssignmentTest, ArrayEquality) {
+        addIndex(BSON("a" << 1));
+        runQuery(fromjson("{a : [1, 2, 3]}"));
+
+        ASSERT_EQUALS(getNumSolutions(), 2U);
+        assertSolutionExists("{cscan: 1}");
+        assertSolutionExists("{fetch: {ixscan: {a: 1}}}");
+    }
+
     //
     // Geo
     // http://docs.mongodb.org/manual/reference/operator/query-geospatial/#geospatial-query-compatibility-chart


### PR DESCRIPTION
The bounds for a query like {a: [1, 2, 3]} in the new query framework are currently [MinKey, MaxKey]. This change optimizes array equality queries by tightening the index bounds. The bounds for the query {a: [1, 2, 3]} should now consist of the two point intervals [1, 1] and [[1,2,3], [1,2,3]].
