### PR TITLE
SERVER-14049 fix v8 SConscript python path

### DIFF
--- a/src/third_party/v8/SConscript
+++ b/src/third_party/v8/SConscript
@@ -29,7 +29,7 @@
 import sys
 from os.path import join, dirname, abspath
 root_dir = dirname(File('SConscript').rfile().abspath)
-sys.path.append(join(root_dir, 'tools'))
+sys.path.insert(0, join(root_dir, 'tools'))
 import js2c
 
 Import("env windows linux darwin solaris freebsd debugBuild openbsd")


### PR DESCRIPTION
Fix third-party v8 building when required python libs are also installed on the system.

The local python patch should be searched at first to avoid conflicts or incompatible libs versions used during the build process.

See SERVER-14049 for details.
