### PR TITLE
Improve error message for expected array query properties

### DIFF
--- a/src/mongo/db/matcher/expression_parser.cpp
+++ b/src/mongo/db/matcher/expression_parser.cpp
@@ -296,7 +296,7 @@ StatusWithMatchExpression MatchExpressionParser::_parse(const BSONObj& obj, int 
             // TODO: optimize if block?
             if (mongoutils::str::equals("or", rest)) {
                 if (e.type() != Array)
-                    return {Status(ErrorCodes::BadValue, "$or needs an array")};
+                    return {Status(ErrorCodes::BadValue, "$or must be an array")};
                 std::unique_ptr<OrMatchExpression> temp = stdx::make_unique<OrMatchExpression>();
                 Status s = _parseTreeList(e.Obj(), temp.get(), level);
                 if (!s.isOK())
@@ -304,7 +304,7 @@ StatusWithMatchExpression MatchExpressionParser::_parse(const BSONObj& obj, int 
                 root->add(temp.release());
             } else if (mongoutils::str::equals("and", rest)) {
                 if (e.type() != Array)
-                    return {Status(ErrorCodes::BadValue, "and needs an array")};
+                    return {Status(ErrorCodes::BadValue, "$and must be an array")};
                 std::unique_ptr<AndMatchExpression> temp = stdx::make_unique<AndMatchExpression>();
                 Status s = _parseTreeList(e.Obj(), temp.get(), level);
                 if (!s.isOK())
@@ -312,7 +312,7 @@ StatusWithMatchExpression MatchExpressionParser::_parse(const BSONObj& obj, int 
                 root->add(temp.release());
             } else if (mongoutils::str::equals("nor", rest)) {
                 if (e.type() != Array)
-                    return {Status(ErrorCodes::BadValue, "and needs an array")};
+                    return {Status(ErrorCodes::BadValue, "$nor must be an array")};
                 std::unique_ptr<NorMatchExpression> temp = stdx::make_unique<NorMatchExpression>();
                 Status s = _parseTreeList(e.Obj(), temp.get(), level);
                 if (!s.isOK())


### PR DESCRIPTION
`and needs an array` is not very descriptive - should at least be `$and needs an array`.

Fixed `$nor` error not being reported as an `$and` property error