### PR TITLE
SERVER-18007 support non-default constructible types in StatusWith

### DIFF
--- a/src/mongo/base/status-inl.h
+++ b/src/mongo/base/status-inl.h
@@ -30,12 +30,16 @@
 namespace mongo {
 
     inline Status Status::OK() {
-        return Status();
+        return Status(nullptr);
     }
 
     inline Status::Status(const Status& other)
         : _error(other._error) {
         ref(_error);
+    }
+
+    inline Status::Status(ErrorInfo* ei) :
+        _error(ei) {
     }
 
     inline Status& Status::operator=(const Status& other) {
@@ -47,13 +51,13 @@ namespace mongo {
 
     inline Status::Status(Status&& other) BOOST_NOEXCEPT
         : _error(other._error) {
-        other._error = nullptr;
+        other._error = &Status::kUninitialized;
     }
 
     inline Status& Status::operator=(Status&& other) BOOST_NOEXCEPT {
         unref(_error);
         _error = other._error;
-        other._error = nullptr;
+        other._error = &Status::kUninitialized;
         return *this;
     }
 
@@ -86,7 +90,7 @@ namespace mongo {
     }
 
     inline Status::Status()
-        : _error(NULL) {
+        : _error(&kUninitialized) {
     }
 
     inline void Status::ref(ErrorInfo* error) {

--- a/src/mongo/base/status.cpp
+++ b/src/mongo/base/status.cpp
@@ -43,6 +43,10 @@ namespace mongo {
         return needRep ? new ErrorInfo(c, std::move(r), l) : NULL;
     }
 
+    Status::ErrorInfo Status::kUninitialized(ErrorCodes::NotYetInitialized,
+                                             "Not initialized!",
+                                             0);
+
     Status::Status(ErrorCodes::Error code, std::string reason, int location)
         : _error(ErrorInfo::create(code, std::move(reason), location)) {
         ref(_error);

--- a/src/mongo/base/status.h
+++ b/src/mongo/base/status.h
@@ -118,6 +118,10 @@ namespace mongo {
         inline AtomicUInt32::WordType refCount() const;
 
     private:
+
+        /**
+         * Returns an uninitialized non-OK status.
+         */
         inline Status();
 
         struct ErrorInfo {
@@ -131,7 +135,15 @@ namespace mongo {
             ErrorInfo(ErrorCodes::Error code, std::string reason, int location);
         };
 
+        explicit inline Status(ErrorInfo* ei);
+
         ErrorInfo* _error;
+
+        /**
+         * A special ErrorInfo representing an uninitialized or moved-from Status.
+         * This is intentionally non-OK().
+         */
+        static ErrorInfo kUninitialized;
 
         /**
          * Increment/Decrement the reference counter inside an ErrorInfo
@@ -140,6 +152,9 @@ namespace mongo {
          */
         static inline void ref(ErrorInfo* error);
         static inline void unref(ErrorInfo* error);
+
+        // StatusWith needs access to the default constructor of Status.
+        template<typename T> friend class StatusWith;
     };
 
     inline bool operator==(const ErrorCodes::Error lhs, const Status& rhs);

--- a/src/mongo/base/status_test.cpp
+++ b/src/mongo/base/status_test.cpp
@@ -74,15 +74,14 @@ namespace {
         ASSERT_EQUALS(orig.refCount(), 2U);
     }
 
-    TEST(Cloning, MoveCopyOK) {
+    TEST(Cloning, MoveCopyNotOK) {
         Status orig = Status::OK();
         ASSERT_TRUE(orig.isOK());
         ASSERT_EQUALS(orig.refCount(), 0U);
 
         Status dest(std::move(orig));
 
-        ASSERT_TRUE(orig.isOK());
-        ASSERT_EQUALS(orig.refCount(), 0U);
+        ASSERT_FALSE(orig.isOK());
 
         ASSERT_TRUE(dest.isOK());
         ASSERT_EQUALS(dest.refCount(), 0U);
@@ -95,8 +94,7 @@ namespace {
 
         Status dest(std::move(orig));
 
-        ASSERT_TRUE(orig.isOK());
-        ASSERT_EQUALS(orig.refCount(), 0U);
+        ASSERT_FALSE(orig.isOK());
 
         ASSERT_FALSE(dest.isOK());
         ASSERT_EQUALS(dest.refCount(), 1U);
@@ -115,8 +113,7 @@ namespace {
 
         dest = std::move(orig);
 
-        ASSERT_TRUE(orig.isOK());
-        ASSERT_EQUALS(orig.refCount(), 0U);
+        ASSERT_FALSE(orig.isOK());
 
         ASSERT_TRUE(dest.isOK());
         ASSERT_EQUALS(dest.refCount(), 0U);
@@ -137,8 +134,7 @@ namespace {
 
         dest = std::move(orig);
 
-        ASSERT_TRUE(orig.isOK());
-        ASSERT_EQUALS(orig.refCount(), 0U);
+        ASSERT_FALSE(orig.isOK());
 
         ASSERT_FALSE(dest.isOK());
         ASSERT_EQUALS(dest.refCount(), 1U);
@@ -159,8 +155,7 @@ namespace {
 
         dest = std::move(orig);
 
-        ASSERT_TRUE(orig.isOK());
-        ASSERT_EQUALS(orig.refCount(), 0U);
+        ASSERT_FALSE(orig.isOK());
 
         ASSERT_FALSE(dest.isOK());
         ASSERT_EQUALS(dest.refCount(), 1U);
@@ -186,8 +181,7 @@ namespace {
         ASSERT_EQUALS(orig.code(), ErrorCodes::MaxError);
         ASSERT_EQUALS(orig.reason(), "error");
 
-        ASSERT_TRUE(dest.isOK());
-        ASSERT_EQUALS(dest.refCount(), 0U);
+        ASSERT_FALSE(dest.isOK());
     }
 
     TEST(Cloning, OKIsNotRefCounted) {

--- a/src/mongo/base/status_with_test.cpp
+++ b/src/mongo/base/status_with_test.cpp
@@ -36,10 +36,11 @@
 
 namespace {
 
+    using mongo::makeStatusWith;
     using mongo::StatusWith;
 
     TEST(StatusWith, makeStatusWith) {
-        using mongo::makeStatusWith;
+
         using mongo::StringData;
 
         auto s1 = makeStatusWith<int>(3);
@@ -73,6 +74,22 @@ namespace {
         // Check that we use T(...) and not T{...}
         // ASSERT_EQUALS requires an ostream overload for vector<int>
         ASSERT_TRUE(makeStatusWith<std::vector<int>>(1, 2) == std::vector<int>{2});
+    }
+
+    TEST(StatusWith, nonDefaultConstructible) {
+
+        class NoDefault {
+            NoDefault() = delete;
+        public:
+            NoDefault(int x) : _x{x} {};
+            int _x{0};
+        };
+
+        auto swND = makeStatusWith<NoDefault>(1);
+        ASSERT_TRUE(swND.getValue()._x = 1);
+
+        auto swNDerror = StatusWith<NoDefault>(mongo::ErrorCodes::BadValue, "foo");
+        ASSERT_FALSE(swNDerror.isOK());
     }
 
 }  // namespace

--- a/src/mongo/util/assert_util.h
+++ b/src/mongo/util/assert_util.h
@@ -40,6 +40,10 @@
 #include "mongo/util/concurrency/thread_name.h"
 #include "mongo/util/debug_util.h"
 
+#define MONGO_INCLUDE_INVARIANT_H_WHITELISTED
+#include "mongo/util/invariant.h"
+#undef MONGO_INCLUDE_INVARIANT_H_WHITELISTED
+
 namespace mongo {
 
     enum CommonErrorCodes {
@@ -175,7 +179,6 @@ namespace mongo {
     };
 
     MONGO_COMPILER_NORETURN void verifyFailed(const char* expr, const char* file, unsigned line);
-    MONGO_COMPILER_NORETURN void invariantFailed(const char* expr, const char* file, unsigned line);
     MONGO_COMPILER_NORETURN void invariantOKFailed(const char* expr, const Status& status, const char *file, unsigned line);
     void wasserted(const char* expr, const char* file, unsigned line);
     MONGO_COMPILER_NORETURN void fassertFailed( int msgid );
@@ -296,11 +299,6 @@ namespace mongo {
         }                                                               \
     } while (false)
 
-#define MONGO_invariant(_Expression) do {                               \
-        if (MONGO_unlikely(!(_Expression))) {                           \
-            ::mongo::invariantFailed(#_Expression, __FILE__, __LINE__); \
-        }                                                               \
-    } while (false)
 
 #define MONGO_invariantOK(expression) do {                                                    \
     const ::mongo::Status _invariantOK_status = expression;                                   \

--- a/src/mongo/util/invariant.h
+++ b/src/mongo/util/invariant.h
@@ -1,0 +1,54 @@
+/*    Copyright 2015 MongoDB Inc.
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under the terms of the GNU Affero General Public License, version 3,
+ *    as published by the Free Software Foundation.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *    As a special exception, the copyright holders give permission to link the
+ *    code of portions of this program with the OpenSSL library under certain
+ *    conditions as described in each individual source file and distribute
+ *    linked combinations including the program with the OpenSSL library. You
+ *    must comply with the GNU Affero General Public License in all respects
+ *    for all of the code used other than as permitted herein. If you modify
+ *    file(s) with this exception, you may extend this exception to your
+ *    version of the file(s), but you are not obligated to do so. If you do not
+ *    wish to do so, delete this exception statement from your version. If you
+ *    delete this exception statement from all source files in the program,
+ *    then also delete it in the license file.
+ */
+
+#pragma once
+
+#include "mongo/platform/compiler.h"
+
+namespace mongo {
+
+/**
+ * This include exists so that mongo/base/status_with.h can use the invariant macro without causing
+ * a circular include chain. It should never be included directly in any other file other than that
+ * one (and assert_util.h).
+ */
+
+#if !defined(MONGO_INCLUDE_INVARIANT_H_WHITELISTED)
+#error "Include assert_util.h instead of invariant.h."
+#endif
+
+MONGO_COMPILER_NORETURN void invariantFailed(const char* expr, const char* file, unsigned line);
+
+#define MONGO_invariant(_Expression) do {                               \
+        if (MONGO_unlikely(!(_Expression))) {                           \
+            ::mongo::invariantFailed(#_Expression, __FILE__, __LINE__); \
+        }                                                               \
+    } while (false)
+
+#define invariant MONGO_invariant
+
+}  // namespace mongo


### PR DESCRIPTION
using github PRs while internal CR is down.

- mongo::Status now has a special moved from Status state.
- mongo::StatusWith now holds a std::aligned_storage instead of a
concrete T
- some header hacks to be able to use invariant() from status_with.h