### PR TITLE
SERVER-13144 SERVER-14237 The "size" parameter for non-capped collections stopped being honored in HEAD

### DIFF
--- a/jstests/core/extent_server14237.js
+++ b/jstests/core/extent_server14237.js
@@ -1,0 +1,29 @@
+/* SERVER-14237: The "size" parameter for non-capped collections
+ * stopped being honored in HEAD
+ */
+
+var ns = "server_xxxxx";
+db.getCollection(ns).drop();
+
+/* Testing for a single constant size may accidentally coincide with
+ * the default size of extents, resulting in a false-negative.
+ */
+var sizes = [      500 * 1024 + 1, // approx. 500 KiB
+                  1024 * 1024 + 1, //           1 MiB
+              2 * 1024 * 1024 + 1  //           2 MiB
+            ];
+for (var i = 0; i < sizes.length; i++) {
+    db.createCollection(ns, { size: sizes[i] });
+
+    var meta = db.system.namespaces.findOne({name: db + "." + ns});
+    assert.eq(
+        meta.options.size, sizes[i],
+        "initial extent size recorded in system.namespaces");
+
+    var stats = db.getCollection(ns).stats();
+    assert.gte( // The size of extent will be quantized so "gte" not "eq".
+        stats.storageSize, sizes[i],
+        "initial extent size of non-capped collection");
+
+    db.getCollection(ns).drop();
+}

--- a/src/mongo/db/catalog/collection_options.cpp
+++ b/src/mongo/db/catalog/collection_options.cpp
@@ -80,8 +80,6 @@ namespace mongo {
                 cappedSize = e.numberLong();
                 if ( cappedSize < 0 )
                     return Status( ErrorCodes::BadValue, "size has to be >= 0" );
-                cappedSize += 0xff;
-                cappedSize &= 0xffffffffffffff00LL;
             }
             else if ( fieldName == "max" ) {
                 if ( !options["capped"].trueValue() || !e.isNumber() ) {
@@ -127,11 +125,11 @@ namespace mongo {
         BSONObjBuilder b;
         if ( capped ) {
             b.appendBool( "capped", true );
-            if ( cappedSize )
-                b.appendNumber( "size", cappedSize );
             if ( cappedMaxDocs )
                 b.appendNumber( "max", cappedMaxDocs );
         }
+        if ( cappedSize )
+            b.appendNumber( "size", cappedSize );
 
         if ( initialNumExtents )
             b.appendNumber( "$nExtents", initialNumExtents );

--- a/src/mongo/db/storage/mmap_v1/mmap_v1_engine.cpp
+++ b/src/mongo/db/storage/mmap_v1/mmap_v1_engine.cpp
@@ -448,12 +448,20 @@ namespace mongo {
                     // extents, which is invalid.
                     int sz = _massageExtentSize( &_extentManager,
                                                  options.cappedSize - rs->storageSize() );
+                    sz += 0xff;
                     sz &= 0xffffff00;
                     rs->increaseStorageSize( txn, sz, -1 );
                 } while( rs->storageSize() < options.cappedSize );
             }
             else {
-                rs->increaseStorageSize( txn, _extentManager.initialSize( 128 ), -1 );
+                int sz;
+                if ( options.cappedSize > 0 ) {
+                    sz = _extentManager.quantizeExtentSize( options.cappedSize );
+                }
+                else {
+                    sz = _extentManager.initialSize( 128 );
+                }
+                rs->increaseStorageSize( txn, sz, -1 );
             }
         }
 


### PR DESCRIPTION
The documentation for [db.createCollection](http://docs.mongodb.org/manual/reference/method/db.createCollection/) states the following for the `size` parameter:

> If `capped` is false, you can use this field to preallocate space for an ordinary collection.

This was true prior to `r2.7.1` but the `size` parameter gets silently ignored in `HEAD` when the collection to be created is not capped. It was the only (documented) way not to allocate a lot of extents for a collection that was supposed to grow to a large size, say 500 MiB.
