### PR TITLE
SERVER-10670 Add missing check on result from AuthorizationManager::_initializeUserFromPrivilegeDocument

### DIFF
--- a/src/mongo/db/auth/authorization_manager.cpp
+++ b/src/mongo/db/auth/authorization_manager.cpp
@@ -514,6 +514,10 @@ namespace mongo {
             return status;
         }
         status = parser.initializeUserPrivilegesFromUserDocument(privDoc, user);
+        if (!status.isOK()) {
+            return status;
+        }
+
         return Status::OK();
     }
 


### PR DESCRIPTION
Just noticed this while working on something else: the status returned from `initializeUserPrivilegesFromUserDocument` is being ignored at the end of `AuthorizationManager::_initializeUserFromPrivilegeDocument`.

This could be more succinctly fixed by just changing `return Status::OK()` to `return status`, and I originally did that, but I noticed that another function in the same file (`AuthorizationManager::initialize`) is also doing a similar explicit check, so I figured doing it this was more consistent and less prone to accidental breakage by later changes.

No worries if whoever is reviewing this would prefer to fix this some other way: just wanted to bring it to attention.
