### PR TITLE
extend the function of UUID() 

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1225,7 +1225,7 @@ else:
     env.AppendUnique( CPPDEFINES=[ 'NDEBUG' ] )
 
 if env.TargetOSIs('linux'):
-    env.Append( LIBS=['m'] )
+    env.Append( LIBS=['m','uuid'],LIBPATH=['/usr/lib/x86_64-linux-gnu'] )
 
 elif env.TargetOSIs('solaris'):
      env.Append( LIBS=["socket","resolv","lgrp"] )


### PR DESCRIPTION
extend the function of UUID() so that it now automatically generates and returns an time-based UUID when called with no parameter(uuid in hexdecimal) provided
it is now valid on linux system
