### PR TITLE
SERVER-13037 Fix misspelling ("compatability" to "compatibility")

### DIFF
--- a/src/mongo/bson/bsonobjbuilder.h
+++ b/src/mongo/bson/bsonobjbuilder.h
@@ -793,7 +793,7 @@ namespace mongo {
             return _b.subarrayStart( num() );
         }
 
-        // These should only be used where you really need interface compatability with BSONObjBuilder
+        // These should only be used where you really need interface compatibility with BSONObjBuilder
         // Currently they are only used by update.cpp and it should probably stay that way
         BufBuilder &subobjStart( const StringData& name ) {
             fill( name );

--- a/src/mongo/db/structure/catalog/namespace_details.cpp
+++ b/src/mongo/db/structure/catalog/namespace_details.cpp
@@ -85,7 +85,7 @@ namespace mongo {
         _lastExtentSize = 0;
         _nIndexes = 0;
         _isCapped = capped;
-        _maxDocsInCapped = 0x7fffffff; // no limit (value is for pre-v2.3.2 compatability)
+        _maxDocsInCapped = 0x7fffffff; // no limit (value is for pre-v2.3.2 compatibility)
         _paddingFactor = 1.0;
         _systemFlags = 0;
         _userFlags = 0;

--- a/src/mongo/shell/mongo.js
+++ b/src/mongo/shell/mongo.js
@@ -200,7 +200,7 @@ Mongo.prototype.writeMode = function() {
         // good with whatever is already set
     }
     else if ( this._writeMode == "commands" ) {
-        print("Cannot use commands write mode, degrading to compatability mode");
+        print("Cannot use commands write mode, degrading to compatibility mode");
         this._writeMode = "compatibility";
     }
     


### PR DESCRIPTION
This pull request responds to an [open issue](https://jira.mongodb.org/browse/SERVER-13037) regarding a misspelled word in an error message given by the MongoDB shell. I also corrected two other instances of the mistake which appeared in comments. The "issue" is trivial, but addressing it does add a little polish to MongoDB. All tests still pass on my personal machine, a MacBook Air running Mavericks (OS X 10.9.2), but I have only tested with the "origin/master" branch from GitHub. I'm not sure whether new tests are really necessary for this sort of thing, so I haven't written any yet.
