### PR TITLE
SERVER-15517 use slashes rather than double quotes for escaping in shel...

### DIFF
--- a/jstests/tool/command_line_quotes.js
+++ b/jstests/tool/command_line_quotes.js
@@ -1,0 +1,22 @@
+jsTest.log("Testing spaces in mongodump command-line options...");
+
+var mongod = MongoRunner.runMongod(); 
+var coll = mongod.getDB("spaces").coll;
+coll.drop();
+coll.insert({a: 1});
+coll.insert({a: 2});
+
+var query = "{\"a\": {\"$gt\": 1} }";
+assert(!MongoRunner.runMongoTool(
+  "mongodump",
+  {
+    "host": "127.0.0.1:" + mongod.port,
+    "db": "spaces",
+    "collection": "coll",
+    "query": query
+  }
+));
+
+MongoRunner.stopMongod(mongod);
+
+jsTest.log("Test completed successfully");

--- a/src/mongo/shell/shell_utils_launcher.cpp
+++ b/src/mongo/shell/shell_utils_launcher.cpp
@@ -375,7 +375,7 @@ namespace mongo {
                     ss << '"';
                     // escape all embedded quotes
                     for (size_t j=0; j<_argv[i].size(); ++j) {
-                        if (_argv[i][j]=='"') ss << '"';
+                        if (_argv[i][j]=='"') ss << '\\';
                         ss << _argv[i][j];
                     }
                     ss << '"';


### PR DESCRIPTION
...l launcher

This stops the new golang tools from breaking on command-line options with spaces in them. According to Mark B., it's the correct way to escape quotes.
