### PR TITLE
SERVER-16196 Re-enable FSM workloads for standalone mongod

### DIFF
--- a/jstests/parallel/fsm_all.js
+++ b/jstests/parallel/fsm_all.js
@@ -6,7 +6,6 @@ var blacklist = [
     'indexed_insert_multikey.js' // SERVER-16143
 ].map(function(file) { return dir + '/' + file; });
 
-// SERVER-16196 re-enable executing workloads
-// runWorkloadsSerially(ls(dir).filter(function(file) {
-//     return !Array.contains(blacklist, file);
-// }));
+runWorkloadsSerially(ls(dir).filter(function(file) {
+    return !Array.contains(blacklist, file);
+}));


### PR DESCRIPTION
SERVER-16394 fixed the JSThreadConfig leak. Based on a patch build I ran, ~7.5%
of an EC2 instance's memory is now being used during the FSM tests on linux
64-bit. Mem usage is much better than before.
