### PR TITLE
shell: possible to specify cursor options in db.runCommand

### DIFF
--- a/src/mongo/shell/db.js
+++ b/src/mongo/shell/db.js
@@ -44,7 +44,7 @@ DB.prototype.commandHelp = function( name ){
     return res.help;
 }
 
-DB.prototype.runCommand = function( obj, extra ){
+DB.prototype.runCommand = function( obj, extra, options ){
     if ( typeof( obj ) == "string" ){
         var n = {};
         n[obj] = 1;
@@ -55,7 +55,7 @@ DB.prototype.runCommand = function( obj, extra ){
             }
         }
     }
-    return this.getCollection( "$cmd" ).findOne( obj );
+    return this.getCollection( "$cmd" ).findOne( obj, undefined, options );
 }
 
 DB.prototype._dbCommand = DB.prototype.runCommand;


### PR DESCRIPTION
There is no way, how to specify cursor options when executing db.runCommand.