### PR TITLE
SERVER-13452 Add support for detection of 64-bit powerpc

### DIFF
--- a/src/mongo/platform/bits.h
+++ b/src/mongo/platform/bits.h
@@ -19,7 +19,7 @@
 
 // figure out if we're on a 64 or 32 bit system
 
-#if defined(__x86_64__) || defined(__amd64__) || defined(_WIN64) || defined(__aarch64__)
+#if defined(__x86_64__) || defined(__amd64__) || defined(_WIN64) || defined(__aarch64__) || defined(__powerpc64__)
 #define MONGO_PLATFORM_64
 #elif defined(__i386__) || defined(_WIN32) || defined(__arm__)
 #define MONGO_PLATFORM_32


### PR DESCRIPTION
Ubuntu 14.04 will ship with a little-endian PowerPC 64 bit architecture;
add compiler macro check to detect this platform correctly.

Note that right now, there is no v8 support for ppc64el; however its
possible to build without javascript support to enable MongoDB on this
new architecture.
