### PR TITLE
Server 15793 Storage engine's updateRecord function should take oldRec

### DIFF
--- a/src/mongo/db/catalog/collection.cpp
+++ b/src/mongo/db/catalog/collection.cpp
@@ -350,6 +350,7 @@ namespace mongo {
         // object is removed from all indexes.
         StatusWith<RecordId> newLocation = _recordStore->updateRecord( txn,
                                                                       oldLocation,
+                                                                      RecordData(objOld.objdata(), objOld.objsize()),
                                                                       objNew.objdata(),
                                                                       objNew.objsize(),
                                                                       _enforceQuota( enforceQuota ),

--- a/src/mongo/db/storage/devnull/devnull_kv_engine.cpp
+++ b/src/mongo/db/storage/devnull/devnull_kv_engine.cpp
@@ -100,6 +100,7 @@ namespace mongo {
 
         virtual StatusWith<RecordId> updateRecord( OperationContext* txn,
                                                   const RecordId& oldLocation,
+                                                  const RecordData& oldRec,
                                                   const char* data,
                                                   int len,
                                                   bool enforceQuota,

--- a/src/mongo/db/storage/in_memory/in_memory_record_store.cpp
+++ b/src/mongo/db/storage/in_memory/in_memory_record_store.cpp
@@ -292,6 +292,7 @@ namespace mongo {
 
     StatusWith<RecordId> InMemoryRecordStore::updateRecord(OperationContext* txn,
                                                           const RecordId& loc,
+                                                          const RecordData& oldRec,
                                                           const char* data,
                                                           int len,
                                                           bool enforceQuota,

--- a/src/mongo/db/storage/in_memory/in_memory_record_store.h
+++ b/src/mongo/db/storage/in_memory/in_memory_record_store.h
@@ -74,6 +74,7 @@ namespace mongo {
 
         virtual StatusWith<RecordId> updateRecord( OperationContext* txn,
                                                   const RecordId& oldLocation,
+                                                  const RecordData& oldRec,
                                                   const char* data,
                                                   int len,
                                                   bool enforceQuota,

--- a/src/mongo/db/storage/kv/kv_catalog.cpp
+++ b/src/mongo/db/storage/kv/kv_catalog.cpp
@@ -277,6 +277,7 @@ namespace {
 
         RecordId loc;
         BSONObj obj = _findEntry( opCtx, ns, &loc );
+        BSONObj newObj;
 
         {
             // rebuilt doc
@@ -303,14 +304,15 @@ namespace {
 
             // add whatever is left
             b.appendElementsUnique( obj );
-            obj = b.obj();
+            newObj = b.obj();
         }
 
         LOG(3) << "recording new metadata: " << obj;
         StatusWith<RecordId> status = _rs->updateRecord( opCtx,
                                                         loc,
-                                                        obj.objdata(),
-                                                        obj.objsize(),
+                                                        RecordData(obj.objdata(), obj.objsize()),
+                                                        newObj.objdata(),
+                                                        newObj.objsize(),
                                                         false,
                                                         NULL );
         fassert( 28521, status.getStatus() );
@@ -348,6 +350,7 @@ namespace {
             BSONObj obj = b.obj();
             StatusWith<RecordId> status = _rs->updateRecord( opCtx,
                                                             loc,
+                                                            RecordData(old.objdata(), old.objsize()),
                                                             obj.objdata(),
                                                             obj.objsize(),
                                                             false,

--- a/src/mongo/db/storage/mmap_v1/catalog/namespace_details_rsv1_metadata.cpp
+++ b/src/mongo/db/storage/mmap_v1/catalog/namespace_details_rsv1_metadata.cpp
@@ -229,6 +229,7 @@ namespace mongo {
 
             StatusWith<RecordId> result = _namespaceRecordStore->updateRecord(txn,
                                                                               loc,
+                                                                              RecordData(oldEntry.objdata(), oldEntry.objsize()),
                                                                               newEntry.objdata(),
                                                                               newEntry.objsize(),
                                                                               false,

--- a/src/mongo/db/storage/mmap_v1/heap_record_store_btree.h
+++ b/src/mongo/db/storage/mmap_v1/heap_record_store_btree.h
@@ -74,6 +74,7 @@ namespace mongo {
 
         virtual StatusWith<RecordId> updateRecord(OperationContext* txn,
                                                  const RecordId& oldLocation,
+                                                 const RecordData& oldRec,
                                                  const char* data,
                                                  int len,
                                                  bool enforceQuota,

--- a/src/mongo/db/storage/mmap_v1/record_store_v1_base.cpp
+++ b/src/mongo/db/storage/mmap_v1/record_store_v1_base.cpp
@@ -366,6 +366,7 @@ namespace mongo {
 
     StatusWith<RecordId> RecordStoreV1Base::updateRecord( OperationContext* txn,
                                                          const RecordId& oldLocation,
+                                                         const RecordData& oldRec,
                                                          const char* data,
                                                          int dataSize,
                                                          bool enforceQuota,

--- a/src/mongo/db/storage/mmap_v1/record_store_v1_base.h
+++ b/src/mongo/db/storage/mmap_v1/record_store_v1_base.h
@@ -208,6 +208,7 @@ namespace mongo {
 
         virtual StatusWith<RecordId> updateRecord( OperationContext* txn,
                                                    const RecordId& oldLocation,
+                                                   const RecordData& oldRec,
                                                    const char* data,
                                                    int len,
                                                    bool enforceQuota,

--- a/src/mongo/db/storage/record_store.h
+++ b/src/mongo/db/storage/record_store.h
@@ -177,6 +177,7 @@ namespace mongo {
          */
         virtual StatusWith<RecordId> updateRecord( OperationContext* txn,
                                                   const RecordId& oldLocation,
+                                                  const RecordData& oldRec,
                                                   const char* data,
                                                   int len,
                                                   bool enforceQuota,

--- a/src/mongo/db/storage/record_store_test_harness.cpp
+++ b/src/mongo/db/storage/record_store_test_harness.cpp
@@ -234,13 +234,14 @@ namespace mongo {
         string s2 = "eliot was here again";
 
         RecordId loc;
+        RecordData record(s1.c_str(), s1.size() + 1);
         {
             scoped_ptr<OperationContext> opCtx( harnessHelper->newOperationContext() );
             {
                 WriteUnitOfWork uow( opCtx.get() );
                 StatusWith<RecordId> res = rs->insertRecord( opCtx.get(),
-                                                           s1.c_str(), s1.size() + 1,
-                                                           false );
+                                                             record.data(), record.size(),
+                                                             false );
                 ASSERT_OK( res.getStatus() );
                 loc = res.getValue();
                 uow.commit();
@@ -258,8 +259,9 @@ namespace mongo {
             {
                 WriteUnitOfWork uow( opCtx.get() );
                 StatusWith<RecordId> res = rs->updateRecord( opCtx.get(), loc,
-                                                           s2.c_str(), s2.size() + 1,
-                                                           false, NULL );
+                                                             record,
+                                                             s2.c_str(), s2.size() + 1,
+                                                             false, NULL );
                 ASSERT_OK( res.getStatus() );
                 loc = res.getValue();
                 uow.commit();

--- a/src/mongo/db/storage/record_store_test_updaterecord.cpp
+++ b/src/mongo/db/storage/record_store_test_updaterecord.cpp
@@ -56,13 +56,14 @@ namespace mongo {
 
         string data = "my record";
         RecordId loc;
+        const RecordData record(data.c_str(), data.size() + 1);
         {
             scoped_ptr<OperationContext> opCtx( harnessHelper->newOperationContext() );
             {
                 WriteUnitOfWork uow( opCtx.get() );
                 StatusWith<RecordId> res = rs->insertRecord( opCtx.get(),
-                                                            data.c_str(),
-                                                            data.size() + 1,
+                                                            record.data(),
+                                                            record.size(),
                                                             false );
                 ASSERT_OK( res.getStatus() );
                 loc = res.getValue();
@@ -82,6 +83,7 @@ namespace mongo {
                 WriteUnitOfWork uow( opCtx.get() );
                 StatusWith<RecordId> res = rs->updateRecord( opCtx.get(),
                                                             loc,
+                                                            record,
                                                             data.c_str(),
                                                             data.size() + 1,
                                                             false,
@@ -114,6 +116,7 @@ namespace mongo {
 
         const int nToInsert = 10;
         RecordId locs[nToInsert];
+        RecordData records[nToInsert];
         for ( int i = 0; i < nToInsert; i++ ) {
             scoped_ptr<OperationContext> opCtx( harnessHelper->newOperationContext() );
             {
@@ -128,6 +131,7 @@ namespace mongo {
                                                             false );
                 ASSERT_OK( res.getStatus() );
                 locs[i] = res.getValue();
+                records[i] = RecordData(data.c_str(), data.size() + 1);
                 uow.commit();
             }
         }
@@ -147,6 +151,7 @@ namespace mongo {
                 WriteUnitOfWork uow( opCtx.get() );
                 StatusWith<RecordId> res = rs->updateRecord( opCtx.get(),
                                                             locs[i],
+                                                            records[i],
                                                             data.c_str(),
                                                             data.size() + 1,
                                                             false,
@@ -183,13 +188,14 @@ namespace mongo {
 
         string oldData = "my record";
         RecordId loc;
+        const RecordData oldRecord(oldData.c_str(), oldData.size() + 1);
         {
             scoped_ptr<OperationContext> opCtx( harnessHelper->newOperationContext() );
             {
                 WriteUnitOfWork uow( opCtx.get() );
                 StatusWith<RecordId> res = rs->insertRecord( opCtx.get(),
-                                                            oldData.c_str(),
-                                                            oldData.size() + 1,
+                                                            oldRecord.data(),
+                                                            oldRecord.size(),
                                                             false );
                 ASSERT_OK( res.getStatus() );
                 loc = res.getValue();
@@ -211,6 +217,7 @@ namespace mongo {
                 WriteUnitOfWork uow( opCtx.get() );
                 StatusWith<RecordId> res = rs->updateRecord( opCtx.get(),
                                                             loc,
+                                                            oldRecord,
                                                             newData.c_str(),
                                                             newData.size() + 1,
                                                             false,

--- a/src/mongo/db/storage/rocks/rocks_record_store.cpp
+++ b/src/mongo/db/storage/rocks/rocks_record_store.cpp
@@ -395,6 +395,7 @@ namespace mongo {
 
     StatusWith<RecordId> RocksRecordStore::updateRecord( OperationContext* txn,
                                                         const RecordId& loc,
+                                                        const RecordData& oldRec,
                                                         const char* data,
                                                         int len,
                                                         bool enforceQuota,

--- a/src/mongo/db/storage/rocks/rocks_record_store.cpp
+++ b/src/mongo/db/storage/rocks/rocks_record_store.cpp
@@ -405,14 +405,7 @@ namespace mongo {
             throw WriteConflictException();
         }
 
-        std::string old_value;
-        auto status = ru->Get(_columnFamily.get(), _makeKey(loc), &old_value);
-
-        if ( !status.ok() ) {
-            return StatusWith<RecordId>( ErrorCodes::InternalError, status.ToString() );
-        }
-
-        int old_length = old_value.size();
+        const int old_length = oldRec.size();
 
         ru->writeBatch()->Put(_columnFamily.get(), _makeKey(loc), rocksdb::Slice(data, len));
 

--- a/src/mongo/db/storage/rocks/rocks_record_store.h
+++ b/src/mongo/db/storage/rocks/rocks_record_store.h
@@ -121,6 +121,7 @@ namespace mongo {
 
         virtual StatusWith<RecordId> updateRecord( OperationContext* txn,
                                                   const RecordId& oldLocation,
+                                                  const RecordData& oldRec,
                                                   const char* data,
                                                   int len,
                                                   bool enforceQuota,

--- a/src/mongo/db/storage/rocks/rocks_record_store_test.cpp
+++ b/src/mongo/db/storage/rocks/rocks_record_store_test.cpp
@@ -134,12 +134,12 @@ namespace mongo {
             rs->dataFor( t1.get(), loc1 );
             rs->dataFor( t2.get(), loc1 );
 
-            ASSERT_OK( rs->updateRecord( t1.get(), loc1, "b", 2, false, NULL ).getStatus() );
-            ASSERT_OK( rs->updateRecord( t1.get(), loc2, "B", 2, false, NULL ).getStatus() );
+            ASSERT_OK( rs->updateRecord( t1.get(), loc1, RecordData("a", 2), "b", 2, false, NULL ).getStatus() );
+            ASSERT_OK( rs->updateRecord( t1.get(), loc2, RecordData("a", 2), "B", 2, false, NULL ).getStatus() );
 
             try {
                 // this should fail
-                rs->updateRecord( t2.get(), loc1, "c", 2, false, NULL );
+                rs->updateRecord( t2.get(), loc1, RecordData("a", 2), "c", 2, false, NULL );
                 ASSERT( 0 );
             }
             catch ( WriteConflictException& dle ) {
@@ -185,7 +185,7 @@ namespace mongo {
 
             {
                 WriteUnitOfWork w( t1.get() );
-                ASSERT_OK( rs->updateRecord( t1.get(), loc1, "b", 2, false, NULL ).getStatus() );
+                ASSERT_OK( rs->updateRecord( t1.get(), loc1, RecordData("a", 2), "b", 2, false, NULL ).getStatus() );
                 w.commit();
             }
 
@@ -194,7 +194,7 @@ namespace mongo {
                 ASSERT_EQUALS( string("a"), rs->dataFor( t2.get(), loc1 ).data() );
                 try {
                     // this should fail as our version of loc1 is too old
-                    rs->updateRecord( t2.get(), loc1, "c", 2, false, NULL );
+                    rs->updateRecord( t2.get(), loc1, RecordData("a", 2), "c", 2, false, NULL );
                     ASSERT( 0 );
                 }
                 catch ( WriteConflictException& dle ) {

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_record_store.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_record_store.cpp
@@ -546,6 +546,7 @@ namespace {
 
     StatusWith<RecordId> WiredTigerRecordStore::updateRecord( OperationContext* txn,
                                                               const RecordId& loc,
+                                                              const RecordData& oldRec,
                                                               const char* data,
                                                               int len,
                                                               bool enforceQuota,

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_record_store.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_record_store.cpp
@@ -559,11 +559,7 @@ namespace {
         int ret = c->search(c);
         invariantWTOK(ret);
 
-        WT_ITEM old_value;
-        ret = c->get_value(c, &old_value);
-        invariantWTOK(ret);
-
-        int old_length = old_value.size;
+        const int old_length = oldRec.size();
 
         c->set_key(c, _makeKey(loc));
         WiredTigerItem value(data, len);

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_record_store.h
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_record_store.h
@@ -119,6 +119,7 @@ namespace mongo {
 
         virtual StatusWith<RecordId> updateRecord( OperationContext* txn,
                                                   const RecordId& oldLocation,
+                                                  const RecordData& oldRec,
                                                   const char* data,
                                                   int len,
                                                   bool enforceQuota,

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_record_store_test.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_record_store_test.cpp
@@ -198,12 +198,12 @@ namespace mongo {
             rs->dataFor( t1.get(), loc1 );
             rs->dataFor( t2.get(), loc1 );
 
-            ASSERT_OK( rs->updateRecord( t1.get(), loc1, "b", 2, false, NULL ).getStatus() );
-            ASSERT_OK( rs->updateRecord( t1.get(), loc2, "B", 2, false, NULL ).getStatus() );
+            ASSERT_OK( rs->updateRecord( t1.get(), loc1, RecordData("a", 2), "b", 2, false, NULL ).getStatus() );
+            ASSERT_OK( rs->updateRecord( t1.get(), loc2, RecordData("a", 2), "B", 2, false, NULL ).getStatus() );
 
             try {
                 // this should fail
-                rs->updateRecord( t2.get(), loc1, "c", 2, false, NULL );
+                rs->updateRecord( t2.get(), loc1, RecordData("a", 2), "c", 2, false, NULL );
                 ASSERT( 0 );
             }
             catch ( WriteConflictException& dle ) {
@@ -249,7 +249,7 @@ namespace mongo {
 
             {
                 WriteUnitOfWork w( t1.get() );
-                ASSERT_OK( rs->updateRecord( t1.get(), loc1, "b", 2, false, NULL ).getStatus() );
+                ASSERT_OK( rs->updateRecord( t1.get(), loc1, RecordData("a", 2), "b", 2, false, NULL ).getStatus() );
                 w.commit();
             }
 
@@ -258,7 +258,7 @@ namespace mongo {
                 ASSERT_EQUALS( string("a"), rs->dataFor( t2.get(), loc1 ).data() );
                 try {
                     // this should fail as our version of loc1 is too old
-                    rs->updateRecord( t2.get(), loc1, "c", 2, false, NULL );
+                    rs->updateRecord( t2.get(), loc1, RecordData("a", 2), "c", 2, false, NULL );
                     ASSERT( 0 );
                 }
                 catch ( WriteConflictException& dle ) {


### PR DESCRIPTION
This is a new pull request for https://jira.mongodb.org/browse/SERVER-15793. The original one - #837, was recently closed due to merge conflicts. This one is based on a newer commit by @esmet : https://github.com/Tokutek/tokumxse/commit/6ce943fc1bb7994d68524d4fb8956a7cd46290ad, and an top of it adds changes to RocksDB and WiredTiger storage engines to take advantage of the passed-in old record.
Many thanks to John Esmet who authored the bulk of the changes in this pull request!