### PR TITLE
SERVER-12128 Change Earth radius from 6371 to 6378.1 to reflect constant used by MongoDB

### DIFF
--- a/jstests/geo_array2.js
+++ b/jstests/geo_array2.js
@@ -81,7 +81,7 @@ for( var i = -1; i < 2; i++ ){
 		// Do nearSphere check
 		
 		// Earth Radius
-		var eRad = 6371
+		var eRad = 6378.1
 				
 		nearResults = db.geoarray2.find( { loc : { $nearSphere : center , $maxDistance : 500 /* km */ / eRad }, type : type } ).toArray()
 		

--- a/jstests/geo_center_sphere2.js
+++ b/jstests/geo_center_sphere2.js
@@ -32,7 +32,7 @@ for ( var test = 0; test < numTests; test++ ) {
 	Random.srand( 1337 + test );
 	
 	var radius = 5000 * Random.rand() // km
-	radius = radius / 6371 // radians
+	radius = radius / 6378.1 // radians
 	var numDocs = Math.floor( 400 * Random.rand() )
 	// TODO: Wrapping uses the error value to figure out what would overlap...
 	var bits = Math.floor( 5 + Random.rand() * 28 )

--- a/src/third_party/s2/s2edgeindex_test.cc
+++ b/src/third_party/s2/s2edgeindex_test.cc
@@ -31,7 +31,7 @@ DECLARE_bool(always_recurse_on_children);
 
 typedef pair<S2Point, S2Point> S2Edge;
 
-static const double kEarthRadiusMeters = 6371000;
+static const double kEarthRadiusMeters = 6378100;
 
 
 


### PR DESCRIPTION
constant kRadiusOfEarthInMeters is defined as 6378.1 \* 1000 in mongo/src/mongo/db/geo/geoconstants.h. 

Changed tests that referenced Earth radius in km as 6371 to reflect the constant value.
