### PR TITLE
SERVER-13242 replace tabs in log messages with spaces

### DIFF
--- a/src/mongo/util/progress_meter.cpp
+++ b/src/mongo/util/progress_meter.cpp
@@ -68,14 +68,14 @@ namespace mongo {
         if ( _total > 0 ) {
             int per = (int)( ( (double)_done * 100.0 ) / (double)_total );
             LogstreamBuilder out = log();
-            out << "\t\t" << _name << ": " << _done;
+            out << "  " << _name << ": " << _done;
 
             if (_showTotal) {
-                out << '/' << _total << '\t' << per << '%';
+                out << '/' << _total << ' ' << per << '%';
             }
 
             if ( ! _units.empty() ) {
-                out << "\t(" << _units << ")";
+                out << " (" << _units << ")";
             }
             out << endl;
         }
@@ -90,7 +90,7 @@ namespace mongo {
         buf << _name << ": " << _done << '/' << _total << ' ' << (_done*100)/_total << '%';
         
         if ( ! _units.empty() ) {
-            buf << "\t(" << _units << ")" << endl;
+            buf << " (" << _units << ")" << endl;
         }
         
         return buf.str();


### PR DESCRIPTION
[SERVER-13242 - Remove tab characters from log messages](https://jira.mongodb.org/browse/SERVER-13242)
