### PR TITLE
SERVER-10564 plan cache data storage mechanism

### DIFF
--- a/src/mongo/db/query/SConscript
+++ b/src/mongo/db/query/SConscript
@@ -72,6 +72,16 @@ env.Library(
     ],
 )
 
+env.Library(
+    target="query_planner_test_lib",
+    source=[
+        "query_planner_test_lib.cpp",
+    ],
+    LIBDEPS=[
+        "query_planner",
+    ],
+)
+
 env.StaticLibrary(
     target="query_logger",
     source=[
@@ -138,7 +148,7 @@ env.CppUnitTest(
         "plan_cache_test.cpp"
     ],
     LIBDEPS=[
-        "query_planner",
+        "query_planner_test_lib",
     ],
 )
 
@@ -158,6 +168,6 @@ env.CppUnitTest(
         "query_planner_test.cpp"
     ],
     LIBDEPS=[
-        "query_planner",
+        "query_planner_test_lib",
     ],
 )

--- a/src/mongo/db/query/plan_cache_test.cpp
+++ b/src/mongo/db/query/plan_cache_test.cpp
@@ -32,10 +32,17 @@
 
 #include "mongo/db/query/plan_cache.h"
 
+#include <ostream>
 #include <sstream>
 #include <memory>
+#include "mongo/db/jsobj.h"
 #include "mongo/db/json.h"
+#include "mongo/db/query/qlog.h"
+#include "mongo/db/query/query_planner.h"
+#include "mongo/db/query/query_planner_test_lib.h"
+#include "mongo/db/query/query_solution.h"
 #include "mongo/unittest/unittest.h"
+#include "mongo/util/assert_util.h"
 
 using namespace mongo;
 
@@ -258,6 +265,552 @@ namespace {
         testGetPlanCacheKey("{}", "{a: 1}", "anaa");
         testGetPlanCacheKey("{}", "{a: -1}", "anda");
         testGetPlanCacheKey("{}", "{a: {$meta: 'textScore'}}", "anta");
+    }
+
+    /**
+     * Each test in the CachePlanSelectionTest suite goes through
+     * the following flow:
+     *
+     * 1) Run QueryPlanner::plan on the query, with specified indices
+     * available. This simulates the case in which we failed to plan from
+     * the plan cache, and fell back on selecting a plan ourselves. The
+     * enumerator will run, and cache data will be stashed into each solution
+     * that it generates.
+     *
+     * 2) Use firstMatchingSolution to select one of the solutions generated
+     * by QueryPlanner::plan. This simulates the multi plan runner picking
+     * the "best solution".
+     *
+     * 3) The cache data stashed inside the "best solution" is used to
+     * make a CachedSolution which looks exactly like the data structure that
+     * would be returned from the cache. This simulates a plan cache hit.
+     *
+     * 4) Call QueryPlanner::planFromCache, passing it the CachedSolution.
+     * This exercises the code which is able to map from a CachedSolution to
+     * a full-blown QuerySolution. Finally, assert that the query solution
+     * recovered from the cache is identical to the original "best solution".
+     */
+    class CachePlanSelectionTest : public mongo::unittest::Test {
+    protected:
+        void setUp() {
+            params.options = QueryPlannerParams::INCLUDE_COLLSCAN;
+            addIndex(BSON("_id" << 1));
+        }
+
+        void tearDown() {
+            delete cq;
+
+            for (vector<QuerySolution*>::iterator it = solns.begin(); it != solns.end(); ++it) {
+                delete *it;
+            }
+        }
+
+        void addIndex(BSONObj keyPattern, bool multikey = false) {
+            // The first false means not multikey.
+            // The second false means not sparse.
+            // The third arg is the index name and I am egotistical.
+            params.indices.push_back(IndexEntry(keyPattern, multikey, false,
+                                                "hari_king_of_the_stove"));
+        }
+
+        void addIndex(BSONObj keyPattern, bool multikey, bool sparse) {
+            params.indices.push_back(IndexEntry(keyPattern, multikey, sparse,
+                                                "note_to_self_dont_break_build"));
+        }
+
+        //
+        // Execute planner.
+        //
+
+        void runQuery(BSONObj query) {
+            runQuerySortProjSkipLimit(query, BSONObj(), BSONObj(), 0, 0);
+        }
+
+        void runQuerySortProj(const BSONObj& query, const BSONObj& sort, const BSONObj& proj) {
+            runQuerySortProjSkipLimit(query, sort, proj, 0, 0);
+        }
+
+        void runQuerySkipLimit(const BSONObj& query, long long skip, long long limit) {
+            runQuerySortProjSkipLimit(query, BSONObj(), BSONObj(), skip, limit);
+        }
+
+        void runQueryHint(const BSONObj& query, const BSONObj& hint) {
+            runQuerySortProjSkipLimitHint(query, BSONObj(), BSONObj(), 0, 0, hint);
+        }
+
+        void runQuerySortProjSkipLimit(const BSONObj& query,
+                                       const BSONObj& sort, const BSONObj& proj,
+                                       long long skip, long long limit) {
+            runQuerySortProjSkipLimitHint(query, sort, proj, skip, limit, BSONObj());
+        }
+
+        void runQuerySortHint(const BSONObj& query, const BSONObj& sort, const BSONObj& hint) {
+            runQuerySortProjSkipLimitHint(query, sort, BSONObj(), 0, 0, hint);
+        }
+
+        void runQueryHintMinMax(const BSONObj& query, const BSONObj& hint,
+                                const BSONObj& minObj, const BSONObj& maxObj) {
+
+            runQueryFull(query, BSONObj(), BSONObj(), 0, 0, hint, minObj, maxObj, false);
+        }
+
+        void runQuerySortProjSkipLimitHint(const BSONObj& query,
+                                           const BSONObj& sort, const BSONObj& proj,
+                                           long long skip, long long limit,
+                                           const BSONObj& hint) {
+            runQueryFull(query, sort, proj, skip, limit, hint, BSONObj(), BSONObj(), false);
+        }
+
+        void runQuerySnapshot(const BSONObj& query) {
+            runQueryFull(query, BSONObj(), BSONObj(), 0, 0, BSONObj(), BSONObj(),
+                         BSONObj(), true);
+        }
+
+        void runQueryFull(const BSONObj& query,
+                          const BSONObj& sort, const BSONObj& proj,
+                          long long skip, long long limit,
+                          const BSONObj& hint,
+                          const BSONObj& minObj,
+                          const BSONObj& maxObj,
+                          bool snapshot) {
+            solns.clear();
+            Status s = CanonicalQuery::canonicalize(ns, query, sort, proj, skip, limit, hint,
+                                                    minObj, maxObj, snapshot, &cq);
+            if (!s.isOK()) { cq = NULL; }
+            ASSERT_OK(s);
+            s = QueryPlanner::plan(*cq, params, &solns);
+            ASSERT_OK(s);
+        }
+
+        //
+        // Solution introspection.
+        //
+
+        void dumpSolutions(ostream& ost) const {
+            for (vector<QuerySolution*>::const_iterator it = solns.begin();
+                    it != solns.end();
+                    ++it) {
+                ost << (*it)->toString() << endl;
+            }
+        }
+
+        void dumpSolutions() const {
+            dumpSolutions(std::cout);
+        }
+
+        /**
+         * Plan 'query' from the cache. A mock cache entry is created using
+         * the cacheData stored inside the QuerySolution 'soln'.
+         *
+         * Does not take ownership of 'soln'.
+         */
+        QuerySolution* planQueryFromCache(const BSONObj& query, const QuerySolution& soln) const {
+            return planQueryFromCache(query, BSONObj(), BSONObj(), soln);
+        }
+
+        /**
+         * Plan 'query' from the cache with sort order 'sort' and
+         * projection 'proj'. A mock cache entry is created using
+         * the cacheData stored inside the QuerySolution 'soln'.
+         *
+         * Does not take ownership of 'soln'.
+         */
+        QuerySolution* planQueryFromCache(const BSONObj& query,
+                                          const BSONObj& sort,
+                                          const BSONObj& proj,
+                                          const QuerySolution& soln) const {
+            CanonicalQuery* cq;
+            Status s = CanonicalQuery::canonicalize(ns, query, sort, proj, &cq);
+            ASSERT_OK(s);
+            scoped_ptr<CanonicalQuery> scopedCq(cq);
+            cq = NULL;
+
+            CachedSolution cachedSoln;
+            cachedSoln.key = ck;
+            cachedSoln.plannerData.reset(soln.cacheData->clone());
+
+            QuerySolution* out;
+            s = QueryPlanner::planFromCache(*scopedCq.get(), params, &cachedSoln, &out);
+            ASSERT_OK(s);
+
+            return out;
+        }
+
+        /**
+         * @param solnJson -- a json representation of a query solution.
+         *
+         * Returns the first solution matching 'solnJson', or fails if
+         * no match is found.
+         */
+        QuerySolution* firstMatchingSolution(const string& solnJson) const {
+            BSONObj testSoln = fromjson(solnJson);
+            for (vector<QuerySolution*>::const_iterator it = solns.begin();
+                    it != solns.end();
+                    ++it) {
+                QuerySolutionNode* root = (*it)->root.get();
+                if (QueryPlannerTestLib::solutionMatches(testSoln, root)) {
+                    return *it;
+                }
+            }
+
+            std::stringstream ss;
+            ss << "Could not find a match for solution " << solnJson
+               << " All solutions generated: " << std::endl;
+            dumpSolutions(ss);
+            FAIL(ss.str());
+
+            return NULL;
+        }
+
+        /**
+         * Assert that the QuerySolution 'trueSoln' matches the JSON-based representation
+         * of the solution in 'solnJson'.
+         *
+         * Relies on solutionMatches() -- see query_planner_test_lib.h
+         */
+        void assertSolutionMatches(QuerySolution* trueSoln, const string& solnJson) const {
+            BSONObj testSoln = fromjson(solnJson);
+            if (!QueryPlannerTestLib::solutionMatches(testSoln, trueSoln->root.get())) {
+                std::stringstream ss;
+                ss << "Expected solution " << solnJson << " did not match true solution: "
+                   << trueSoln->toString() << std::endl;
+                FAIL(ss.str());
+            }
+        }
+
+        /**
+         * Overloaded so that it is not necessary to specificy sort and project.
+         */
+        void assertPlanCacheRecoversSolution(const BSONObj& query, const string& solnJson) {
+            assertPlanCacheRecoversSolution(query, BSONObj(), BSONObj(), solnJson);
+        }
+
+        /**
+         * First, the solution matching 'solnJson' is retrieved from the vector
+         * of solutions generated by QueryPlanner::plan. This solution is
+         * then passed into planQueryFromCache(). Asserts that the solution
+         * generated by QueryPlanner::planFromCache matches 'solnJson'.
+         *
+         * Must be called after calling one of the runQuery* methods.
+         *
+         * Together, 'query', 'sort', and 'proj' should specify the query which
+         * was previously run using one of the runQuery* methods.
+         */
+        void assertPlanCacheRecoversSolution(const BSONObj& query,
+                                             const BSONObj& sort,
+                                             const BSONObj& proj,
+                                             const string& solnJson) {
+            QuerySolution* bestSoln = firstMatchingSolution(solnJson);
+            QuerySolution* planSoln = planQueryFromCache(query, sort, proj, *bestSoln);
+            assertSolutionMatches(planSoln, solnJson);
+        }
+
+        /**
+         * Check that the solution will not be cached. The planner will store
+         * cache data inside non-cachable solutions, but will not do so for
+         * non-cachable solutions. Therefore, we just have to check that
+         * cache data is NULL.
+         */
+        void assertNotCached(const string& solnJson) {
+            QuerySolution* bestSoln = firstMatchingSolution(solnJson);
+            ASSERT(NULL != bestSoln);
+            ASSERT(NULL == bestSoln->cacheData.get());
+        }
+
+        static const PlanCacheKey ck;
+
+        BSONObj queryObj;
+        CanonicalQuery* cq;
+        QueryPlannerParams params;
+        vector<QuerySolution*> solns;
+    };
+
+    const PlanCacheKey CachePlanSelectionTest::ck = "mock_cache_key";
+
+    //
+    // Equality
+    //
+
+    TEST_F(CachePlanSelectionTest, EqualityIndexScan) {
+        addIndex(BSON("x" << 1));
+        runQuery(BSON("x" << 5));
+
+        assertPlanCacheRecoversSolution(BSON("x" << 5),
+            "{fetch: {filter: null, node: {ixscan: {pattern: {x: 1}}}}}");
+    }
+
+    TEST_F(CachePlanSelectionTest, EqualityIndexScanWithTrailingFields) {
+        addIndex(BSON("x" << 1 << "y" << 1));
+        runQuery(BSON("x" << 5));
+
+        assertPlanCacheRecoversSolution(BSON("x" << 5),
+            "{fetch: {filter: null, node: {ixscan: {pattern: {x: 1, y: 1}}}}}");
+    }
+
+    //
+    // Geo
+    //
+
+    TEST_F(CachePlanSelectionTest, Basic2DNonNear) {
+        addIndex(BSON("a" << "2d"));
+        BSONObj query;
+
+        // Polygon
+        query = fromjson("{a : { $within: { $polygon : [[0,0], [2,0], [4,0]] } }}");
+        runQuery(query);
+        assertPlanCacheRecoversSolution(query,
+            "{fetch: {node: {geo2d: {a: '2d'}}}}");
+
+        // Center
+        query = fromjson("{a : { $within : { $center : [[ 5, 5 ], 7 ] } }}");
+        runQuery(query);
+        assertPlanCacheRecoversSolution(query,
+            "{fetch: {node: {geo2d: {a: '2d'}}}}");
+
+        // Centersphere
+        query = fromjson("{a : { $within : { $centerSphere : [[ 10, 20 ], 0.01 ] } }}");
+        runQuery(query);
+        assertPlanCacheRecoversSolution(query,
+            "{fetch: {node: {geo2d: {a: '2d'}}}}");
+
+        // Within box.
+        query = fromjson("{a : {$within: {$box : [[0,0],[9,9]]}}}");
+        runQuery(query);
+        assertPlanCacheRecoversSolution(query,
+            "{fetch: {node: {geo2d: {a: '2d'}}}}");
+    }
+
+    TEST_F(CachePlanSelectionTest, Basic2DSphereNonNear) {
+        addIndex(BSON("a" << "2dsphere"));
+        BSONObj query;
+
+        query = fromjson("{a: {$geoIntersects: {$geometry: {type: 'Point',"
+                                                           "coordinates: [10.0, 10.0]}}}}");
+        runQuery(query);
+        assertPlanCacheRecoversSolution(query,
+            "{fetch: {node: {ixscan: {pattern: {a: '2dsphere'}}}}}");
+
+        query = fromjson("{a : { $geoWithin : { $centerSphere : [[ 10, 20 ], 0.01 ] } }}");
+        runQuery(query);
+        assertPlanCacheRecoversSolution(query,
+            "{fetch: {node: {ixscan: {pattern: {a: '2dsphere'}}}}}");
+    }
+
+    TEST_F(CachePlanSelectionTest, Basic2DSphereGeoNear) {
+        addIndex(BSON("a" << "2dsphere"));
+        BSONObj query;
+
+        query = fromjson("{a: {$nearSphere: [0,0], $maxDistance: 0.31 }}");
+        runQuery(query);
+        assertPlanCacheRecoversSolution(query, "{geoNear2dsphere: {a: '2dsphere'}}");
+
+        query = fromjson("{a: {$geoNear: {$geometry: {type: 'Point', coordinates: [0,0]},"
+                                          "$maxDistance:100}}}");
+        runQuery(query);
+        assertPlanCacheRecoversSolution(query, "{geoNear2dsphere: {a: '2dsphere'}}");
+    }
+
+    TEST_F(CachePlanSelectionTest, Basic2DSphereGeoNearReverseCompound) {
+        addIndex(BSON("x" << 1));
+        addIndex(BSON("x" << 1 << "a" << "2dsphere"));
+        BSONObj query = fromjson("{x:1, a: {$nearSphere: [0,0], $maxDistance: 0.31 }}");
+        runQuery(query);
+        assertPlanCacheRecoversSolution(query, "{geoNear2dsphere: {x: 1, a: '2dsphere'}}");
+    }
+
+    TEST_F(CachePlanSelectionTest, TwoDSphereNoGeoPred) {
+        addIndex(BSON("x" << 1 << "a" << "2dsphere"));
+        runQuery(BSON("x" << 1));
+        assertPlanCacheRecoversSolution(BSON("x" << 1),
+            "{fetch: {node: {ixscan: {pattern: {x: 1, a: '2dsphere'}}}}}");
+    }
+
+    TEST_F(CachePlanSelectionTest, Or2DNonNear) {
+        addIndex(BSON("a" << "2d"));
+        addIndex(BSON("b" << "2d"));
+        BSONObj query = fromjson("{$or: [ {a : { $within : { $polygon : [[0,0], [2,0], [4,0]] } }},"
+                                        " {b : { $within : { $center : [[ 5, 5 ], 7 ] } }} ]}");
+
+        runQuery(query);
+        assertPlanCacheRecoversSolution(query,
+            "{fetch: {node: {or: {nodes: [{geo2d: {a: '2d'}}, {geo2d: {b: '2d'}}]}}}}");
+    }
+
+    TEST_F(CachePlanSelectionTest, Or2DSphereNonNear) {
+        addIndex(BSON("a" << "2dsphere"));
+        addIndex(BSON("b" << "2dsphere"));
+        BSONObj query = fromjson("{$or: [ {a: {$geoIntersects: {$geometry: {type: 'Point', coordinates: [10.0, 10.0]}}}},"
+                                 " {b: {$geoWithin: { $centerSphere: [[ 10, 20 ], 0.01 ] } }} ]}");
+
+        runQuery(query);
+        assertPlanCacheRecoversSolution(query,
+            "{or: {nodes: [{fetch: {node: {ixscan: {pattern: {a: '2dsphere'}}}}},"
+                          "{fetch: {node: {ixscan: {pattern: {b: '2dsphere'}}}}}]}}");
+    }
+
+    //
+    // tree operations
+    //
+
+    TEST_F(CachePlanSelectionTest, TwoPredicatesAnding) {
+        addIndex(BSON("x" << 1));
+        BSONObj query = fromjson("{$and: [ {x: {$gt: 1}}, {x: {$lt: 3}} ] }");
+        runQuery(query);
+        assertPlanCacheRecoversSolution(query,
+            "{fetch: {filter: null, node: {ixscan: {filter: null, pattern: {x: 1}}}}}");
+    }
+
+    TEST_F(CachePlanSelectionTest, SimpleOr) {
+        addIndex(BSON("a" << 1));
+        BSONObj query = fromjson("{$or: [{a: 20}, {a: 21}]}");
+        runQuery(query);
+        assertPlanCacheRecoversSolution(query,
+            "{fetch: {filter: null, node: {ixscan: {filter: null, pattern: {a:1}}}}}");
+    }
+
+    TEST_F(CachePlanSelectionTest, OrWithAndChild) {
+        addIndex(BSON("a" << 1));
+        BSONObj query = fromjson("{$or: [{a: 20}, {$and: [{a:1}, {b:7}]}]}");
+        runQuery(query);
+        assertPlanCacheRecoversSolution(query,
+            "{fetch: {filter: null, node: {or: {nodes: ["
+                "{ixscan: {filter: null, pattern: {a: 1}}}, "
+                "{fetch: {filter: {b: 7}, node: {ixscan: "
+                "{filter: null, pattern: {a: 1}}}}}]}}}}");
+    }
+
+    TEST_F(CachePlanSelectionTest, AndWithUnindexedOrChild) {
+        addIndex(BSON("a" << 1));
+        BSONObj query = fromjson("{a:20, $or: [{b:1}, {c:7}]}");
+        runQuery(query);
+        assertPlanCacheRecoversSolution(query,
+            "{fetch: {filter: {$or: [{b: 1}, {c: 7}]}, node: "
+                "{ixscan: {filter: null, pattern: {a: 1}}}}}");
+    }
+
+
+    TEST_F(CachePlanSelectionTest, AndWithOrWithOneIndex) {
+        addIndex(BSON("b" << 1));
+        addIndex(BSON("a" << 1));
+        BSONObj query = fromjson("{$or: [{b:1}, {c:7}], a:20}");
+        runQuery(query);
+        assertPlanCacheRecoversSolution(query,
+            "{fetch: {filter: {$or: [{b: 1}, {c: 7}]}, "
+                "node: {ixscan: {filter: null, pattern: {a: 1}}}}}");
+    }
+
+    //
+    // Sort orders
+    //
+
+    // SERVER-1205.
+    TEST_F(CachePlanSelectionTest, MergeSort) {
+        addIndex(BSON("a" << 1 << "c" << 1));
+        addIndex(BSON("b" << 1 << "c" << 1));
+
+        BSONObj query = fromjson("{$or: [{a:1}, {b:1}]}");
+        BSONObj sort = BSON("c" << 1);
+        runQuerySortProj(query, sort, BSONObj());
+
+        assertNotCached("{sort: {pattern: {c: 1}, limit: 0, node: {cscan: {dir: 1}}}}");
+        assertPlanCacheRecoversSolution(query, sort, BSONObj(),
+            "{fetch: {node: {mergeSort: {nodes: "
+                "[{ixscan: {pattern: {a: 1, c: 1}}}, {ixscan: {pattern: {b: 1, c: 1}}}]}}}}");
+    }
+
+    // SERVER-1205 as well.
+    TEST_F(CachePlanSelectionTest, NoMergeSortIfNoSortWanted) {
+        addIndex(BSON("a" << 1 << "c" << 1));
+        addIndex(BSON("b" << 1 << "c" << 1));
+
+        BSONObj query = fromjson("{$or: [{a:1}, {b:1}]}");
+        runQuerySortProj(query, BSONObj(), BSONObj());
+
+        assertPlanCacheRecoversSolution(query, BSONObj(), BSONObj(),
+            "{fetch: {filter: null, node: {or: {nodes: ["
+                "{ixscan: {filter: null, pattern: {a: 1, c: 1}}}, "
+                "{ixscan: {filter: null, pattern: {b: 1, c: 1}}}]}}}}");
+    }
+
+    // SERVER-10801
+    TEST_F(CachePlanSelectionTest, SortOnGeoQuery) {
+        addIndex(BSON("timestamp" << -1 << "position" << "2dsphere"));
+        BSONObj query = fromjson("{position: {$geoWithin: {$geometry: {type: \"Polygon\", coordinates: [[[1, 1], [1, 90], [180, 90], [180, 1], [1, 1]]]}}}}");
+        BSONObj sort = fromjson("{timestamp: -1}");
+        runQuerySortProj(query, sort, BSONObj());
+
+        assertPlanCacheRecoversSolution(query, sort, BSONObj(),
+            "{fetch: {node: {ixscan: {pattern: {timestamp: -1, position: '2dsphere'}}}}}");
+    }
+
+    // SERVER-9257
+    TEST_F(CachePlanSelectionTest, CompoundGeoNoGeoPredicate) {
+        addIndex(BSON("creationDate" << 1 << "foo.bar" << "2dsphere"));
+        BSONObj query = fromjson("{creationDate: {$gt: 7}}");
+        BSONObj sort = fromjson("{creationDate: 1}");
+        runQuerySortProj(query, sort, BSONObj());
+
+        assertPlanCacheRecoversSolution(query, sort, BSONObj(),
+            "{fetch: {node: {ixscan: {pattern: {creationDate: 1, 'foo.bar': '2dsphere'}}}}}");
+    }
+
+    TEST_F(CachePlanSelectionTest, ReverseScanForSort) {
+        addIndex(BSON("_id" << 1));
+        runQuerySortProj(BSONObj(), fromjson("{_id: -1}"), BSONObj());
+        assertPlanCacheRecoversSolution(BSONObj(), fromjson("{_id: -1}"), BSONObj(),
+            "{fetch: {filter: null, node: {ixscan: {filter: null, pattern: {_id: 1}}}}}");
+    }
+
+    //
+    // Check queries that, at least for now, are not cached.
+    //
+
+    TEST_F(CachePlanSelectionTest, NoUsefulIndicesNotCached) {
+        addIndex(BSON("a" << 1 << "b" << 1));
+        addIndex(BSON("c" << 1));
+        runQuery(BSON("b" << 4));
+        assertNotCached("{cscan: {dir: 1}}");
+    }
+
+    TEST_F(CachePlanSelectionTest, OrWithoutEnoughIndicesNotCached) {
+        addIndex(BSON("a" << 1));
+        runQuery(fromjson("{$or: [{a: 20}, {b: 21}]}"));
+        assertNotCached("{cscan: {dir: 1, filter: {$or: [{a: 20}, {b: 21}]}}}");
+    }
+
+    TEST_F(CachePlanSelectionTest, GeoNear2DNotCached) {
+        addIndex(BSON("a" << "2d"));
+        runQuery(fromjson("{a: {$near: [0,0], $maxDistance:0.3 }}"));
+        assertNotCached("{geoNear2d: {a: '2d'}}");
+    }
+
+    TEST_F(CachePlanSelectionTest, MinNotCached) {
+        addIndex(BSON("a" << 1));
+        runQueryHintMinMax(BSONObj(), BSONObj(), fromjson("{a: 1}"), BSONObj());
+        assertNotCached("{fetch: {filter: null, "
+                           "node: {ixscan: {filter: null, pattern: {a: 1}}}}}");
+    }
+
+    TEST_F(CachePlanSelectionTest, MaxNotCached) {
+        addIndex(BSON("a" << 1));
+        runQueryHintMinMax(BSONObj(), BSONObj(), BSONObj(), fromjson("{a: 1}"));
+        assertNotCached("{fetch: {filter: null, "
+                            "node: {ixscan: {filter: null, pattern: {a: 1}}}}}");
+    }
+
+    TEST_F(CachePlanSelectionTest, NaturalHintNotCached) {
+        addIndex(BSON("a" << 1));
+        addIndex(BSON("b" << 1));
+        runQuerySortHint(BSON("a" << 1), BSON("b" << 1), BSON("$natural" << 1));
+        assertNotCached("{sort: {pattern: {b: 1}, limit: 0, node: "
+                            "{cscan: {filter: {a: 1}, dir: 1}}}}");
+    }
+
+    TEST_F(CachePlanSelectionTest, HintValidNotCached) {
+        addIndex(BSON("a" << 1));
+        runQueryHint(BSONObj(), fromjson("{a: 1}"));
+        assertNotCached("{fetch: {filter: null, "
+                            "node: {ixscan: {filter: null, pattern: {a: 1}}}}}");
     }
 
 }  // namespace

--- a/src/mongo/db/query/query_planner_test.cpp
+++ b/src/mongo/db/query/query_planner_test.cpp
@@ -30,6 +30,8 @@
  * This file contains tests for mongo/db/query/query_planner.cpp
  */
 
+#include "mongo/db/query/query_planner_test_lib.h"
+
 #include <ostream>
 #include <sstream>
 #include "mongo/db/jsobj.h"
@@ -228,345 +230,6 @@ namespace {
             FAIL(ss.str());
         }
 
-        /**
-         * Looks in the children stored in the 'nodes' field of 'testSoln'
-         * to see if they match the 'children' field of 'trueSoln'.
-         *
-         * This does an unordered comparison, i.e. childrenMatch returns true
-         * as long as the set of subtrees in testSoln's 'nodes' matches the set of
-         * subtrees in trueSoln's 'children' vector.
-         */
-        bool childrenMatch(const BSONObj& testSoln, const QuerySolutionNode* trueSoln) const {
-            BSONElement children = testSoln["nodes"];
-            if (children.eoo() || !children.isABSONObj()) { return false; }
-
-            // The order of the children array in testSoln might not match
-            // the order in trueSoln, so we have to check all combos with
-            // these nested loops.
-            BSONObjIterator i(children.Obj());
-            while (i.more()) {
-                BSONElement child = i.next();
-                if (child.eoo() || !child.isABSONObj()) { return false; }
-
-                // try to match against one of the QuerySolutionNode's children
-                bool found = false;
-                for (size_t j = 0; j < trueSoln->children.size(); ++j) {
-                    if (solutionMatches(child.Obj(), trueSoln->children[j])) {
-                        found = true;
-                        break;
-                    }
-                }
-
-                // we couldn't match child
-                if (!found) { return false; }
-            }
-
-            return true;
-        }
-
-        bool filterMatches(const BSONObj& testFilter,
-                           const QuerySolutionNode* trueFilterNode) const {
-            if (NULL == trueFilterNode->filter) { return false; }
-            StatusWithMatchExpression swme = MatchExpressionParser::parse(testFilter);
-            if (!swme.isOK()) {
-                return false;
-            }
-            MatchExpression* root = swme.getValue();
-            return trueFilterNode->filter->equivalent(root);
-        }
-
-        void appendIntervalBound(BSONObjBuilder& bob, BSONElement& el) const {
-            if (el.type() == String) {
-                std::string data = el.String();
-                if (data == "MaxKey") {
-                    bob.appendMaxKey("");
-                }
-                else if (data == "MinKey") {
-                    bob.appendMinKey("");
-                }
-                else {
-                    bob.appendAs(el, "");
-                }
-            }
-            else {
-                bob.appendAs(el, "");
-            }
-        }
-
-        bool intervalMatches(const BSONObj& testInt, const Interval trueInt) const {
-            BSONObjIterator it(testInt);
-            if (!it.more()) { return false; }
-            BSONElement low = it.next();
-            if (!it.more()) { return false; }
-            BSONElement high = it.next();
-            if (!it.more()) { return false; }
-            bool startInclusive = it.next().Bool();
-            if (!it.more()) { return false; }
-            bool endInclusive = it.next().Bool();
-            if (it.more()) { return false; }
-
-            BSONObjBuilder bob;
-            appendIntervalBound(bob, low);
-            appendIntervalBound(bob, high);
-            Interval toCompare(bob.obj(), startInclusive, endInclusive);
-
-            return Interval::INTERVAL_EQUALS == trueInt.compare(toCompare);
-        }
-
-        /**
-         * Return whether the BSON representation of the index bounds in 'testBounds'
-         * matches 'trueBounds'.
-         *
-         * 'testBounds' should be of the following format:
-         *    {<field 1>: <oil 1>, <field 2>: <oil 2>, ...}
-         *  Each ordered interval list (e.g. <oil 1>) is an array of arrays of the format
-         *    [[<low 1>,<high 1>,<lowInclusive 1>,<highInclusive 1>], ...]
-         *
-         *  For example,
-         *    {a: [[1,2,true,false], [3,4,false,true]], b: [[-Infinity, Infinity]]}
-         *  Means that the index bounds on field 'a' consists of the two intervals
-         *  [1,2) and (3,4] and the index bounds on field 'b' are [-Infinity, Infinity].
-         *
-         */
-        bool boundsMatch(const BSONObj& testBounds, const IndexBounds trueBounds) const {
-            // Iterate over the fields on which we have index bounds.
-            BSONObjIterator fieldIt(testBounds);
-            int fieldItCount = 0;
-            while (fieldIt.more()) {
-                BSONElement arrEl = fieldIt.next();
-                if (arrEl.type() != Array) {
-                    return false;
-                }
-                // Iterate over an ordered interval list for
-                // a particular field.
-                BSONObjIterator oilIt(arrEl.Obj());
-                int oilItCount = 0;
-                while (oilIt.more()) {
-                    BSONElement intervalEl = oilIt.next();
-                    if (intervalEl.type() != Array) {
-                        return false;
-                    }
-                    Interval trueInt = trueBounds.getInterval(fieldItCount, oilItCount);
-                    if (!intervalMatches(intervalEl.Obj(), trueInt)) {
-                        return false;
-                    }
-                    ++oilItCount;
-                }
-                ++fieldItCount;
-            }
-
-            return true;
-        }
-
-        bool solutionMatches(const BSONObj& testSoln, const QuerySolutionNode* trueSoln) const {
-            //
-            // leaf nodes
-            //
-            if (STAGE_COLLSCAN == trueSoln->getType()) {
-                const CollectionScanNode* csn = static_cast<const CollectionScanNode*>(trueSoln);
-                BSONElement el = testSoln["cscan"];
-                if (el.eoo() || !el.isABSONObj()) { return false; }
-                BSONObj csObj = el.Obj();
-
-                BSONElement dir = csObj["dir"];
-                if (dir.eoo() || !dir.isNumber()) { return false; }
-                if (dir.numberInt() != csn->direction) { return false; }
-
-                BSONElement filter = csObj["filter"];
-                if (filter.eoo()) {
-                    return true;
-                }
-                else if (filter.isNull()) {
-                    return NULL == csn->filter;
-                }
-                else if (!filter.isABSONObj()) {
-                    return false;
-                }
-                return filterMatches(filter.Obj(), trueSoln);
-            }
-            else if (STAGE_IXSCAN == trueSoln->getType()) {
-                const IndexScanNode* ixn = static_cast<const IndexScanNode*>(trueSoln);
-                BSONElement el = testSoln["ixscan"];
-                if (el.eoo() || !el.isABSONObj()) { return false; }
-                BSONObj ixscanObj = el.Obj();
-
-                BSONElement pattern = ixscanObj["pattern"];
-                if (pattern.eoo() || !pattern.isABSONObj()) { return false; }
-                if (pattern.Obj() != ixn->indexKeyPattern) { return false; }
-
-                BSONElement bounds = ixscanObj["bounds"];
-                if (!bounds.eoo()) {
-                    if (!bounds.isABSONObj()) {
-                        return false;
-                    }
-                    else if (!boundsMatch(bounds.Obj(), ixn->bounds)) {
-                        return false;
-                    }
-                }
-
-                BSONElement dir = ixscanObj["dir"];
-                if (!dir.eoo() && NumberInt == dir.type()) {
-                    if (dir.numberInt() != ixn->direction) {
-                        return false;
-                    }
-                }
-
-                BSONElement filter = ixscanObj["filter"];
-                if (filter.eoo()) {
-                    return true;
-                }
-                else if (filter.isNull()) {
-                    return NULL == ixn->filter;
-                }
-                else if (!filter.isABSONObj()) {
-                    return false;
-                }
-                return filterMatches(filter.Obj(), trueSoln);
-            }
-            else if (STAGE_GEO_2D == trueSoln->getType()) {
-                const Geo2DNode* node = static_cast<const Geo2DNode*>(trueSoln);
-                BSONElement el = testSoln["geo2d"];
-                if (el.eoo() || !el.isABSONObj()) { return false; }
-                BSONObj geoObj = el.Obj();
-                return geoObj == node->indexKeyPattern;
-            }
-            else if (STAGE_GEO_NEAR_2D == trueSoln->getType()) {
-                const GeoNear2DNode* node = static_cast<const GeoNear2DNode*>(trueSoln);
-                BSONElement el = testSoln["geoNear2d"];
-                if (el.eoo() || !el.isABSONObj()) { return false; }
-                BSONObj geoObj = el.Obj();
-                return geoObj == node->indexKeyPattern;
-            }
-            else if (STAGE_GEO_NEAR_2DSPHERE == trueSoln->getType()) {
-                const GeoNear2DSphereNode* node = static_cast<const GeoNear2DSphereNode*>(trueSoln);
-                BSONElement el = testSoln["geoNear2dsphere"];
-                if (el.eoo() || !el.isABSONObj()) { return false; }
-                BSONObj geoObj = el.Obj();
-                return geoObj == node->indexKeyPattern;
-            }
-
-            //
-            // internal nodes
-            //
-
-            if (STAGE_FETCH == trueSoln->getType()) {
-                const FetchNode* fn = static_cast<const FetchNode*>(trueSoln);
-
-                BSONElement el = testSoln["fetch"];
-                if (el.eoo() || !el.isABSONObj()) { return false; }
-                BSONObj fetchObj = el.Obj();
-
-                BSONElement filter = fetchObj["filter"];
-                if (!filter.eoo()) {
-                    if (filter.isNull()) {
-                        if (NULL != fn->filter) { return false; }
-                    }
-                    else if (!filter.isABSONObj()) {
-                        return false;
-                    }
-                    else if (!filterMatches(filter.Obj(), trueSoln)) {
-                        return false;
-                    }
-                }
-
-                BSONElement child = fetchObj["node"];
-                if (child.eoo() || !child.isABSONObj()) { return false; }
-                return solutionMatches(child.Obj(), fn->children[0]);
-            }
-            else if (STAGE_OR == trueSoln->getType()) {
-                const OrNode * orn = static_cast<const OrNode*>(trueSoln);
-                BSONElement el = testSoln["or"];
-                if (el.eoo() || !el.isABSONObj()) { return false; }
-                BSONObj orObj = el.Obj();
-                return childrenMatch(orObj, orn);
-            }
-            else if (STAGE_AND_HASH == trueSoln->getType()) {
-                const AndHashNode* ahn = static_cast<const AndHashNode*>(trueSoln);
-                BSONElement el = testSoln["andHash"];
-                if (el.eoo() || !el.isABSONObj()) { return false; }
-                BSONObj andHashObj = el.Obj();
-                // XXX: andHashObj can have filter
-                return childrenMatch(andHashObj, ahn);
-            }
-            else if (STAGE_AND_SORTED == trueSoln->getType()) {
-                const AndSortedNode* asn = static_cast<const AndSortedNode*>(trueSoln);
-                BSONElement el = testSoln["andSorted"];
-                if (el.eoo() || !el.isABSONObj()) { return false; }
-                BSONObj andSortedObj = el.Obj();
-                // XXX: anSortedObj can have filter too
-                return childrenMatch(andSortedObj, asn);
-            }
-            else if (STAGE_PROJECTION == trueSoln->getType()) {
-                const ProjectionNode* pn = static_cast<const ProjectionNode*>(trueSoln);
-
-                BSONElement el = testSoln["proj"];
-                if (el.eoo() || !el.isABSONObj()) { return false; }
-                BSONObj projObj = el.Obj();
-
-                BSONElement spec = projObj["spec"];
-                if (spec.eoo() || !spec.isABSONObj()) { return false; }
-                BSONElement child = projObj["node"];
-                if (child.eoo() || !child.isABSONObj()) { return false; }
-
-                return (spec.Obj() == pn->projection)
-                       && solutionMatches(child.Obj(), pn->children[0]);
-            }
-            else if (STAGE_SORT == trueSoln->getType()) {
-                const SortNode* sn = static_cast<const SortNode*>(trueSoln);
-                BSONElement el = testSoln["sort"];
-                if (el.eoo() || !el.isABSONObj()) { return false; }
-                BSONObj sortObj = el.Obj();
-
-                BSONElement patternEl = sortObj["pattern"];
-                if (patternEl.eoo() || !patternEl.isABSONObj()) { return false; }
-                BSONElement limitEl = sortObj["limit"];
-                if (!limitEl.isNumber()) { return false; }
-                BSONElement child = sortObj["node"];
-                if (child.eoo() || !child.isABSONObj()) { return false; }
-
-                return (patternEl.Obj() == sn->pattern)
-                       && (limitEl.numberInt() == sn->limit)
-                       && solutionMatches(child.Obj(), sn->children[0]);
-            }
-            else if (STAGE_SORT_MERGE == trueSoln->getType()) {
-                const MergeSortNode* msn = static_cast<const MergeSortNode*>(trueSoln);
-                BSONElement el = testSoln["mergeSort"];
-                if (el.eoo() || !el.isABSONObj()) { return false; }
-                BSONObj mergeSortObj = el.Obj();
-                return childrenMatch(mergeSortObj, msn);
-            }
-            else if (STAGE_SKIP == trueSoln->getType()) {
-                const SkipNode* sn = static_cast<const SkipNode*>(trueSoln);
-                BSONElement el = testSoln["skip"];
-                if (el.eoo() || !el.isABSONObj()) { return false; }
-                BSONObj sortObj = el.Obj();
-
-                BSONElement skipEl = sortObj["n"];
-                if (!skipEl.isNumber()) { return false; }
-                BSONElement child = sortObj["node"];
-                if (child.eoo() || !child.isABSONObj()) { return false; }
-
-                return (skipEl.numberInt() == sn->skip)
-                       && solutionMatches(child.Obj(), sn->children[0]);
-            }
-            else if (STAGE_LIMIT == trueSoln->getType()) {
-                const LimitNode* ln = static_cast<const LimitNode*>(trueSoln);
-                BSONElement el = testSoln["limit"];
-                if (el.eoo() || !el.isABSONObj()) { return false; }
-                BSONObj sortObj = el.Obj();
-
-                BSONElement limitEl = sortObj["n"];
-                if (!limitEl.isNumber()) { return false; }
-                BSONElement child = sortObj["node"];
-                if (child.eoo() || !child.isABSONObj()) { return false; }
-
-                return (limitEl.numberInt() == ln->limit)
-                       && solutionMatches(child.Obj(), ln->children[0]);
-            }
-
-            return false;
-        }
-
         size_t numSolutionMatches(const string& solnJson) const {
             BSONObj testSoln = fromjson(solnJson);
             size_t matches = 0;
@@ -574,7 +237,7 @@ namespace {
                     it != solns.end();
                     ++it) {
                 QuerySolutionNode* root = (*it)->root.get();
-                if (solutionMatches(testSoln, root)) {
+                if (QueryPlannerTestLib::solutionMatches(testSoln, root)) {
                     ++matches;
                 }
             }
@@ -2226,6 +1889,74 @@ namespace {
                                  "node: {andSorted: {nodes: ["
                                          "{ixscan: {filter: null, pattern: {'a.b':1}}},"
                                          "{ixscan: {filter: null, pattern: {'a.c':1}}}]}}}}");
+    }
+
+    //
+    // Test bad input to query planner helpers.
+    //
+
+    TEST(BadInputTest, CacheDataFromTaggedTree) {
+        PlanCacheIndexTree* indexTree;
+
+        // Null match expression.
+        vector<IndexEntry> relevantIndices;
+        Status s = QueryPlanner::cacheDataFromTaggedTree(NULL, relevantIndices, &indexTree);
+        ASSERT_NOT_OK(s);
+        ASSERT(NULL == indexTree);
+
+        // No relevant index matching the index tag.
+        relevantIndices.push_back(IndexEntry(BSON("a" << 1), false, false, "a_1"));
+
+        CanonicalQuery *cq;
+        Status cqStatus = CanonicalQuery::canonicalize(ns, BSON("a" << 3), &cq);
+        ASSERT_OK(cqStatus);
+        boost::scoped_ptr<CanonicalQuery> scopedCq(cq);
+        scopedCq->root()->setTag(new IndexTag(1));
+
+        s = QueryPlanner::cacheDataFromTaggedTree(scopedCq->root(), relevantIndices, &indexTree);
+        ASSERT_NOT_OK(s);
+        ASSERT(NULL == indexTree);
+    }
+
+    TEST(BadInputTest, TagAccordingToCache) {
+        CanonicalQuery *cq;
+        Status cqStatus = CanonicalQuery::canonicalize(ns, BSON("a" << 3), &cq);
+        ASSERT_OK(cqStatus);
+        boost::scoped_ptr<CanonicalQuery> scopedCq(cq);
+
+        PlanCacheIndexTree* indexTree = new PlanCacheIndexTree();
+        indexTree->setIndexEntry(IndexEntry(BSON("a" << 1), false, false, "a_1"));
+
+        map<BSONObj, size_t> indexMap;
+
+        // Null filter.
+        Status s = QueryPlanner::tagAccordingToCache(NULL, indexTree, indexMap);
+        ASSERT_NOT_OK(s);
+
+        // Null indexTree.
+        s = QueryPlanner::tagAccordingToCache(scopedCq->root(), NULL, indexMap);
+        ASSERT_NOT_OK(s);
+
+        // Index not found.
+        s = QueryPlanner::tagAccordingToCache(scopedCq->root(), indexTree, indexMap);
+        ASSERT_NOT_OK(s);
+
+        // Index found once added to the map.
+        indexMap[BSON("a" << 1)] = 0;
+        s = QueryPlanner::tagAccordingToCache(scopedCq->root(), indexTree, indexMap);
+        ASSERT_OK(s);
+
+        // Regenerate canonical query in order to clear tags.
+        cqStatus = CanonicalQuery::canonicalize(ns, BSON("a" << 3), &cq);
+        ASSERT_OK(cqStatus);
+        scopedCq.reset(cq);
+
+        // Mismatched tree topology.
+        PlanCacheIndexTree* child = new PlanCacheIndexTree();
+        child->setIndexEntry(IndexEntry(BSON("a" << 1), false, false, "a_1"));
+        indexTree->children.push_back(child);
+        s = QueryPlanner::tagAccordingToCache(scopedCq->root(), indexTree, indexMap);
+        ASSERT_NOT_OK(s);
     }
 
 }  // namespace

--- a/src/mongo/db/query/query_planner_test_lib.cpp
+++ b/src/mongo/db/query/query_planner_test_lib.cpp
@@ -1,0 +1,394 @@
+/**
+ *    Copyright (C) 2013 10gen Inc.
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under the terms of the GNU Affero General Public License, version 3,
+ *    as published by the Free Software Foundation.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *    As a special exception, the copyright holders give permission to link the
+ *    code of portions of this program with the OpenSSL library under certain
+ *    conditions as described in each individual source file and distribute
+ *    linked combinations including the program with the OpenSSL library. You
+ *    must comply with the GNU Affero General Public License in all respects for
+ *    all of the code used other than as permitted herein. If you modify file(s)
+ *    with this exception, you may extend this exception to your version of the
+ *    file(s), but you are not obligated to do so. If you do not wish to do so,
+ *    delete this exception statement from your version. If you delete this
+ *    exception statement from all source files in the program, then also delete
+ *    it in the license file.
+ */
+
+/**
+ * This file contains tests for mongo/db/query/query_planner.cpp
+ */
+
+#include "mongo/db/query/query_planner_test_lib.h"
+
+#include <ostream>
+#include <sstream>
+#include "mongo/db/jsobj.h"
+#include "mongo/db/json.h"
+#include "mongo/db/matcher/expression_parser.h"
+#include "mongo/db/query/qlog.h"
+#include "mongo/db/query/query_planner.h"
+#include "mongo/db/query/query_solution.h"
+#include "mongo/unittest/unittest.h"
+#include "mongo/util/assert_util.h"
+
+namespace {
+
+    using namespace mongo;
+
+    bool filterMatches(const BSONObj& testFilter,
+                       const QuerySolutionNode* trueFilterNode) {
+        if (NULL == trueFilterNode->filter) { return false; }
+        StatusWithMatchExpression swme = MatchExpressionParser::parse(testFilter);
+        if (!swme.isOK()) {
+            return false;
+        }
+        MatchExpression* root = swme.getValue();
+        return trueFilterNode->filter->equivalent(root);
+    }
+
+    void appendIntervalBound(BSONObjBuilder& bob, BSONElement& el) {
+        if (el.type() == String) {
+            std::string data = el.String();
+            if (data == "MaxKey") {
+                bob.appendMaxKey("");
+            }
+            else if (data == "MinKey") {
+                bob.appendMinKey("");
+            }
+            else {
+                bob.appendAs(el, "");
+            }
+        }
+        else {
+            bob.appendAs(el, "");
+        }
+    }
+
+    bool intervalMatches(const BSONObj& testInt, const Interval trueInt) {
+        BSONObjIterator it(testInt);
+        if (!it.more()) { return false; }
+        BSONElement low = it.next();
+        if (!it.more()) { return false; }
+        BSONElement high = it.next();
+        if (!it.more()) { return false; }
+        bool startInclusive = it.next().Bool();
+        if (!it.more()) { return false; }
+        bool endInclusive = it.next().Bool();
+        if (it.more()) { return false; }
+
+        BSONObjBuilder bob;
+        appendIntervalBound(bob, low);
+        appendIntervalBound(bob, high);
+        Interval toCompare(bob.obj(), startInclusive, endInclusive);
+
+        return Interval::INTERVAL_EQUALS == trueInt.compare(toCompare);
+    }
+
+    /**
+     * Returns whether the BSON representation of the index bounds in
+     * 'testBounds' matches 'trueBounds'.
+     *
+     * 'testBounds' should be of the following format:
+     *    {<field 1>: <oil 1>, <field 2>: <oil 2>, ...}
+     * Each ordered interval list (e.g. <oil 1>) is an array of arrays of
+     * the format:
+     *    [[<low 1>,<high 1>,<lowInclusive 1>,<highInclusive 1>], ...]
+     *
+     * For example,
+     *    {a: [[1,2,true,false], [3,4,false,true]], b: [[-Infinity, Infinity]]}
+     * Means that the index bounds on field 'a' consist of the two intervals
+     * [1, 2) and (3, 4] and the index bounds on field 'b' are [-Infinity, Infinity].
+     */
+    bool boundsMatch(const BSONObj& testBounds, const IndexBounds trueBounds) {
+        // Iterate over the fields on which we have index bounds.
+        BSONObjIterator fieldIt(testBounds);
+        int fieldItCount = 0;
+        while (fieldIt.more()) {
+            BSONElement arrEl = fieldIt.next();
+            if (arrEl.type() != Array) {
+                return false;
+            }
+            // Iterate over an ordered interval list for
+            // a particular field.
+            BSONObjIterator oilIt(arrEl.Obj());
+            int oilItCount = 0;
+            while (oilIt.more()) {
+                BSONElement intervalEl = oilIt.next();
+                if (intervalEl.type() != Array) {
+                    return false;
+                }
+                Interval trueInt = trueBounds.getInterval(fieldItCount, oilItCount);
+                if (!intervalMatches(intervalEl.Obj(), trueInt)) {
+                    return false;
+                }
+                ++oilItCount;
+            }
+            ++fieldItCount;
+        }
+
+        return true;
+    }
+
+} // namespace
+
+namespace mongo {
+
+    /**
+     * Looks in the children stored in the 'nodes' field of 'testSoln'
+     * to see if thet match the 'children' field of 'trueSoln'.
+     *
+     * This does an unordered comparison, i.e. childrenMatch returns
+     * true as long as the set of subtrees in testSoln's 'nodes' matches
+     * the set of subtrees in trueSoln's 'children' vector.
+     */
+    static bool childrenMatch(const BSONObj& testSoln, const QuerySolutionNode* trueSoln) {
+        BSONElement children = testSoln["nodes"];
+        if (children.eoo() || !children.isABSONObj()) { return false; }
+
+        // The order of the children array in testSoln might not match
+        // the order in trueSoln, so we have to check all combos with
+        // these nested loops.
+        BSONObjIterator i(children.Obj());
+        while (i.more()) {
+            BSONElement child = i.next();
+            if (child.eoo() || !child.isABSONObj()) { return false; }
+
+            // try to match against one of the QuerySolutionNode's children
+            bool found = false;
+            for (size_t j = 0; j < trueSoln->children.size(); ++j) {
+                if (QueryPlannerTestLib::solutionMatches(child.Obj(), trueSoln->children[j])) {
+                    found = true;
+                    break;
+                }
+            }
+
+            // we couldn't match child
+            if (!found) { return false; }
+        }
+
+        return true;
+    }
+
+    // static
+    bool QueryPlannerTestLib::solutionMatches(const BSONObj& testSoln,
+                                              const QuerySolutionNode* trueSoln) {
+        //
+        // leaf nodes
+        //
+        if (STAGE_COLLSCAN == trueSoln->getType()) {
+            const CollectionScanNode* csn = static_cast<const CollectionScanNode*>(trueSoln);
+            BSONElement el = testSoln["cscan"];
+            if (el.eoo() || !el.isABSONObj()) { return false; }
+            BSONObj csObj = el.Obj();
+
+            BSONElement dir = csObj["dir"];
+            if (dir.eoo() || !dir.isNumber()) { return false; }
+            if (dir.numberInt() != csn->direction) { return false; }
+
+            BSONElement filter = csObj["filter"];
+            if (filter.eoo()) {
+                return true;
+            }
+            else if (filter.isNull()) {
+                return NULL == csn->filter;
+            }
+            else if (!filter.isABSONObj()) {
+                return false;
+            }
+            return filterMatches(filter.Obj(), trueSoln);
+        }
+        else if (STAGE_IXSCAN == trueSoln->getType()) {
+            const IndexScanNode* ixn = static_cast<const IndexScanNode*>(trueSoln);
+            BSONElement el = testSoln["ixscan"];
+            if (el.eoo() || !el.isABSONObj()) { return false; }
+            BSONObj ixscanObj = el.Obj();
+
+            BSONElement pattern = ixscanObj["pattern"];
+            if (pattern.eoo() || !pattern.isABSONObj()) { return false; }
+            if (pattern.Obj() != ixn->indexKeyPattern) { return false; }
+
+            BSONElement bounds = ixscanObj["bounds"];
+            if (!bounds.eoo()) {
+                if (!bounds.isABSONObj()) {
+                    return false;
+                }
+                else if (!boundsMatch(bounds.Obj(), ixn->bounds)) {
+                    return false;
+                }
+            }
+
+            BSONElement dir = ixscanObj["dir"];
+            if (!dir.eoo() && NumberInt == dir.type()) {
+                if (dir.numberInt() != ixn->direction) {
+                    return false;
+                }
+            }
+
+            BSONElement filter = ixscanObj["filter"];
+            if (filter.eoo()) {
+                return true;
+            }
+            else if (filter.isNull()) {
+                return NULL == ixn->filter;
+            }
+            else if (!filter.isABSONObj()) {
+                return false;
+            }
+            return filterMatches(filter.Obj(), trueSoln);
+        }
+        else if (STAGE_GEO_2D == trueSoln->getType()) {
+            const Geo2DNode* node = static_cast<const Geo2DNode*>(trueSoln);
+            BSONElement el = testSoln["geo2d"];
+            if (el.eoo() || !el.isABSONObj()) { return false; }
+            BSONObj geoObj = el.Obj();
+            return geoObj == node->indexKeyPattern;
+        }
+        else if (STAGE_GEO_NEAR_2D == trueSoln->getType()) {
+            const GeoNear2DNode* node = static_cast<const GeoNear2DNode*>(trueSoln);
+            BSONElement el = testSoln["geoNear2d"];
+            if (el.eoo() || !el.isABSONObj()) { return false; }
+            BSONObj geoObj = el.Obj();
+            return geoObj == node->indexKeyPattern;
+        }
+        else if (STAGE_GEO_NEAR_2DSPHERE == trueSoln->getType()) {
+            const GeoNear2DSphereNode* node = static_cast<const GeoNear2DSphereNode*>(trueSoln);
+            BSONElement el = testSoln["geoNear2dsphere"];
+            if (el.eoo() || !el.isABSONObj()) { return false; }
+            BSONObj geoObj = el.Obj();
+            return geoObj == node->indexKeyPattern;
+        }
+
+        //
+        // internal nodes
+        //
+        if (STAGE_FETCH == trueSoln->getType()) {
+            const FetchNode* fn = static_cast<const FetchNode*>(trueSoln);
+
+            BSONElement el = testSoln["fetch"];
+            if (el.eoo() || !el.isABSONObj()) { return false; }
+            BSONObj fetchObj = el.Obj();
+
+            BSONElement filter = fetchObj["filter"];
+            if (!filter.eoo()) {
+                if (filter.isNull()) {
+                    if (NULL != fn->filter) { return false; }
+                }
+                else if (!filter.isABSONObj()) {
+                    return false;
+                }
+                else if (!filterMatches(filter.Obj(), trueSoln)) {
+                    return false;
+                }
+            }
+
+            BSONElement child = fetchObj["node"];
+            if (child.eoo() || !child.isABSONObj()) { return false; }
+            return solutionMatches(child.Obj(), fn->children[0]);
+        }
+        else if (STAGE_OR == trueSoln->getType()) {
+            const OrNode * orn = static_cast<const OrNode*>(trueSoln);
+            BSONElement el = testSoln["or"];
+            if (el.eoo() || !el.isABSONObj()) { return false; }
+            BSONObj orObj = el.Obj();
+            return childrenMatch(orObj, orn);
+        }
+        else if (STAGE_AND_HASH == trueSoln->getType()) {
+            const AndHashNode* ahn = static_cast<const AndHashNode*>(trueSoln);
+            BSONElement el = testSoln["andHash"];
+            if (el.eoo() || !el.isABSONObj()) { return false; }
+            BSONObj andHashObj = el.Obj();
+            // XXX: andHashObj can have filter
+            return childrenMatch(andHashObj, ahn);
+        }
+        else if (STAGE_AND_SORTED == trueSoln->getType()) {
+            const AndSortedNode* asn = static_cast<const AndSortedNode*>(trueSoln);
+            BSONElement el = testSoln["andSorted"];
+            if (el.eoo() || !el.isABSONObj()) { return false; }
+            BSONObj andSortedObj = el.Obj();
+            // XXX: anSortedObj can have filter too
+            return childrenMatch(andSortedObj, asn);
+        }
+        else if (STAGE_PROJECTION == trueSoln->getType()) {
+            const ProjectionNode* pn = static_cast<const ProjectionNode*>(trueSoln);
+
+            BSONElement el = testSoln["proj"];
+            if (el.eoo() || !el.isABSONObj()) { return false; }
+            BSONObj projObj = el.Obj();
+
+            BSONElement spec = projObj["spec"];
+            if (spec.eoo() || !spec.isABSONObj()) { return false; }
+            BSONElement child = projObj["node"];
+            if (child.eoo() || !child.isABSONObj()) { return false; }
+
+            return (spec.Obj() == pn->projection)
+                   && solutionMatches(child.Obj(), pn->children[0]);
+        }
+        else if (STAGE_SORT == trueSoln->getType()) {
+            const SortNode* sn = static_cast<const SortNode*>(trueSoln);
+            BSONElement el = testSoln["sort"];
+            if (el.eoo() || !el.isABSONObj()) { return false; }
+            BSONObj sortObj = el.Obj();
+
+            BSONElement patternEl = sortObj["pattern"];
+            if (patternEl.eoo() || !patternEl.isABSONObj()) { return false; }
+            BSONElement limitEl = sortObj["limit"];
+            if (!limitEl.isNumber()) { return false; }
+            BSONElement child = sortObj["node"];
+            if (child.eoo() || !child.isABSONObj()) { return false; }
+
+            return (patternEl.Obj() == sn->pattern)
+                   && (limitEl.numberInt() == sn->limit)
+                   && solutionMatches(child.Obj(), sn->children[0]);
+        }
+        else if (STAGE_SORT_MERGE == trueSoln->getType()) {
+            const MergeSortNode* msn = static_cast<const MergeSortNode*>(trueSoln);
+            BSONElement el = testSoln["mergeSort"];
+            if (el.eoo() || !el.isABSONObj()) { return false; }
+            BSONObj mergeSortObj = el.Obj();
+            return childrenMatch(mergeSortObj, msn);
+        }
+        else if (STAGE_SKIP == trueSoln->getType()) {
+            const SkipNode* sn = static_cast<const SkipNode*>(trueSoln);
+            BSONElement el = testSoln["skip"];
+            if (el.eoo() || !el.isABSONObj()) { return false; }
+            BSONObj sortObj = el.Obj();
+
+            BSONElement skipEl = sortObj["n"];
+            if (!skipEl.isNumber()) { return false; }
+            BSONElement child = sortObj["node"];
+            if (child.eoo() || !child.isABSONObj()) { return false; }
+
+            return (skipEl.numberInt() == sn->skip)
+                   && solutionMatches(child.Obj(), sn->children[0]);
+        }
+        else if (STAGE_LIMIT == trueSoln->getType()) {
+            const LimitNode* ln = static_cast<const LimitNode*>(trueSoln);
+            BSONElement el = testSoln["limit"];
+            if (el.eoo() || !el.isABSONObj()) { return false; }
+            BSONObj sortObj = el.Obj();
+
+            BSONElement limitEl = sortObj["n"];
+            if (!limitEl.isNumber()) { return false; }
+            BSONElement child = sortObj["node"];
+            if (child.eoo() || !child.isABSONObj()) { return false; }
+
+            return (limitEl.numberInt() == ln->limit)
+                   && solutionMatches(child.Obj(), ln->children[0]);
+        }
+
+        return false;
+    }
+
+}  // namespace mongo

--- a/src/mongo/db/query/query_planner_test_lib.h
+++ b/src/mongo/db/query/query_planner_test_lib.h
@@ -1,0 +1,58 @@
+/**
+ *    Copyright (C) 2013 10gen Inc.
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under the terms of the GNU Affero General Public License, version 3,
+ *    as published by the Free Software Foundation.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *    As a special exception, the copyright holders give permission to link the
+ *    code of portions of this program with the OpenSSL library under certain
+ *    conditions as described in each individual source file and distribute
+ *    linked combinations including the program with the OpenSSL library. You
+ *    must comply with the GNU Affero General Public License in all respects for
+ *    all of the code used other than as permitted herein. If you modify file(s)
+ *    with this exception, you may extend this exception to your version of the
+ *    file(s), but you are not obligated to do so. If you do not wish to do so,
+ *    delete this exception statement from your version. If you delete this
+ *    exception statement from all source files in the program, then also delete
+ *    it in the license file.
+ */
+
+/**
+ * This file contains tests for mongo/db/query/query_planner.cpp
+ */
+
+#include <ostream>
+#include <sstream>
+#include "mongo/db/jsobj.h"
+#include "mongo/db/json.h"
+#include "mongo/db/matcher/expression_parser.h"
+#include "mongo/db/query/qlog.h"
+#include "mongo/db/query/query_planner.h"
+#include "mongo/db/query/query_solution.h"
+#include "mongo/unittest/unittest.h"
+#include "mongo/util/assert_util.h"
+
+namespace mongo {
+
+    class QueryPlannerTestLib {
+    public:
+        /**
+         * @param testSoln -- a BSON representation of a query solution
+         * @param trueSoln -- the root node of a query solution tree
+         *
+         * Returns true if the BSON representation matches the actual
+         * tree, otherwise returns false.
+         */
+        static bool solutionMatches(const BSONObj& testSoln, const QuerySolutionNode* trueSoln);
+    };
+
+}  // namespace mongo

--- a/src/mongo/db/query/query_solution.h
+++ b/src/mongo/db/query/query_solution.h
@@ -33,6 +33,7 @@
 #include "mongo/db/geo/geoquery.h"
 #include "mongo/db/fts/fts_query.h"
 #include "mongo/db/query/index_bounds.h"
+#include "mongo/db/query/plan_cache.h"
 #include "mongo/db/query/stage_types.h"
 
 namespace mongo {
@@ -167,6 +168,9 @@ namespace mongo {
         // XXX temporary: if it has a sort stage the sort wasn't provided by an index,
         // so we use that index (if it exists) to provide a sort.
         bool hasSortStage;
+
+        // Owned here. Used by the plan cache.
+        boost::scoped_ptr<SolutionCacheData> cacheData;
 
         /**
          * Output a human-readable string representing the plan.


### PR DESCRIPTION
The plan cache now builds a tree isomorphic to the tagged match expression in order to store the index tags used by a plan. On cache hit, this tree is used to tag the match expression. The tagged tree can then be fed through the access planner in order to recreate the original query solution.
