### PR TITLE
TOOLS-261 dumprestore_auth test must allow listIndexes permission

### DIFF
--- a/jstests/tool/dumprestore_auth.js
+++ b/jstests/tool/dumprestore_auth.js
@@ -14,7 +14,7 @@ adminDB.createUser({user: 'restore', pwd: 'password', roles: ['restore']});
 
 // Add user defined roles & users with those roles
 var testUserAdmin = c.getDB().getSiblingDB(dbName);
-var backupActions = ["find","listCollections"];
+var backupActions = ["find","listCollections", "listIndexes"];
 testUserAdmin.createRole({role: "backupFoo",
    privileges: [{resource: {db: dbName, collection: "foo"}, actions:backupActions},
                 {resource: {db: dbName, collection: "system.indexes"},


### PR DESCRIPTION
To support storage engines besides mmapv1 the tools will be transitioning away from querying system.indexes directly in favor of using the listIndexes command. The custom role used in this test must include permissions to run listIndexes so that the dump can proceed successfully.
