### PR TITLE
SERVER-17651: Moved generateCacheKey() to run inside getPlanCacheKey, removed the function inside init()

### DIFF
--- a/src/mongo/db/query/canonical_query.cpp
+++ b/src/mongo/db/query/canonical_query.cpp
@@ -548,8 +548,6 @@ namespace mongo {
             return validStatus;
         }
 
-        this->generateCacheKey();
-
         // Validate the projection if there is one.
         if (!_pq->getProj().isEmpty()) {
             ParsedProjection* pp;
@@ -604,6 +602,9 @@ namespace mongo {
     }
 
     const PlanCacheKey& CanonicalQuery::getPlanCacheKey() const {
+        if (_cacheKey.empty()) {
+            const_cast<CanonicalQuery*>(this)->generateCacheKey();
+        }
         return _cacheKey;
     }
 


### PR DESCRIPTION
uses str::string's empty() for the initial check