### PR TITLE
SERVER-7285 Add mongod.service file for Linux

### DIFF
--- a/rpm/mongod.service
+++ b/rpm/mongod.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=High-performance, schema-free document-oriented database
+
+[Service]
+User=mongod
+Group=mongod
+Environment="OPTIONS=--quiet -f /etc/mongod.conf"
+ExecStart=/usr/local/bin/mongod $OPTIONS run
+PIDFile=/var/run/mongodb/mongod.pid
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Add a systemd .service file. This is used in place of System V init scripts on most current Linux distributions.

This uses the existing mongod.conf file in the same folder.
