### PR TITLE
SERVER-16002 SERVER-16369 - Cluster / standalone auth tests.

### DIFF
--- a/buildscripts/smoke.py
+++ b/buildscripts/smoke.py
@@ -514,7 +514,7 @@ def runTest(test, result):
         if os.path.basename(path) in ('python', 'python.exe'):
             path = argv[1]
     elif ext == ".js":
-        argv = [shell_executable, "--port", mongod_port, '--authenticationMechanism', authMechanism]
+        argv = [shell_executable, "--port", mongod_port]
         
         setShellWriteModeForTest(path, argv)
         

--- a/jstests/auth/iteration_count_control.js
+++ b/jstests/auth/iteration_count_control.js
@@ -1,0 +1,37 @@
+// Test SCRAM iterationCount control.
+load('./jstests/multiVersion/libs/auth_helpers.js');
+
+var conn = MongoRunner.runMongod({auth: ''});
+
+var testIterationCountControl = function(){
+    var adminDB = conn.getDB('admin');
+    adminDB.createUser({user: 'user1', pwd: 'pass',
+                        roles: jsTest.adminUserRoles});
+    assert(adminDB.auth({user: 'user1', pwd: 'pass'}));
+
+    var userDoc = getUserDoc(adminDB, 'user1');
+    assert.eq(10000, userDoc.credentials['SCRAM-SHA-1'].iterationCount);
+
+    // Changing iterationCount should not affect existing users.
+    assert.commandWorked(adminDB.runCommand({setParameter: 1,
+                                             scramIterationCount: 5000}));
+    userDoc = getUserDoc(adminDB, 'user1');
+    assert.eq(10000, userDoc.credentials['SCRAM-SHA-1'].iterationCount);
+
+    // But it should take effect when the user's password is changed.
+    adminDB.updateUser('user1', {pwd: 'pass',
+                                 roles: jsTest.adminUserRoles});
+    userDoc = getUserDoc(adminDB, 'user1');
+    assert.eq(5000, userDoc.credentials['SCRAM-SHA-1'].iterationCount);
+
+    // Test invalid values for iterationCount. 5000 is the minimum value.
+    assert.commandFailed(adminDB.runCommand({setParameter: 1,
+                                             scramIterationCount: 4999}));
+    assert.commandFailed(adminDB.runCommand({setParameter: 1,
+                                             scramIterationCount: -5000}));
+    assert.commandFailed(adminDB.runCommand(
+        {setParameter: 1, scramIterationCount: 12345678901234567890}));
+}
+
+testIterationCountControl();
+MongoRunner.stopMongod(conn);

--- a/jstests/auth/user_special_chars.js
+++ b/jstests/auth/user_special_chars.js
@@ -1,0 +1,14 @@
+// Test creating and authenticating a user with special characters.
+var conn = MongoRunner.runMongod({auth: ''});
+
+var testUserSpecialCharacters = function(){
+    // Create a user with special characters, make sure it can auth.
+    var adminDB = conn.getDB('admin');
+    adminDB.createUser({user: '~`!@#$%^&*()-_+={}[]||;:",.//><', pwd: 'pass',
+                        roles: jsTest.adminUserRoles});
+    assert(adminDB.auth({user: '~`!@#$%^&*()-_+={}[]||;:",.//><',
+                         pwd: 'pass'}));
+}
+
+testUserSpecialCharacters();
+MongoRunner.stopMongod(conn);

--- a/jstests/multiVersion/auth_rolling_upgrade_cluster.js
+++ b/jstests/multiVersion/auth_rolling_upgrade_cluster.js
@@ -1,0 +1,153 @@
+// This tests a few different things:
+// 1. That we can upgrade a cluster with keyfile auth from 2.6 to 2.8.
+// 2. That after upgrade but before authSchemaUpgrade both MONGODB-CR and
+//    SCRAM-SHA-1 work.
+// 3. That in 2. user documents only have MONGODB-CR credentials.
+// 4. That after authSchemaUpgrade only SCRAM-SHA-1 works.
+// 5. That in 4. user documents only have SCRAM-SHA-1 credentials.
+// 6. That after authSchemaUpgrade a downgraded cluster can no longer auth.
+load('./jstests/multiVersion/libs/auth_helpers.js');
+load('./jstests/multiVersion/libs/multi_cluster.js');
+
+var oldVersion = "2.6";
+var newVersion = "2.8";
+
+// enableBalancer: true is required to get auth working with 2.6
+var options = {
+    mongosOptions: {binVersion: oldVersion},
+    configOptions: {binVersion: oldVersion},
+    shardOptions: {binVersion: oldVersion},
+    nopreallocj: 1,
+    separateConfig: true,
+    sync: true,
+    useHostname: true,
+    enableBalancer: true
+}
+
+// Step 1. Create a new 2.6 cluster with keyfile auth, add a user, test
+// that auth works, upgrade the cluster to 2.8 and test auth again.
+var st = new ShardingTest({shards: 2, mongos: 1, other: options,
+                           keyFile: 'jstests/libs/key1'});
+
+var mongos = st.s;
+var configConnStr = st._configDB;
+var adminDB = mongos.getDB('admin');
+
+adminDB.createUser({user: 'user1', pwd: 'password',
+                    roles: jsTest.adminUserRoles});
+
+assert(adminDB.auth({mechanism: 'MONGODB-CR',
+                     user: 'user1', pwd: 'password'}));
+// 2.6 doesn't support SCRAM so this should fail.
+assert.eq(false, adminDB.auth({mechanism: 'SCRAM-SHA-1',
+                               user: 'user1', pwd: 'password'}));
+
+// Authenticate so stopBalancer will work. Don't specify mechanism here to test
+// that a 2.8 shell uses the correct default for a 2.6 server.
+assert(adminDB.auth({user: 'user1', pwd: 'password'}));
+// The balancer has to be off to upgrade the config server from v5 to v6.
+st.stopBalancer();
+
+// Upgrade config server from v5 to v6.
+var mongos = MongoRunner.runMongos({binVersion: newVersion,
+                                    configdb: configConnStr,
+                                    keyFile: 'jstests/libs/key1',
+                                    upgrade: ""});
+
+// Upgrade both config server and mongos. Both are necessary for SCRAM to work.
+st.upgradeCluster(newVersion, {upgradeShards: false,
+                               upgradeConfigs: true,
+                               upgradeMongos: true});
+
+// Solve a race condition. During upgradeCluster mongos instances are
+// restarted first, then the config servers. Restart the mongoses here
+// again to force them to reconnect to the config servers quickly before
+// we move on.
+st.restartMongoses();
+
+mongos = st.s;
+adminDB = mongos.getDB('admin');
+
+// Step 2. We haven't run authSchemaUpgrade so MONGODB-CR should still work.
+assert(adminDB.auth({mechanism: 'MONGODB-CR', user: 'user1',
+                     pwd: 'password'}));
+verifyUserDoc(adminDB, 'user1', true, false);
+
+adminDB.updateUser('user1', {pwd: 'newpassword',
+                             roles: jsTest.adminUserRoles});
+adminDB.createUser({user: 'user2', pwd: 'password',
+                    roles: jsTest.adminUserRoles});
+
+// Step 3. We haven't run authSchemaUpgrade so there shouldn't be
+// any stored SCRAM-SHA-1 credentials.
+verifyUserDoc(adminDB, 'user1', true, false);
+verifyUserDoc(adminDB, 'user2', true, false);
+
+// Regardless, SCRAM-SHA-1 and MONGODB-CR should still work.
+verifyAuth(adminDB, 'user1', 'newpassword', true, true);
+verifyAuth(adminDB, 'user2', 'password', true, true);
+
+// Upgrade the shards, then run the same tests again.
+st.upgradeCluster(newVersion, {upgradeShards: true,
+                               upgradeConfigs: false,
+                               upgradeMongos: false});
+
+assert(adminDB.auth({mechanism: 'MONGODB-CR',
+                     user: 'user1', pwd: 'newpassword'}));
+verifyUserDoc(adminDB, 'user1', true, false);
+verifyUserDoc(adminDB, 'user2', true, false);
+
+adminDB.updateUser('user2', {pwd: 'newpassword',
+                             roles: jsTest.adminUserRoles});
+adminDB.createUser({user: 'user3', pwd: 'password',
+                    roles: jsTest.adminUserRoles });
+
+verifyUserDoc(adminDB, 'user2', true, false);
+verifyUserDoc(adminDB, 'user3', true, false);
+
+verifyAuth(adminDB, 'user2', 'newpassword', true, true);
+verifyAuth(adminDB, 'user3', 'password', true, true);
+
+// Step 4. After authSchemaUpgrade MONGODB-CR will no longer work since
+// MONGODB-CR credentials have been removed.
+assert(adminDB.runCommand('authSchemaUpgrade'));
+
+adminDB.createUser({user: 'user4', pwd: 'password',
+                    roles: jsTest.adminUserRoles});
+
+verifyAuth(adminDB, 'user4', 'password', false, true);
+verifyAuth(adminDB, 'user1', 'newpassword', false, true);
+
+// Step 5. After authSchemaUpgrade there shouldn't be MONGODB-CR credentials.
+verifyUserDoc(adminDB, 'user1', false, true);
+verifyUserDoc(adminDB, 'user2', false, true);
+verifyUserDoc(adminDB, 'user3', false, true);
+verifyUserDoc(adminDB, 'user4', false, true);
+
+assert.eq(false, adminDB.auth({mechanism: 'NOT-A-MECHANISM',
+                               user: 'user4', pwd: 'password'}));
+
+// Step 6. Finally, downgrade the cluster back to 2.6.
+
+// Downgrade shards
+st.upgradeCluster(oldVersion, {upgradeShards: true,
+                               upgradeConfigs: false,
+                               upgradeMongos: false});
+// Downgrade configs
+st.upgradeCluster(oldVersion, {upgradeShards: false,
+                               upgradeConfigs: true,
+                               upgradeMongos: false});
+// Downgrade mongoses
+st.upgradeCluster(oldVersion, {upgradeShards: false,
+                               upgradeConfigs: false,
+                               upgradeMongos: true }); 
+
+mongos = st.s;
+adminDB = mongos.getDB('admin');
+
+// Since we ran authSchemaUpgrade before the downgrade it is no longer
+// possible to authenticate.
+verifyAuth(adminDB, 'user4', 'password', false, false);
+verifyAuth(adminDB, 'user1', 'newpassword', false, false);
+
+st.stop();

--- a/jstests/multiVersion/auth_upgrade_downgrade_cluster.js
+++ b/jstests/multiVersion/auth_upgrade_downgrade_cluster.js
@@ -1,0 +1,99 @@
+// Test that we can upgrade a cluster using keyfile auth from 2.6 to 2.8,
+// downgrade back again and MONGODB-CR auth will continue to work
+// regardless of server version. SCRAM-SHA-1 should work when mongos
+// and the config servers are version 2.8.
+load('./jstests/multiVersion/libs/auth_helpers.js');
+load('./jstests/multiVersion/libs/multi_cluster.js');
+
+var oldVersion = "2.6";
+var newVersion = "2.8";
+
+// enableBalancer: true is required to get auth working with 2.6
+var options = {
+    mongosOptions: {binVersion: oldVersion},
+    configOptions: {binVersion: oldVersion},
+    shardOptions: {binVersion: oldVersion},
+    nopreallocj: 1,
+    separateConfig: true,
+    sync: true,
+    useHostname: true,
+    enableBalancer: true
+}
+
+var st = new ShardingTest({shards: 2, mongos: 1, other: options,
+                           keyFile: 'jstests/libs/key1'});
+
+var mongos = st.s;
+var configConnStr = st._configDB;
+var adminDB = mongos.getDB('admin');
+
+adminDB.createUser({user: 'admin', pwd: 'password',
+                    roles: jsTest.adminUserRoles});
+
+assert(adminDB.auth({mechanism: 'MONGODB-CR',
+                     user: 'admin', pwd: 'password'}));
+
+// The balancer has to be off to upgrade the config server from v5 to v6.
+st.stopBalancer();
+// Upgrade config server from v5 to v6
+var mongos = MongoRunner.runMongos({binVersion: newVersion,
+                                    configdb: configConnStr,
+                                    keyFile: 'jstests/libs/key1',
+                                    upgrade: ""});
+
+// Upgrade cluster
+st.upgradeCluster(newVersion, {upgradeShards: true,
+                               upgradeConfigs: true, upgradeMongos: true });
+
+// Solve a race condition. During upgradeCluster mongos instances are
+// restarted first, then the config servers. Restart the mongoses here
+// again to force them to reconnect to the config servers quickly before
+// we move on.
+st.restartMongoses();
+
+mongos = st.s;
+adminDB = mongos.getDB('admin');
+
+// We haven't run authSchemaUpgrade so MONGODB-CR should still work.
+assert(adminDB.auth({mechanism: 'MONGODB-CR',
+                     user: 'admin', pwd: 'password'}));
+
+adminDB.createUser({user: 'user1', pwd: 'password',
+                    roles: jsTest.adminUserRoles});
+verifyUserDoc(adminDB, 'user1', true, false);
+
+verifyAuth(adminDB, 'user1', 'password', true, true);
+
+// Downgrade shards
+st.upgradeCluster(oldVersion, {upgradeShards: true,
+                               upgradeConfigs: false,
+                               upgradeMongos: false});
+// Downgrade configs
+st.upgradeCluster(oldVersion, {upgradeShards: false,
+                               upgradeConfigs: true,
+                               upgradeMongos: false});
+// Downgrade mongoses
+st.upgradeCluster(oldVersion, {upgradeShards: false,
+                               upgradeConfigs: false,
+                               upgradeMongos: true});
+
+mongos = st.s;
+adminDB = mongos.getDB('admin');
+
+// We never ran authSchemaUpgrade so MONGODB-CR should still work
+// after downgrade. SCRAM, obviously, will no longer work.
+assert(adminDB.auth({mechanism: 'MONGODB-CR',
+                     user: 'admin', pwd: 'password'}));
+
+adminDB.updateUser('user1', {pwd: 'newpassword',
+                             roles: jsTest.adminUserRoles});
+adminDB.createUser({user: 'user2',
+                    pwd: 'password', roles: jsTest.adminUserRoles});
+
+verifyUserDoc(adminDB, 'user1', true, false);
+verifyUserDoc(adminDB, 'user2', true, false);
+
+verifyAuth(adminDB, 'user1', 'newpassword', true, false);
+verifyAuth(adminDB, 'user2', 'password', true, false);
+
+st.stop();

--- a/jstests/multiVersion/auth_upgrade_downgrade_standalone.js
+++ b/jstests/multiVersion/auth_upgrade_downgrade_standalone.js
@@ -1,0 +1,115 @@
+// Standalone upgrade / downgrade tests.
+load('./jstests/multiVersion/libs/auth_helpers.js');
+
+var legacyVersion = "2.4"
+var oldVersion = "2.6"
+var newVersion = "2.8"
+
+var conn = MongoRunner.runMongod({binVersion: legacyVersion,
+                                  auth: ''});
+
+var test28Shell24Mongod = function(){
+    // Test that the 2.8 shell can authenticate a 2.4 mongod.
+    var adminDB = conn.getDB('admin');
+
+    // Note - the 2.8 shell no longer includes addUser, so we
+    // have to manually create the user here, including the
+    // password hash.
+    adminDB.system.users.insert({user: 'user1',
+                                 pwd: 'e7e8a26d330dbb8bef5b1886ceb5e290'});
+
+    // Test auth with and without explicit mechanism.
+    assert(adminDB.auth({user: 'user1', pwd: 'password'}));
+    assert(adminDB.auth({mechanism: 'MONGODB-CR',
+                         user: 'user1', pwd: 'password'}));
+}
+
+var testUpgrade26 = function(){
+    // Upgrade mongod to 2.6, do authSchemaUpgrade, add another user.
+    MongoRunner.stopMongod(conn);
+    conn = MongoRunner.runMongod({restart: conn.runId, binVersion: oldVersion});
+    var adminDB = conn.getDB('admin');
+
+    // Test auth with and without explicit mechanism.
+    assert(adminDB.auth({user: 'user1', pwd: 'password'}));
+    assert(adminDB.auth({mechanism: 'MONGODB-CR',
+                         user: 'user1', pwd: 'password'}));
+
+    adminDB.runCommand('authSchemaUpgrade');
+    assert(adminDB.auth({mechanism: 'MONGODB-CR',
+                         user: 'user1', pwd: 'password'}));
+
+    adminDB.updateUser('user1', {pwd: 'pass',
+                                 roles: jsTest.adminUserRoles});
+    assert(adminDB.auth({mechanism: 'MONGODB-CR',
+                         user: 'user1', pwd: 'pass'}));
+
+    adminDB.createUser({user: 'user2', pwd: 'pass',
+                        roles: jsTest.adminUserRoles});
+    assert(adminDB.auth({mechanism: 'MONGODB-CR',
+                         user: 'user2', pwd: 'pass'}));
+}
+
+var testUpgrade28NoSchemaUpgrade = function(){
+    // Upgrade mongod to 2.8, test that MONGODB-CR and SCRAM both work,
+    // update a user, make sure both still work.
+    MongoRunner.stopMongod(conn);
+    conn = MongoRunner.runMongod({restart: conn.runId, binVersion: newVersion});
+    var adminDB = conn.getDB('admin');
+    verifyAuth(adminDB, 'user1', 'pass', true, true);
+
+    // We haven't run authSchemaUpgrade so there shouldn't be
+    // any stored SCRAM-SHA-1 credentials.
+    verifyUserDoc(adminDB, 'user1', true, false);
+    verifyUserDoc(adminDB, 'user2', true, false);
+
+    adminDB.updateUser('user1', {pwd: 'newpass',
+                                 roles: jsTest.adminUserRoles});
+    verifyAuth(adminDB, 'user1', 'newpass', true, true);
+    verifyUserDoc(adminDB, 'user1', true, false);
+}
+
+var testDowngrade26PreSchemaUpgrade = function(){
+    // Downgrade to 2.6, make sure MONGODB-CR still works.
+    MongoRunner.stopMongod(conn);
+    conn = MongoRunner.runMongod({restart: conn.runId, binVersion: oldVersion});
+    var adminDB = conn.getDB('admin');
+    assert(adminDB.auth({user: 'user1', pwd: 'newpass'}));
+    assert(adminDB.auth({mechanism: 'MONGODB-CR',
+                         user: 'user1', pwd: 'newpass'}));
+}
+
+var testUpgrade28WithSchemaUpgrade = function(){
+    // Upgrade back to 2.8, do authSchemaUpgrade, verify auth and user docs.
+    MongoRunner.stopMongod(conn);
+    conn = MongoRunner.runMongod({restart: conn.runId, binVersion: newVersion});
+    var adminDB = conn.getDB('admin');
+    verifyAuth(adminDB, 'user1', 'newpass', true, true);
+    adminDB.runCommand('authSchemaUpgrade');
+
+    // After authSchemaUpgrade MONGODB-CR no longer works.
+    verifyAuth(adminDB, 'user1', 'newpass', false, true);
+    verifyAuth(adminDB, 'user2', 'pass', false, true);
+
+    // All users should only have SCRAM credentials.
+    verifyUserDoc(adminDB, 'user1', false, true);
+    verifyUserDoc(adminDB, 'user2', false, true);
+}
+
+var testDowngrade26PostSchemaUpgrade = function(){
+    // Downgrade to 2.6 again, nothing should work.
+    MongoRunner.stopMongod(conn);
+    conn = MongoRunner.runMongod({restart: conn.runId, binVersion: oldVersion});
+    var adminDB = conn.getDB('admin');
+    verifyAuth(adminDB, 'user1', 'pass', false, false);
+    verifyAuth(adminDB, 'user2', 'pass', false, false);
+}
+
+test28Shell24Mongod();
+testUpgrade26();
+testUpgrade28NoSchemaUpgrade();
+testDowngrade26PreSchemaUpgrade();
+testUpgrade28WithSchemaUpgrade();
+testDowngrade26PostSchemaUpgrade();
+
+MongoRunner.stopMongod(conn);

--- a/jstests/multiVersion/libs/auth_helpers.js
+++ b/jstests/multiVersion/libs/auth_helpers.js
@@ -1,0 +1,25 @@
+// Helpers for auth upgrade tests.
+
+// Get a user document for username in db.
+var getUserDoc = function(db, username){
+    return db.runCommand({'usersInfo': {user: username, db: db._name},
+                          showCredentials: true}).users[0]
+}
+
+// Verify that the user document for username in db
+// has MONGODB-CR credentials (or not) and SCRAM-SHA-1
+// credentials (or not).
+var verifyUserDoc = function(db, username, hasCR, hasSCRAM){
+    var userDoc = getUserDoc(db, username);
+    assert.eq(hasCR, 'MONGODB-CR' in userDoc.credentials);
+    assert.eq(hasSCRAM, 'SCRAM-SHA-1' in userDoc.credentials);
+}
+
+// Verify that that we can authenticate (or not) using MONGODB-CR
+// and SCRAM-SHA-1 to db using username and password.
+var verifyAuth = function(db, username, password, passCR, passSCRAM){
+    assert.eq(passCR, db.auth({mechanism: 'MONGODB-CR',
+                               user: username, pwd: password}));
+    assert.eq(passSCRAM, db.auth({mechanism: 'SCRAM-SHA-1',
+                                  user: username, pwd: password}));
+}


### PR DESCRIPTION
I've combined both tickets into one pull request since they both rely on the change to smoke.py and the new file, auth_helpers.js.
