### PR TITLE
SERVER-9840 Fix grammar in $let agg expression error message.

### DIFF
--- a/src/mongo/db/pipeline/expression.cpp
+++ b/src/mongo/db/pipeline/expression.cpp
@@ -1476,7 +1476,7 @@ namespace {
 
         verify(str::equals(expr.fieldName(), "$let"));
 
-        uassert(16874, "$let only supports an object as it's argument",
+        uassert(16874, "$let only supports an object as its argument",
                 expr.type() == Object);
         const BSONObj args = expr.embeddedObject();
 


### PR DESCRIPTION
Replace "it's argument" with correct possessive "its argument".
