### PR TITLE
SERVER-9923 mongod blocks writes to all databases if filesystem hosting one database is full

### DIFF
--- a/src/mongo/db/client.cpp
+++ b/src/mongo/db/client.cpp
@@ -362,7 +362,7 @@ namespace mongo {
     void Client::Context::_finishInit() {
         dassert( Lock::isLocked() );
         int writeLocked = Lock::somethingWriteLocked();
-        if ( writeLocked && FileAllocator::get()->hasFailed() ) {
+        if ( writeLocked && FileAllocator::get()->hasFailed(_ns) ) {
             uassert(14031, "Can't take a write lock while out of disk space", false);
         }
         

--- a/src/mongo/util/file_allocator.h
+++ b/src/mongo/util/file_allocator.h
@@ -54,7 +54,7 @@ namespace mongo {
 
         void waitUntilFinished() const;
         
-        bool hasFailed() const;
+        bool hasFailed(const string &database) const;
 
         static void ensureLength(int fd, long size);
 
@@ -65,7 +65,7 @@ namespace mongo {
 
         FileAllocator();
 
-        void checkFailure();
+        void checkFailure(string &database);
 
         // caller must hold pendingMutex_ lock.  Returns size if allocated or
         // allocation requested, -1 otherwise.
@@ -89,10 +89,11 @@ namespace mongo {
         // unique number for temporary files
         static unsigned long long _uniqueNumber;
 
-        bool _failed;
+        map<string, bool> _failed;
 
         static FileAllocator* _instance;
 
     };
+        string getDbName(const string& filename);
 
 } // namespace mongo


### PR DESCRIPTION
The main change here is changing FileAllocator::_failed  from bool to map<string db, bool>. 
besides that,  I also changed FileAllocator::run to release lock before sleep 10 seconds in exception case.  and also move the failed file name to the pending last.   Please let me know there is any issue for this change.  thanks!