### PR TITLE
SERVER-3304 Allow Date and Timestamp to be converted interchangeably.

### DIFF
--- a/jstests/core/date2.js
+++ b/jstests/core/date2.js
@@ -8,6 +8,4 @@ t.ensureIndex( {a:1} );
 
 t.save( {a:new Timestamp()} );
 
-if ( 0 ) { // SERVER-3304
 assert.eq( 1, t.find( {a:{$gt:new Date(0)}} ).itcount() );
-}

--- a/jstests/core/type3.js
+++ b/jstests/core/type3.js
@@ -45,16 +45,12 @@ assert.eq( [[{$maxElement:1},{$maxElement:1}]], t.find( {a:{$type:127}} ).hint( 
 t.remove({});
 t.save( {a:new Timestamp()} );
 assert.eq( 1, t.find( {a:{$type:17}} ).itcount() );
-if ( 0 ) { // SERVER-3304
 assert.eq( 0, t.find( {a:{$type:9}} ).itcount() );
-}
 
 // Type Date
 t.remove({});
 t.save( {a:new Date()} );
-if ( 0 ) { // SERVER-3304
 assert.eq( 0, t.find( {a:{$type:17}} ).itcount() );
-}
 assert.eq( 1, t.find( {a:{$type:9}} ).itcount() );
 
 // Type Code

--- a/src/mongo/bson/bsonelement.cpp
+++ b/src/mongo/bson/bsonelement.cpp
@@ -831,14 +831,10 @@ namespace mongo {
         case Bool:
             return *l.value() - *r.value();
         case Timestamp:
-            // unsigned compare for timestamps - note they are not really dates but (ordinal + time_t)
-            if ( l.date() < r.date() )
-                return -1;
-            return l.date() == r.date() ? 0 : 1;
         case Date:
             {
-                long long a = (long long) l.Date().millis;
-                long long b = (long long) r.Date().millis;
+                long long a = (long long) l.date().millis;
+                long long b = (long long) r.date().millis;
                 if( a < b ) 
                     return -1;
                 return a == b ? 0 : 1;

--- a/src/mongo/bson/bsonelement.h
+++ b/src/mongo/bson/bsonelement.h
@@ -193,6 +193,9 @@ namespace mongo {
             @see Bool(), trueValue()
         */
         Date_t date() const {
+            // SERVER-3304
+            if (type() == mongo::Timestamp )
+                return timestampTime();
             return *reinterpret_cast< const Date_t* >( value() );
         }
 
@@ -502,7 +505,12 @@ namespace mongo {
         friend class BSONObjIterator;
         friend class BSONObj;
         const BSONElement& chk(int t) const {
-            if ( t != type() ) {
+            // SERVER-3304
+            int mytype = type();
+            if ( (t == mongo::Timestamp && mytype == mongo::Date) ||
+                 (t == mongo::Date && mytype == mongo::Timestamp) )
+                t = mytype;
+            if ( t != mytype ) {
                 StringBuilder ss;
                 if( eoo() )
                     ss << "field not found, expected type " << t;


### PR DESCRIPTION
This fixes issues such as SERVER-3304 where an index cannot contain both a date and a timestamp because they cannot be compared.

https://jira.mongodb.org/browse/SERVER-3304
