### PR TITLE
SERVER-14802 Fixed problem with sleepmillis() on Windows due to default timer resolution being typically higher than 15ms

### DIFF
--- a/src/mongo/util/platform_init.cpp
+++ b/src/mongo/util/platform_init.cpp
@@ -26,7 +26,10 @@
 *    then also delete it in the license file.
 */
 
+#include "mongo/platform/basic.h"
+
 #ifdef _WIN32
+#include <mmsystem.h>
 #include <crtdbg.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -37,7 +40,6 @@
 #include "mongo/util/stacktrace.h"
 
 #ifdef _WIN32
-#include <mmsystem.h>
 
 namespace mongo {
 


### PR DESCRIPTION
All sleepmillis() calls with values lesser than timer resolution will sleep AT LEAST the timer resolution value, making Mongo be really slow on certain use cases. Like when implementing consumer/producer patterns using capped collections to stream objects back and forth
