### PR TITLE
SERVER-16499 Fix sh.getBalancerLockDetails

### DIFF
--- a/src/mongo/shell/utils_sh.js
+++ b/src/mongo/shell/utils_sh.js
@@ -387,7 +387,7 @@ sh.getBalancerLockDetails = function() {
     if (lock.state == 0){
         return false;
     }
-    return lock.state;
+    return lock;
 }
 
 sh.getBalancerWindow = function() {


### PR DESCRIPTION
returning the state instead of the whole lock object. This gives "undefined" in certain sh.status() outputs
