### PR TITLE
SERVER-14388 Fixup detection of yaml-cpp system library

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1658,7 +1658,7 @@ def doConfigure(myenv):
         conf.FindSysLibDep("stemmer", ["stemmer"])
 
     if use_system_version_of_library("yaml"):
-        conf.FindSysLibDep("yaml", ["yaml"])
+        conf.FindSysLibDep("yaml", ["yaml-cpp"])
 
     if use_system_version_of_library("boost"):
         if not conf.CheckCXXHeader( "boost/filesystem/operations.hpp" ):


### PR DESCRIPTION
The use of --use-system-yaml was incorrectly searching for yaml-cpp
under the 'yaml' name.

Search for yaml-cpp instead.

Signed-off-by: James Page james.page@ubuntu.com
