### PR TITLE
SERVER-15085 Fix rocks storage restart failure

### DIFF
--- a/src/mongo/db/storage/rocks/rocks_engine.cpp
+++ b/src/mongo/db/storage/rocks/rocks_engine.cpp
@@ -303,7 +303,7 @@ namespace mongo {
         ROCKS_STATUS_OK( s );
 
         const BSONObj optionsObj = options.toBSON();
-        const rocksdb::Slice key( ns.toString() + "-options" );
+        const std::string key = ns.toString() + "-options";
         const rocksdb::Slice value( optionsObj.objdata(), optionsObj.objsize() );
 
         dynamic_cast<RocksRecoveryUnit*>( txn->recoveryUnit() )->writeBatch()->Put(_defaultHandle,
@@ -551,7 +551,7 @@ namespace mongo {
                 invariant( families[i].options.comparator );
                 entry->indexNameToComparator[indexName].reset( families[i].options.comparator );
             } else {
-                rocksdb::Slice optionsKey( ns + "-options" );
+                std::string optionsKey = ns + "-options";
                 std::string value;
                 rocksdb::Status status = _db->Get(rocksdb::ReadOptions(), optionsKey, &value);
 


### PR DESCRIPTION
This patch fixes MongoDB+RocksDB restart issue. rocksdb::Slice doesn't own the data it points. A string needs to be kept to own the key.
