### PR TITLE
SERVER-10026 query migration js test updates

### DIFF
--- a/jstests/arrayfind2.js
+++ b/jstests/arrayfind2.js
@@ -22,11 +22,6 @@ go( "no index" );
 t.ensureIndex( { a : 1 } );
 go( "index(a)" );
 
-// QUERY MIGRATION
-// New query systems does not print bounds for a query that doesn use indices
-// printjson( t.find( { a : { $all : [ { $elemMatch : { x : 3 } } ] } } ).explain() );
-// assert.eq( {}, t.find( { a : { $all : [ { $elemMatch : { x : 3 } } ] } } ).explain().indexBounds );
-
 t.ensureIndex( { "a.x": 1 } );
 
 assert.eq( {"a.x":[[3,3]]}, t.find( { a : { $all : [ { $elemMatch : { x : 3 } } ] } } ).explain().indexBounds );

--- a/jstests/countc.js
+++ b/jstests/countc.js
@@ -64,8 +64,7 @@ assert.eq( 1, t.count( { a:{ $lte:new Date( 1 ) } } ) );
 // Querying for 'undefined' triggers an error.
 t.drop();
 t.ensureIndex( { a:1 } );
-// QUERY_MIGRATION: WHAT DO WE REALLY WANT TO CHECK FOR HERE?
-// assert.throws( function() { t.count( { a:undefined } ); } );
+assert.throws( function() { t.count( { a:undefined } ); } );
 
 
 // Count using a descending order index.

--- a/jstests/covered_index_simple_1.js
+++ b/jstests/covered_index_simple_1.js
@@ -51,12 +51,5 @@ var plan = coll.find({foo:"2"}, {foo:1, _id:0}).hint({foo:1}).explain()
 assert.eq(true, plan.indexOnly, "simple.1.7 - indexOnly should be true on covered query")
 assert.eq(0, plan.nscannedObjects, "simple.1.7 - nscannedObjects should be 0 for covered query")
 
-// Test not in query
-// QUERY_MIGRATION: using an ixscan for this is a bad idea.  We don't do it.
-//var plan = coll.find({foo:{$nin:[5,8]}}, {foo:1, _id:0}).hint({foo:1}).explain()
-//assert.eq(true, plan.indexOnly, "simple.1.8 - indexOnly should be true on covered query")
-// This should be 0 but is not due to be bug https://jira.mongodb.org/browse/SERVER-3187
-//assert.eq(28, plan.nscannedObjects, "simple.1.8 - nscannedObjects should be 0 for covered query")
-
 print ('all tests pass')
 

--- a/jstests/covered_index_simple_2.js
+++ b/jstests/covered_index_simple_2.js
@@ -40,11 +40,4 @@ var plan = coll.find({foo:{$in:[5,8]}}, {foo:1, _id:0}).hint({foo:1}).explain()
 assert.eq(true, plan.indexOnly, "simple.2.6 - indexOnly should be true on covered query")
 assert.eq(0, plan.nscannedObjects, "simple.2.6 - nscannedObjects should be 0 for covered query")
 
-// Test not in query
-// QUERY_MIGRATION: $nin with an ixscan is a bad idea.
-//var plan = coll.find({foo:{$nin:[5,8]}}, {foo:1, _id:0}).hint({foo:1}).explain()
-//assert.eq(true, plan.indexOnly, "simple.2.7 - indexOnly should be true on covered query")
-// this should be 0 but is not due to bug https://jira.mongodb.org/browse/SERVER-3187
-//assert.eq(13, plan.nscannedObjects, "simple.2.7 - nscannedObjects should be 0 for covered query")
-
 print ('all tests pass')

--- a/jstests/explain6.js
+++ b/jstests/explain6.js
@@ -14,16 +14,12 @@ t.ensureIndex( {a:1} );
 explain = t.find( {a:null,b:null} ).skip( 1 ).explain( true );
 assert.eq( 0, explain.n );
 
-// QUERY MIGRATION
-// printjson( explain )
-// Old Comment: With multiple plans, the skip information is not known to the plan
-// In the new query system, the skip applies to alternative plans as well
-// assert.eq( 1, explain.allPlans[ 0 ].n );
+printjson( explain );
+assert.eq( 0, explain.allPlans[ 0 ].n );
 
 t.dropIndexes();
 explain = t.find().skip( 1 ).sort({a:1}).explain( true );
 // Skip is applied for an in memory sort.
 assert.eq( 0, explain.n );
 printjson(explain);
-// See above comment about query migration
-// assert.eq( 1, explain.allPlans[ 0 ].n );
+assert.eq( 0, explain.allPlans[ 0 ].n );

--- a/jstests/explain8.js
+++ b/jstests/explain8.js
@@ -22,9 +22,3 @@ explain = t.find( { $or:clauses } ).explain( true );
 
 // Verify the duration of the whole query, and of each clause.
 assert.gt( explain.millis, 1000 - 500 + 2000 - 500 + 3000 - 500 );
-
-// QUERY MIGRATION
-// The new system doesnt measure branches of the or
-//for( j = 0; j < 3; ++j ) {
-//    assert.gt( explain.clauses[ j ].millis, ( j + 1 ) * 1000 - 500 );
-//}

--- a/jstests/in7.js
+++ b/jstests/in7.js
@@ -1,7 +1,0 @@
-t = db.jstests_slow_in1;
-
-t.drop();
-t.ensureIndex( {a:1,b:1,c:1,d:1,e:1,f:1,g:1} );
-i = {$in:[ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 ]};
-// QUERY_MIGRATION SHOULD THIS THROW?
-//assert.throws.automsg( function() { t.count( {a:i,b:i,c:i,d:i,e:i,f:i,g:i} ); } );

--- a/jstests/ori.js
+++ b/jstests/ori.js
@@ -14,8 +14,7 @@ t.save( {a:10,b:2,c:4} );
 assert.eq( 2, t.count( {$or:[{a:{$gt:0,$lt:5},b:2},{a:10,c:4}]} ) );
 // Two $or clauses expected to be scanned.
 
-// QUERY_MIGRATION: we may merge sort these
-//assert.eq( 2, t.find( {$or:[{a:{$gt:0,$lt:5},b:2},{a:10,c:4}]} ).explain().clauses.length );
+assert.eq( 2, t.find( {$or:[{a:{$gt:0,$lt:5},b:2},{a:10,c:4}]} ).explain().clauses.length );
 assert.eq( 2, t.count( {$or:[{a:10,b:2},{a:{$gt:0,$lt:5},c:4}]} ) );
 
 t.drop();
@@ -48,8 +47,5 @@ assert.isnull( t.find( {$or:[{a:{$gt:0,$lt:5}},{a:10,b:1}]} ).explain().clauses 
 assert.eq( 2, t.count( {$or:[{a:{$lt:5,$gt:0}},{a:10,b:1}]} ) );
 // Now a:10 is not scanned in the first clause so the second clause is not eliminated.
 
-// QUERY MIGRATION
-// This is worth investigating. Execution is choosing a collection scan over the or over
-// over index plans
-// printjson( t.find( {$or:[{a:{$lt:5,$gt:0}},{a:10,b:1}]} ).explain() )
-// assert.eq( 2, t.find( {$or:[{a:{$lt:5,$gt:0}},{a:10,b:1}]} ).explain().clauses.length );
+printjson( t.find( {$or:[{a:{$lt:5,$gt:0}},{a:10,b:1}]} ).explain() )
+assert.eq( 2, t.find( {$or:[{a:{$lt:5,$gt:0}},{a:10,b:1}]} ).explain().clauses.length );


### PR DESCRIPTION
In the process of enabling the new query system, many js tests were disabled and marked QUERY_MIGRATION. This commit re-enables some QUERY_MIGRATION tests that are now passing, and deletes others that are no longer relevant under the new system.
