### PR TITLE
Acknowledge user based environment

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -815,6 +815,7 @@ envDict = dict(BUILD_ROOT=buildDir,
                INSTALL_DIR=installDir,
                CONFIG_HEADER_DEFINES={},
                LIBDEPS_TAG_EXPANSIONS=[],
+               ENV = os.environ,
                )
 
 env = Environment(variables=env_vars, **envDict)


### PR DESCRIPTION
In our environment we build entire Linux toolchain (gcc, python, etc.) and would like to build mongo against it. This is necessary since our build nodes run old version of toolchain. The scons system needs to acknowledge user environment in this case to pick up custom gcc/g++/python tools. The proposed change fix that issue by reading user environment.