### PR TITLE
[SERVER-18135] Backport SERVER-15182 to 2.6 and fix mutexdebugger too

### DIFF
--- a/src/mongo/client/dbclientcursor.cpp
+++ b/src/mongo/client/dbclientcursor.cpp
@@ -325,9 +325,6 @@ namespace mongo {
     }
 
     DBClientCursor::~DBClientCursor() {
-        if (!this)
-            return;
-
         DESTRUCTOR_GUARD (
 
         if ( cursorId && _ownCursor && ! inShutdown() ) {

--- a/src/mongo/client/dbclientcursor.h
+++ b/src/mongo/client/dbclientcursor.h
@@ -117,7 +117,7 @@ namespace mongo {
            'dead' may be preset yet some data still queued and locally
            available from the dbclientcursor.
         */
-        bool isDead() const { return  !this || cursorId == 0; }
+        bool isDead() const { return cursorId == 0; }
 
         bool tailable() const { return (opts & QueryOption_CursorTailable) != 0; }
 

--- a/src/mongo/util/concurrency/mutexdebugger.h
+++ b/src/mongo/util/concurrency/mutexdebugger.h
@@ -87,7 +87,7 @@ namespace mongo {
         }
 
         void entering(mid m) {
-            if( this == 0 || m == 0 ) return;
+            if( m == 0 ) return;
             verify( magic == 0x12345678 );
 
             Preceeding *_preceeding = us.get();
@@ -147,7 +147,7 @@ namespace mongo {
             }
         }
         void leaving(mid m) {
-            if( this == 0 || m == 0 ) return; // still in startup pre-main()
+            if( m == 0 ) return; // still in startup pre-main()
             Preceeding& preceeding = *us.get();
             preceeding[m]--;
             if( preceeding[m] < 0 ) {


### PR DESCRIPTION
Clang 3.5+ has issues with the checks on `this`, throwing a
`'this' pointer cannot be null in well-defined C++ code` error.

I didn't write a test because it's just a backport of fixes that have
been in master/2.7 since September 2014. 