### PR TITLE
SERVER-15623 Test that w:0 is prohibited in getLastErrorDefaults.

### DIFF
--- a/jstests/multiVersion/add_newer_secondary_w0.js
+++ b/jstests/multiVersion/add_newer_secondary_w0.js
@@ -1,0 +1,57 @@
+/*
+ * Test that replSetInitiate prohibits w:0 in getLastErrorDefaults when
+ * a primary is on an old version and the secondary is latest, SERVER-13055.
+ */
+
+load('./jstests/multiVersion/libs/multi_rs.js');
+
+var oldVersion = '2.6';
+var newVersion = 'latest';
+
+jsTestLog('Start one-member set with old version.');
+
+var replTest = new ReplSetTest({nodes: {
+    n0: {binVersion: oldVersion}}});
+
+var conns = replTest.startSet();
+var conf = replTest.getReplSetConfig();
+
+conf.settings = {getLastErrorDefaults: {w: 0}};
+printjson(conf);
+replTest.initiate(conf);
+
+// Wait for a primary node....
+var primary = replTest.getPrimary();
+
+jsTestLog('Add secondary running new version.');
+
+var newSecondary = replTest.start(1, {binVersion: newVersion});
+var conf2 = conns[0].getDB('local').system.replset.findOne();
+
+printjson(newSecondary.host);
+
+conf2.members.push({_id: 1, host: newSecondary.host});
+conf2.version++;
+
+jsTestLog('Attempting to set new config:');
+printjson(conf2);
+
+var admin = conns[0].getDB("admin");
+var response = admin.runCommand({replSetReconfig: conf2});
+printjson(response);
+printjson(replTest.status());
+
+jsTestLog('Waiting up to 30 seconds for secondary....');
+
+var secondary = replTest.getSecondary(30 * 1000);
+
+jsTestLog('Secondary is up: ' + secondary.host);
+
+// Secondary should see bad config and remove itself.
+replTest.waitForState(secondary, replTest.REMOVED);
+
+// Since we added the new secondary directly we must stop it directly.
+MongoRunner.stopMongod(newSecondary.port);
+
+// Stop the primary.
+replTest.stopSet();

--- a/jstests/replsets/initiate_prohibits_w0.js
+++ b/jstests/replsets/initiate_prohibits_w0.js
@@ -1,0 +1,35 @@
+/*
+ * Test that replSetInitiate prohibits w:0 in getLastErrorDefaults,
+ * SERVER-13055.
+ */
+
+var InvalidReplicaSetConfig = 93;
+
+var replTest = new ReplSetTest({name: 'prohibit_w0', nodes: 1});
+var nodes = replTest.nodeList();
+var conns = replTest.startSet();
+var admin = conns[0].getDB("admin");
+
+function testInitiate(gleDefaults) {
+    var conf = replTest.getReplSetConfig();
+    jsTestLog('conf');
+    printjson(conf);
+    conf.settings = gleDefaults;
+
+    var response = admin.runCommand({replSetInitiate: conf});
+    assert.commandFailedWithCode(response, InvalidReplicaSetConfig);
+}
+
+/*
+ * Try to initiate with w: 0 in getLastErrorDefaults.
+ */
+testInitiate({
+    getLastErrorDefaults: {w: 0}});
+
+/*
+ * Try to initiate with w: 0 and other options in getLastErrorDefaults.
+ */
+testInitiate({
+    getLastErrorDefaults: {w: 0, j: false, wtimeout: 100, fsync: true}});
+
+replTest.stopSet();

--- a/jstests/replsets/reconfig_prohibits_w0.js
+++ b/jstests/replsets/reconfig_prohibits_w0.js
@@ -1,0 +1,40 @@
+/*
+ * Test that replSetReconfig prohibits w:0 in getLastErrorDefaults,
+ * SERVER-13055.
+ */
+
+var NewReplicaSetConfigurationIncompatible = 103;
+
+var replTest = new ReplSetTest({name: 'prohibit_w0', nodes: 1});
+var nodes = replTest.nodeList();
+var conns = replTest.startSet();
+var admin = conns[0].getDB("admin");
+
+replTest.initiate({
+    _id: 'prohibit_w0',
+    members: [{_id: 0, host: nodes[0]}]});
+
+function testReconfig(gleDefaults) {
+    var conf = admin.runCommand({replSetGetConfig: 1}).config;
+    jsTestLog('conf');
+    printjson(conf);
+    conf.settings = gleDefaults;
+    conf.version++;
+
+    var response = admin.runCommand({replSetReconfig: conf});
+    assert.commandFailedWithCode(response, NewReplicaSetConfigurationIncompatible);
+}
+
+/*
+ * Try to reconfig with w: 0 in getLastErrorDefaults.
+ */
+testReconfig({
+    getLastErrorDefaults: {w: 0}});
+
+/*
+ * Try to reconfig with w: 0 and other options in getLastErrorDefaults.
+ */
+testReconfig({
+    getLastErrorDefaults: {w: 0, j: false, wtimeout: 100, fsync: true}});
+
+replTest.stopSet();

--- a/src/mongo/shell/replsettest.js
+++ b/src/mongo/shell/replsettest.js
@@ -1054,6 +1054,7 @@ ReplSetTest.State.PRIMARY = 1
 ReplSetTest.State.SECONDARY = 2
 ReplSetTest.State.RECOVERING = 3
 ReplSetTest.State.ARBITER = 7
+ReplSetTest.State.REMOVED = 10
 
 /** 
  * Overflows a replica set secondary or secondaries, specified by id or conn.


### PR DESCRIPTION
Test of SERVER-13055: we now prohibit {w:0} in a replica set config's getLastErrorDefaults.
