### PR TITLE
SERVER-3223 js test for upsert with $bit

### DIFF
--- a/jstests/verify_update_mods.js
+++ b/jstests/verify_update_mods.js
@@ -57,6 +57,15 @@ t.update({}, {$bit:{a:{and:NumberLong(1)}}})
 assert.automsg( "!db.getLastError()" );
 t.remove()
 
+// SERVER-3223 test $bit can do an upsert
+t.update({_id:1}, {$bit:{a:{and:NumberLong(3)}}}, true);
+assert.eq(t.findOne({_id:1}).a, NumberLong(0), "$bit upsert with and");
+t.update({_id:2}, {$bit:{b:{or:NumberLong(3)}}}, true);
+assert.eq(t.findOne({_id:2}).b, NumberLong(3), "$bit upsert with or (long)");
+t.update({_id:3}, {$bit:{"c.d":{or:NumberInt(3)}}}, true);
+assert.eq(t.findOne({_id:3}).c.d, NumberInt(3), "$bit upsert with or (int)");
+t.remove();
+
 t.save({_id:1});
 t.update({}, {$currentDate:{a:true}})
 assert.automsg( "!db.getLastError()" );


### PR DESCRIPTION
In 2.4 upsert did not work with $bit. This has been fixed by the update() refactor in 2.5, so I'm adding a js regression test before closing out the ticket.
