### PR TITLE
SERVER-12682 Add warning on OS X if libc++ is selected and osx-version-min is < 10.7.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -46,6 +46,9 @@ def findSettingsSetup():
     sys.path.append( ".." )
     sys.path.append( "../../" )
 
+def versiontuple(v):
+    return tuple(map(int, (v.split("."))))
+
 # --- platform identification ---
 #
 # This needs to precede the options section so that we can only offer some options on certain
@@ -1226,6 +1229,8 @@ def doConfigure(myenv):
         if not using_clang():
             print( 'libc++ is currently only supported for clang')
             Exit(1)
+        if darwin and has_option('osx-version-min') and versiontuple(min_version) < versiontuple('10.7'):
+            print("Warning: You passed option 'libc++'. You probably want to also pass 'osx-version-min=10.7' or higher for libc++ support.")
         if AddToCXXFLAGSIfSupported(myenv, '-stdlib=libc++'):
             myenv.Append(LINKFLAGS=['-stdlib=libc++'])
         else:


### PR DESCRIPTION
See issue: https://jira.mongodb.org/browse/SERVER-12682
