### PR TITLE
Fix numeric detection in REST API

### DIFF
--- a/src/mongo/db/restapi.cpp
+++ b/src/mongo/db/restapi.cpp
@@ -167,9 +167,10 @@ public:
 
             char* temp;
 
-            // TODO: this is how i guess if something is a number.  pretty lame right now
+            // TODO: this is how i guess if something is a number.  pretty lame right now,
+            // but less lame than it used to be
             double number = strtod(val, &temp);
-            if (temp != val)
+            if (temp && !*temp)
                 queryBuilder.append(field, number);
             else
                 queryBuilder.append(field, val);


### PR DESCRIPTION
Currently, a request with JSON of the form { "key": "1value" } will be interpreted as { "key": 1 }.  This patch leaves strings as strings unless the entire string is consumed by the numeric interpretation.  
