### PR TITLE
SERVER-11980 Only invalidate the user cache on mongos if authorization i...

### DIFF
--- a/src/mongo/db/auth/authorization_manager.cpp
+++ b/src/mongo/db/auth/authorization_manager.cpp
@@ -238,18 +238,18 @@ namespace mongo {
             _authzManager->_isFetchPhaseBusy = true;
         }
 
-        uint64_t _startGeneration;
+        OID _startGeneration;
         bool _isThisGuardInFetchPhase;
         AuthorizationManager* _authzManager;
         boost::unique_lock<boost::mutex> _lock;
     };
 
     AuthorizationManager::AuthorizationManager(AuthzManagerExternalState* externalState) :
-        _authEnabled(false),
-        _externalState(externalState),
-        _version(schemaVersionInvalid),
-        _cacheGeneration(0),
-        _isFetchPhaseBusy(false) {
+            _authEnabled(false),
+            _externalState(externalState),
+            _version(schemaVersionInvalid),
+            _isFetchPhaseBusy(false) {
+        _updateCacheGeneration_inlock();
     }
 
     AuthorizationManager::~AuthorizationManager() {
@@ -290,6 +290,11 @@ namespace mongo {
 
     bool AuthorizationManager::getSupportOldStylePrivilegeDocuments() {
         return _doesSupportOldStylePrivileges;
+    }
+
+    OID AuthorizationManager::getCacheGeneration() {
+        CacheGuard guard(this, CacheGuard::fetchSynchronizationManual);
+        return _cacheGeneration;
     }
 
     void AuthorizationManager::setAuthEnabled(bool enabled) {
@@ -844,7 +849,7 @@ namespace mongo {
 
     void AuthorizationManager::invalidateUserByName(const UserName& userName) {
         CacheGuard guard(this, CacheGuard::fetchSynchronizationManual);
-        ++_cacheGeneration;
+        _updateCacheGeneration_inlock();
         unordered_map<UserName, User*>::iterator it = _userCache.find(userName);
         if (it == _userCache.end()) {
             return;
@@ -857,7 +862,7 @@ namespace mongo {
 
     void AuthorizationManager::invalidateUsersFromDB(const std::string& dbname) {
         CacheGuard guard(this, CacheGuard::fetchSynchronizationManual);
-        ++_cacheGeneration;
+        _updateCacheGeneration_inlock();
         unordered_map<UserName, User*>::iterator it = _userCache.begin();
         while (it != _userCache.end()) {
             User* user = it->second;
@@ -876,7 +881,7 @@ namespace mongo {
     }
 
     void AuthorizationManager::_invalidateUserCache_inlock() {
-        ++_cacheGeneration;
+        _updateCacheGeneration_inlock();
         for (unordered_map<UserName, User*>::iterator it = _userCache.begin();
                 it != _userCache.end(); ++it) {
             fassert(17266, it->second != internalSecurity.user);
@@ -1407,7 +1412,12 @@ namespace {
             return true;
         }
     }
+
 }  // namespace
+
+    void AuthorizationManager::_updateCacheGeneration_inlock() {
+        _cacheGeneration = OID::gen();
+    }
 
     void AuthorizationManager::logOp(
             const char* op,

--- a/src/mongo/db/auth/authorization_manager.h
+++ b/src/mongo/db/auth/authorization_manager.h
@@ -38,6 +38,7 @@
 #include "mongo/base/disallow_copying.h"
 #include "mongo/base/status.h"
 #include "mongo/bson/mutable/element.h"
+#include "mongo/bson/oid.h"
 #include "mongo/db/auth/action_set.h"
 #include "mongo/db/auth/resource_pattern.h"
 #include "mongo/db/auth/role_graph.h"
@@ -175,6 +176,11 @@ namespace mongo {
          * schemaVersionInvalid (0).
          */
         Status getAuthorizationVersion(int* version);
+
+        /**
+         * Returns the user cache generation identifier.
+         */
+        OID getCacheGeneration();
 
         // Returns true if there exists at least one privilege document in the system.
         bool hasAnyPrivilegeDocuments() const;
@@ -445,6 +451,11 @@ namespace mongo {
         void _invalidateUserCache_inlock();
 
         /**
+         * Updates _cacheGeneration to a new OID
+         */
+        void _updateCacheGeneration_inlock();
+
+        /**
          * Fetches user information from a v2-schema user document for the named user,
          * and stores a pointer to a new user object into *acquiredUser on success.
          */
@@ -488,10 +499,10 @@ namespace mongo {
         unordered_map<UserName, User*> _userCache;
 
         /**
-         * Current generation of cached data.  Bumped every time part of the cache gets
-         * invalidated.
+         * Current generation of cached data.  Updated every time part of the cache gets
+         * invalidated.  Protected by CacheGuard.
          */
-        uint64_t _cacheGeneration;
+        OID _cacheGeneration;
 
         /**
          * True if there is an update to the _userCache in progress, and that update is currently in

--- a/src/mongo/db/auth/user_cache_invalidator_job.cpp
+++ b/src/mongo/db/auth/user_cache_invalidator_job.cpp
@@ -19,16 +19,21 @@
 
 #include <string>
 
+#include "mongo/base/status.h"
+#include "mongo/base/status_with.h"
 #include "mongo/db/auth/authorization_manager.h"
 #include "mongo/db/client.h"
+#include "mongo/db/commands.h"
 #include "mongo/db/server_parameters.h"
+#include "mongo/s/config.h"
 #include "mongo/util/background.h"
 #include "mongo/util/log.h"
 
 namespace mongo {
 namespace {
 
-    int userCacheInvalidationIntervalSecs = 60 * 10; // 10 minute default
+    // How often to check with the config servers whether authorization information has changed.
+    int userCacheInvalidationIntervalSecs = 30; // 30 second default
 
     class ExportedInvalidationIntervalParameter : public ExportedServerParameter<int> {
     public:
@@ -41,26 +46,75 @@ namespace {
 
         virtual Status validate( const int& potentialNewValue )
         {
-            if (potentialNewValue < 30 || potentialNewValue > 86400) {
+            if (potentialNewValue < 1 || potentialNewValue > 86400) {
                 return Status(ErrorCodes::BadValue,
-                              "userCacheInvalidationIntervalSecs must be between 30 " 
+                              "userCacheInvalidationIntervalSecs must be between 1 "
                               "and 86400 (24 hours)");
             }
             return Status::OK();
         }
     } exportedIntervalParam;
 
+    StatusWith<OID> getCurrentCacheGeneration() {
+        try {
+            ConnectionString config = configServer.getConnectionString();
+            ScopedDbConnection conn(config.toString(), 30);
+
+            BSONObj result;
+            conn->runCommand("admin", BSON("_getUserCacheGeneration" << 1), result);
+            conn.done();
+
+            Status status = Command::getStatusFromCommandResult(result);
+            if (!status.isOK()) {
+                return StatusWith<OID>(status);
+            }
+
+            return StatusWith<OID>(result["cacheGeneration"].OID());
+        } catch (const DBException& e) {
+            return StatusWith<OID>(e.toStatus());
+        } catch (const std::exception& e) {
+            return StatusWith<OID>(ErrorCodes::UnknownError, e.what());
+        }
+    }
+
 } // namespace
+
+    UserCacheInvalidator::UserCacheInvalidator(AuthorizationManager* authzManager) :
+            _authzManager(authzManager) {
+        _previousCacheGeneration = _authzManager->getCacheGeneration();
+    }
 
     void UserCacheInvalidator::run() {
         Client::initThread("UserCacheInvalidatorThread");
+
         while (true) {
             sleepsecs(userCacheInvalidationIntervalSecs);
             if (inShutdown()) {
                 break;
             }
-            LOG(1) << "Invalidating user cache" << endl;
-            _authzManager->invalidateUserCache();
+
+            StatusWith<OID> currentGeneration = getCurrentCacheGeneration();
+            if (!currentGeneration.isOK()) {
+                if (currentGeneration.getStatus().code() == ErrorCodes::CommandNotFound) {
+                    warning() << "_getUserCacheGeneration command not found on config server(s), "
+                            "this most likely means you are running an outdated version of mongod "
+                            "on the config servers" << std::endl;
+                } else {
+                    warning() << "An error occurred while fetching current user cache generation "
+                            "to check if user cache needs invalidation: " <<
+                            currentGeneration.getStatus() << std::endl;
+                }
+                // When in doubt, invalidate the cache
+                _authzManager->invalidateUserCache();
+            }
+
+            if (currentGeneration.getValue() != _previousCacheGeneration) {
+                log() << "User cache generation changed from " << _previousCacheGeneration <<
+                        " to " << currentGeneration.getValue() << "; invalidating user cache" <<
+                        std::endl;
+                _authzManager->invalidateUserCache();
+                _previousCacheGeneration = currentGeneration.getValue();
+            }
         }
     }
 

--- a/src/mongo/db/auth/user_cache_invalidator_job.h
+++ b/src/mongo/db/auth/user_cache_invalidator_job.h
@@ -13,6 +13,7 @@
  *    limitations under the License.
  */
 
+#include "mongo/bson/oid.h"
 #include "mongo/util/background.h"
 
 #include <string>
@@ -21,11 +22,15 @@ namespace mongo {
 
     class AuthorizationManager;
 
-    // Background job that periodically causes the AuthorizationManager to throw out its in-memory
-    // cache of User objects (which contains the users' credentials, roles, privileges, etc).
+    /**
+     * Background job that runs only in mongos and periodically checks in with the config servers
+     * to determine whether any authorization information has changed, and if so causes the
+     * AuthorizationManager to throw out its in-memory cache of User objects (which contains the
+     * users' credentials, roles, privileges, etc).
+     */
     class UserCacheInvalidator : public BackgroundJob {
     public:
-        UserCacheInvalidator(AuthorizationManager* authzManager) : _authzManager(authzManager) {}
+        explicit UserCacheInvalidator(AuthorizationManager* authzManager);
 
     protected:
         virtual std::string name() const;
@@ -33,6 +38,7 @@ namespace mongo {
 
     private:
         AuthorizationManager* _authzManager;
+        OID _previousCacheGeneration;
     };
 
 } // namespace mongo


### PR DESCRIPTION
...nformation actually changed

(cherry picked from commit a51c7bcac0b93ea0a0da73974bac6c469075864d)

add missing functions

remove _invalidateRelevantCacheData and extractUserNameFromIdString

---
This is now a single commit with me as the author. Is that ok @stbrody ?