### PR TITLE
SERVER-12461 Use larger values to test for too large $position arguments.

### DIFF
--- a/src/mongo/db/ops/modifier_push_test.cpp
+++ b/src/mongo/db/ops/modifier_push_test.cpp
@@ -1293,8 +1293,8 @@ namespace {
                "{$push: {a: { $each: [1], $position:3.000000000001}}}",
                "{$push: {a: { $each: [1], $position:1.2}}}",
                "{$push: {a: { $each: [1], $position:-1.2}}}",
-               "{$push: {a: { $each: [1], $position:9223372036854775810}}}",
-               "{$push: {a: { $each: [1], $position:-9223372036854775810}}}",
+               "{$push: {a: { $each: [1], $position:9.0e19}}}",
+               "{$push: {a: { $each: [1], $position:-9.0e19}}}",
                NULL,
         };
 


### PR DESCRIPTION
The previous values were integers that were just 3 away from the largest
possible 64-bit integer, were parsed as the same float as the largest possible
integer, and so were accepted.  This changes them to be 10 times as large.

I observed this failure on an aarch64 / arm64 system.  I don't really understand why it passes on x86.
