### PR TITLE
SERVER-17913 Log voters at the default loglevel

### DIFF
--- a/src/mongo/db/repl/elect_cmd_runner.cpp
+++ b/src/mongo/db/repl/elect_cmd_runner.cpp
@@ -114,7 +114,8 @@ namespace repl {
 
         if (response.isOK()) {
             BSONObj res = response.getValue().data;
-            LOG(1) << "elect res: " << res.toString();
+            log() << "received " << res["vote"] << " votes from " << request.target;
+            LOG(1) << "full elect res: " << res.toString();
             BSONElement vote(res["vote"]); 
             if (vote.type() != mongo::NumberInt) {
                 error() << "wrong type for vote argument in replSetElect command: " << 


### PR DESCRIPTION
Here is an example log:

2015-04-15T19:20:36.452+0000 I REPL     [ReplicationExecutor] Member ip-10-136-108-244:27017 is now in state SECONDARY
2015-04-15T19:20:36.452+0000 I REPL     [ReplicationExecutor] Standing for election
2015-04-15T19:20:36.453+0000 I REPL     [ReplicationExecutor] possible election tie; sleeping 300ms until 2015-04-15T19:20:36.753+0000
2015-04-15T19:20:36.753+0000 I REPL     [ReplicationExecutor] Standing for election
2015-04-15T19:20:36.753+0000 I REPL     [ReplicationExecutor] running for election
2015-04-15T19:20:36.753+0000 I REPL     [ReplicationExecutor] received vote: 1 votes from ip-10-136-108-244:27017
2015-04-15T19:20:36.753+0000 I REPL     [ReplicationExecutor] election succeeded, assuming primary role
2015-04-15T19:20:36.753+0000 I REPL     [ReplicationExecutor] transition to PRIMARY