### PR TITLE
SERVER-14931 linenoise incorrectly duplicates lines containing multi-byte characters, when text wraps

### DIFF
--- a/src/mongo/shell/linenoise.cpp
+++ b/src/mongo/shell/linenoise.cpp
@@ -2419,6 +2419,7 @@ int InputBuffer::getInputLine( PromptBase& pi ) {
                     buf32[len] = '\0';
                     if ( pi.promptIndentation + len < pi.promptScreenColumns ) {
                         if ( len > pi.promptPreviousInputLen )
+                            len = calculateColumnPosition( buf32, len );
                             pi.promptPreviousInputLen = len;
                         /* Avoid a full update of the line in the
                          * trivial case. */


### PR DESCRIPTION
whenever enter the character on mongodb shell, didn't recalculated the length.
There no problem write in only single byte but write multibyte characters on shell, not matched length and width.

for example. shell total width is 30. then I can write 30 characters of single byte character. but if I can use multibyte like "Korean" I reach out the end of shell only 15 characters. So I should recalculate whenever someone write the character.
