### PR TITLE
SERVER-12136 hook additional profiler fields up to the query system

### DIFF
--- a/jstests/profile4.js
+++ b/jstests/profile4.js
@@ -18,15 +18,12 @@ function lastOp() {
     return p;
 }
 
-// QUERY MIGRATION
-// The new query system is still not connected to the query profiling facility
-//
 function checkLastOp( spec ) {
-//    p = lastOp();
-//    for( i in spec ) {
-//        s = spec[ i ];
-//        assert.eq( s[ 1 ], p[ s[ 0 ] ], s[ 0 ] );
-//    }
+    p = lastOp();
+    for( i in spec ) {
+        s = spec[ i ];
+        assert.eq( s[ 1 ], p[ s[ 0 ] ], s[ 0 ] );
+    }
 }
 
 try {

--- a/src/mongo/db/query/idhack_runner.cpp
+++ b/src/mongo/db/query/idhack_runner.cpp
@@ -164,8 +164,10 @@ namespace mongo {
     }
 
     Status IDHackRunner::getExplainPlan(TypeExplain** explain) const {
-        // This shouldn't be called anyway as idhack is only used when there is no explain.
-        return Status(ErrorCodes::InternalError, "no stats available to explain plan");
+        // The explain plan simply indicates that the plan is idhack.
+        *explain = new TypeExplain();
+        (*explain)->setIDHack(true);
+        return Status::OK();
     }
 
 } // namespace mongo

--- a/src/mongo/db/query/type_explain.cpp
+++ b/src/mongo/db/query/type_explain.cpp
@@ -276,6 +276,9 @@ namespace mongo {
         _indexOnly = false;
         _isIndexOnlySet = false;
 
+        _idHack = false;
+        _isIDHackSet = false;
+
         _nYields = 0;
         _isNYieldsSet = false;
 
@@ -337,6 +340,9 @@ namespace mongo {
 
         other->_indexOnly = _indexOnly;
         other->_isIndexOnlySet = _isIndexOnlySet;
+
+        other->_idHack = _idHack;
+        other->_isIDHackSet = _isIDHackSet;
 
         other->_nYields = _nYields;
         other->_isNYieldsSet = _isNYieldsSet;
@@ -585,6 +591,24 @@ namespace mongo {
     bool TypeExplain::getIndexOnly() const {
         verify(_isIndexOnlySet);
         return _indexOnly;
+    }
+
+    void TypeExplain::setIDHack(bool idhack) {
+        _idHack = idhack;
+        _isIDHackSet = true;
+    }
+
+    void TypeExplain::unsetIDHack() {
+        _isIDHackSet = false;
+    }
+
+    bool TypeExplain::isIDHackSet() const {
+        return _isIDHackSet;
+    }
+
+    bool TypeExplain::getIDHack() const {
+        verify(_isIDHackSet);
+        return _idHack;
     }
 
     void TypeExplain::setNYields(long long nYields) {

--- a/src/mongo/db/query/type_explain.h
+++ b/src/mongo/db/query/type_explain.h
@@ -142,6 +142,11 @@ namespace mongo {
         bool isIndexOnlySet() const;
         bool getIndexOnly() const;
 
+        void setIDHack(bool idhack);
+        void unsetIDHack();
+        bool isIDHackSet() const;
+        bool getIDHack() const;
+
         void setNYields(long long nYields);
         void unsetNYields();
         bool isNYieldsSet() const;
@@ -221,6 +226,10 @@ namespace mongo {
         // (O)  number of entries retrieved either from an index or collection across all plans
         bool _indexOnly;
         bool _isIndexOnlySet;
+
+        // (O)  whether the idhack was used to answer this query
+        bool _idHack;
+        bool _isIDHackSet;
 
         // (O)  number times this plan released and reacquired its lock
         long long _nYields;


### PR DESCRIPTION
Specifically, ensure that the fields scanAndOrder, nscanned, and idhack are set properly in the profiler output.
