### PR TITLE
SERVER-15187 Fix lifetime problem with stashed RecoveryUnit

### DIFF
--- a/src/mongo/db/clientcursor.h
+++ b/src/mongo/db/clientcursor.h
@@ -245,14 +245,17 @@ namespace mongo {
         // is coming from (or a vestige of) an ongoing migration.
         CollectionMetadataPtr _collMetadata;
 
+        // Only one of these is not-NULL.
+        RecoveryUnit* _unownedRU;
+        std::auto_ptr<RecoveryUnit> _ownedRU;
+        // NOTE: _ownedRU must come before _exec, because _ownedRU must outlive _exec.
+        // The storage engine can have resources in the PlanExecutor that rely on
+        // the RecoveryUnit being alive.
+
         //
         // The underlying execution machinery.
         //
         scoped_ptr<PlanExecutor> _exec;
-
-        // Only one of these is not-NULL.
-        RecoveryUnit* _unownedRU;
-        std::auto_ptr<RecoveryUnit> _ownedRU;
     };
 
     /**


### PR DESCRIPTION
When a ClientCursor owns a RecoveryUnit, it should destroy its
PlanExecutor before the RecoveryUnit, because storage engines in
general expect the RecoveryUnit to outlive cursors.

In particular, this fixes a bug where BDBCursor's destructor would fail
to close its Dbc\* since the DbTxn\* in BDBRecoveryUnit was already gone.
