### PR TITLE
SERVER-15057 fix one potential deadlock in rocks storage when dropping ...

### DIFF
--- a/src/mongo/db/storage/rocks/rocks_collection_catalog_entry.h
+++ b/src/mongo/db/storage/rocks/rocks_collection_catalog_entry.h
@@ -62,6 +62,9 @@ namespace mongo {
         virtual Status removeIndex( OperationContext* txn,
                                     const StringData& indexName );
 
+        void removeIndexWithoutDroppingCF( OperationContext* txn,
+                                           const StringData& indexName );
+
         virtual Status prepareForIndexBuild( OperationContext* txn,
                                              const IndexDescriptor* spec );
 
@@ -98,6 +101,8 @@ namespace mongo {
         MetaData _getMetaData_inlock() const;
         MetaData _getMetaData_inlock( rocksdb::DB* db ) const;
 
+        void _removeIndexFromMetaData_inlock( const StringData& indexName );
+
         void _putMetaData_inlock( const MetaData& in );
 
         RocksEngine* _engine; // not owned
@@ -107,6 +112,7 @@ namespace mongo {
 
         // lock which must be acquired before calling _getMetaData_inlock(). Protects the metadata
         // stored in the metadata column family.
+        // Locking order RocksEngine::_entryMapMutex before _metaDataMutex
         mutable boost::mutex _metaDataMutex;
     };
 

--- a/src/mongo/db/storage/rocks/rocks_engine.h
+++ b/src/mongo/db/storage/rocks/rocks_engine.h
@@ -117,10 +117,16 @@ namespace mongo {
          * column family does not exist, then ordering must be a non-empty optional, containing
          * the Ordering for the index.
          */
-        rocksdb::ColumnFamilyHandle* getIndexColumnFamily(
-                              const StringData& ns,
-                              const StringData& indexName,
-                              const boost::optional<Ordering> order = boost::none );
+        rocksdb::ColumnFamilyHandle* getIndexColumnFamily( const StringData& ns,
+                                                           const StringData& indexName,
+                                                           const Ordering& order );
+
+        /**
+         * Will return NULL if doesn't exist.
+         */
+        rocksdb::ColumnFamilyHandle* getIndexColumnFamilyNoCreate(const StringData& ns,
+                                                                   const StringData& indexName );
+
         /**
          * Completely removes a column family. Input pointer is invalid after calling
          */
@@ -150,6 +156,18 @@ namespace mongo {
         static rocksdb::Options dbOptions();
 
     private:
+        rocksdb::ColumnFamilyHandle* _getIndexColumnFamilyNoCreate_inlock(
+                                                                     const StringData& ns,
+                                                                     const StringData& indexName);
+
+        rocksdb::ColumnFamilyHandle* _createIndexColumnFamily_inlock( const StringData& ns,
+                                                                      const StringData& indexName,
+                                                                      const Ordering& order );
+
+        void _removeColumnFamily_inlock( rocksdb::ColumnFamilyHandle** cfh,
+                                         const StringData& indexName,
+                                         const StringData& ns );
+
         Status _dropCollection_inlock( OperationContext* opCtx, const StringData& ns );
 
         rocksdb::ColumnFamilyOptions _collectionOptions() const;


### PR DESCRIPTION
A potential deadlock is possible in  RocksEngine::dropCollection(), when trying to acquire _entryMapMutex the second time. Here is an example call stack:
...
#7 mongo::RocksEngine::getIndexColumnFamily at src/mongo/db/storage/rocks/rocks_engine.cpp:224
#8 mongo::RocksCollectionCatalogEntry::removeIndex at src/mongo/db/storage/rocks/rocks_collection_catalog_entry.cpp:121
#9 mongo::RocksEngine::_dropCollection_inlock at src/mongo/db/storage/rocks/rocks_engine.cpp:348
#10 mongo::RocksEngine::dropDatabase at src/mongo/db/storage/rocks/rocks_engine.cpp:188

...

Fix it by avoid holding any _entryMapMutex inside RocksEngine::dropCollection().
