### PR TITLE
SERVER-16621 emit at mapper may run out of memory

### DIFF
--- a/src/mongo/db/commands/mr.cpp
+++ b/src/mongo/db/commands/mr.cpp
@@ -1150,6 +1150,10 @@ namespace mongo {
             return a.objsize() + 16;
         }
 
+        bool State::reduceEmitInMemoryUsageIfNeeded() {
+            return !_jsMode && (_size > _config.maxInMemSize || _dupCount > (_temp->size() * _config.reduceTriggerRatio));
+        }
+
         void State::reduceAndSpillInMemoryStateIfNeeded() {
             // Make sure no DB locks are held, because this method manages its own locking and
             // write units of work.
@@ -1398,7 +1402,7 @@ namespace mongo {
                             // acquire it again.
                             //
                             numInputs++;
-                            if (numInputs % 100 == 0) {
+                            if (numInputs % 100 == 0 || state.reduceEmitInMemoryUsageIfNeeded()) {
                                 Timer t;
 
                                 // TODO: As an optimization, we might want to do the save/restore

--- a/src/mongo/db/commands/mr.h
+++ b/src/mongo/db/commands/mr.h
@@ -260,6 +260,18 @@ namespace mongo {
             void emit( const BSONObj& a );
 
             /**
+             * Checks the emit in-memory usage in mapper. The mapper may generate lots of items 
+             * and each item is kept in-memory at this state. It would be crashed when run out 
+             * of memory.
+             *
+             * NOTE: Skip the checking when using v8 engine (_jsMode: true). The best way is 
+             * checking at emit function and transfers in memory storage to temp collection. 
+             * Current state is checking at each document handled because the framework flow 
+             * designed.
+             */
+            bool reduceEmitInMemoryUsageIfNeeded();
+
+            /**
             * Checks the size of the transient in-memory results accumulated so far and potentially
             * runs reduce in order to compact them. If the data is still too large, it will be 
             * spilled to the output collection.


### PR DESCRIPTION
The mapper may generate lots of items and each item is kept in-memory at this state. It would be crashed when run out of memory.

NOTE: Skip the checking when using v8 engine (_jsMode: true). The best way is checking at emit function and transfers in memory storage to temp collection. Current state is checking at each document handled because the framework flow designed.

--

https://github.com/changyy/mongo-mapper-emit-out-of-memory/

Job is done via jsMode=true.
Mongod crashed via jsMode = false:
https://github.com/changyy/mongo-mapper-emit-out-of-memory/blob/master/index.js#L91
```
$ tail -f /var/log/mongodb/mongod.log
...
Assertion: 10000:out of memory BufBuilder
```

The purpose of mapper: 
```
INPUT: ["1", "2", "3"]
OUTPUT: ["1-1", "1-2", "2-1", "1-3", "3-1", "2-2", "2-3", "3-2", "3-3"]
```

Execute the index.js and restart the mongod. (it crashed because out of memory).

No item_pair_jsmode_off (jsMode = false):
```
> show collections
item_pair_jsmode_on
rec
system.indexes
> db.item_pair_jsmode_on.count()
4163817
```