### PR TITLE
SERVER-14679 (CentOS 7/RHEL 7) init.d script should create directory for pid file

### DIFF
--- a/rpm/init.d-mongod
+++ b/rpm/init.d-mongod
@@ -24,6 +24,7 @@ SYSCONFIG="/etc/sysconfig/mongod"
 # for now.  This can go away when this script stops supporting 1.8.
 DBPATH=`awk -F'[:=]' -v IGNORECASE=1 '/^[[:blank:]]*dbpath[[:blank:]]*[:=][[:blank:]]*/{print $2}' "$CONFIGFILE" | tr -d '[:blank:]'`
 PIDFILEPATH=`awk -F'[:=]' -v IGNORECASE=1 '/^[[:blank:]]*pidfilepath[[:blank:]]*[:=][[:blank:]]*/{print $2}' "$CONFIGFILE" | tr -d '[:blank:]'`
+PIDDIR=`dirname $PIDFILEPATH`
 
 mongod=${MONGOD-/usr/bin/mongod}
 
@@ -46,6 +47,11 @@ fi
 
 start()
 {
+  # Make sure the default pidfile directory exists
+  if [ ! -d $PIDDIR ]; then
+    install -d -m 0755 -o $MONGO_USER -g $MONGO_GROUP $PIDDIR
+  fi
+
   # Recommended ulimit values for mongod or mongos
   # See http://docs.mongodb.org/manual/reference/ulimit/#recommended-settings
   #


### PR DESCRIPTION
Modified the startup scripts for CentOS/RHEL 7 to check wether the directory for the pidfile exists and create it if needed.

Signed-off-by: Markus W. Mahlberg markus.mahlberg@me.com
