### PR TITLE
SERVER-13635 Improvements to RocksDB storage engine

### DIFF
--- a/src/mongo/db/storage/rocks/SConscript
+++ b/src/mongo/db/storage/rocks/SConscript
@@ -16,6 +16,7 @@ if has_option("rocksdb"):
         LIBDEPS= [
             '$BUILD_DIR/mongo/bson',
             '$BUILD_DIR/mongo/db/catalog/collection_options',
+            '$BUILD_DIR/mongo/db/index/index_descriptor',
             '$BUILD_DIR/mongo/db/storage/index_entry_comparison',
             '$BUILD_DIR/mongo/foundation',
             '$BUILD_DIR/third_party/shim_snappy',

--- a/src/mongo/db/storage/rocks/rocks_database_catalog_entry_mongod.cpp
+++ b/src/mongo/db/storage/rocks/rocks_database_catalog_entry_mongod.cpp
@@ -28,7 +28,6 @@
  *    it in the license file.
  */
 
-
 #include "mongo/db/storage/rocks/rocks_database_catalog_entry.h"
 
 #include <boost/optional.hpp>
@@ -45,7 +44,7 @@
 #include "mongo/db/storage/rocks/rocks_sorted_data_impl.h"
 #include "mongo/db/storage/rocks/rocks_collection_catalog_entry.h"
 #include "mongo/db/storage/rocks/rocks_engine.h"
-
+#include "mongo/util/log.h"
 
 namespace mongo {
 
@@ -53,13 +52,15 @@ namespace mongo {
                                                            const CollectionCatalogEntry* collection,
                                                            IndexCatalogEntry* index ) {
         const IndexDescriptor* desc = index->descriptor();
-        const boost::optional<Ordering> order( Ordering::make( desc->keyPattern() ) );
+        const Ordering order( Ordering::make( desc->keyPattern() ) );
 
         rocksdb::ColumnFamilyHandle* cf = _engine->getIndexColumnFamily( collection->ns().ns(),
                                                                          desc->indexName(),
                                                                          order );
 
-        std::auto_ptr<RocksSortedDataImpl> raw( new RocksSortedDataImpl( _engine->getDB(), cf ) );
+        std::auto_ptr<RocksSortedDataImpl> raw( new RocksSortedDataImpl( _engine->getDB(),
+                                                                         cf,
+                                                                         order ) );
 
         const string& type = index->descriptor()->getAccessMethodName();
 

--- a/src/mongo/db/storage/rocks/rocks_record_store.h
+++ b/src/mongo/db/storage/rocks/rocks_record_store.h
@@ -145,6 +145,11 @@ namespace mongo {
         bool cappedMaxDocs() const { invariant(_isCapped); return _cappedMaxDocs; }
         bool cappedMaxSize() const { invariant(_isCapped); return _cappedMaxSize; }
 
+        /**
+         * Drops metadata held by the record store
+         */
+        void dropRsMetaData( OperationContext* opCtx );
+
         static rocksdb::Comparator* newRocksCollectionComparator();
     private:
 
@@ -203,8 +208,14 @@ namespace mongo {
         AtomicUInt64 _nextIdNum;
         long long _dataSize;
         long long _numRecords;
-        rocksdb::ReadOptions _defaultReadOptions;
-        mutable boost::mutex _numRecordsLock;
-        mutable boost::mutex _dataSizeLock;
+
+        const string _dataSizeKey;
+        const string _numRecordsKey;
+
+        // locks
+        // TODO I think that when you get one of these, you generally need to acquire the other.
+        // These could probably be moved into a single lock.
+        boost::mutex _numRecordsLock;
+        boost::mutex _dataSizeLock;
     };
 }

--- a/src/mongo/db/storage/rocks/rocks_sorted_data_impl.h
+++ b/src/mongo/db/storage/rocks/rocks_sorted_data_impl.h
@@ -32,6 +32,7 @@
 
 #include <rocksdb/db.h>
 
+#include "mongo/bson/ordering.h"
 #include "mongo/db/storage/index_entry_comparison.h"
 
 #pragma once
@@ -61,7 +62,7 @@ namespace mongo {
     class RocksSortedDataImpl : public SortedDataInterface {
         MONGO_DISALLOW_COPYING( RocksSortedDataImpl );
     public:
-        RocksSortedDataImpl( rocksdb::DB* db, rocksdb::ColumnFamilyHandle* cf );
+        RocksSortedDataImpl( rocksdb::DB* db, rocksdb::ColumnFamilyHandle* cf, Ordering order );
 
         virtual SortedDataBuilderInterface* getBulkBuilder(OperationContext* txn, bool dupsAllowed);
 
@@ -102,6 +103,9 @@ namespace mongo {
         // Each index is stored as a single column family, so this stores the handle to the
         // relevant column family
         rocksdb::ColumnFamilyHandle* _columnFamily; // not owned
+
+        // used to construct RocksCursors
+        const Ordering _order;
 
         /**
          * Creates an error code message out of a key

--- a/src/mongo/db/storage/rocks/rocks_sorted_data_impl_test.cpp
+++ b/src/mongo/db/storage/rocks/rocks_sorted_data_impl_test.cpp
@@ -77,12 +77,14 @@ namespace mongo {
         return db;
     }
 
+    const Ordering dummyOrdering = Ordering::make( BSONObj() );
+
     TEST( RocksRecordStoreTest, BrainDead ) {
         unittest::TempDir td( _rocksSortedDataTestDir );
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
         {
-            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily() );
+            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily(), dummyOrdering );
 
             BSONObj key = BSON( "" << 1 );
             DiskLoc loc( 5, 16 );
@@ -132,7 +134,7 @@ namespace mongo {
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
         {
-            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily() );
+            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily(), dummyOrdering );
 
             BSONObj key = BSON( "" << 1 );
             DiskLoc loc( 5, 16 );
@@ -169,7 +171,7 @@ namespace mongo {
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
         {
-            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily() );
+            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily(), dummyOrdering );
 
             {
                 MyOperationContext opCtx( db.get() );
@@ -219,7 +221,7 @@ namespace mongo {
         {
             boost::shared_ptr<rocksdb::ColumnFamilyHandle> cfh = makeColumnFamily( db.get() );
 
-            RocksSortedDataImpl sortedData( db.get(), cfh.get() );
+            RocksSortedDataImpl sortedData( db.get(), cfh.get(), dummyOrdering );
 
             {
                 MyOperationContext opCtx( db.get() );
@@ -248,7 +250,7 @@ namespace mongo {
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
         {
-            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily() );
+            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily(), dummyOrdering );
 
             {
                 MyOperationContext opCtx( db.get() );
@@ -292,7 +294,7 @@ namespace mongo {
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
         {
-            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily() );
+            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily(), dummyOrdering );
 
             {
                 MyOperationContext opCtx( db.get() );
@@ -346,7 +348,7 @@ namespace mongo {
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
         {
-            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily() );
+            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily(), dummyOrdering );
 
             {
                 MyOperationContext opCtx( db.get() );
@@ -390,7 +392,7 @@ namespace mongo {
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
         {
-            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily() );
+            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily(), dummyOrdering );
 
             {
                 MyOperationContext opCtx( db.get() );
@@ -442,7 +444,7 @@ namespace mongo {
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
         {
-            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily() );
+            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily(), dummyOrdering );
 
             {
                 MyOperationContext opCtx( db.get() );
@@ -490,7 +492,7 @@ namespace mongo {
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
         {
-            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily() );
+            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily(), dummyOrdering );
 
             {
                 MyOperationContext opCtx( db.get() );
@@ -548,7 +550,7 @@ namespace mongo {
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
         {
-            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily() );
+            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily(), dummyOrdering );
 
             BSONObj key = BSON( "" << 1 );
             DiskLoc loc( 5, 16 );
@@ -586,7 +588,7 @@ namespace mongo {
         {
             boost::shared_ptr<rocksdb::ColumnFamilyHandle> cfh = makeColumnFamily( db.get() );
 
-            RocksSortedDataImpl sortedData( db.get(), cfh.get() );
+            RocksSortedDataImpl sortedData( db.get(), cfh.get(), dummyOrdering );
 
             {
                 MyOperationContext opCtx( db.get() );
@@ -615,7 +617,7 @@ namespace mongo {
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
         {
-            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily() );
+            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily(), dummyOrdering );
 
             {
                 MyOperationContext opCtx( db.get() );
@@ -669,7 +671,7 @@ namespace mongo {
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
         {
-            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily() );
+            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily(), dummyOrdering );
 
             {
                 MyOperationContext opCtx( db.get() );
@@ -713,7 +715,7 @@ namespace mongo {
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
         {
-            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily() );
+            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily(), dummyOrdering );
 
             {
                 MyOperationContext opCtx( db.get() );
@@ -770,7 +772,7 @@ namespace mongo {
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
         {
-            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily() );
+            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily(), dummyOrdering );
 
             {
                 MyOperationContext opCtx( db.get() );
@@ -820,7 +822,7 @@ namespace mongo {
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
         {
-            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily() );
+            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily(), dummyOrdering );
 
             {
                 MyOperationContext opCtx( db.get() );
@@ -869,7 +871,7 @@ namespace mongo {
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
         {
-            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily() );
+            RocksSortedDataImpl sortedData( db.get(), db->DefaultColumnFamily(), dummyOrdering );
 
             {
                 MyOperationContext opCtx( db.get() );


### PR DESCRIPTION
Changes:
        - RocksCollectionCatalogEntry owner now RocksEngine
        - All metadata now resides in a single column family
        - Fixed a bug with rocks sorted data reverse iterators
          hitting an EOF when seeking past the last entry in
          an index

JIRA: https://jira.mongodb.org/browse/SERVER-13635
