### PR TITLE
SERVER-17808 Ensure availability in initial_sync_unsupported_auth_schema.js

### DIFF
--- a/jstests/replsets/initial_sync_unsupported_auth_schema.js
+++ b/jstests/replsets/initial_sync_unsupported_auth_schema.js
@@ -4,7 +4,9 @@
 function testInitialSyncAbortsWithUnsupportedAuthSchema(schema) {
     'use strict';
 
-    var rst = new ReplSetTest({nodes: 1});
+    // Create a replica set with one data-bearing node and one arbiter to
+    // ensure availability when the added node fasserts later in the test
+    var rst = new ReplSetTest({nodes: {n0: {}, arbiter: {}}});
     rst.startSet();
     rst.initiate();
 
@@ -39,7 +41,9 @@ function testInitialSyncAbortsWithUnsupportedAuthSchema(schema) {
 function testInitialSyncAbortsWithExistingUserAndNoAuthSchema() {
     'use strict';
 
-    var rst = new ReplSetTest({nodes: 1});
+    // Create a replica set with one data-bearing node and one arbiter to
+    // ensure availability when the added node fasserts later in the test
+    var rst = new ReplSetTest({nodes: {n0: {}, arbiter: {}}});
     rst.startSet();
     rst.initiate();
 


### PR DESCRIPTION
Previously, the test could fail if the primary transitioned to a secondary before reInitiate finished executing.