### PR TITLE
SERVER-12128 Inconsistent Earth radius used in tests / documentation

### DIFF
--- a/src/mongo/db/geo/geoconstants.h
+++ b/src/mongo/db/geo/geoconstants.h
@@ -31,6 +31,6 @@
 namespace mongo {
 
     // Thanks, Wikipedia.
-    const double kRadiusOfEarthInMeters = (6378.1 * 1000);
+    const double kRadiusOfEarthInMeters = (6371 * 1000);
 
 }  // namespace mongo


### PR DESCRIPTION
MongoDB tests and documentation utilize mean Earth radius (6371km) rather than equatorial radius (6378.1km). Because Earth is not a perfect sphere, mean radius may be a more appropriate constant.

Ref: https://github.com/mongodb/mongo/pull/580#issuecomment-30535697
