### PR TITLE
SERVER-18162 Make init.d script for suse work when /var/run/mongodb doesn't exist.

### DIFF
--- a/rpm/init.d-mongod.suse
+++ b/rpm/init.d-mongod.suse
@@ -36,6 +36,8 @@ if [ -f "$SYSCONFIG" ]; then
     . "$SYSCONFIG"
 fi
 
+PIDDIR=`dirname $PIDFILEPATH`
+
 # Handle NUMA access to CPUs (SERVER-3574)
 # This verifies the existence of numactl as well as testing that the command works
 NUMACTL_ARGS="--interleave=all"


### PR DESCRIPTION
When using tmpfs for `/var/run` or cleaning up that directory, mongod fails to start because of a missing `PIDDIR` variable in the init.d script. This pull request adds that variable to `rpm/init.d-mongod.suse
` the same way it's defined on `rpm/init.d-mongod`.