### PR TITLE
SERVER-7596 Fix the replacement order of , and = in SCRAM user name

### DIFF
--- a/src/mongo/client/sasl_scramsha1_client_conversation.cpp
+++ b/src/mongo/client/sasl_scramsha1_client_conversation.cpp
@@ -85,8 +85,8 @@ namespace mongo {
      * =2C and =3D respectively.
      */
     static void encodeSCRAMUsername(std::string& user) {
-        boost::replace_all(user, ",", "=2C");
         boost::replace_all(user, "=", "=3D");
+        boost::replace_all(user, ",", "=2C");
     }
 
     /*


### PR DESCRIPTION
If we replace , with =2C first and then replace = with =3D then , becomes =3D2C rather then staying =2C
