### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README
+++ b/README
@@ -48,19 +48,19 @@ PACKAGING
 
 DOCUMENTATION
 
-  http://www.mongodb.org/
+  https://www.mongodb.org/
  
 CLOUD MANAGED MONGODB
 
-  http://cloud.mongodb.com/
+  https://www.mongodb.com/cloud
 
 MAIL LISTS AND IRC
 
-  http://dochub.mongodb.org/core/community
+  https://www.mongodb.org/about/community/
   
 LEARN MONGODB
 
-  http://university.mongodb.com/
+  https://university.mongodb.com/
 
 32 BIT BUILD NOTES
 


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### Other Corrected URLs 
Was | Now 
--- | --- 
http://cloud.mongodb.com/ | https://www.mongodb.com/cloud 
http://dochub.mongodb.org/core/community | https://www.mongodb.org/about/community/ 
http://university.mongodb.com/ | https://university.mongodb.com/ 
http://www.mongodb.org/ | https://www.mongodb.org/ 
