### PR TITLE
SERVER-15979: Remove mmap_v1isms from tool suite

### DIFF
--- a/jstests/tool/dumprestore4.js
+++ b/jstests/tool/dumprestore4.js
@@ -18,13 +18,14 @@ dbname = db.getName();
 dbname2 = "NOT_"+dbname;
 
 db2=db.getSisterDB( dbname2 );
+c2 = db2.getCollection( c.getName() );
 
 db.dropDatabase(); // make sure it's empty
 db2.dropDatabase(); // make sure everybody's empty
 
-assert.eq( 0 , db.system.indexes.count() , "setup1" );
+assert.eq( 0 , c.getIndexes().length , "setup1" );
 c.ensureIndex({ x : 1} );
-assert.eq( 2 , db.system.indexes.count() , "setup2" ); // _id and x_1
+assert.eq( 2 , c.getIndexes().length , "setup2" ); // _id and x_1
 
 assert.eq( 0, t.runTool( "dump" , "-d" , dbname, "--out", t.ext ), "dump")
 
@@ -35,8 +36,8 @@ c.drop();
 assert.eq( 0, t.runTool( "restore" , "--dir" , t.ext + "/" + dbname, "-d", dbname2 ), "restore" );
 
 // issue (1)
-assert.eq( 2 , db2.system.indexes.count() , "after restore 1" );
+assert.eq( 2 , c2.getIndexes().length , "after restore 1" );
 // issue (2)
-assert.eq( 0 , db.system.indexes.count() , "after restore 2" );
+assert.eq( 0 , c.getIndexes().length , "after restore 2" );
 
 t.stop();

--- a/jstests/tool/dumprestore6.js
+++ b/jstests/tool/dumprestore6.js
@@ -11,7 +11,7 @@ t.runTool("restore", "--dir", "jstests/tool/data/dumprestore6", "--db", "jstests
 
 assert.soon( "c.findOne()" , "no data after sleep" );
 assert.eq( 1 , c.count() , "after restore" );
-assert.eq( 1 , db.system.indexes.findOne({name:'a_1'}).v, "index version wasn't updated")
+assert.eq( 1 , c.getIndexes().filter(function(ix) { return ix.name === 'a_1'; })[0].v, "index version wasn't updated")
 assert.eq( 1, c.count({v:0}), "dropped the 'v' field from a non-index collection")
 
 db.dropDatabase()
@@ -21,7 +21,7 @@ t.runTool("restore", "--dir", "jstests/tool/data/dumprestore6", "--db", "jstests
 
 assert.soon( "c.findOne()" , "no data after sleep2" );
 assert.eq( 1 , c.count() , "after restore2" );
-assert.eq( 0 , db.system.indexes.findOne({name:'a_1'}).v, "index version wasn't maintained")
+assert.eq( 0 , c.getIndexes().filter(function(ix) { return ix.name === 'a_1'; })[0].v, "index version wasn't maintained")
 assert.eq( 1, c.count({v:0}), "dropped the 'v' field from a non-index collection")
 
 t.stop();

--- a/jstests/tool/dumprestore8.js
+++ b/jstests/tool/dumprestore8.js
@@ -31,7 +31,8 @@ db.bar.ensureIndex({x:1});
 barDocCount = db.bar.count();
 assert.gt( barDocCount, 0 , "No documents inserted" );
 assert.lt( db.bar.count(), 1000 , "Capped collection didn't evict documents" );
-assert.eq( 5 , db.system.indexes.count() , "Indexes weren't created right" );
+assert.eq( 3 , db.foo.getIndexes().length , "Indexes on foo weren't created right" );
+assert.eq( 2 , db.bar.getIndexes().length , "Indexes on bar weren't created right" );
 
 
 // Full dump/restore
@@ -41,7 +42,8 @@ t.runTool( "dump" , "--out" , t.ext );
 db.dropDatabase();
 assert.eq( 0 , db.foo.count() , "foo not dropped" );
 assert.eq( 0 , db.bar.count() , "bar not dropped" );
-assert.eq( 0 , db.system.indexes.count() , "indexes not dropped" );
+assert.eq( 0 , db.foo.getIndexes().length , "indexes on foo not dropped" );
+assert.eq( 0 , db.bar.getIndexes().length , "indexes on bar not dropped" );
 
 t.runTool( "restore" , "--dir" , t.ext );
 
@@ -52,7 +54,8 @@ for (var i = 0; i < 10; i++) {
     db.bar.save({x:i});
 }
 assert.eq( barDocCount, db.bar.count(), "Capped collection didn't evict documents after restore." );
-assert.eq( 5 , db.system.indexes.count() , "Indexes weren't created correctly by restore" );
+assert.eq( 3 , db.foo.getIndexes().length , "Indexes on foo weren't created correctly by restore" );
+assert.eq( 2 , db.bar.getIndexes().length , "Indexes on bar weren't created correctly by restore" );
 
 
 // Dump/restore single DB
@@ -64,7 +67,8 @@ t.runTool( "dump" , "-d", dbname, "--out" , dumppath );
 db.dropDatabase();
 assert.eq( 0 , db.foo.count() , "foo not dropped2" );
 assert.eq( 0 , db.bar.count() , "bar not dropped2" );
-assert.eq( 0 , db.system.indexes.count() , "indexes not dropped2" );
+assert.eq( 0 , db.foo.getIndexes().length , "indexes on foo not dropped2" );
+assert.eq( 0 , db.bar.getIndexes().length , "indexes on bar not dropped2" );
 
 t.runTool( "restore" , "-d", dbname2, "--dir" , dumppath + dbname );
 
@@ -77,7 +81,8 @@ for (var i = 0; i < 10; i++) {
     db.bar.save({x:i});
 }
 assert.eq( barDocCount, db.bar.count(), "Capped collection didn't evict documents after restore 2." );
-assert.eq( 5 , db.system.indexes.count() , "Indexes weren't created correctly by restore 2" );
+assert.eq( 3 , db.foo.getIndexes().length , "Indexes on foo weren't created correctly by restore 2" );
+assert.eq( 2 , db.bar.getIndexes().length , "Indexes on bar weren't created correctly by restore 2" );
 
 
 // Dump/restore single collection
@@ -88,7 +93,8 @@ t.runTool( "dump" , "-d", dbname2, "-c", "bar", "--out" , dumppath );
 
 db.dropDatabase();
 assert.eq( 0 , db.bar.count() , "bar not dropped3" );
-assert.eq( 0 , db.system.indexes.count() , "indexes not dropped3" );
+assert.eq( 0 , db.foo.getIndexes().length , "indexes on foo not dropped3" );
+assert.eq( 0 , db.bar.getIndexes().length , "indexes on bar not dropped3" );
 
 t.runTool( "restore" , "-d", dbname, "-c", "baz", "--dir" , dumppath + dbname2 + "/bar.bson" );
 
@@ -100,6 +106,6 @@ for (var i = 0; i < 10; i++) {
     db.baz.save({x:i});
 }
 assert.eq( barDocCount, db.baz.count(), "Capped collection didn't evict documents after restore 3." );
-assert.eq( 2 , db.system.indexes.count() , "Indexes weren't created correctly by restore 3" );
+assert.eq( 2 , db.baz.getIndexes().length , "Indexes on baz weren't created correctly by restore 3" );
 
 t.stop();

--- a/jstests/tool/dumprestoreWithNoOptions.js
+++ b/jstests/tool/dumprestoreWithNoOptions.js
@@ -24,7 +24,7 @@ db.dropDatabase();
 
 var options = { capped: true, size: 4096, autoIndexId: true };
 db.createCollection('capped', options);
-assert.eq( 1, db.system.indexes.count(), "auto index not created" );
+assert.eq( 1, db.capped.getIndexes().length, "auto index not created" );
 var cappedOptions = db.capped.exists().options;
 for ( var opt in options ) {
     assert.eq(options[opt], cappedOptions[opt],
@@ -38,7 +38,7 @@ t.runTool( "dump" , "--out" , t.ext );
 
 db.dropDatabase();
 assert.eq( 0, db.capped.count(), "capped not dropped");
-assert.eq( 0, db.system.indexes.count(), "indexes not dropped" );
+assert.eq( 0, db.capped.getIndexes().length, "indexes not dropped" );
 
 t.runTool( "restore" , "--dir" , t.ext , "--noOptionsRestore", "--w=1");
 
@@ -52,7 +52,7 @@ assert.eq( {}, db.capped.exists().options,
 db.dropDatabase();
 var options = { capped: true, size: 4096, autoIndexId: true };
 db.createCollection('capped', options);
-assert.eq( 1, db.system.indexes.count(), "auto index not created" );
+assert.eq( 1, db.capped.getIndexes().length, "auto index not created" );
 var cappedOptions = db.capped.exists().options;
 for ( var opt in options ) {
   assert.eq(options[opt], cappedOptions[opt], 'invalid option')
@@ -65,7 +65,7 @@ t.runTool( "dump" , "-d", dbname, "--out" , dumppath );
 
 db.dropDatabase();
 assert.eq( 0, db.capped.count(), "capped not dropped");
-assert.eq( 0, db.system.indexes.count(), "indexes not dropped" );
+assert.eq( 0, db.capped.getIndexes().length, "indexes not dropped" );
 
 t.runTool( "restore" , "-d", dbname2, "--dir" , dumppath + dbname, "--noOptionsRestore", "--w=1");
 
@@ -81,7 +81,7 @@ assert.eq( {}, db.capped.exists().options,
 db.dropDatabase();
 var options = { capped: true, size: 4096, autoIndexId: true };
 db.createCollection('capped', options);
-assert.eq( 1, db.system.indexes.count(), "auto index not created" );
+assert.eq( 1, db.capped.getIndexes().length, "auto index not created" );
 var cappedOptions = db.capped.exists().options;
 for ( var opt in options ) {
   assert.eq(options[opt], cappedOptions[opt], 'invalid option')
@@ -97,7 +97,7 @@ t.runTool( "dump" , "-d", dbname, "-c", "capped", "--out" , dumppath );
 db.dropDatabase();
 
 assert.eq( 0, db.capped.count(), "capped not dropped");
-assert.eq( 0, db.system.indexes.count(), "indexes not dropped" );
+assert.eq( 0, db.capped.getIndexes().length, "indexes not dropped" );
 
 t.runTool( "restore", "-d", dbname, "--drop", "--noOptionsRestore", dumppath + dbname, "--w=1");
 

--- a/jstests/tool/dumprestore_auth2.js
+++ b/jstests/tool/dumprestore_auth2.js
@@ -25,10 +25,10 @@ coll.insert({word: "tomato"});
 assert.eq(1, coll.count());
 
 assert.eq(4, admindb.system.users.count(), "setup users")
-assert.eq(2, admindb.system.indexes.count({ns: "admin.system.users"}),
+assert.eq(2, admindb.system.users.getIndexes().length,
           "setup2: " + tojson( admindb.system.users.getIndexes() ) );
 assert.eq(1, admindb.system.roles.count(), "setup3")
-assert.eq(2, admindb.system.indexes.count({ns: "admin.system.roles"}), "setup4")
+assert.eq(2, admindb.system.roles.getIndexes().length, "setup4")
 assert.eq(1, admindb.system.version.count());
 var versionDoc = admindb.system.version.findOne();
 
@@ -58,10 +58,10 @@ t.runTool("restore", "--dir", t.ext, "--username", "restore", "--password", "pas
 
 assert.soon("admindb.system.users.findOne()", "no data after restore");
 assert.eq(4, admindb.system.users.count(), "didn't restore users");
-assert.eq(2, admindb.system.indexes.count({ns: "admin.system.users"}),
+assert.eq(2, admindb.system.users.getIndexes().length,
           "didn't restore user indexes");
 assert.eq(1, admindb.system.roles.find({role:'customRole'}).count(), "didn't restore roles");
-assert.eq(2, admindb.system.indexes.count({ns: "admin.system.roles"}),
+assert.eq(2, admindb.system.roles.getIndexes().length,
           "didn't restore role indexes");
 
 admindb.logout();
@@ -85,9 +85,9 @@ assert.soon("1 == admindb.system.users.find({user:'root'}).count()", "didn't res
 assert.eq(0, admindb.system.users.find({user:'root2'}).count(), "didn't drop users");
 assert.eq(0, admindb.system.roles.find({role:'customRole2'}).count(), "didn't drop roles");
 assert.eq(1, admindb.system.roles.find({role:'customRole'}).count(), "didn't restore roles");
-assert.eq(2, admindb.system.indexes.count({ns: "admin.system.users"}),
+assert.eq(2, admindb.system.users.getIndexes().length,
           "didn't maintain user indexes");
-assert.eq(2, admindb.system.indexes.count({ns: "admin.system.roles"}),
+assert.eq(2, admindb.system.roles.getIndexes().length,
           "didn't maintain role indexes");
 assert.eq(1, admindb.system.version.count(), "didn't restore version");
 assert.docEq(versionDoc, admindb.system.version.findOne(), "version doc wasn't restored properly");

--- a/jstests/tool/restorewithauth.js
+++ b/jstests/tool/restorewithauth.js
@@ -30,10 +30,12 @@ for( var i = 0; i < 4; i++ ) {
 assert.eq( foo.system.namespaces.count({name: "foo.bar"}), 1 )
 
 //make sure it has no index except _id
-assert.eq(foo.system.indexes.count(), 2);
+assert.eq(foo.bar.getIndexes().length, 1);
+assert.eq(foo.baz.getIndexes().length, 1);
 
 foo.bar.createIndex({x:1});
-assert.eq(foo.system.indexes.count(), 3);
+assert.eq(foo.bar.getIndexes().length, 2);
+assert.eq(foo.baz.getIndexes().length, 1);
 
 // get data dump
 var dumpdir = MongoRunner.dataDir + "/restorewithauth-dump1/";
@@ -108,6 +110,7 @@ assert.eq(foo.system.namespaces.count({name: "foo.bar"}), 1);
 assert.eq(foo.system.namespaces.count({name: "foo.baz"}), 1);
 assert.eq(foo.bar.count(), 4);
 assert.eq(foo.baz.count(), 4);
-assert.eq(foo.system.indexes.count(), 3); // _id on foo, _id on bar, x on foo
+assert.eq(foo.bar.getIndexes().length, 2);
+assert.eq(foo.baz.getIndexes().length, 1);
 
 stopMongod( port );


### PR DESCRIPTION
Some of the tests in the tool suite rely on the existence of mmapv1 specific collections such as system.namespaces and system.indexes, I have removed those. There is still a failure in dumprestore_auth.js that I will resolve in a forthcoming pull request.
