### PR TITLE
SERVER-18955 Have sendNextBatch set the correct batch

### DIFF
--- a/jstests/sharding/sharded_limit_batchsize.js
+++ b/jstests/sharding/sharded_limit_batchsize.js
@@ -2,11 +2,29 @@
 // of limit and batchSize with sort return the correct results, and do not issue
 // unnecessary getmores (see SERVER-14299).
 
+
+/**
+ * This function checks that the log on the mongoD never shows the mongoS asking for all documents
+ * to be returned.  This occurs if ntoreturn:0 is present in the log.
+ */
+function checkLogForBatching(log) {
+	var haveGetMore = false;
+	log.forEach(function(logline) {
+		if (logline.search("getmore") != 0) {
+			haveGetMore = true;
+			//All ntoreturn should be the batch size, not 0
+			assert.eq(logline.search("ntoreturn:0"), -1)
+		}
+	});
+	assert.eq(haveGetMore, true);
+}
+
 /**
  * Test the correctness of queries with sort and batchSize on a sharded cluster,
  * running the queries against collection 'coll'.
  */
 function testBatchSize(coll) {
+	//Roll the cursor over the second batch and make sure it's correctly sized
     assert.eq(20, coll.find().sort({x: 1}).batchSize(3).itcount());
     assert.eq(15, coll.find().sort({x: 1}).batchSize(3).skip(5).itcount());
 }
@@ -84,10 +102,13 @@ for (var i=1; i<=10; ++i) {
 //
 
 jsTest.log("Running batchSize tests against sharded collection.");
-testBatchSize(shardedCol, st.shard0);
+st.shard0.adminCommand({setParameter: 1, logLevel : 1});
+testBatchSize(shardedCol);
+st.shard0.adminCommand({setParameter: 1, logLevel : 0});
+checkLogForBatching(st.shard0.adminCommand({ getLog: 'global' }).log);
 
 jsTest.log("Running batchSize tests against non-sharded collection.");
-testBatchSize(unshardedCol, st.shard0);
+testBatchSize(unshardedCol);
 
 //
 // Run tests for limit. These should *not* issue getmores. We confirm this

--- a/src/mongo/s/cursors.h
+++ b/src/mongo/s/cursors.h
@@ -66,7 +66,7 @@ public:
      *
      * @return true if this is not the final batch.
      */
-    bool sendNextBatch(int ntoreturn, BufBuilder& buffer, int& docCount);
+    bool sendNextBatch(int batchSize, BufBuilder& buffer, int& docCount);
 
     void accessed();
     /** @return idle time in ms */


### PR DESCRIPTION
ShardedClientCursor::sendNextBatch should set the correct batch size prior to all calls to more() or next().  Currently, if the first call to more() for a getMore requires calling to the shard, batch size 0 is used if the prior iteration of the loop exited due to docCount reaching batchSize.
