### PR TITLE
SERVER-21209: Fix in configuration file

### DIFF
--- a/rpm/init.d-mongod
+++ b/rpm/init.d-mongod
@@ -19,7 +19,7 @@ CONFIGFILE="/etc/mongod.conf"
 OPTIONS=" -f $CONFIGFILE"
 SYSCONFIG="/etc/sysconfig/mongod"
 
-PIDFILEPATH=`awk -F'[:=]' -v IGNORECASE=1 '/^[[:blank:]]*(processManagement\.)?pidfilepath[[:blank:]]*[:=][[:blank:]]*/{print $2}' "$CONFIGFILE" | tr -d "[:blank:]\"'"`
+PIDFILEPATH=`awk -F'[:=]' -v IGNORECASE=1 '/^[[:blank:]]*(processManagement\.)?pidfilepath[[:blank:]]*[:=][[:blank:]]*/{print $2}' "$CONFIGFILE" | tr -d "[:blank:]\"'" | awk -F"#" '{print $1}'`
 
 mongod=${MONGOD-/usr/bin/mongod}
 

--- a/rpm/init.d-mongod.suse
+++ b/rpm/init.d-mongod.suse
@@ -25,7 +25,7 @@ CONFIGFILE="/etc/mongod.conf"
 OPTIONS=" -f $CONFIGFILE"
 SYSCONFIG="/etc/sysconfig/mongod"
 
-PIDFILEPATH=`awk -F'[:=]' -v IGNORECASE=1 '/^[[:blank:]]*(processManagement\.)?pidfilepath[[:blank:]]*[:=][[:blank:]]*/{print $2}' "$CONFIGFILE" | tr -d "[:blank:]\"'"`
+PIDFILEPATH=`awk -F'[:=]' -v IGNORECASE=1 '/^[[:blank:]]*(processManagement\.)?pidfilepath[[:blank:]]*[:=][[:blank:]]*/{print $2}' "$CONFIGFILE" | tr -d "[:blank:]\"'" | awk -F"#" '{print $1}'`
 
 mongod=${MONGOD-/usr/bin/mongod}
 

--- a/rpm/mongod.conf
+++ b/rpm/mongod.conf
@@ -21,7 +21,7 @@ storage:
 # how the process runs
 processManagement:
   fork: true  # fork and run in background
-  pidFilePath: /var/run/mongodb/mongod.pid  # location of pidfile
+  pidFilePath: /var/run/mongodb/mongod.pid
 
 # network interfaces
 net:

--- a/rpm/mongod.conf
+++ b/rpm/mongod.conf
@@ -21,7 +21,7 @@ storage:
 # how the process runs
 processManagement:
   fork: true  # fork and run in background
-  pidFilePath: /var/run/mongodb/mongod.pid
+  pidFilePath: /var/run/mongodb/mongod.pid  # location of pidfile
 
 # network interfaces
 net:


### PR DESCRIPTION
I noticed (CentOS 6) that the init script fails to parse the contents of the configuration file as expected resulting in failure to stop the service when asked. 

The error steps in from [this][l1] line in the init script:
```
PIDFILEPATH=`awk -F'[:=]' -v IGNORECASE=1 '/^[[:blank:]]*(processManagement\.)?pidfilepath[[:blank:]]*[:=][[:blank:]]*/{print $2}' "$CONFIGFILE" | tr -d "[:blank:]\"'"`
```

What happens is that the `PIDFILEPATH` variable gets populated with all contents following the variable `pidFilePath` in the configuration file with spaces omitted. Hence using the default configuration file the bash variable gets the value:

```
# echo $PIDFILEPATH
/var/run/mongodb/mongod.pid#locationofpidfile
```

I guess another way of fixing this is adding something like `..| awk -F# '{print $1}'` within the command but maybe it's better to have a cleaner configuration file. 

[l1]: https://github.com/mongodb/mongo/blob/master/rpm/init.d-mongod#L22