### PR TITLE
SERVER-12296 cache a backup plan for blocking sort solutions

### DIFF
--- a/jstests/sortl.js
+++ b/jstests/sortl.js
@@ -30,12 +30,10 @@ for( i = 0; i < 40; ++i ) {
     t.save( { a:2, b:i, c:big } );
 }
 
-// QUERY_MIGRATION: Plan cache does not invalidate
-// a cached plan that will fail due to an out-of-memory error.
-/*recordIndex( 'a_1', { a:1 }, { b:1 } );
+recordIndex( 'a_1', { a:1 }, { b:1 } );
 result = t.find( { a:2 }, { a:1, b:1 } ).sort( { b:1 } ).toArray();
 assert.eq( 40, result.length );
-checkBOrdering( result );*/
+checkBOrdering( result );
 
 // An optimal in order plan is recorded and reused.
 recordIndex( 'b_1', { b:{ $gte:0 } }, { b:1 } );

--- a/src/mongo/db/query/cached_plan_runner.h
+++ b/src/mongo/db/query/cached_plan_runner.h
@@ -86,12 +86,28 @@ namespace mongo {
          */
         virtual Status getExplainPlan(TypeExplain** explain) const;
 
+        /**
+         * Takes ownership of all arguments.
+         */
+        void setBackupPlan(QuerySolution* qs, PlanStage* root, WorkingSet* ws);
+
     private:
         void updateCache();
 
         boost::scoped_ptr<CanonicalQuery> _canonicalQuery;
         boost::scoped_ptr<QuerySolution> _solution;
         boost::scoped_ptr<PlanExecutor> _exec;
+
+        // Owned here. If non-NULL, then this plan executor is capable
+        // of executing a backup plan in the case of a blocking sort.
+        std::auto_ptr<PlanExecutor> _backupPlan;
+
+        // Owned here. If non-NULL, contains the query solution corresponding
+        // to the backup plan.
+        boost::scoped_ptr<QuerySolution> _backupSolution;
+
+        // Whether the executor for the winning plan has produced results yet.
+        bool _alreadyProduced;
 
         // Have we updated the cache with our plan stats yet?
         bool _updatedCache;

--- a/src/mongo/db/query/plan_cache.h
+++ b/src/mongo/db/query/plan_cache.h
@@ -195,6 +195,10 @@ namespace mongo {
         // Owned here.
         std::vector<SolutionCacheData*> plannerData;
 
+        // An index into plannerData indicating the SolutionCacheData which should be
+        // used to produce a backup solution in the case of a blocking sort.
+        boost::optional<size_t> backupSoln;
+
         // Pin information
         bool pinned;
 
@@ -246,6 +250,10 @@ namespace mongo {
         // represents. Each SolutionCacheData is fully owned here, so in order to return
         // it from the cache a deep copy is made and returned inside CachedSolution.
         std::vector<SolutionCacheData*> plannerData;
+
+        // An index into plannerData indicating the SolutionCacheData which should be
+        // used to produce a backup solution in the case of a blocking sort.
+        boost::optional<size_t> backupSoln;
 
         // Why the best solution was picked.
         // TODO: Do we want to store other information like the other plans considered?

--- a/src/mongo/db/query/plan_cache_test.cpp
+++ b/src/mongo/db/query/plan_cache_test.cpp
@@ -607,8 +607,9 @@ namespace {
             PlanCacheEntry entry(solutions, new PlanRankingDecision());
             CachedSolution cachedSoln(ck, entry);
 
-            QuerySolution* out;
-            s = QueryPlanner::planFromCache(*scopedCq.get(), params, &cachedSoln, &out);
+            QuerySolution *out, *backupOut;
+            s = QueryPlanner::planFromCache(*scopedCq.get(), params, &cachedSoln,
+                                            &out, &backupOut);
             ASSERT_OK(s);
 
             return out;

--- a/src/mongo/db/query/query_planner.h
+++ b/src/mongo/db/query/query_planner.h
@@ -52,10 +52,38 @@ namespace mongo {
                            const QueryPlannerParams& params,
                            std::vector<QuerySolution*>* out);
 
+        /**
+         * Helper that does most of the heavy lifting for the planFromCache
+         * method which this overloads. Whereas the overloaded version plans
+         * from cache twice (once for the winning solution and once from the
+         * backup solution), this version plans from cache once.
+         *
+         * It requires a single SolutionCacheData, rather than a CachedSolution, which
+         * owns a vector of SolutionCacheData instances.
+         */
+        static Status planFromCache(const CanonicalQuery& query,
+                                    const QueryPlannerParams& params,
+                                    SolutionCacheData* cacheData,
+                                    QuerySolution** out);
+
+        /**
+         * Attempt to generate a query solution, given data retrieved
+         * from the plan cache.
+         *
+         * @param query -- query for which we are generating a plan
+         * @param params -- planning parameters
+         * @param cachedSoln -- the CachedSolution retrieved from the plan cache.
+         * @param out -- an out-parameter which will be filled in with the solution
+         *   generated from the cache data
+         * @param backupOut -- if 'out' contains a blocking sort, then backoutOut may
+         *  contain an alternative solution with no blocking sort; otherwise it will
+         *  contain NULL on return.
+         */
         static Status planFromCache(const CanonicalQuery& query,
                                     const QueryPlannerParams& params,
                                     CachedSolution* cachedSoln,
-                                    QuerySolution** out);
+                                    QuerySolution** out,
+                                    QuerySolution** backupOut);
 
         /**
          * Used to generated the index tag tree that will be inserted


### PR DESCRIPTION
If the winning solution chosen by the multi plan runner has a blocking sort, then try and cache a non-blocking sort plan in addition to the winner. The cached plan runner then will fall back on the backup plan if the blocking sort fails due to an out-of-memory error.
