### PR TITLE
SERVER-15517 Remove spaces in dumprestore7.js query

### DIFF
--- a/jstests/tool/dumprestore7.js
+++ b/jstests/tool/dumprestore7.js
@@ -43,9 +43,12 @@ var master = replTest.getMaster();
 step("try mongodump with $timestamp");
 
 var data = MongoRunner.dataDir + "/dumprestore7-dump1/";
-var query = "{\"ts\":{\"$gt\":{\"$timestamp\" : {\"t\":"+ time.ts.t + ",\"i\":" + time.ts.i +" }}}}";
+var query = "{\"ts\":{\"$gt\":{\"$timestamp\":{\"t\":"+ time.ts.t + ",\"i\":" + time.ts.i +"}}}}";
 
-runMongoProgram( "mongodump", "--host", "127.0.0.1:"+replTest.ports[0], "--db", "local", "--collection", "oplog.rs", "--query", query, "--out", data );
+MongoRunner.runMongoTool( "mongodump", 
+    { "host": "127.0.0.1:"+replTest.ports[0], 
+      "db": "local", "collection": "oplog.rs", 
+      "query": query, "out": data });
 
 step("try mongorestore from $timestamp");
 


### PR DESCRIPTION
Removing the spaces from the query string should fix dumprestore7.js on windows - there's some sort of issue with how the go flags library we're using parses the command line on Windows.

Using runMongoTool instead of runMongoProgram is just a little additional cleanup.
