### PR TITLE
SERVER-15055 rocks storage: fix several unit tests

### DIFF
--- a/src/mongo/db/storage/rocks/rocks_record_store.h
+++ b/src/mongo/db/storage/rocks/rocks_record_store.h
@@ -175,6 +175,8 @@ namespace mongo {
             OperationContext* _txn;
             const RocksRecordStore* _rs;
             CollectionScanParams::Direction _dir;
+            bool _reseekKeyValid;
+            std::string _reseekKey;
             boost::scoped_ptr<rocksdb::Iterator> _iterator;
         };
 

--- a/src/mongo/db/storage/rocks/rocks_sorted_data_impl.cpp
+++ b/src/mongo/db/storage/rocks/rocks_sorted_data_impl.cpp
@@ -446,9 +446,9 @@ namespace mongo {
                                             const BSONObj& key,
                                             const DiskLoc& loc) {
         boost::scoped_ptr<SortedDataInterface::Cursor> cursor( newCursor( txn, 1 ) );
-        cursor->locate( key, DiskLoc() );
 
-        if ( cursor->isEOF() || cursor->getDiskLoc() == loc ) {
+        if ( !cursor->locate( key, DiskLoc() ) || cursor->isEOF() ||
+             cursor->getDiskLoc() == loc ) {
             return Status::OK();
         } else {
             return Status( ErrorCodes::DuplicateKey, dupKeyError( key ) );


### PR DESCRIPTION
Several changes:
(1) return nrecords when validating a RocksRecordStore
(2) implement RocksRecordStore::Iterator::restoreState(), which reseek to the last seek location
(3) RocksSortedDataImpl::dupKeyCheck() return false when no exact key is found

This change would fix several tests, including:
jstests/core/apitest_db.js
jstests/core/auth*.js
jstests/core/batch_write_command_insert.js
