### PR TITLE
add shardkey in oplog if necessary

### DIFF
--- a/src/mongo/db/catalog/collection.h
+++ b/src/mongo/db/catalog/collection.h
@@ -157,7 +157,8 @@ namespace mongo {
                              const RecordId& loc,
                              bool cappedOK = false,
                              bool noWarn = false,
-                             BSONObj* deletedId = 0 );
+                             BSONObj* deletedId = 0,
+                             const char* ns = "_" );
 
         /**
          * this does NOT modify the doc before inserting

--- a/src/mongo/db/exec/update.cpp
+++ b/src/mongo/db/exec/update.cpp
@@ -42,6 +42,7 @@
 #include "mongo/db/repl/replication_coordinator_global.h"
 #include "mongo/db/repl/oplog.h"
 #include "mongo/util/log.h"
+#include "mongo/s/d_state.h"
 
 namespace mongo {
 
@@ -590,7 +591,28 @@ namespace mongo {
 
             // Call logOp if requested, and we're not an explain.
             if (request->shouldCallLogOp() && !logObj.isEmpty() && !request->isExplain()) {
-                BSONObj idQuery = driver->makeOplogEntryQuery(newObj, request->isMulti());
+                //BSONObj idQuery = driver->makeOplogEntryQuery(newObj, request->isMulti());
+                BSONObjBuilder patt;
+                
+                if(shardingState.enabled()) {
+                    const char* ns = request->getNamespaceString().ns().c_str();
+                    if(shardingState.hasVersion(ns)) {
+                        CollectionMetadataPtr cm = shardingState.getCollectionMetadata(ns);
+                        BSONObj shardKeyObj = cm->getKeyPattern();
+                        for( BSONObj::iterator i = shardKeyObj.begin(); i.more(); ) {
+                            BSONElement shardKeyElement = i.next();
+                            BSONElement shardField = newObj.getField(shardKeyElement.fieldName());
+                            if ( shardField.eoo() == false ) {
+                                patt.append(shardField);
+                            }
+                        }
+                    }
+                }
+                BSONElement id;
+                if(newObj.getObjectID( id )) {
+                    patt.append(id);
+                }
+                BSONObj idQuery = patt.obj();
                 repl::logOp(_txn,
                             "u",
                             request->getNamespaceString().ns().c_str(),


### PR DESCRIPTION
if ns is sharded,when execing logOp,all shardkey to oplog.
maybe it will make repl sync faster if the data sync can do multi thread by shardkey but not ns now.
and when doing migrate between cluster,add shardkey to oplog will make this more more faster.
no shardkey,all op in one ns must be applied one by one,but with shardkey,ops with different shardkey can be applied at the same time.
