### PR TITLE
SERVER-20019 SpiderMonkey perf improvement by delaying id -> std::string conversion

### DIFF
--- a/src/mongo/scripting/mozjs/db.cpp
+++ b/src/mongo/scripting/mozjs/db.cpp
@@ -56,8 +56,6 @@ void DBInfo::getProperty(JSContext* cx,
 
     ObjectWrapper parentWrapper(cx, parent);
 
-    std::string sname = IdWrapper(cx, id).toString();
-
     // 2nd look into real values, may be cached collection object
     if (!vp.isUndefined()) {
         if (vp.isObject()) {
@@ -77,7 +75,11 @@ void DBInfo::getProperty(JSContext* cx,
     } else if (parentWrapper.hasField(id)) {
         parentWrapper.getValue(id, vp);
         return;
-    } else if (sname.length() == 0 || sname[0] == '_') {
+    } 
+
+    std::string sname = IdWrapper(cx, id).toString();
+
+    if (sname.length() == 0 || sname[0] == '_') {
         // if starts with '_' we dont return collection, one must use getCollection()
         return;
     }


### PR DESCRIPTION
The current SpiderMonkey implementation preemptively generates a string for the IdWrapper of JSid. This id->std::string conversion is expensive and is quite often unnecessary. By delaying the creation of the string until after checking that it is absolutely necessary, we can improve SpiderMonkey performance on the shell by about 20%