### PR TITLE
SERVER-11946 colMod should expose padding factor

### DIFF
--- a/src/mongo/db/dbcommands.cpp
+++ b/src/mongo/db/dbcommands.cpp
@@ -1135,7 +1135,6 @@ namespace mongo {
                     }
 
                     if ( oldPaddingSize != newPaddingSize ) {
-                    	// change userFlags
                         result.append( "PaddingSize_old", oldPaddingSize );
                         nsd->setPaddingFactor( newPaddingSize );
                         if (nsd->paddingFactor() == newPaddingSize){


### PR DESCRIPTION
[SERVER-11946] collMod should expose padding factor.

No test included as no other tests for collMod where found in the code. This call the same function as  organic growth does "nsd->setPaddingFactor()". It only exposes what it done internal so in specific use cases it can be optimized when growth via updates are expected.
