### PR TITLE
SERVER-15702 During collection scans, read the document from the RecordIterator

### DIFF
--- a/src/mongo/db/exec/collection_scan.cpp
+++ b/src/mongo/db/exec/collection_scan.cpp
@@ -108,7 +108,7 @@ namespace mongo {
         WorkingSetID id = _workingSet->allocate();
         WorkingSetMember* member = _workingSet->get(id);
         member->loc = nextLoc;
-        member->obj = _params.collection->docFor(_txn, member->loc);
+        member->obj = _iter->dataFor(member->loc).toBson();
         member->state = WorkingSetMember::LOC_AND_UNOWNED_OBJ;
 
         ++_specificStats.docsTested;


### PR DESCRIPTION
...instead of the Collection. This way the RecordIterator class can optimize document fetch for disklocs that were just returned.

Rationale: RecordIterators may be walking over a data structure that co-locates keys and values, so reading the value for a key just read is inexpensive compared to fetching that value indirectly through another interface (such as the Collection, which will do a new tree traversal).

Jira: https://jira.mongodb.org/browse/SERVER-15702
Discussion: https://groups.google.com/forum/#!topic/mongodb-dev/muyqfHE1lvg
