### PR TITLE
Added 3 hints on debian config file. These could save 3 hours of relying on (not)working examples.

### DIFF
--- a/debian/mongod.conf
+++ b/debian/mongod.conf
@@ -1,11 +1,13 @@
 # mongod.conf
 
+# also used as example in the official docker containers
+
 # for documentation of all options, see:
 #   http://docs.mongodb.org/manual/reference/configuration-options/
 
 # Where and how to store data.
 storage:
-  dbPath: /var/lib/mongodb
+  dbPath: /var/lib/mongodb # Attention when using docker: this path doesn't exist! The standard is /data/db
   journal:
     enabled: true
 #  engine:
@@ -21,7 +23,7 @@ systemLog:
 # network interfaces
 net:
   port: 27017
-  bindIp: 127.0.0.1
+  bindIp: 127.0.0.1  # Listen to local interface only, comment to listen on all interfaces.
 
 
 #processManagement:


### PR DESCRIPTION
The config file for debian (and docker container) needed a few hints.
I spend 3 hours dockerizing mongo while relying on the correctness of this example.
At the end these hints would have saved my day.
[Sure reading the docs for the config files is an option to prevent such problems. But if you guys provide an example it should work or could be fixed at ease ;) ]

The hints/comments between rpm/mongod.conf and debian/mongod.conf are different. I am just saying