### PR TITLE
SERVER-7866 Add space after collection name in balancer error output

### DIFF
--- a/src/mongo/s/balancer_policy.cpp
+++ b/src/mongo/s/balancer_policy.cpp
@@ -479,8 +479,8 @@ namespace mongo {
             }
 
             if ( numJumboChunks ) {
-                error() << "shard: " << from << "ns: " << ns
-                        << "has too many chunks, but they are all jumbo "
+                error() << "shard: " << from << " ns: " << ns
+                        << " has too many chunks, but they are all jumbo "
                         << " numJumboChunks: " << numJumboChunks
                         << endl;
                 continue;


### PR DESCRIPTION
Fixes spacing in error output as in the following:
`ERROR: shard: shard0001ns: test.entrieshas too many chunks, but they are all jumbo  numJumboChunks: 3`
