### PR TITLE
SERVER-15331 don't let readNative be used on non-POD types either

### DIFF
--- a/src/mongo/base/data_view.h
+++ b/src/mongo/base/data_view.h
@@ -52,6 +52,10 @@ namespace mongo {
 
         template<typename T>
         const ConstDataView& readNative(T* t, size_t offset = 0) const {
+#if MONGO_HAVE_STD_IS_TRIVIALLY_COPYABLE
+            static_assert(std::is_trivially_copyable<T>::value,
+                          "Type for DataView::readNative must be trivially copyable");
+#endif
             std::memcpy(t, view(offset), sizeof(*t));
             return *this;
         }


### PR DESCRIPTION
This does the same guard for readNative on compilers that support C++11 type properties.

https://jira.mongodb.org/browse/SERVER-15331
