### PR TITLE
SERVER-18041: Added support for parallel cloning during initial sync

### DIFF
--- a/src/mongo/db/mongod_options.cpp
+++ b/src/mongo/db/mongod_options.cpp
@@ -165,6 +165,12 @@ Status addMongodOptions(moe::OptionSection* options) {
                         "cpu", "cpu", moe::Switch, "periodically show cpu and iowait utilization")
         .setSources(moe::SourceAllLegacy);
 
+    general_options.addOptionChaining("maxReplicationThreads",
+                                      "maxReplicationThreads",
+                                      moe::Int,
+                                      "how many threads should initial sync use for initial replication")
+            .setDefault(moe::Value(0));
+
     general_options.addOptionChaining("sysinfo",
                                       "sysinfo",
                                       moe::Switch,
@@ -1003,6 +1009,9 @@ Status storeMongodOptions(const moe::Environment& params, const std::vector<std:
     }
     if (params.count("cpu")) {
         serverGlobalParams.cpu = params["cpu"].as<bool>();
+    }
+    if (params.count("maxReplicationThreads")) {
+        serverGlobalParams.maxReplicationThreads = params["maxReplicationThreads"].as<int>();
     }
     if (params.count("security.authorization") &&
         params["security.authorization"].as<std::string>() == "disabled") {

--- a/src/mongo/db/server_options.h
+++ b/src/mongo/db/server_options.h
@@ -57,7 +57,8 @@ struct ServerGlobalParams {
           logAppend(false),
           logRenameOnRotate(true),
           logWithSyslog(false),
-          isHttpInterfaceEnabled(false) {
+          isHttpInterfaceEnabled(false),
+          maxReplicationThreads(0){
         started = time(0);
     }
 
@@ -106,7 +107,8 @@ struct ServerGlobalParams {
     bool logWithSyslog;      // True if logging to syslog; must not be set if logpath is set.
     int syslogFacility;      // Facility used when appending messages to the syslog.
 
-    bool isHttpInterfaceEnabled;  // True if the dbwebserver should be enabled.
+    bool isHttpInterfaceEnabled; // True if the dbwebserver should be enabled.
+    int maxReplicationThreads;   // maximal number of threads used during replication, 0 will default to number of cores in the system
 
 #ifndef _WIN32
     ProcessId parentProc;  // --fork pid of initial process


### PR DESCRIPTION
It is extremely important to support for parallel cloning, especially during the index build phase.
As it happens, our MongoDB replicas sit on some powerful machines and its a waste using a single core, especially when using engines like wiredTiger and RocksDB which use compression.
Moreover, using the single core initial sync prevents us from adding new replicas as they take alot of time to copy and build the index (in the order of days), which causes them to loose sync, even after enlarging the oplog window.

Changes:
Updated Cloner to lock just the db it clones, instead of the global lock (as an existing code comment suggested but not implemented)
Added maxReplicationThreads as global server parameter to control number of threads used for initial cloning to prevent Scott's comment about possible DOS other replica set members (suggested by @scotthernandez) defaults to #cores + 1
Obviously its possible to set to 1 thread to keep current behavior.