### PR TITLE
SERVER-15532 Fix assumptions made by geo_s2cursorlimitskip.js test

### DIFF
--- a/jstests/libs/parallelTester.js
+++ b/jstests/libs/parallelTester.js
@@ -161,6 +161,7 @@ if ( typeof _threadInject != "undefined" ){
                                // These tests expect the profiler to be on or off at specific points
                                // during the test run.
                                parallelFilesDir + "/cursor6.js",
+                               parallelFilesDir + "/geo_s2cursorlimitskip.js",
                                parallelFilesDir + "/profile2.js",
                                parallelFilesDir + "/updatee.js"
                               ];


### PR DESCRIPTION
For storage engines that are transactional, the documents that are inserted after the creation of a cursor need not be visible to the cursor. This means that the set of points inserted after the query is issued may not be found, depending on the storage engine.

Note that this test can no longer be run in parallel because we assert a specific number of query and getmore operations have occurred.

https://jira.mongodb.org/browse/SERVER-15532
