### PR TITLE
SERVER-9634 small spelling correction to syslog command line option description

### DIFF
--- a/src/mongo/db/server_options_helpers.cpp
+++ b/src/mongo/db/server_options_helpers.cpp
@@ -218,7 +218,7 @@ namespace {
                                   .setSources(moe::SourceAllLegacy);
 
         options->addOptionChaining("systemLog.syslogFacility", "syslogFacility", moe::String,
-                "syslog facility used for monogdb syslog message");
+                "syslog facility used for mongodb syslog message");
 
 #endif // _WIN32
         options->addOptionChaining("systemLog.logAppend", "logappend", moe::Switch,


### PR DESCRIPTION
Hopefully not a lot to discuss here. Just noticed a misspelling and thought it is worth fixing.
