### PR TITLE
SERVER-14864: making logging better when using fallocate or sparse files

### DIFF
--- a/src/mongo/db/storage/mmap_v1/file_allocator.cpp
+++ b/src/mongo/db/storage/mmap_v1/file_allocator.cpp
@@ -313,6 +313,7 @@ void FileAllocator::ensureLength(int fd, long size) {
             uassert(10443, errnoWithPrefix("FileAllocator: file write failed"), written > 0);
             left -= written;
         }
+		log() << "filling zeroes in file..." << endl;
     }
 }
 
@@ -389,7 +390,7 @@ void FileAllocator::run(FileAllocator* fa) {
             string tmp;
             long fd = 0;
             try {
-                log() << "allocating new datafile " << name << ", filling with zeroes..." << endl;
+                log() << "allocating new datafile " << name << endl;
 
                 boost::filesystem::path parent = ensureParentDirCreated(name);
                 tmp = fa->makeTempFileName(parent);


### PR DESCRIPTION
Testing done: I created a mongodb instance with default file allocation as mmap v01 and checked the logs. The logs did not display that they were zeroing out my file as they were using fallocate for allocating the file.
