### PR TITLE
SERVER-17596 mongo::OID::asTimeT() and mongo::OID::asDateT() should be const

### DIFF
--- a/src/mongo/bson/oid.cpp
+++ b/src/mongo/bson/oid.cpp
@@ -157,7 +157,7 @@ namespace {
                     kInstanceUniqueSize + kIncrementSize);
     }
 
-    time_t OID::asTimeT() {
+    time_t OID::asTimeT() const {
         return getTimestamp();
     }
 

--- a/src/mongo/bson/oid.h
+++ b/src/mongo/bson/oid.h
@@ -139,8 +139,8 @@ namespace mongo {
         /** Set to the min/max OID that could be generated at given timestamp. */
         void init( Date_t date, bool max=false );
 
-        time_t asTimeT();
-        Date_t asDateT() { return asTimeT() * 1000LL; }
+        time_t asTimeT() const;
+        Date_t asDateT() const { return asTimeT() * 1000LL; }
 
         // True iff the OID is not empty
         bool isSet() const {


### PR DESCRIPTION
As `mongo::OID::asDateT()` calls `mongo::OID::asTimeT()`, which calls `OID::getTimestamp()`, which is a const member function, `mongo::OID::asDateT()` and `mongo::OID::asTimeT()` should also be marked const.