### PR TITLE
SERVER-17158 add delimiter to planCacheKey for sort args

### DIFF
--- a/src/mongo/db/query/canonical_query.cpp
+++ b/src/mongo/db/query/canonical_query.cpp
@@ -275,6 +275,11 @@ namespace {
                 *os << "d";
             }
             encodeUserString(elt.fieldName(), os);
+
+            // Sort argument separator
+            if (it.more()) {
+                *os << ",";
+            }
         }
     }
 


### PR DESCRIPTION
The planCacheKey has no delimiter on sort arguments. This can lead to 2
different sets of sort arguments having the same key. This patch adds the
delimiter to address.
Before:
  db.coll.find({a: 1}).sort({a: 1, b: 1}) => eqa~aaab
  db.coll.find({a: 1}).sort({aab: 1}) =>     eqa~aaab
After:
  db.coll.find({a: 1}).sort({a: 1, b: 1}) => eqa~aa,ab
  db.coll.find({a: 1}).sort({aab: 1}) =>     eqa~aaab