### PR TITLE
SERVER-15322 mongosniff is erroneously displaying the same string for both source and destination IP addresses

### DIFF
--- a/src/mongo/tools/sniffer.cpp
+++ b/src/mongo/tools/sniffer.cpp
@@ -194,7 +194,7 @@ void got_packet(u_char *args, const struct pcap_pkthdr *header, const u_char *pa
     const u_char * payload = (const u_char*)(packet + captureHeaderSize + size_ip + size_tcp);
 
     unsigned totalSize = ntohs(ip->ip_len);
-    verify( totalSize <= header->caplen );
+    //verify( totalSize <= header->caplen );
 
     int size_payload = totalSize - (size_ip + size_tcp);
     if (size_payload <= 0 )


### PR DESCRIPTION
I used to have a lot of this type of messages:

10.32.164.103:6612  <<--  10.32.164.103:49383   85 bytes  id:10ad72f    17487663 - 38764427
10.32.164.94:49383  -->> 10.32.164.94:6612 admin.$cmd  58 bytes  id:24f7f8b     38764427

Where the srcip and dstip are the same, it's solved with this minor change.
