### PR TITLE
SERVER-4761 "object" to "document" update

### DIFF
--- a/src/mongo/tools/dump.cpp
+++ b/src/mongo/tools/dump.cpp
@@ -121,11 +121,11 @@ public:
 
         ProgressMeter m(conn(true).count(coll.c_str(), BSONObj(), QueryOption_SlaveOk));
         m.setName("Collection File Writing Progress");
-        m.setUnits("objects");
+        m.setUnits("documents");
 
         doCollection(coll, f, &m);
 
-        toolInfoLog() << "\t\t " << m.done() << " objects" << std::endl;
+        toolInfoLog() << "\t\t " << m.done() << " documents" << std::endl;
     }
 
     void writeMetadataFile( const string coll, boost::filesystem::path outputFile, 
@@ -345,7 +345,7 @@ public:
         // init with double the docs count because we make two passes 
         ProgressMeter m( nsd->numRecords() * 2 );
         m.setName("Repair Progress");
-        m.setUnits("objects");
+        m.setUnits("documents");
 
         Writer w( f , &m );
 
@@ -375,7 +375,7 @@ public:
             toolError() << "ERROR: backwards extent pass failed:" << e.toString() << std::endl;
         }
 
-        toolInfoLog() << "\t\t " << m.done() << " objects" << std::endl;
+        toolInfoLog() << "\t\t " << m.done() << " documents" << std::endl;
     }
     
     int _repair( string dbname ) {
@@ -497,7 +497,7 @@ public:
                 string key = *i;
                 
                 if ( ! dbs[key].isABSONObj() ) {
-                    toolError() << "database field not an object key: " << key << " value: "
+                    toolError() << "database field not an document key: " << key << " value: "
                               << dbs[key] << std::endl;
                     return -3;
                 }


### PR DESCRIPTION
SERVER-4761: Updating dump.cpp to change "object" to "document" for what we are now definitely calling documents, not exhaustive for the ticket.
