### PR TITLE
SERVER-15700 Modify SortedDataInterface to not require unindex() to return whether the index row was deleted

### DIFF
--- a/src/mongo/db/index/btree_based_access_method.h
+++ b/src/mongo/db/index/btree_based_access_method.h
@@ -132,7 +132,7 @@ namespace mongo {
         const IndexDescriptor* _descriptor;
 
     private:
-        bool removeOneKey(OperationContext* txn,
+        void removeOneKey(OperationContext* txn,
                           const BSONObj& key,
                           const DiskLoc& loc,
                           bool dupsAllowed);

--- a/src/mongo/db/storage/heap1/heap1_btree_impl.cpp
+++ b/src/mongo/db/storage/heap1/heap1_btree_impl.cpp
@@ -170,7 +170,7 @@ namespace {
             return Status::OK();
         }
 
-        virtual bool unindex(OperationContext* txn,
+        virtual void unindex(OperationContext* txn,
                              const BSONObj& key,
                              const DiskLoc& loc,
                              bool dupsAllowed) {
@@ -184,8 +184,6 @@ namespace {
                 _currentKeySize -= key.objsize();
                 Heap1RecoveryUnit::notifyIndexRemove( txn, this, key, loc );
             }
-
-            return numDeleted == 1;
         }
 
         virtual void fullValidate(OperationContext* txn, long long *numKeysOut) const {

--- a/src/mongo/db/storage/mmap_v1/btree/btree_interface.cpp
+++ b/src/mongo/db/storage/mmap_v1/btree/btree_interface.cpp
@@ -85,12 +85,12 @@ namespace mongo {
             return _btree->insert(txn, key, loc, dupsAllowed);
         }
 
-        virtual bool unindex(OperationContext* txn,
+        virtual void unindex(OperationContext* txn,
                              const BSONObj& key,
                              const DiskLoc& loc,
                              bool dupsAllowed) {
 
-            return _btree->unindex(txn, key, loc);
+            _btree->unindex(txn, key, loc);
         }
 
         virtual void fullValidate(OperationContext* txn, long long *numKeysOut) const {

--- a/src/mongo/db/storage/sorted_data_interface.h
+++ b/src/mongo/db/storage/sorted_data_interface.h
@@ -77,7 +77,7 @@ namespace mongo {
                               const DiskLoc& loc,
                               bool dupsAllowed) = 0;
 
-        virtual bool unindex(OperationContext* txn,
+        virtual void unindex(OperationContext* txn,
                              const BSONObj& key,
                              const DiskLoc& loc,
                              bool dupsAllowed) = 0;

--- a/src/mongo/db/storage/sorted_data_interface_test_harness.cpp
+++ b/src/mongo/db/storage/sorted_data_interface_test_harness.cpp
@@ -203,7 +203,8 @@ namespace mongo {
             scoped_ptr<OperationContext> opCtx( harnessHelper->newOperationContext() );
             {
                 WriteUnitOfWork uow( opCtx.get() );
-                ASSERT( !sorted->unindex( opCtx.get(), BSON( "" << 1 ), DiskLoc( 5, 20 ), true ) );
+                sorted->unindex( opCtx.get(), BSON( "" << 1 ), DiskLoc( 5, 20 ), true );
+                ASSERT_EQUALS( 1, sorted->numEntries( opCtx.get() ) );
                 uow.commit();
             }
         }
@@ -217,7 +218,8 @@ namespace mongo {
             scoped_ptr<OperationContext> opCtx( harnessHelper->newOperationContext() );
             {
                 WriteUnitOfWork uow( opCtx.get() );
-                ASSERT( !sorted->unindex( opCtx.get(), BSON( "" << 2 ), DiskLoc( 5, 18 ), true ) );
+                sorted->unindex( opCtx.get(), BSON( "" << 2 ), DiskLoc( 5, 18 ), true );
+                ASSERT_EQUALS( 1, sorted->numEntries( opCtx.get() ) );
                 uow.commit();
             }
         }
@@ -232,7 +234,8 @@ namespace mongo {
             scoped_ptr<OperationContext> opCtx( harnessHelper->newOperationContext() );
             {
                 WriteUnitOfWork uow( opCtx.get() );
-                ASSERT( sorted->unindex( opCtx.get(), BSON( "" << 1 ), DiskLoc( 5, 18 ), true ) );
+                sorted->unindex( opCtx.get(), BSON( "" << 1 ), DiskLoc( 5, 18 ), true );
+                ASSERT( sorted->isEmpty( opCtx.get() ) );
                 uow.commit();
             }
         }
@@ -266,7 +269,8 @@ namespace mongo {
             scoped_ptr<OperationContext> opCtx( harnessHelper->newOperationContext() );
             {
                 WriteUnitOfWork uow( opCtx.get() );
-                ASSERT( sorted->unindex( opCtx.get(), BSON( "" << 1 ), DiskLoc( 5, 18 ), true ) );
+                sorted->unindex( opCtx.get(), BSON( "" << 1 ), DiskLoc( 5, 18 ), true );
+                ASSERT( sorted->isEmpty( opCtx.get() ) );
                 // no commit
             }
         }

--- a/src/mongo/db/storage/sorted_data_interface_test_isempty.cpp
+++ b/src/mongo/db/storage/sorted_data_interface_test_isempty.cpp
@@ -65,7 +65,8 @@ namespace mongo {
             scoped_ptr<OperationContext> opCtx( harnessHelper->newOperationContext() );
             {
                 WriteUnitOfWork uow( opCtx.get() );
-                ASSERT( sorted->unindex( opCtx.get(), key1, loc1, false ) );
+                sorted->unindex( opCtx.get(), key1, loc1, false );
+                ASSERT( sorted->isEmpty( opCtx.get() ) );
                 uow.commit();
             }
         }

--- a/src/mongo/db/storage/sorted_data_interface_test_rollback.cpp
+++ b/src/mongo/db/storage/sorted_data_interface_test_rollback.cpp
@@ -107,7 +107,8 @@ namespace mongo {
             scoped_ptr<OperationContext> opCtx( harnessHelper->newOperationContext() );
             {
                 WriteUnitOfWork uow( opCtx.get() );
-                ASSERT( sorted->unindex( opCtx.get(), key2, loc2, true ) );
+                sorted->unindex( opCtx.get(), key2, loc2, true );
+                ASSERT_EQUALS( 1, sorted->numEntries( opCtx.get() ) );
                 // no commit
             }
         }
@@ -135,8 +136,10 @@ namespace mongo {
             scoped_ptr<OperationContext> opCtx( harnessHelper->newOperationContext() );
             {
                 WriteUnitOfWork uow( opCtx.get() );
-                ASSERT( sorted->unindex( opCtx.get(), key1, loc1, true ) );
-                ASSERT( sorted->unindex( opCtx.get(), key3, loc3, true ) );
+                sorted->unindex( opCtx.get(), key1, loc1, true );
+                ASSERT_EQUALS( 2, sorted->numEntries( opCtx.get() ) );
+                sorted->unindex( opCtx.get(), key3, loc3, true );
+                ASSERT_EQUALS( 1, sorted->numEntries( opCtx.get() ) );
                 // no commit
             }
         }

--- a/src/mongo/db/storage/sorted_data_interface_test_unindex.cpp
+++ b/src/mongo/db/storage/sorted_data_interface_test_unindex.cpp
@@ -63,7 +63,8 @@ namespace mongo {
             scoped_ptr<OperationContext> opCtx( harnessHelper->newOperationContext() );
             {
                 WriteUnitOfWork uow( opCtx.get() );
-                ASSERT( sorted->unindex( opCtx.get(), key1, loc1, true ) );
+                sorted->unindex( opCtx.get(), key1, loc1, true );
+                ASSERT( sorted->isEmpty( opCtx.get() ) );
                 uow.commit();
             }
         }
@@ -102,7 +103,8 @@ namespace mongo {
             scoped_ptr<OperationContext> opCtx( harnessHelper->newOperationContext() );
             {
                 WriteUnitOfWork uow( opCtx.get() );
-                ASSERT( sorted->unindex( opCtx.get(), compoundKey1a, loc1, true ) );
+                sorted->unindex( opCtx.get(), compoundKey1a, loc1, true );
+                ASSERT( sorted->isEmpty( opCtx.get() ) );
                 uow.commit();
             }
         }
@@ -142,7 +144,8 @@ namespace mongo {
             scoped_ptr<OperationContext> opCtx( harnessHelper->newOperationContext() );
             {
                 WriteUnitOfWork uow( opCtx.get() );
-                ASSERT( sorted->unindex( opCtx.get(), key2, loc2, true ) );
+                sorted->unindex( opCtx.get(), key2, loc2, true );
+                ASSERT_EQUALS( 1, sorted->numEntries( opCtx.get() ) );
                 uow.commit();
             }
         }
@@ -170,8 +173,10 @@ namespace mongo {
             scoped_ptr<OperationContext> opCtx( harnessHelper->newOperationContext() );
             {
                 WriteUnitOfWork uow( opCtx.get() );
-                ASSERT( sorted->unindex( opCtx.get(), key1, loc1, true ) );
-                ASSERT( sorted->unindex( opCtx.get(), key3, loc3, true ) );
+                sorted->unindex( opCtx.get(), key1, loc1, true );
+                ASSERT_EQUALS( 1, sorted->numEntries( opCtx.get() ) );
+                sorted->unindex( opCtx.get(), key3, loc3, true );
+                ASSERT( sorted->isEmpty( opCtx.get() ) );
                 uow.commit();
             }
         }
@@ -211,7 +216,8 @@ namespace mongo {
             scoped_ptr<OperationContext> opCtx( harnessHelper->newOperationContext() );
             {
                 WriteUnitOfWork uow( opCtx.get() );
-                ASSERT( sorted->unindex( opCtx.get(), key1, loc2, true ) );
+                sorted->unindex( opCtx.get(), key1, loc2, true );
+                ASSERT_EQUALS( 1, sorted->numEntries( opCtx.get() ) );
                 uow.commit();
             }
         }
@@ -239,8 +245,10 @@ namespace mongo {
             scoped_ptr<OperationContext> opCtx( harnessHelper->newOperationContext() );
             {
                 WriteUnitOfWork uow( opCtx.get() );
-                ASSERT( sorted->unindex( opCtx.get(), key1, loc1, true) );
-                ASSERT( sorted->unindex( opCtx.get(), key1, loc3, true ) );
+                sorted->unindex( opCtx.get(), key1, loc1, true);
+                ASSERT_EQUALS( 1, sorted->numEntries( opCtx.get() ) );
+                sorted->unindex( opCtx.get(), key1, loc3, true );
+                ASSERT( sorted->isEmpty( opCtx.get() ) );
                 uow.commit();
             }
         }
@@ -265,7 +273,8 @@ namespace mongo {
             scoped_ptr<OperationContext> opCtx( harnessHelper->newOperationContext() );
             {
                 WriteUnitOfWork uow( opCtx.get() );
-                ASSERT( !sorted->unindex( opCtx.get(), key1, loc1, true ) );
+                sorted->unindex( opCtx.get(), key1, loc1, true );
+                ASSERT( sorted->isEmpty( opCtx.get() ) );
                 uow.commit();
             }
         }


### PR DESCRIPTION
Discussion: https://groups.google.com/forum/#!topic/mongodb-dev/75ZSCUrgmtk
Jira: https://jira.mongodb.org/browse/SERVER-15700
- SortedDataInterface::unindex() modified to return void, no longer checks for existence of target index key
- Storage engine unit tests were modified and cleanly pass
- Development environment: Ubuntu 13.10 with gcc-4.8.1
