### PR TITLE
SERVER-21870: Add space between "supports" and "snapshots" in error message

### DIFF
--- a/src/mongo/db/db.cpp
+++ b/src/mongo/db/db.cpp
@@ -512,7 +512,7 @@ static void _initAndListen(int listenPort) {
             // the CSRS in the REMOVED state. This is handled by the TopologyCoordinator.
             invariant(replSettings.majorityReadConcernEnabled);
             severe() << "Majority read concern requires a storage engine that supports"
-                     << "snapshots, such as wiredTiger. " << storageGlobalParams.engine
+                     << " snapshots, such as wiredTiger. " << storageGlobalParams.engine
                      << " does not support snapshots.";
             exitCleanly(EXIT_BADOPTIONS);
         }


### PR DESCRIPTION
2015-12-11T10:41:40.031-0800 F STORAGE  [initandlisten] Majority read concern requires a storage engine that supportssnapshots, such as wiredTiger. mmapv1 does not support snapshots.

=>

Majority read concern requires a storage engine that supports snapshots, such as wiredTiger. mmapv1 does not support snapshots.