### PR TITLE
SERVER-11840 reduce lock contention in groupcommitwithlimitedlocks

### DIFF
--- a/src/mongo/db/dur_commitjob.h
+++ b/src/mongo/db/dur_commitjob.h
@@ -167,9 +167,12 @@ namespace mongo {
         public:
             /** these called by the groupCommit code as it goes along */
             void commitingBegin();
-            /** the commit code calls this when data reaches the journal (on disk) */
+            /** the commit code calls this when data reaches the journal (on disk).
+             *  because all commit functions hold the durBuilder mutex during the full length of their
+             *  execution, it is guaranteed that the commit number doesn't change between the moment
+             *  that it is set by commitingBegin() and the subsequent call to this method.
+             */
             void committingNotifyCommitted() { 
-                groupCommitMutex.dassertLocked();
                 _notify.notifyAll(_commitNumber); 
             }
             /** we use the commitjob object over and over, calling reset() rather than reconstructing */


### PR DESCRIPTION
Before this fix, groupCommitMutex was held during the calls to WRITETOJOURNAL and WRITETODATAFILES. That prevented writes to occur during these costly operations. With this fix, the mutex is released before these operations.

The groupCommitMutex lock was required to ensure that the commitNumber didn't change between the call to commitJob.commitingBegin() and the call to commitJob.committingNotifyCommitted(). With the addition of the durBuilder mutex, this condition is still respected.

The groupCommitMutex lock also ensured that there was only one thread using __theBuilder at the time. This condition is also still respected because of the new durBuilder mutex.

See more details about the impact of this fix in the bug report https://jira.mongodb.org/browse/SERVER-11840