### PR TITLE
SERVER-10026 port old dbtests to single_solution_runner_test

### DIFF
--- a/jstests/find_dedup.js
+++ b/jstests/find_dedup.js
@@ -1,0 +1,34 @@
+// Test that duplicate query results are not returned.
+
+var t = db.jstests_find_dedup;
+
+function checkDedup(query, idArray) {
+    resultsArr = t.find(query).toArray();
+    assert.eq(resultsArr.length, idArray.length, "same number of results");
+
+    for (var i = 0; i < idArray.length; i++) {
+        assert(("_id" in resultsArr[i]), "result doc missing _id");
+        assert.eq(idArray[i], resultsArr[i]._id, "_id mismatch for doc " + i);
+    }
+}
+
+// Deduping $or
+t.drop();
+t.ensureIndex({a: 1, b: 1});
+t.save({_id: 1, a: 1, b: 1});
+t.save({_id: 2, a: 1, b: 1});
+t.save({_id: 3, a: 2, b: 2});
+t.save({_id: 4, a: 3, b: 3});
+t.save({_id: 5, a: 3, b: 3});
+checkDedup({$or: [{a:{$gte:0,$lte:2},b:{$gte:0,$lte:2}},
+                  {a:{$gte:1,$lte:3},b:{$gte:1,$lte:3}},
+                  {a:{$gte:1,$lte:4},b:{$gte:1,$lte:4}}]},
+           [1, 2, 3, 4, 5]);
+
+// Deduping multikey
+t.drop();
+t.ensureIndex({a: 1, b: 1});
+t.save({_id: 1, a: [1, 2, 3], b: [4, 5, 6]});
+t.save({_id: 2, a: [1, 2, 3], b: [4, 5, 6]});
+checkDedup({$or: [{a: {$in: [1, 2]}}, {b: {$in: [4, 5]}}]}, [1, 2]);
+

--- a/src/mongo/db/query/canonical_query.cpp
+++ b/src/mongo/db/query/canonical_query.cpp
@@ -86,7 +86,7 @@ namespace mongo {
                                         CanonicalQuery** out) {
         BSONObj emptyObj;
         return CanonicalQuery::canonicalize(ns, query, sort, proj, skip, limit, hint,
-                                            emptyObj, emptyObj, out);
+                                            emptyObj, emptyObj, false, out);
     }
 
     // static
@@ -95,12 +95,12 @@ namespace mongo {
                                         long long skip, long long limit,
                                         const BSONObj& hint,
                                         const BSONObj& minObj, const BSONObj& maxObj,
-                                        CanonicalQuery** out) {
+                                        bool snapshot, CanonicalQuery** out) {
         LiteParsedQuery* lpq;
         // Pass empty sort and projection.
         BSONObj emptyObj;
         Status parseStatus = LiteParsedQuery::make(ns, skip, limit, 0, query, proj, sort,
-                                                   hint, minObj, maxObj, &lpq);
+                                                   hint, minObj, maxObj, snapshot, &lpq);
         if (!parseStatus.isOK()) { return parseStatus; }
 
         auto_ptr<CanonicalQuery> cq(new CanonicalQuery());

--- a/src/mongo/db/query/canonical_query.h
+++ b/src/mongo/db/query/canonical_query.h
@@ -68,7 +68,7 @@ namespace mongo {
                                    long long skip, long long limit,
                                    const BSONObj& hint,
                                    const BSONObj& minObj, const BSONObj& maxObj,
-                                   CanonicalQuery** out);
+                                   bool snapshot, CanonicalQuery** out);
 
         // What namespace is this query over?
         const string& ns() const { return _pq->ns(); }

--- a/src/mongo/db/query/lite_parsed_query.cpp
+++ b/src/mongo/db/query/lite_parsed_query.cpp
@@ -47,12 +47,14 @@ namespace mongo {
                                  const BSONObj& query, const BSONObj& proj, const BSONObj& sort,
                                  const BSONObj& hint,
                                  const BSONObj& minObj, const BSONObj& maxObj,
+                                 bool snapshot,
                                  LiteParsedQuery** out) {
         auto_ptr<LiteParsedQuery> pq(new LiteParsedQuery());
         pq->_sort = sort;
         pq->_hint = hint;
         pq->_min = minObj;
         pq->_max = maxObj;
+        pq->_snapshot = snapshot;
 
         Status status = pq->init(ns, ntoskip, ntoreturn, queryOptions, query, proj, false);
         if (status.isOK()) { *out = pq.release(); }

--- a/src/mongo/db/query/lite_parsed_query.h
+++ b/src/mongo/db/query/lite_parsed_query.h
@@ -50,6 +50,7 @@ namespace mongo {
                            const BSONObj& hint,
                            const BSONObj& minObj,
                            const BSONObj& maxObj,
+                           bool snapshot,
                            LiteParsedQuery** out);
 
         /**

--- a/src/mongo/db/query/lite_parsed_query_test.cpp
+++ b/src/mongo/db/query/lite_parsed_query_test.cpp
@@ -45,7 +45,7 @@ namespace {
         LiteParsedQuery* lpq = NULL;
         Status result = LiteParsedQuery::make("testns", 0, 1, 0, BSONObj(), BSONObj(),
                                               fromjson("{a: 1}"), BSONObj(),
-                                              BSONObj(), BSONObj(),
+                                              BSONObj(), BSONObj(), false,
                                               &lpq);
         ASSERT_OK(result);
     }
@@ -54,7 +54,7 @@ namespace {
         LiteParsedQuery* lpq = NULL;
         Status result = LiteParsedQuery::make("testns", 0, 1, 0, BSONObj(), BSONObj(),
                                               fromjson("{a: \"\"}"), BSONObj(),
-                                              BSONObj(), BSONObj(),
+                                              BSONObj(), BSONObj(), false,
                                               &lpq);
         ASSERT_NOT_OK(result);
     }
@@ -64,7 +64,7 @@ namespace {
         Status result = LiteParsedQuery::make("testns", 5, 6, 9, BSON( "x" << 5 ), BSONObj(),
                                               BSONObj(), BSONObj(),
                                               BSONObj(), BSONObj(),
-                                              &lpq);
+                                              false, &lpq);
         ASSERT_OK(result);
         ASSERT_EQUALS(BSON("x" << 5 ), lpq->getFilter());
     }
@@ -74,7 +74,7 @@ namespace {
         Status result = LiteParsedQuery::make("testns", 5, 6, 9, BSON( "x" << 5 ), BSONObj(),
                                               BSONObj(), BSONObj(),
                                               BSONObj(), BSONObj(),
-                                              &lpq);
+                                              false, &lpq);
         ASSERT_OK(result);
         ASSERT_EQUALS(6, lpq->getNumToReturn());
         ASSERT(lpq->wantMore());
@@ -83,7 +83,7 @@ namespace {
         result = LiteParsedQuery::make("testns", 5, -6, 9, BSON( "x" << 5 ), BSONObj(),
                                        BSONObj(), BSONObj(),
                                        BSONObj(), BSONObj(),
-                                       &lpq);
+                                       false, &lpq);
         ASSERT_OK(result);
         ASSERT_EQUALS(6, lpq->getNumToReturn());
         ASSERT(!lpq->wantMore());
@@ -94,7 +94,7 @@ namespace {
         Status result = LiteParsedQuery::make("testns", 0, 0, 0, BSONObj(), BSONObj(),
                                               BSONObj(), BSONObj(),
                                               fromjson("{a: 1}"), fromjson("{b: 1}"),
-                                              &lpq);
+                                              false, &lpq);
         ASSERT_NOT_OK(result);
     }
 
@@ -103,7 +103,7 @@ namespace {
         Status result = LiteParsedQuery::make("testns", 0, 0, 0, BSONObj(), BSONObj(),
                                               BSONObj(), BSONObj(),
                                               fromjson("{a: 1, b: 1}"), fromjson("{a: 1}"),
-                                              &lpq);
+                                              false, &lpq);
         ASSERT_NOT_OK(result);
     }
 
@@ -112,7 +112,7 @@ namespace {
         Status result = LiteParsedQuery::make("testns", 0, 0, 0, BSONObj(), BSONObj(),
                                               BSONObj(), BSONObj(),
                                               fromjson("{a: 1}"), fromjson("{a: 1, b: 1}"),
-                                              &lpq);
+                                              false, &lpq);
         ASSERT_NOT_OK(result);
     }
 

--- a/src/mongo/db/query/plan_cache_test.cpp
+++ b/src/mongo/db/query/plan_cache_test.cpp
@@ -87,7 +87,7 @@ namespace {
                                                      skip, limit,
                                                      hintObj,
                                                      minObj, maxObj,
-                                                     &cq);
+                                                     false, &cq);
         ASSERT_OK(result);
         return cq;
     }

--- a/src/mongo/dbtests/query_single_solution_runner.cpp
+++ b/src/mongo/dbtests/query_single_solution_runner.cpp
@@ -1,0 +1,417 @@
+/**
+ *    Copyright (C) 2013 MongoDB Inc.
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under the terms of the GNU Affero General Public License, version 3,
+ *    as published by the Free Software Foundation.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *    As a special exception, the copyright holders give permission to link the
+ *    code of portions of this program with the OpenSSL library under certain
+ *    conditions as described in each individual source file and distribute
+ *    linked combinations including the program with the OpenSSL library. You
+ *    must comply with the GNU Affero General Public License in all respects
+ *    for all of the code used other than as permitted herein. If you modify
+ *    file(s) with this exception, you may extend this exception to your
+ *    version of the file(s), but you are not obligated to do so. If you do not
+ *    wish to do so, delete this exception statement from your version. If you
+ *    delete this exception statement from all source files in the program,
+ *    then also delete it in the license file.
+ */
+
+#include "mongo/db/clientcursor.h"
+#include "mongo/db/exec/collection_scan.h"
+#include "mongo/db/exec/fetch.h"
+#include "mongo/db/exec/index_scan.h"
+#include "mongo/db/exec/plan_stage.h"
+#include "mongo/db/instance.h"
+#include "mongo/db/json.h"
+#include "mongo/db/matcher/expression_parser.h"
+#include "mongo/db/query/query_solution.h"
+#include "mongo/db/query/single_solution_runner.h"
+#include "mongo/db/structure/collection.h"
+#include "mongo/dbtests/dbtests.h"
+
+namespace QuerySingleSolutionRunner {
+
+    class SingleSolutionRunnerBase {
+    public:
+        SingleSolutionRunnerBase() { }
+
+        virtual ~SingleSolutionRunnerBase() {
+            _client.dropCollection(ns());
+        }
+
+        void addIndex(const BSONObj& obj) {
+            _client.ensureIndex(ns(), obj);
+        }
+
+        void insert(const BSONObj& obj) {
+            _client.insert(ns(), obj);
+        }
+
+        void remove(const BSONObj& obj) {
+            _client.remove(ns(), obj);
+        }
+
+        void dropCollection() {
+            _client.dropCollection(ns());
+        }
+
+        void update(BSONObj& query, BSONObj& updateSpec) {
+            _client.update(ns(), query, updateSpec, false, false);
+        }
+
+        /**
+         * Given a match expression, represented as the BSON object 'filterObj',
+         * create a SingleSolutionRunner capable of executing a simple collection
+         * scan.
+         *
+         * The caller takes ownership of the returned SingleSolutionRunner*.
+         */
+        SingleSolutionRunner* makeCollScanRunner(BSONObj& filterObj) {
+            CollectionScanParams csparams;
+            csparams.ns = ns();
+            csparams.direction = CollectionScanParams::FORWARD;
+            auto_ptr<WorkingSet> ws(new WorkingSet());
+            // Parse the filter.
+            StatusWithMatchExpression swme = MatchExpressionParser::parse(filterObj);
+            verify(swme.isOK());
+            auto_ptr<MatchExpression> filter(swme.getValue());
+            // Make the stage.
+            auto_ptr<PlanStage> root(new CollectionScan(csparams, ws.get(), filter.release()));
+
+            CanonicalQuery* cq;
+            verify(CanonicalQuery::canonicalize(ns(), filterObj, &cq).isOK());
+            verify(NULL != cq);
+
+            // Hand the plan off to the single solution runner.
+            SingleSolutionRunner* ssr = new SingleSolutionRunner(cq, new QuerySolution(),
+                                            root.release(), ws.release());
+            return ssr;
+        }
+
+        /**
+         * @param indexSpec -- a BSONObj giving the index over which to
+         *   scan, e.g. {_id: 1}.
+         * @param start -- the lower bound (inclusive) at which to start
+         *   the index scan
+         * @param end -- the lower bound (inclusive) at which to end the
+         *   index scan
+         *
+         * Returns a SingleSolutionRunner capable of executing an index scan
+         * over the specified index with the specified bounds.
+         *
+         * The caller takes ownership of the returned SingleSolutionRunner*.
+         */
+        SingleSolutionRunner* makeIndexScanRunner(BSONObj& indexSpec, int start, int end) {
+            // Build the index scan stage.
+            IndexScanParams ixparams;
+            ixparams.descriptor = getIndex(indexSpec);
+            ixparams.bounds.isSimpleRange = true;
+            ixparams.bounds.startKey = BSON("" << start);
+            ixparams.bounds.endKey = BSON("" << end);
+            ixparams.bounds.endKeyInclusive = true;
+            ixparams.direction = 1;
+            auto_ptr<WorkingSet> ws(new WorkingSet());
+            IndexScan* ix = new IndexScan(ixparams, ws.get(), NULL);
+            auto_ptr<PlanStage> root(new FetchStage(ws.get(), ix, NULL));
+
+            CanonicalQuery* cq;
+            verify(CanonicalQuery::canonicalize(ns(), BSONObj(), &cq).isOK());
+            verify(NULL != cq);
+
+            // Hand the plan off to the single solution runner.
+            return new SingleSolutionRunner(cq, new QuerySolution(),
+                                            root.release(), ws.release());
+        }
+
+        static const char* ns() { return "unittests.QueryStageSingleSolutionRunner"; }
+
+    private:
+        IndexDescriptor* getIndex(const BSONObj& obj) {
+            Collection* collection = cc().database()->getCollection( ns() );
+            NamespaceDetails* nsd = collection->details();
+            int idxNo = nsd->findIndexByKeyPattern(obj);
+            return collection->getIndexCatalog()->getDescriptor( idxNo );
+        }
+
+        static DBDirectClient _client;
+    };
+
+    DBDirectClient SingleSolutionRunnerBase::_client;
+
+    /**
+     * Test dropping the collection while the
+     * SingleSolutionRunner is doing a collection scan.
+     */
+    class DropCollScan : public SingleSolutionRunnerBase {
+    public:
+        void run() {
+            Client::WriteContext ctx(ns());
+            insert(BSON("_id" << 1));
+            insert(BSON("_id" << 2));
+
+            BSONObj filterObj = fromjson("{_id: {$gt: 0}}");
+            scoped_ptr<SingleSolutionRunner> ssr(makeCollScanRunner(filterObj));
+
+            // Set up autoyielding.
+            ClientCursor::registerRunner(ssr.get());
+            ssr->setYieldPolicy(Runner::YIELD_AUTO);
+
+            BSONObj objOut;
+            ASSERT_EQUALS(Runner::RUNNER_ADVANCED, ssr->getNext(&objOut, NULL));
+            ASSERT_EQUALS(1, objOut["_id"].numberInt());
+
+            // After dropping the collection, the runner
+            // should be dead.
+            dropCollection();
+            ASSERT_EQUALS(Runner::RUNNER_DEAD, ssr->getNext(&objOut, NULL));
+
+            ClientCursor::deregisterRunner(ssr.get());
+        }
+    };
+
+    /**
+     * Test dropping the collection while the
+     * SingleSolutionRunner is doing an index scan.
+     */
+    class DropIndexScan : public SingleSolutionRunnerBase {
+    public:
+        void run() {
+            Client::WriteContext ctx(ns());
+            insert(BSON("_id" << 1 << "a" << 6));
+            insert(BSON("_id" << 2 << "a" << 7));
+            insert(BSON("_id" << 3 << "a" << 8));
+            BSONObj indexSpec = BSON("a" << 1);
+            addIndex(indexSpec);
+
+            scoped_ptr<SingleSolutionRunner> ssr(makeIndexScanRunner(indexSpec, 7, 10));
+
+            // Set up autoyielding.
+            ClientCursor::registerRunner(ssr.get());
+            ssr->setYieldPolicy(Runner::YIELD_AUTO);
+
+            BSONObj objOut;
+            ASSERT_EQUALS(Runner::RUNNER_ADVANCED, ssr->getNext(&objOut, NULL));
+            ASSERT_EQUALS(7, objOut["a"].numberInt());
+
+            // After dropping the collection, the runner
+            // should be dead.
+            dropCollection();
+            ASSERT_EQUALS(Runner::RUNNER_DEAD, ssr->getNext(&objOut, NULL));
+
+            ClientCursor::deregisterRunner(ssr.get());
+        }
+    };
+
+    class SnapshotBase : public SingleSolutionRunnerBase {
+    protected:
+        void setupCollection() {
+            insert(BSON("_id" << 1 << "a" << 1));
+            insert(BSON("_id" << 2 << "a" << 2 << "payload" << "x"));
+            insert(BSON("_id" << 3 << "a" << 3));
+            insert(BSON("_id" << 4 << "a" << 4));
+        }
+
+        /**
+         * Increases a document's size dramatically such that the document
+         * exceeds the available padding and must be moved to the end of
+         * the collection.
+         */
+        void forceDocumentMove() {
+            BSONObj query = BSON("_id" << 2);
+            BSONObj updateSpec = BSON("$set" << BSON("payload" << payload8k()));
+            update(query, updateSpec);
+        }
+
+        std::string payload8k() {
+            return std::string(8*1024, 'x');
+        }
+
+        /**
+         * Given an array of ints, 'expectedIds', and a SingleSolutionRunner,
+         * 'ssr', uses the runner to iterate through the collection. While
+         * iterating, asserts that the _id of each successive document equals
+         * the respective integer in 'expectedIds'.
+         */
+        void checkIds(int* expectedIds, SingleSolutionRunner* ssr) {
+            BSONObj objOut;
+            int idcount = 0;
+            while (Runner::RUNNER_ADVANCED == ssr->getNext(&objOut, NULL)) {
+                ASSERT_EQUALS(expectedIds[idcount], objOut["_id"].numberInt());
+                ++idcount;
+            }
+        }
+    };
+
+    /**
+     * Create a scenario in which the same document is returned
+     * twice due to a concurrent document move and collection
+     * scan.
+     */
+    class SnapshotControl : public SnapshotBase {
+    public:
+        void run() {
+            Client::WriteContext ctx(ns());
+            setupCollection();
+
+            BSONObj filterObj = fromjson("{a: {$gte: 2}}");
+            scoped_ptr<SingleSolutionRunner> ssr(makeCollScanRunner(filterObj));
+
+            BSONObj objOut;
+            ASSERT_EQUALS(Runner::RUNNER_ADVANCED, ssr->getNext(&objOut, NULL));
+            ASSERT_EQUALS(2, objOut["a"].numberInt());
+
+            forceDocumentMove();
+
+            int ids[] = {3, 4, 2};
+            checkIds(ids, ssr.get());
+        }
+    };
+
+    /**
+     * A snapshot is really just a hint that means scan the _id index.
+     * Make sure that we do not see the document move with an _id
+     * index scan.
+     */
+    class SnapshotTest : public SnapshotBase {
+    public:
+        void run() {
+            Client::WriteContext ctx(ns());
+            setupCollection();
+            BSONObj indexSpec = BSON("_id" << 1);
+            addIndex(indexSpec);
+
+            BSONObj filterObj = fromjson("{a: {$gte: 2}}");
+            scoped_ptr<SingleSolutionRunner> ssr(makeIndexScanRunner(indexSpec, 2, 5));
+
+            BSONObj objOut;
+            ASSERT_EQUALS(Runner::RUNNER_ADVANCED, ssr->getNext(&objOut, NULL));
+            ASSERT_EQUALS(2, objOut["a"].numberInt());
+
+            forceDocumentMove();
+
+            // Since this time we're scanning the _id index,
+            // we should not see the moved document again.
+            int ids[] = {3, 4};
+            checkIds(ids, ssr.get());
+        }
+    };
+
+    namespace ClientCursor {
+
+        using mongo::ClientCursor;
+
+        /**
+         * Test invalidation of ClientCursor.
+         */
+        class Invalidate : public SingleSolutionRunnerBase {
+        public:
+            void run() {
+                Client::WriteContext ctx(ns());
+                insert(BSON("a" << 1 << "b" << 1));
+
+                BSONObj filterObj = fromjson("{_id: {$gt: 0}, b: {$gt: 0}}");
+                SingleSolutionRunner* ssr = makeCollScanRunner(filterObj);
+
+                // Make a client cursor from the runner.
+                new ClientCursor(ssr, 0, BSONObj());
+
+                // There should be one cursor before invalidation,
+                // and zero cursors after invalidation.
+                ASSERT_EQUALS(1U, ClientCursor::numCursors());
+                ClientCursor::invalidate(ns());
+                ASSERT_EQUALS(0U, ClientCursor::numCursors());
+            }
+        };
+
+        /**
+         * Test that pinned client cursors persist even after
+         * invalidation.
+         */
+        class InvalidatePinned : public SingleSolutionRunnerBase {
+        public:
+            void run() {
+                Client::WriteContext ctx(ns());
+                insert(BSON("a" << 1 << "b" << 1));
+
+                BSONObj filterObj = fromjson("{_id: {$gt: 0}, b: {$gt: 0}}");
+                SingleSolutionRunner* ssr = makeCollScanRunner(filterObj);
+
+                // Make a client cursor from the runner.
+                ClientCursor* cc = new ClientCursor(ssr, 0, BSONObj());
+                ClientCursorPin ccPin(cc->cursorid());
+
+                // If the cursor is pinned, it sticks around,
+                // even after invalidation.
+                ASSERT_EQUALS(1U, ClientCursor::numCursors());
+                ClientCursor::invalidate(ns());
+                ASSERT_EQUALS(1U, ClientCursor::numCursors());
+
+                // The invalidation should have killed the runner.
+                BSONObj objOut;
+                ASSERT_EQUALS(Runner::RUNNER_DEAD, ssr->getNext(&objOut, NULL));
+
+                // Deleting the underlying cursor should cause the
+                // number of cursors to return to 0.
+                ccPin.deleteUnderlying();
+                ASSERT_EQUALS(0U, ClientCursor::numCursors());
+            }
+        };
+
+        /**
+         * Test that client cursors time out and get
+         * deleted.
+         */
+        class Timeout : public SingleSolutionRunnerBase {
+        public:
+            void run() {
+                {
+                    Client::WriteContext ctx(ns());
+                    insert(BSON("a" << 1 << "b" << 1));
+                }
+
+                {
+                    Client::ReadContext ctx(ns());
+
+                    BSONObj filterObj = fromjson("{_id: {$gt: 0}, b: {$gt: 0}}");
+                    SingleSolutionRunner* ssr = makeCollScanRunner(filterObj);
+
+                    // Make a client cursor from the runner.
+                    new ClientCursor(ssr, 0, BSONObj());
+                }
+
+                // There should be one cursor before timeout,
+                // and zero cursors after timeout.
+                ASSERT_EQUALS(1U, ClientCursor::numCursors());
+                ClientCursor::idleTimeReport(600001);
+                ASSERT_EQUALS(0U, ClientCursor::numCursors());
+            }
+        };
+
+    } // namespace ClientCursor
+
+    class All : public Suite {
+    public:
+        All() : Suite( "query_single_solution_runner" ) { }
+
+        void setupTests() {
+            add<DropCollScan>();
+            add<DropIndexScan>();
+            add<SnapshotControl>();
+            add<SnapshotTest>();
+            add<ClientCursor::Invalidate>();
+            add<ClientCursor::InvalidatePinned>();
+            add<ClientCursor::Timeout>();
+        }
+    }  queryMultiPlanRunnerAll;
+
+}  // namespace QuerySingleSolutionRunner


### PR DESCRIPTION
Test cases from dbtests/queryoptimizercursortests.cpp for dead query code need to be ported to the new system. This adds some new dbtests (and a js test) that try to cover some analogous cases. The major change is an added dbtest for SingleSolutionRunner.
