### PR TITLE
Fixing compilation error of the server on ppc64le architecture

### DIFF
--- a/src/third_party/wiredtiger/src/include/gcc.h
+++ b/src/third_party/wiredtiger/src/include/gcc.h
@@ -178,7 +178,7 @@ __wt_atomic_cas_ptr(void *vp, void *old, void *new)
 
 #elif defined(__PPC64__) || defined(PPC64)
 #define	WT_PAUSE()	__asm__ volatile("ori 0,0,0" ::: "memory")
-#define	WT_FULL_BARRIER()	do {
+#define	WT_FULL_BARRIER()	do {                                      \
 	__asm__ volatile ("sync" ::: "memory");				\
 } while (0)
 #define	WT_READ_BARRIER()	WT_FULL_BARRIER()


### PR DESCRIPTION
This is the change required to build mongodb server on RHEL 7.1 ppc64le.