### PR TITLE
SERVER-15960 dumpfilename1.js test should not depend on single-threaded semantics

### DIFF
--- a/jstests/tool/dumpfilename1.js
+++ b/jstests/tool/dumpfilename1.js
@@ -1,24 +1,13 @@
 //dumpfilename1.js
 
-//Test designed to make sure error that dumping a collection with "/" in the name doesn't crash the system.
-//An error is logged and given to the user, but the other collections should dump and restore OK.  
+//Test designed to make sure error that dumping a collection with "/" fails
 
 t = new ToolTest( "dumpfilename1" );
 
 t.startDB( "foo" );
+
 c = t.db;
 assert.writeOK(c.getCollection("df/").insert({ a: 3 }));
-assert.writeOK(c.getCollection("df").insert({ a: 2 }));
-
-t.runTool( "dump" , "--out" , t.ext );
-
-assert(c.getCollection("df/").drop(),"cannot drop 1");
-assert(c.getCollection("df").drop(), "cannot drop 2");
-
-t.runTool( "restore" , "--dir" , t.ext );
-
-assert.eq( 0 , c.getCollection("df/").count() , "collection 1 does not restore properly" );
-assert.eq( 1 , c.getCollection("df").count() , "collection 2 does not restore properly" );
-
+assert(t.runTool( "dump" , "--out" , t.ext ) != 0, "dump should fail with non-zero return code")
 t.stop();
 


### PR DESCRIPTION
This test relies on the single threaded semantics of the legacy mongodump. I have modified it to no longer rely on a specific ordering in which collections are processed.
