### PR TITLE
SERVER-13177 Checking return value of connect. Proceed only if connected

### DIFF
--- a/src/mongo/tools/oplog.cpp
+++ b/src/mongo/tools/oplog.cpp
@@ -55,7 +55,14 @@ public:
         
         repl::OplogReader r;
         r.setTailingQueryOptions( QueryOption_SlaveOk | QueryOption_AwaitData );
-        r.connect(mongoOplogGlobalParams.from);
+
+        bool connected = r.connect(mongoOplogGlobalParams.from);
+
+        if (!connected)
+        {
+            toolInfoLog() << "unable to connect to "<< mongoOplogGlobalParams.from << std::endl;
+            return -1;
+        }
 
         toolInfoLog() << "connected" << std::endl;
 


### PR DESCRIPTION
Fixed https://jira.mongodb.org/browse/SERVER-13177.
Adding a check for return of connect() and proceed only if connect was successful.
