### PR TITLE
SERVER-10026 stop testing old code in dbtest suite 'query'

### DIFF
--- a/src/mongo/db/query/lite_parsed_query_test.cpp
+++ b/src/mongo/db/query/lite_parsed_query_test.cpp
@@ -55,6 +55,30 @@ namespace {
         ASSERT_NOT_OK(result);
     }
 
+    TEST(LiteParsedQueryTest, GetFilter) {
+        LiteParsedQuery* lpq = NULL;
+        Status result = LiteParsedQuery::make("testns", 5, 6, 9, BSON( "x" << 5 ), BSONObj(),
+                                              BSONObj(), BSONObj(), &lpq);
+        ASSERT_OK(result);
+        ASSERT_EQUALS(BSON("x" << 5 ), lpq->getFilter());
+    }
+
+    TEST(LiteParsedQueryTest, NumToReturn) {
+        LiteParsedQuery* lpq = NULL;
+        Status result = LiteParsedQuery::make("testns", 5, 6, 9, BSON( "x" << 5 ), BSONObj(),
+                                              BSONObj(), BSONObj(), &lpq);
+        ASSERT_OK(result);
+        ASSERT_EQUALS(6, lpq->getNumToReturn());
+        ASSERT(lpq->wantMore());
+
+        lpq = NULL;
+        result = LiteParsedQuery::make("testns", 5, -6, 9, BSON( "x" << 5 ), BSONObj(),
+                                       BSONObj(), BSONObj(), &lpq);
+        ASSERT_OK(result);
+        ASSERT_EQUALS(6, lpq->getNumToReturn());
+        ASSERT(!lpq->wantMore());
+    }
+
     //
     // Text meta BSON element validation
     //


### PR DESCRIPTION
Touches only dbtests and unit tests. Removes tests from the dbtest suite named 'query' that call soon-to-be-removed code. Some cases have been ported to the unit tests for the new query system.
