### PR TITLE
SERVER-10026 cleanup positional projection operator validation

### DIFF
--- a/src/mongo/db/query/canonical_query.cpp
+++ b/src/mongo/db/query/canonical_query.cpp
@@ -245,7 +245,7 @@ namespace mongo {
         // Validate the projection if there is one.
         if (!_pq->getProj().isEmpty()) {
             ParsedProjection* pp;
-            Status projStatus = ParsedProjection::make(_pq->getProj(), _pq->getFilter(), &pp);
+            Status projStatus = ParsedProjection::make(_pq->getProj(), root, &pp);
             if (!projStatus.isOK()) {
                 return projStatus;
             }

--- a/src/mongo/db/query/parsed_projection.h
+++ b/src/mongo/db/query/parsed_projection.h
@@ -49,7 +49,8 @@ namespace mongo {
          * Returns Status::OK() if it's a valid spec.
          * Returns a Status indicating how it's invalid otherwise.
          */
-        static Status make(const BSONObj& spec, const BSONObj& query, ParsedProjection** out);
+        static Status make(const BSONObj& spec, const MatchExpression* const query,
+                           ParsedProjection** out);
 
         /**
          * Is the full document required to compute this projection?
@@ -76,6 +77,18 @@ namespace mongo {
          * Must go through ::make
          */
         ParsedProjection() : _requiresDocument(true) { }
+
+        /**
+         * Returns true if the MatchExpression 'query' queries against
+         * the field named by 'matchfield'. This deeply traverses logical
+         * nodes in the matchfield and returns true if any of the children
+         * have the field (so if 'query' is {$and: [{a: 1}, {b: 1}]} and
+         * 'matchfield' is "b", the return value is true).
+         *
+         * Does not take ownership of 'query'.
+         */
+        static bool _hasPositionalOperatorMatch(const MatchExpression* const query,
+                                                const std::string& matchfield);
 
         // XXX stringdata?
         vector<string> _requiredFields;


### PR DESCRIPTION
1) Refactors the validation of the positional projection operator so that it all happens in one place.

2) Adds validation which prevents the positional operator from appearing twice in a path, e.g. the projection "a.$.b.$". There is comparable validation for the update version of the positional operator, so we should do it here too.

3) Cleaner code for ensuring that the positional operator matches the query document. The cleaned up version also traverses logical match expression nodes, which we didn't properly do before.
