### PR TITLE
TOOLS-492 stat1.js should explicitly specify --authenticationDatabase

### DIFF
--- a/jstests/tool/stat1.js
+++ b/jstests/tool/stat1.js
@@ -9,8 +9,8 @@ db = m.getDB( "admin" );
 db.createUser({user:  "eliot" , pwd: "eliot", roles: jsTest.adminUserRoles});
 assert( db.auth( "eliot" , "eliot" ) , "auth failed" );
 
-x = runMongoProgram( "mongostat", "--host", "127.0.0.1:"+port, "--username", "eliot", "--password", "eliot", "--rowcount", "1" );
+x = runMongoProgram( "mongostat", "--host", "127.0.0.1:"+port, "--username", "eliot", "--password", "eliot", "--rowcount", "1", "--authenticationDatabase", "admin" );
 assert.eq(x, 0, "mongostat should exit successfully with eliot:eliot");
 
-x = runMongoProgram( "mongostat", "--host", "127.0.0.1:"+port, "--username", "eliot", "--password", "wrong", "--rowcount", "1" );
+x = runMongoProgram( "mongostat", "--host", "127.0.0.1:"+port, "--username", "eliot", "--password", "wrong", "--rowcount", "1", "--authenticationDatabase", "admin" );
 assert.eq(x, _isWindows() ? -1 : 255, "mongostat should exit with -1 with eliot:wrong");


### PR DESCRIPTION
in the next RC, the new mongostat/mongotop will require --authenticationDatabase to be set when using auth. 
this updates the test so that stat1.js won't start to fail once we bump the tools RC to include this change.
