### PR TITLE
SERVER-15296 Hook up RocksSortedDataImpl with SortedDataInterface test harness

### DIFF
--- a/src/mongo/db/storage/rocks/SConscript
+++ b/src/mongo/db/storage/rocks/SConscript
@@ -75,3 +75,13 @@ if has_option("rocksdb"):
             ]
         )
 
+
+    env.CppUnitTest(
+       target='storage_rocks_sorted_data_impl_harness_test',
+       source=['rocks_sorted_data_impl_harness_test.cpp'
+               ],
+       LIBDEPS=[
+            'storage_rocks_fake',
+            '$BUILD_DIR/mongo/db/storage/sorted_data_interface_test_harness'
+            ]
+       )

--- a/src/mongo/db/storage/rocks/rocks_collection_catalog_entry.cpp
+++ b/src/mongo/db/storage/rocks/rocks_collection_catalog_entry.cpp
@@ -42,6 +42,7 @@ namespace mongo {
     /**
      * bson schema
      * { ns: <name for sanity>,
+     *   options : <bson spec>,
      *   indexes : [ { spec : <bson spec>,
      *                 ready: <bool>,
      *                 head: DiskLoc,

--- a/src/mongo/db/storage/rocks/rocks_engine.cpp
+++ b/src/mongo/db/storage/rocks/rocks_engine.cpp
@@ -41,6 +41,7 @@
 #include <rocksdb/db.h>
 #include <rocksdb/slice.h>
 #include <rocksdb/options.h>
+#include <rocksdb/utilities/write_batch_with_index.h>
 
 #include "mongo/db/catalog/collection_options.h"
 #include "mongo/db/operation_context.h"
@@ -113,7 +114,7 @@ namespace mongo {
 
     RecoveryUnit* RocksEngine::newRecoveryUnit( OperationContext* opCtx ) {
         /* TODO change to false when unit of work hooked up*/
-        return new RocksRecoveryUnit( _db.get(), true );
+        return new RocksRecoveryUnit(_db.get(), true);
     }
 
     void RocksEngine::listDatabases( std::vector<std::string>* out ) const {
@@ -159,6 +160,7 @@ namespace mongo {
 
     void RocksEngine::cleanShutdown(OperationContext* txn) {
         // no locking here because this is only called while single-threaded.
+        dynamic_cast<RocksRecoveryUnit*>(txn->recoveryUnit())->destroy();
         _entryMap = EntryMap();
         _dbCatalogMap = DbCatalogMap();
         _collectionComparator.reset();

--- a/src/mongo/db/storage/rocks/rocks_engine.h
+++ b/src/mongo/db/storage/rocks/rocks_engine.h
@@ -128,7 +128,6 @@ namespace mongo {
          */
         rocksdb::ColumnFamilyHandle* getIndexColumnFamilyNoCreate(const StringData& ns,
                                                                    const StringData& indexName );
-
         /**
          * Completely removes a column family. Input pointer is invalid after calling
          */

--- a/src/mongo/db/storage/rocks/rocks_engine_test.cpp
+++ b/src/mongo/db/storage/rocks/rocks_engine_test.cpp
@@ -50,9 +50,8 @@ namespace mongo {
 
     class MyOperationContext : public OperationContextNoop {
     public:
-        MyOperationContext( RocksEngine* engine )
-            : OperationContextNoop( new RocksRecoveryUnit( engine->getDB(), false ) ) {
-        }
+        MyOperationContext(RocksEngine* engine)
+            : OperationContextNoop(new RocksRecoveryUnit(engine->getDB(), false)) {}
     };
 
     TEST( RocksEngineTest, Start1 ) {
@@ -301,9 +300,10 @@ namespace mongo {
         }
 
         {
-            RocksEngine engine( path );
-            RocksRecordStore* rs = engine.getEntry( "test.foo" )->recordStore.get();
-            ASSERT_EQUALS( s, rs->dataFor( NULL, loc ).data() );
+            RocksEngine engine(path);
+            RocksRecordStore* rs = engine.getEntry("test.foo")->recordStore.get();
+            MyOperationContext opCtx(&engine);
+            ASSERT_EQUALS(s, rs->dataFor(&opCtx, loc).data());
         }
 
     }

--- a/src/mongo/db/storage/rocks/rocks_recovery_unit.h
+++ b/src/mongo/db/storage/rocks/rocks_recovery_unit.h
@@ -33,6 +33,7 @@
 #include <map>
 #include <stack>
 #include <string>
+#include <vector>
 
 #include <boost/scoped_ptr.hpp>
 #include <boost/shared_ptr.hpp>
@@ -43,7 +44,8 @@
 namespace rocksdb {
     class DB;
     class Snapshot;
-    class WriteBatch;
+    class WriteBatchWithIndex;
+    class Comparator;
 }
 
 namespace mongo {
@@ -51,7 +53,7 @@ namespace mongo {
     class RocksRecoveryUnit : public RecoveryUnit {
         MONGO_DISALLOW_COPYING(RocksRecoveryUnit);
     public:
-        RocksRecoveryUnit( rocksdb::DB* db, bool defaultCommit );
+        RocksRecoveryUnit(rocksdb::DB* db, bool defaultCommit);
         virtual ~RocksRecoveryUnit();
 
         virtual void beginUnitOfWork();
@@ -69,19 +71,28 @@ namespace mongo {
 
         // local api
 
-        rocksdb::WriteBatch* writeBatch();
+        // we need to call this during cleanShutdown(), to make sure that the destructor doesn't try
+        // to commit (or rollback) the changes
+        void destroy();
+
+        rocksdb::WriteBatchWithIndex* writeBatch();
 
         const rocksdb::Snapshot* snapshot();
 
     private:
+        void _destroyInternal();
+
         rocksdb::DB* _db; // not owned
         bool _defaultCommit;
 
-        boost::scoped_ptr<rocksdb::WriteBatch> _writeBatch; // owned
-        int _depth;
+        boost::scoped_ptr<rocksdb::WriteBatchWithIndex> _writeBatch; // owned
 
         // bare because we need to call ReleaseSnapshot when we're done with this
         const rocksdb::Snapshot* _snapshot; // owned
+
+        std::vector<Change*> _changes;
+
+        bool _destroyed;
     };
 
 }

--- a/src/mongo/db/storage/rocks/rocks_sorted_data_impl_harness_test.cpp
+++ b/src/mongo/db/storage/rocks/rocks_sorted_data_impl_harness_test.cpp
@@ -1,0 +1,70 @@
+/**
+ *    Copyright (C) 2014 MongoDB Inc.
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under the terms of the GNU Affero General Public License, version 3,
+ *    as published by the Free Software Foundation.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *    As a special exception, the copyright holders give permission to link the
+ *    code of portions of this program with the OpenSSL library under certain
+ *    conditions as described in each individual source file and distribute
+ *    linked combinations including the program with the OpenSSL library. You
+ *    must comply with the GNU Affero General Public License in all respects for
+ *    all of the code used other than as permitted herein. If you modify file(s)
+ *    with this exception, you may extend this exception to your version of the
+ *    file(s), but you are not obligated to do so. If you do not wish to do so,
+ *    delete this exception statement from your version. If you delete this
+ *    exception statement from all source files in the program, then also delete
+ *    it in the license file.
+ */
+
+#include <boost/shared_ptr.hpp>
+#include <boost/filesystem/operations.hpp>
+
+#include <rocksdb/comparator.h>
+#include <rocksdb/db.h>
+#include <rocksdb/options.h>
+#include <rocksdb/slice.h>
+
+#include "mongo/db/storage/rocks/rocks_engine.h"
+#include "mongo/db/storage/sorted_data_interface_test_harness.h"
+#include "mongo/unittest/temp_dir.h"
+#include "mongo/unittest/unittest.h"
+#include "mongo/db/storage/rocks/rocks_sorted_data_impl.h"
+#include "mongo/db/storage/rocks/rocks_recovery_unit.h"
+
+namespace mongo {
+
+    class RocksHarnessHelper : public HarnessHelper {
+       public:
+        RocksHarnessHelper() : _order(Ordering::make(BSONObj())), _tempDir(_testNamespace) {
+            boost::filesystem::remove_all(_tempDir.path());
+            rocksdb::DB* db;
+            rocksdb::Status s = rocksdb::DB::Open(RocksEngine::dbOptions(), _tempDir.path(), &db);
+            ASSERT(s.ok());
+            _db.reset(db);
+        }
+
+        virtual SortedDataInterface* newSortedDataInterface() {
+            return new RocksSortedDataImpl(_db.get(), _db->DefaultColumnFamily(), _order);
+        }
+
+        virtual RecoveryUnit* newRecoveryUnit() { return new RocksRecoveryUnit(_db.get(), false); }
+
+       private:
+        Ordering _order;
+        string _testNamespace = "mongo-rocks-sorted-data-test";
+        unittest::TempDir _tempDir;
+        scoped_ptr<rocksdb::DB> _db;
+    };
+
+    HarnessHelper* newHarnessHelper() { return new RocksHarnessHelper(); }
+}

--- a/src/mongo/db/storage/rocks/rocks_sorted_data_impl_test.cpp
+++ b/src/mongo/db/storage/rocks/rocks_sorted_data_impl_test.cpp
@@ -79,7 +79,7 @@ namespace mongo {
 
     const Ordering dummyOrdering = Ordering::make( BSONObj() );
 
-    TEST( RocksRecordStoreTest, BrainDead ) {
+    TEST( RocksSortedDataTest, BrainDead ) {
         unittest::TempDir td( _rocksSortedDataTestDir );
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
@@ -129,7 +129,7 @@ namespace mongo {
         }
     }
 
-    TEST( RocksRecordStoreTest, Locate1 ) {
+    TEST( RocksSortedDataTest, Locate1 ) {
         unittest::TempDir td( _rocksSortedDataTestDir );
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
@@ -166,7 +166,7 @@ namespace mongo {
         }
     }
 
-    TEST( RocksRecordStoreTest, Locate2 ) {
+    TEST( RocksSortedDataTest, Locate2 ) {
         unittest::TempDir td( _rocksSortedDataTestDir );
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
@@ -188,7 +188,7 @@ namespace mongo {
             {
                 MyOperationContext opCtx( db.get() );
                 scoped_ptr<SortedDataInterface::Cursor> cursor( sortedData.newCursor( &opCtx, 1 ) );
-                ASSERT( cursor->locate( BSON( "a" << 2 ), DiskLoc(0,0) ) );
+                ASSERT( !cursor->locate( BSON( "a" << 2 ), DiskLoc(0,0) ) );
                 ASSERT( !cursor->isEOF()  );
                 ASSERT_EQUALS( BSON( "" << 2 ), cursor->getKey() );
                 ASSERT_EQUALS( DiskLoc(1,2), cursor->getDiskLoc() );
@@ -214,7 +214,7 @@ namespace mongo {
         return boost::shared_ptr<rocksdb::ColumnFamilyHandle>( cfh );
     }
 
-    TEST( RocksRecordStoreTest, LocateInexact ) {
+    TEST( RocksSortedDataTest, LocateInexact ) {
         unittest::TempDir td( _rocksSortedDataTestDir );
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
@@ -245,7 +245,7 @@ namespace mongo {
         }
     }
 
-    TEST( RocksRecordStoreTest, Snapshots ) {
+    TEST( RocksSortedDataTest, Snapshots ) {
         unittest::TempDir td( _rocksSortedDataTestDir );
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
@@ -289,7 +289,7 @@ namespace mongo {
         }
     }
 
-    TEST( RocksRecordStoreTest, SaveAndRestorePositionSimple ) {
+    TEST( RocksSortedDataTest, SaveAndRestorePositionSimple ) {
         unittest::TempDir td( _rocksSortedDataTestDir );
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
@@ -311,7 +311,7 @@ namespace mongo {
             {
                 MyOperationContext opCtx( db.get() );
                 scoped_ptr<SortedDataInterface::Cursor> cursor( sortedData.newCursor( &opCtx, 1 ) );
-                ASSERT( cursor->locate( BSON( "a" << 1 ), DiskLoc(0,0) ) );
+                ASSERT( !cursor->locate( BSON( "a" << 1 ), DiskLoc(0,0) ) );
                 ASSERT( !cursor->isEOF()  );
                 ASSERT_EQUALS( BSON( "" << 1 ), cursor->getKey() );
                 ASSERT_EQUALS( DiskLoc(1,1), cursor->getDiskLoc() );
@@ -326,7 +326,7 @@ namespace mongo {
                 ASSERT_EQUALS( DiskLoc(1,1), cursor->getDiskLoc() );
 
                 // repeat, with a different value
-                ASSERT( cursor->locate( BSON( "a" << 2 ), DiskLoc(0,0) ) );
+                ASSERT( !cursor->locate( BSON( "a" << 2 ), DiskLoc(0,0) ) );
                 ASSERT( !cursor->isEOF()  );
                 ASSERT_EQUALS( BSON( "" << 2 ), cursor->getKey() );
                 ASSERT_EQUALS( DiskLoc(1,2), cursor->getDiskLoc() );
@@ -343,7 +343,7 @@ namespace mongo {
         }
     }
 
-    TEST( RocksRecordStoreTest, SaveAndRestorePositionEOF ) {
+    TEST( RocksSortedDataTest, SaveAndRestorePositionEOF ) {
         unittest::TempDir td( _rocksSortedDataTestDir );
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
@@ -365,7 +365,7 @@ namespace mongo {
             {
                 MyOperationContext opCtx( db.get() );
                 scoped_ptr<SortedDataInterface::Cursor> cursor( sortedData.newCursor( &opCtx, 1 ) );
-                ASSERT( cursor->locate( BSON( "a" << 1 ), DiskLoc(0,0) ) );
+                ASSERT( !cursor->locate( BSON( "a" << 1 ), DiskLoc(0,0) ) );
                 ASSERT( !cursor->isEOF()  );
                 ASSERT_EQUALS( BSON( "" << 1 ), cursor->getKey() );
                 ASSERT_EQUALS( DiskLoc(1,1), cursor->getDiskLoc() );
@@ -387,7 +387,7 @@ namespace mongo {
         }
     }
 
-    TEST( RocksRecordStoreTest, SaveAndRestorePositionInsert ) {
+    TEST( RocksSortedDataTest, SaveAndRestorePositionInsert ) {
         unittest::TempDir td( _rocksSortedDataTestDir );
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
@@ -409,7 +409,7 @@ namespace mongo {
             {
                 MyOperationContext opCtx( db.get() );
                 scoped_ptr<SortedDataInterface::Cursor> cursor( sortedData.newCursor( &opCtx, 1 ) );
-                ASSERT( cursor->locate( BSON( "" << 3 ), DiskLoc(0,0) ) );
+                ASSERT( !cursor->locate( BSON( "" << 3 ), DiskLoc(0,0) ) );
                 ASSERT( !cursor->isEOF()  );
                 ASSERT_EQUALS( BSON( "" << 3 ), cursor->getKey() );
                 ASSERT_EQUALS( DiskLoc(1,3), cursor->getDiskLoc() );
@@ -439,7 +439,7 @@ namespace mongo {
         }
     }
 
-    TEST( RocksRecordStoreTest, SaveAndRestorePositionDelete2 ) {
+    TEST( RocksSortedDataTest, SaveAndRestorePositionDelete2 ) {
         unittest::TempDir td( _rocksSortedDataTestDir );
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
@@ -461,7 +461,7 @@ namespace mongo {
             {
                 MyOperationContext opCtx( db.get() );
                 scoped_ptr<SortedDataInterface::Cursor> cursor( sortedData.newCursor( &opCtx, 1 ) );
-                ASSERT( cursor->locate( BSON( "" << 2 ), DiskLoc(0,0) ) );
+                ASSERT( !cursor->locate( BSON( "" << 2 ), DiskLoc(0,0) ) );
                 ASSERT( !cursor->isEOF()  );
                 ASSERT_EQUALS( BSON( "" << 2 ), cursor->getKey() );
                 ASSERT_EQUALS( DiskLoc(1,2), cursor->getDiskLoc() );
@@ -487,7 +487,7 @@ namespace mongo {
         }
     }
 
-    TEST( RocksRecordStoreTest, SaveAndRestorePositionDelete3 ) {
+    TEST( RocksSortedDataTest, SaveAndRestorePositionDelete3 ) {
         unittest::TempDir td( _rocksSortedDataTestDir );
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
@@ -509,7 +509,7 @@ namespace mongo {
             {
                 MyOperationContext opCtx( db.get() );
                 scoped_ptr<SortedDataInterface::Cursor> cursor( sortedData.newCursor( &opCtx, 1 ) );
-                ASSERT( cursor->locate( BSON( "" << 2 ), DiskLoc(0,0) ) );
+                ASSERT( !cursor->locate( BSON( "" << 2 ), DiskLoc(0,0) ) );
                 ASSERT( !cursor->isEOF()  );
                 ASSERT_EQUALS( BSON( "" << 2 ), cursor->getKey() );
                 ASSERT_EQUALS( DiskLoc(1,2), cursor->getDiskLoc() );
@@ -545,7 +545,7 @@ namespace mongo {
         }
     }
 
-    TEST( RocksRecordStoreTest, Locate1Reverse ) {
+    TEST( RocksSortedDataTest, Locate1Reverse ) {
         unittest::TempDir td( _rocksSortedDataTestDir );
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
@@ -581,7 +581,7 @@ namespace mongo {
         }
     }
 
-    TEST( RocksRecordStoreTest, LocateInexactReverse ) {
+    TEST( RocksSortedDataTest, LocateInexactReverse ) {
         unittest::TempDir td( _rocksSortedDataTestDir );
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
@@ -612,7 +612,7 @@ namespace mongo {
         }
     }
 
-    TEST( RocksRecordStoreTest, SaveAndRestorePositionReverseSimple ) {
+    TEST( RocksSortedDataTest, SaveAndRestorePositionReverseSimple ) {
         unittest::TempDir td( _rocksSortedDataTestDir );
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
@@ -634,7 +634,7 @@ namespace mongo {
             {
                 MyOperationContext opCtx( db.get() );
                 scoped_ptr<SortedDataInterface::Cursor> cursor( sortedData.newCursor( &opCtx, -1 ) );
-                ASSERT( cursor->locate( BSON( "a" << 1 ), DiskLoc(0,0) ) );
+                ASSERT( !cursor->locate( BSON( "a" << 1 ), DiskLoc(2,0) ) );
                 ASSERT( !cursor->isEOF()  );
                 ASSERT_EQUALS( BSON( "" << 1 ), cursor->getKey() );
                 ASSERT_EQUALS( DiskLoc(1,1), cursor->getDiskLoc() );
@@ -649,7 +649,7 @@ namespace mongo {
                 ASSERT_EQUALS( DiskLoc(1,1), cursor->getDiskLoc() );
 
                 // repeat, with a different value
-                ASSERT( cursor->locate( BSON( "a" << 2 ), DiskLoc(0,0) ) );
+                ASSERT( !cursor->locate( BSON( "a" << 2 ), DiskLoc(2,0) ) );
                 ASSERT( !cursor->isEOF()  );
                 ASSERT_EQUALS( BSON( "" << 2 ), cursor->getKey() );
                 ASSERT_EQUALS( DiskLoc(1,2), cursor->getDiskLoc() );
@@ -666,7 +666,7 @@ namespace mongo {
         }
     }
 
-    TEST( RocksRecordStoreTest, SaveAndRestorePositionEOFReverse ) {
+    TEST( RocksSortedDataTest, SaveAndRestorePositionEOFReverse ) {
         unittest::TempDir td( _rocksSortedDataTestDir );
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
@@ -710,7 +710,7 @@ namespace mongo {
         }
     }
 
-    TEST( RocksRecordStoreTest, SaveAndRestorePositionInsertReverse ) {
+    TEST( RocksSortedDataTest, SaveAndRestorePositionInsertReverse ) {
         unittest::TempDir td( _rocksSortedDataTestDir );
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
@@ -732,7 +732,7 @@ namespace mongo {
                 MyOperationContext opCtx( db.get() );
                 scoped_ptr<SortedDataInterface::Cursor> cursor( sortedData.newCursor( &opCtx,
                                                                                       -1 ) );
-                ASSERT( cursor->locate( BSON( "" << 3 ), DiskLoc(0,0) ) );
+                ASSERT( !cursor->locate( BSON( "" << 3 ), DiskLoc(2,0) ) );
                 ASSERT( !cursor->isEOF()  );
                 ASSERT_EQUALS( BSON( "" << 3 ), cursor->getKey() );
                 ASSERT_EQUALS( DiskLoc(1,3), cursor->getDiskLoc() );
@@ -767,7 +767,7 @@ namespace mongo {
         }
     }
 
-    TEST( RocksRecordStoreTest, SaveAndRestorePositionDelete1Reverse ) {
+    TEST( RocksSortedDataTest, SaveAndRestorePositionDelete1Reverse ) {
         unittest::TempDir td( _rocksSortedDataTestDir );
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
@@ -790,7 +790,7 @@ namespace mongo {
                 MyOperationContext opCtx( db.get() );
                 scoped_ptr<SortedDataInterface::Cursor> cursor( sortedData.newCursor( &opCtx,
                                                                                       -1 ) );
-                ASSERT( cursor->locate( BSON( "" << 3 ), DiskLoc(0,0) ) );
+                ASSERT( !cursor->locate( BSON( "" << 3 ), DiskLoc(2,0) ) );
                 ASSERT( !cursor->isEOF()  );
                 ASSERT_EQUALS( BSON( "" << 3 ), cursor->getKey() );
                 ASSERT_EQUALS( DiskLoc(1,3), cursor->getDiskLoc() );
@@ -817,7 +817,7 @@ namespace mongo {
         }
     }
 
-    TEST( RocksRecordStoreTest, SaveAndRestorePositionDelete2Reverse ) {
+    TEST( RocksSortedDataTest, SaveAndRestorePositionDelete2Reverse ) {
         unittest::TempDir td( _rocksSortedDataTestDir );
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
@@ -840,7 +840,7 @@ namespace mongo {
                 MyOperationContext opCtx( db.get() );
                 scoped_ptr<SortedDataInterface::Cursor> cursor( sortedData.newCursor( &opCtx,
                                                                                       -1 ) );
-                ASSERT( cursor->locate( BSON( "" << 2 ), DiskLoc(0,0) ) );
+                ASSERT( !cursor->locate( BSON( "" << 2 ), DiskLoc(2,0) ) );
                 ASSERT( !cursor->isEOF()  );
                 ASSERT_EQUALS( BSON( "" << 2 ), cursor->getKey() );
                 ASSERT_EQUALS( DiskLoc(1,2), cursor->getDiskLoc() );
@@ -866,7 +866,7 @@ namespace mongo {
         }
     }
 
-    TEST( RocksRecordStoreTest, SaveAndRestorePositionDelete3Reverse ) {
+    TEST( RocksSortedDataTest, SaveAndRestorePositionDelete3Reverse ) {
         unittest::TempDir td( _rocksSortedDataTestDir );
         scoped_ptr<rocksdb::DB> db( getDB( td.path() ) );
 
@@ -889,7 +889,7 @@ namespace mongo {
                 MyOperationContext opCtx( db.get() );
                 scoped_ptr<SortedDataInterface::Cursor> cursor( sortedData.newCursor( &opCtx,
                                                                                       -1 ) );
-                ASSERT( cursor->locate( BSON( "" << 2 ), DiskLoc(0,0) ) );
+                ASSERT( !cursor->locate( BSON( "" << 2 ), DiskLoc(2,0) ) );
                 ASSERT( !cursor->isEOF()  );
                 ASSERT_EQUALS( BSON( "" << 2 ), cursor->getKey() );
                 ASSERT_EQUALS( DiskLoc(1,2), cursor->getDiskLoc() );

--- a/src/mongo/db/storage/sorted_data_interface_test_harness.cpp
+++ b/src/mongo/db/storage/sorted_data_interface_test_harness.cpp
@@ -494,40 +494,41 @@ namespace mongo {
             }
         }
 
-        scoped_ptr<SortedDataInterface::Cursor> cursor( sorted->newCursor( NULL, 1 ) );
+        scoped_ptr<OperationContext> opCtx(harnessHelper->newOperationContext());
+        scoped_ptr<SortedDataInterface::Cursor> cursor( sorted->newCursor( opCtx.get(), 1 ) );
         ASSERT( !cursor->locate( BSON( "" << 5 ), DiskLoc(0,0) ) );
         ASSERT( !cursor->isEOF()  );
         ASSERT_EQUALS( BSON( "" << 5 ), cursor->getKey() );
         cursor->advance();
         ASSERT_EQUALS( BSON( "" << 7 ), cursor->getKey() );
 
-        cursor.reset( sorted->newCursor( NULL, -1 ) );
+        cursor.reset( sorted->newCursor( opCtx.get(), -1 ) );
         ASSERT( !cursor->locate( BSON( "" << 5 ), DiskLoc(0,0) ) );
         ASSERT( !cursor->isEOF()  );
         ASSERT_EQUALS( BSON( "" << 4 ), cursor->getKey() );
 
-        cursor.reset( sorted->newCursor( NULL, -1 ) );
+        cursor.reset( sorted->newCursor( opCtx.get(), -1 ) );
         ASSERT( !cursor->locate( BSON( "" << 5 ), maxDiskLoc ) );
         ASSERT( !cursor->isEOF()  );
         ASSERT_EQUALS( BSON( "" << 5 ), cursor->getKey() );
         cursor->advance();
         ASSERT_EQUALS( BSON( "" << 4 ), cursor->getKey() );
 
-        cursor.reset( sorted->newCursor( NULL, -1 ) );
+        cursor.reset( sorted->newCursor( opCtx.get(), -1 ) );
         ASSERT( !cursor->locate( BSON( "" << 5 ), minDiskLoc ) );
         ASSERT( !cursor->isEOF()  );
         ASSERT_EQUALS( BSON( "" << 4 ), cursor->getKey() );
         cursor->advance();
         ASSERT_EQUALS( BSON( "" << 3 ), cursor->getKey() );
 
-        cursor.reset( sorted->newCursor( NULL, -1 ) );
+        cursor.reset( sorted->newCursor( opCtx.get(), -1 ) );
         cursor->locate( BSON( "" << 6 ), maxDiskLoc );
         ASSERT( !cursor->isEOF()  );
         ASSERT_EQUALS( BSON( "" << 5 ), cursor->getKey() );
         cursor->advance();
         ASSERT_EQUALS( BSON( "" << 4 ), cursor->getKey() );
 
-        cursor.reset( sorted->newCursor( NULL, -1 ) );
+        cursor.reset( sorted->newCursor( opCtx.get(), -1 ) );
         cursor->locate( BSON( "" << 500 ), maxDiskLoc );
         ASSERT( !cursor->isEOF()  );
         ASSERT_EQUALS( BSON( "" << 9 ), cursor->getKey() );


### PR DESCRIPTION
This commit includes number of changes:
- Hook up RocksSortedDataImpl to sorted data interface tester
- Bunch of fixes in RocksSortedDataImpl. I'm not sure of some of the semantics since there is no interface documentation, but this seems to pass the unit tests. I'm waiting for the clarification here: https://groups.google.com/forum/#!topic/mongodb-dev/pvpCXNbe2KM
- Fix some compile issues due to upstream changes
- Fix RocksRecoveryUnit according to documentation in RecoveryUnit
- Add .clang-format file to rocks root dir, which will help us style our code
- Fix rocks_sorted_data_impl_test
