### PR TITLE
SERVER-12461 Ensure LexNumCmp::cmp only returns 1, -1 or 0

### DIFF
--- a/src/mongo/util/stringutils.cpp
+++ b/src/mongo/util/stringutils.cpp
@@ -107,7 +107,7 @@ namespace mongo {
                                           sd2.rawData() + s2,
                                           len1 );
                         if ( result )
-                            return result;
+                            return ( result > 0) ? 1 : -1;
                     }
 
                     // otherwise, the numbers are equal


### PR DESCRIPTION
strncmp's documentation says:

```
It returns an integer less than, equal to, or greater than
zero if s1 is found, respectively, to be less than, to match,
or be greater than s2.
```

LexNumCmp::cmp is tested as returning only -1, 1 or 0 but returns the
return value of strncmp directly.  This changes it to clamp the return
value to -1, 1 or 0.

This was another test failure observed on aarch64.
