### PR TITLE
SERVER-16716 Removing host string arg length limitation for mongo shell

### DIFF
--- a/src/mongo/scripting/v8-3.25_db.cpp
+++ b/src/mongo/scripting/v8-3.25_db.cpp
@@ -126,13 +126,10 @@ namespace mongo {
 
     v8::Local<v8::Value> mongoConsExternal(V8Scope* scope,
                                            const v8::FunctionCallbackInfo<v8::Value>& args) {
-        char host[255];
+        string host = "127.0.0.1";
         if (args.Length() > 0 && args[0]->IsString()) {
-            uassert(16666, "string argument too long", args[0]->ToString()->Utf8Length() < 250);
-            args[0]->ToString()->WriteUtf8(host);
-        }
-        else {
-            strcpy(host, "127.0.0.1");
+            v8::String::Utf8Value utf(args[0]);
+            host = string(*utf);
         }
 
         // only allow function template to be used by a constructor

--- a/src/mongo/scripting/v8_db.cpp
+++ b/src/mongo/scripting/v8_db.cpp
@@ -127,13 +127,10 @@ namespace mongo {
 
 
     v8::Handle<v8::Value> mongoConsExternal(V8Scope* scope, const v8::Arguments& args) {
-        char host[255];
+        string host = "127.0.0.1";
         if (args.Length() > 0 && args[0]->IsString()) {
-            uassert(16666, "string argument too long", args[0]->ToString()->Utf8Length() < 250);
-            args[0]->ToString()->WriteAscii(host);
-        }
-        else {
-            strcpy(host, "127.0.0.1");
+            v8::String::Utf8Value utf(args[0]);
+            host = string(*utf);
         }
 
         // only allow function template to be used by a constructor


### PR DESCRIPTION
This patch removes the artificial 250 char limit for the --host argumber of the mongo shell command.