### PR TITLE
add ns to error log of a bad ttl index, would eliminate the need to writ...

### DIFF
--- a/src/mongo/db/ttl.cpp
+++ b/src/mongo/db/ttl.cpp
@@ -214,7 +214,7 @@ namespace mongo {
             BSONObj key = idx["key"].Obj();
             const string ns = idx["ns"].String();
             if ( key.nFields() != 1 ) {
-                error() << "key for ttl index can only have 1 field" << endl;
+                error() << "key for ttl index with ns " << ns << " can only have 1 field" << endl;
                 return true;
             }
             if ( !idx[secondsExpireField].isNumber() ) {


### PR DESCRIPTION
Had a case today where someone in our organization had created some bad ttl indexes. Since the ns was already available it the code, it would have been nice to just know where the problem was from the error message.