### PR TITLE
SERVER-9634 Fix typo in mongoperf; 'optoins' -> 'options'.

### DIFF
--- a/src/mongo/client/examples/mongoperf.cpp
+++ b/src/mongo/client/examples/mongoperf.cpp
@@ -200,7 +200,7 @@ void go() {
 
     cout << "testing..."<< endl;
 
-    cout << "optoins:" << o.toString() << endl;
+    cout << "options:" << o.toString() << endl;
     unsigned wthr = 1;
     if( !o["nThreads"].eoo() ) {
         wthr = (unsigned) o["nThreads"].Int();


### PR DESCRIPTION
Fixed a minor typo.
