### PR TITLE
SERVER-15161 RocksCursor::_reverseLocate() should seek to last if can't find the key

### DIFF
--- a/src/mongo/db/storage/rocks/rocks_sorted_data_impl.cpp
+++ b/src/mongo/db/storage/rocks/rocks_sorted_data_impl.cpp
@@ -246,7 +246,7 @@ namespace mongo {
                 _checkStatus();
 
                 if ( !_iterator->Valid() ) { // seeking outside the range of the index
-                    _iterator->SeekToFirst();
+                    _iterator->SeekToLast();
                     _checkStatus();
 
                     if ( _iterator->Valid() ) {


### PR DESCRIPTION
This patch will fix following tests:

jstests/core/cursor3.js
jstests/core/cursor5.js
jstests/core/cursor6.js
jstests/core/cursor7.js
jstests/core/fts2.js
jstests/core/fts3.js
jstests/core/fts4.js
jstests/core/fts5.js
jstests/core/fts6.js
jstests/core/fts_blog.js
jstests/core/fts_blogwild.js
jstests/core/fts_enabled.js
jstests/core/fts_explain.js
jstests/core/fts_index3.js
jstests/core/fts_index.js
jstests/core/fts_index_version1.js
jstests/core/fts_mix.js
jstests/core/fts_partition1.js
jstests/core/fts_partition_no_multikey.js
jstests/core/fts_phrase.js
jstests/core/fts_projection.js
jstests/core/fts_proj.js
jstests/core/fts_querylang.js
jstests/core/fts_score_sort.js
jstests/core/fts_spanish.js
jstests/core/index5.js
(maybe more).

We should position Rocks cursor to the last entry if seek returns !Valid() for backward case.
