### PR TITLE
SERVER-15271 rocks engine doesn't return capped information in RocksRecordStore::appendCustomStats()

### DIFF
--- a/src/mongo/db/storage/rocks/rocks_record_store.cpp
+++ b/src/mongo/db/storage/rocks/rocks_record_store.cpp
@@ -384,6 +384,11 @@ namespace mongo {
                                               BSONObjBuilder* result,
                                               double scale ) const {
         string statsString;
+        result->appendBool( "capped", _isCapped );
+        if (_isCapped) {
+            result->appendIntOrLL("max", _cappedMaxDocs);
+            result->appendIntOrLL("maxSize", _cappedMaxSize);
+        }
         bool valid = _db->GetProperty( _columnFamily, "rocksdb.stats", &statsString );
         invariant( valid );
         result->append( "stats", statsString );


### PR DESCRIPTION
Simply copy the logic from HeapRecordStore::appendCustomStats() to RocksRecordStore::appendCustomStats() which would pass the dbadmin.js.
