### PR TITLE
SERVER-14623 ObjectId.fromDate is not correct for all dates

### DIFF
--- a/jstests/core/shelltypes.js
+++ b/jstests/core/shelltypes.js
@@ -72,10 +72,27 @@ assert.throws(function() { ObjectId.fromDate(12345); }, null,
 assert.throws(function() { ObjectId.fromDate(dateA.toISOString()); }, null,
               "ObjectId.fromDate should error on string value" );
 
+// SERVER-14623 dates less than or equal to 1978-07-04T21:24:15Z fail
+var checkFromDate = function (millis,expected,comment){
+    oid = ObjectId.fromDate(new Date(millis))
+    assert.eq(oid.valueOf(), expected,comment );
+}
+
+// SERVER 14623
+checkFromDate(Math.pow(2,28)   * 1000 ,"100000000000000000000000","1978-07-04T21:24:16Z");
+checkFromDate((Math.pow(2,28)  * 1000) - 1 ,"0fffffff0000000000000000","1978-07-04T21:24:15Z");
+checkFromDate(0                  ,"000000000000000000000000","start of epoch");
+
+// test date upper limit
+checkFromDate((Math.pow(2,32) * 1000) -1  ,"ffffffff0000000000000000","last valid date");
+assert.throws(function() { ObjectId.fromDate(new Date(Math.pow(2,32)  * 1000)); }, null,
+              "ObjectId limited to 4 bytes for seconds" );
+
 // ObjectId.fromDate - Date
 b = ObjectId.fromDate(dateA);
 printjson(a);
 assert.eq(tojson(a.getTimestamp()), tojson(b.getTimestamp()), "ObjectId.fromDate - Date");
+
 
 
 

--- a/src/mongo/shell/types.js
+++ b/src/mongo/shell/types.js
@@ -376,9 +376,7 @@ ObjectId.fromDate = function(source) {
     var seconds = Math.floor(sourceDate.getTime()/1000);
 
     // Generate hex timestamp with padding.
-    var hexSeconds = seconds.toString(16);
-    var padding = "0000000000000000";
-    var hexTimestamp = hexSeconds + padding;
+    var hexTimestamp = seconds.toString(16).pad(8,false,'0') + "0000000000000000";
 
     // Create an ObjectId with hex timestamp.
     var objectId = ObjectId(hexTimestamp);


### PR DESCRIPTION
There is an under-run for dates less than 1978-07-04T21:24:15Z ('Math.pow(2,28) - 1' seconds)
Added extra test for upper date limit.
