### PR TITLE
Making pidFilePath optional in Redhat init script

### DIFF
--- a/rpm/init.d-mongod
+++ b/rpm/init.d-mongod
@@ -30,6 +30,10 @@ if [ -f "$SYSCONFIG" ]; then
     . "$SYSCONFIG"
 fi
 
+if [ -z "$PIDFILEPATH" ]; then
+    PIDFILEPATH="/var/run/mongodb/mongod.pid"
+fi
+
 PIDDIR=`dirname $PIDFILEPATH`
 
 # Handle NUMA access to CPUs (SERVER-3574)


### PR DESCRIPTION
As defined in https://docs.mongodb.org/manual/reference/configuration-options/#processmanagement-options, the processManagement.pidFilePath is optional.
