### PR TITLE
SERVER-14818 add file_allocator_bench to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,8 @@ scratch
 /loadgen
 /docgen
 
+/file_allocator_bench
+
 *.tgz
 *.zip
 *.tar.gz


### PR DESCRIPTION
Ideally file_allocator_bench shouldn't be built to the root, but in the meantime we should add it to the gitignore
