### PR TITLE
SERVER-14836 SSL certificate expiration date in db.serverStatus()

### DIFF
--- a/src/mongo/db/commands/server_status.cpp
+++ b/src/mongo/db/commands/server_status.cpp
@@ -43,6 +43,7 @@
 #include "mongo/db/stats/counters.h"
 #include "mongo/platform/process_id.h"
 #include "mongo/util/net/listen.h"
+#include "mongo/util/net/ssl_manager.h"
 #include "mongo/util/processinfo.h"
 #include "mongo/util/ramlog.h"
 #include "mongo/util/version.h"
@@ -256,6 +257,24 @@ namespace mongo {
             }
                 
         } network;
+
+#ifdef MONGO_SSL
+        class Security : public ServerStatusSection {
+        public:
+            Security() : ServerStatusSection( "security" ) {}
+            virtual bool includeByDefault() const { return true; }
+
+            BSONObj generateSection(const BSONElement& configElement) const {
+                BSONObjBuilder security;
+                if (getSSLManager()) {
+                    security.appendDate( "SSLCertificateExpirationDate",
+                                         getSSLManager()->getServerCertificateExpirationDate() );
+                }
+
+                return security.obj();
+            }
+        } security;
+#endif
 
         class MemBase : public ServerStatusMetric {
         public:

--- a/src/mongo/util/net/ssl_manager.h
+++ b/src/mongo/util/net/ssl_manager.h
@@ -33,6 +33,7 @@
 
 #include "mongo/base/disallow_copying.h"
 #include "mongo/util/net/sock.h"
+#include "mongo/util/time_support.h"
 
 #include <openssl/err.h>
 #include <openssl/ssl.h>
@@ -105,6 +106,12 @@ namespace mongo {
          * @return the subject name.
          */
         virtual std::string getClientSubjectName() = 0;
+
+        /**
+         * Gets the expiration date of our own server certificate.
+         * @return the expiration date.
+         */
+        virtual Date_t getServerCertificateExpirationDate() = 0;
 
         /**
         * Fetches the error text for an error code, in a thread-safe manner.


### PR DESCRIPTION
If a server is running with SSL, db.serverStatus() should include the expiration date of the SSL certificate.
https://jira.mongodb.org/browse/SERVER-14836
