### PR TITLE
SERVER-12461 Do not let GCC use FMA instructions for DistributionEstimators& operator<<

### DIFF
--- a/src/mongo/util/descriptive_stats.h
+++ b/src/mongo/util/descriptive_stats.h
@@ -20,6 +20,12 @@
 #include "mongo/db/jsobj.h"
 #include "mongo/util/assert_util.h"
 
+#if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && (__GNUC_MINOR__ >= 8)))
+#define NO_FUSED_MULTIPLY_ADD __attribute__((optimize("fp-contract=off")))
+#else
+#define NO_FUSED_MULTIPLY_ADD
+#endif
+
 /**
  * These classes provide online descriptive statistics estimator capable
  * of computing the mean, standard deviation and quantiles.
@@ -112,7 +118,7 @@ namespace mongo {
     public:
         DistributionEstimators();
 
-        DistributionEstimators& operator <<(const double sample);
+        DistributionEstimators& operator <<(const double sample) NO_FUSED_MULTIPLY_ADD;
 
         /**
          * Number of computed quantiles, excluding minimum and maximum.


### PR DESCRIPTION
One of the descriptive_stats tests (TEST(SummaryEstimators,
TestNominalResults)) fails on arm64 because the error between the estimated
quantile and the true value is ever so slightly over the tolerance.  Disabling
gcc's use of fused-multiply add instructions for DistributionEstimators&
operator << brings the error back within the tolerance.

There are obviously other ways this could be fixed; obvious ones include changing the tolerance in the test or disabling fp-contract on the command line for all files.  But this one works.
