### PR TITLE
make ConfigCoordinator errors more descriptive

### DIFF
--- a/src/mongo/s/write_ops/config_coordinator.cpp
+++ b/src/mongo/s/write_ops/config_coordinator.cpp
@@ -298,16 +298,23 @@ namespace mongo {
         clientResponse->setErrCode( ErrorCodes::ManualInterventionRequired );
         clientResponse->setErrMessage( "config write was not consistent, "
                                        "manual intervention may be required. "
-                                       "config responses: " + builder.obj().toString() );
+                                       "config responses: " + builder.obj().toString(false, true) );
     }
 
     static void combineFsyncErrors( const vector<ConfigFsyncResponse*>& responses,
                                     BatchedCommandResponse* clientResponse ) {
 
+        BSONObjBuilder builder;                                                                          
+        for ( vector<ConfigFsyncResponse*>::const_iterator it = responses.begin(); it != responses.end();
+                ++it ) {
+            builder.append( ( *it )->configHost.toString(), ( *it )->response.toBSON() );
+        }
+
         clientResponse->setOk( false );
         clientResponse->setErrCode( ErrorCodes::RemoteValidationError );
         clientResponse->setErrMessage( "could not verify config servers were "
-                                       "active and reachable before write" );
+                                       "active and reachable before write. "
+                                       "config responses: " + builder.obj().toString(false, true) );
     }
 
     /**


### PR DESCRIPTION
Had a problem when any update to config database from mongos resulted in `"could not verify config servers were active and reachable before write."`, yet all config servers were up and running.
After this fix the error message will include config servers responses. Error with message like: 

```
could not verify config servers were active and reachable before write. config responses { 
    mongo-cfg1:27010: { ok: 1 }, 
    mongo-cfg2:27010: { ok: 1 }, 
    mongo-cfg3:27010: { ok: 0, code: 15907, errmsg: \"could not initialize sharding on connection mongo-cfg3:27010 (172.20.0.3) :: caused by :: mongos specified a different config database string : stored : mongo:27110,mongo2:27110,mongo-cfg3:27010 vs given : mongo-cfg1:27010,mongo-cfg2:27010,mongo-cfg3:27010\" } 
}
```

makes it much easier to identify and fix the problem.
