### PR TITLE
SERVER-10026 git rid of $and match expressions with a single child

### DIFF
--- a/src/mongo/db/query/planner_access.cpp
+++ b/src/mongo/db/query/planner_access.cpp
@@ -597,8 +597,18 @@ namespace mongo {
         if (root->numChildren() > 0) {
             FetchNode* fetch = new FetchNode();
             verify(NULL != autoRoot.get());
-            // Takes ownership.
-            fetch->filter.reset(autoRoot.release());
+            if (autoRoot->numChildren() == 1) {
+                // An $and of one thing is that thing.
+                MatchExpression* child = autoRoot->getChild(0);
+                autoRoot->getChildVector()->clear();
+                // Takes ownership.
+                fetch->filter.reset(child);
+                // 'autoRoot' will delete the empty $and.
+            }
+            else { // root->numChildren() > 1
+                // Takes ownership.
+                fetch->filter.reset(autoRoot.release());
+            }
             // takes ownership
             fetch->children.push_back(andResult);
             andResult = fetch;

--- a/src/mongo/db/query/query_planner_test.cpp
+++ b/src/mongo/db/query/query_planner_test.cpp
@@ -635,8 +635,8 @@ namespace {
         assertSolutionExists("{cscan: {dir: 1}}");
         assertSolutionExists("{fetch: {filter: null, node: {or: {nodes: ["
                                 "{ixscan: {filter: null, pattern: {a: 1}}}, "
-                                "{fetch: {filter: {$and: [{b: 7}]}, "
-                                         "node: {ixscan: {filter: null, pattern: {a: 1}}}}}]}}}}");
+                                "{fetch: {filter: {b: 7}, node: {ixscan: "
+                                "{filter: null, pattern: {a: 1}}}}}]}}}}");
     }
 
     TEST_F(IndexAssignmentTest, AndWithUnindexedOrChild) {
@@ -645,8 +645,8 @@ namespace {
 
         ASSERT_EQUALS(getNumSolutions(), 2U);
         assertSolutionExists("{cscan: {dir: 1}}");
-        assertSolutionExists("{fetch: {filter: {$and: [{$or: [{b: 1}, {c: 7}]}]}, "
-                                "node: {ixscan: {filter: null, pattern: {a: 1}}}}}");
+        assertSolutionExists("{fetch: {filter: {$or: [{b: 1}, {c: 7}]}, node: "
+                                "{ixscan: {filter: null, pattern: {a: 1}}}}}");
     }
 
 
@@ -657,7 +657,7 @@ namespace {
 
         ASSERT_EQUALS(getNumSolutions(), 2U);
         assertSolutionExists("{cscan: {dir: 1}}");
-        assertSolutionExists("{fetch: {filter: {$and: [{$or: [{b: 1}, {c: 7}]}]}, "
+        assertSolutionExists("{fetch: {filter: {$or: [{b: 1}, {c: 7}]}, "
                                 "node: {ixscan: {filter: null, pattern: {a: 1}}}}}");
     }
 
@@ -818,7 +818,7 @@ namespace {
 
         ASSERT_EQUALS(getNumSolutions(), 2U);
         assertSolutionExists("{cscan: {dir: 1}}");
-        assertSolutionExists("{fetch: {filter: {$and: [{z: 10}]}, node: "
+        assertSolutionExists("{fetch: {filter: {z: 10}, node: "
                                 "{ixscan: {filter: null, pattern: {x: 1, y: 1, z: 1}}}}}");
     }
 


### PR DESCRIPTION
In some cases, the query planner used to leave filters in the query solution tree that were $and expressions with a single child. For instance, there might be a FETCH node whose filter is {$and: [{a: 3}]}. This change removes these extra $and match expression nodes (i.e. the FETCH filter will now simply be {a: 3}).
