### PR TITLE
TOOLS-488 Tools exit 1 on error

### DIFF
--- a/jstests/tool/dumprestore3.js
+++ b/jstests/tool/dumprestore3.js
@@ -44,7 +44,7 @@ resetDbpath(data);
 runMongoProgram( "mongodump", "--host", "127.0.0.1:"+port, "--out", data );
 
 var x = runMongoProgram( "mongorestore", "--host", "127.0.0.1:"+replTest.ports[1], "--dir", data );
-assert.eq(x, _isWindows() ? -1 : 255, "mongorestore should exit w/ -1 on slave");
+assert.neq(x, 0, "mongorestore should exit w/ 1 on slave");
 
 step("try mongoimport to slave");
 
@@ -52,7 +52,7 @@ dataFile = MongoRunner.dataDir + "/dumprestore3-other2.json";
 runMongoProgram( "mongoexport", "--host", "127.0.0.1:"+port, "--out", dataFile, "--db", "foo", "--collection", "bar" );
 
 x = runMongoProgram( "mongoimport", "--host", "127.0.0.1:"+replTest.ports[1], "--file", dataFile );
-assert.eq(x, _isWindows() ? -1 : 255, "mongoreimport should exit w/ -1 on slave"); // windows return is signed
+assert.neq(x, 0, "mongoreimport should exit w/ 1 on slave");
 
 step("stopSet");
 replTest.stopSet();

--- a/jstests/tool/stat1.js
+++ b/jstests/tool/stat1.js
@@ -13,4 +13,4 @@ x = runMongoProgram( "mongostat", "--host", "127.0.0.1:"+port, "--username", "el
 assert.eq(x, 0, "mongostat should exit successfully with eliot:eliot");
 
 x = runMongoProgram( "mongostat", "--host", "127.0.0.1:"+port, "--username", "eliot", "--password", "wrong", "--rowcount", "1", "--authenticationDatabase", "admin" );
-assert.eq(x, _isWindows() ? -1 : 255, "mongostat should exit with -1 with eliot:wrong");
+assert.neq(x, 0, "mongostat should exit with -1 with eliot:wrong");


### PR DESCRIPTION
This patch specifically alters these tests that check for specific exit codes, allowing them to run successfully with the version of tools that exit -1/255 or with the version of the tools that exit 1
