### PR TITLE
SERVER-22847: Online change oplog size when using wiredtiger 

### DIFF
--- a/jstests/core/collmod_capped.js
+++ b/jstests/core/collmod_capped.js
@@ -1,0 +1,109 @@
+// Basic js tests for the collMod command.
+// Test setting the cappedSize, cappedMaxDocs 
+// Run test: mongo jstests/core/collmod_capped.js
+// need start mongod with WiredTiger storage engine
+
+function debug( x ) {
+    //printjson( x );
+}
+
+var coll = "collModTest";
+var t = db.getCollection( coll );
+t.drop();
+
+var maxSize = 104857600;
+var maxDocs = 5;
+db.createCollection( coll, {capped: true, size: maxSize, max: maxDocs} );
+
+// test maxDocs
+var t = db.getCollection( coll );
+
+for (var i = 0; i < 100; i++) {
+   t.insert({x: i});
+}
+
+assert.eq(t.count(), maxDocs);
+assert(t.stats().size <= maxSize);
+
+// increase maxDocs limit
+var maxDocs = 10;
+assert.commandWorked(
+        db.runCommand({collMod: coll, cappedMaxDocs: maxDocs})
+        );
+
+for (var i = 0; i < 1000; i++) {
+   t.insert({x: i});
+}
+
+assert.eq(t.count(), maxDocs);
+assert(t.stats().size <= maxSize);
+
+// decrease maxDocs limit
+var maxDocs = 5;
+assert.commandWorked(
+        db.runCommand({collMod: coll, cappedMaxDocs: maxDocs})
+        );
+
+for (var i = 0; i < 1000; i++) {
+   t.insert({x: i});
+}
+
+assert.eq(t.count(), maxDocs);
+assert(t.stats().size <= maxSize);
+
+t.drop();
+
+var maxSize = 4096;
+var maxDocs = -1;
+db.createCollection( coll, {capped: true, size: maxSize, max: maxDocs} );
+
+// test maxSize
+var t = db.getCollection( coll );
+
+for (var i = 0; i < 1000; i++) {
+   t.insert({x: i});
+}
+
+assert(t.count() < 1000);
+assert(t.stats().size <= maxSize);
+
+// increase maxSize
+var maxSize = 8192;
+assert.commandWorked(
+        db.runCommand({collMod: coll, cappedSize: maxSize})
+        );
+
+var before = t.count();
+for (var i = 0; i < 1000; i++) {
+   t.insert({x: i});
+}
+var after = t.count();
+
+assert(t.count() < 1000);
+assert(before < after);
+assert(t.stats().size <= maxSize);
+
+// decrease maxSize
+var maxSize = 4096;
+assert.commandWorked(
+        db.runCommand({collMod: coll, cappedSize: maxSize})
+        );
+
+var before = t.count();
+for (var i = 0; i < 1000; i++) {
+   t.insert({x: i});
+}
+var after = t.count();
+
+assert(t.count() < 1000);
+assert(before > after);
+assert(t.stats().size <= maxSize);
+
+
+
+
+
+
+
+
+

--- a/src/mongo/db/catalog/collection_catalog_entry.h
+++ b/src/mongo/db/catalog/collection_catalog_entry.h
@@ -107,6 +107,12 @@ public:
                                  StringData validationLevel,
                                  StringData validationAction) = 0;
 
+    /**
+     * Update capped collection config, only WiredTiger engine support
+     */
+    virtual void updateCappedSize(OperationContext* txn, long long cappedSize) {}
+    virtual void updateCappedMaxDocs(OperationContext* txn, long long cappedMaxDocs) {}
+
 private:
     NamespaceString _ns;
 };

--- a/src/mongo/db/storage/kv/kv_collection_catalog_entry.cpp
+++ b/src/mongo/db/storage/kv/kv_collection_catalog_entry.cpp
@@ -174,6 +174,18 @@ void KVCollectionCatalogEntry::updateValidator(OperationContext* txn,
     _catalog->putMetaData(txn, ns().toString(), md);
 }
 
+void KVCollectionCatalogEntry::updateCappedSize(OperationContext* txn, long long cappedSize) {
+    MetaData md = _getMetaData(txn);
+    md.options.cappedSize = cappedSize;
+    _catalog->putMetaData(txn, ns().toString(), md);
+}
+
+void KVCollectionCatalogEntry::updateCappedMaxDocs(OperationContext* txn, long long cappedMaxDocs) {
+    MetaData md = _getMetaData(txn);
+    md.options.cappedMaxDocs = cappedMaxDocs;
+    _catalog->putMetaData(txn, ns().toString(), md);
+}
+
 BSONCollectionCatalogEntry::MetaData KVCollectionCatalogEntry::_getMetaData(
     OperationContext* txn) const {
     return _catalog->getMetaData(txn, ns().toString());

--- a/src/mongo/db/storage/kv/kv_collection_catalog_entry.h
+++ b/src/mongo/db/storage/kv/kv_collection_catalog_entry.h
@@ -73,6 +73,9 @@ public:
                          StringData validationLevel,
                          StringData validationAction) final;
 
+    void updateCappedSize(OperationContext* txn, long long cappedSize) final;
+    void updateCappedMaxDocs(OperationContext* txn, long long cappedMaxDocs) final;
+
     RecordStore* getRecordStore() {
         return _recordStore.get();
     }

--- a/src/mongo/db/storage/record_store.h
+++ b/src/mongo/db/storage/record_store.h
@@ -586,6 +586,13 @@ public:
                                         long long numRecords,
                                         long long dataSize) = 0;
 
+    /**
+     * support modify capped collection config
+     * if storage engine cannot support this feature, simple return false
+     */
+    virtual bool setCappedSize(long long cappedSize) { return false; }
+    virtual bool setCappedMaxDocs(long long cappedMaxDocs) { return false; }
+
 protected:
     std::string _ns;
 };

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_record_store.h
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_record_store.h
@@ -206,6 +206,16 @@ public:
     int64_t cappedMaxDocs() const;
     int64_t cappedMaxSize() const;
 
+    virtual bool setCappedSize(long long cappedSize) {
+        _cappedMaxSize = cappedSize;
+        return true;
+    }
+
+    virtual bool setCappedMaxDocs(long long cappedMaxDocs) {
+        _cappedMaxDocs = cappedMaxDocs;
+        return true;
+    }
+
     const std::string& getURI() const {
         return _uri;
     }
@@ -277,9 +287,9 @@ private:
     const bool _isEphemeral;
     // True if the namespace of this record store starts with "local.oplog.", and false otherwise.
     const bool _isOplog;
-    const int64_t _cappedMaxSize;
+    int64_t _cappedMaxSize;
     const int64_t _cappedMaxSizeSlack;  // when to start applying backpressure
-    const int64_t _cappedMaxDocs;
+    int64_t _cappedMaxDocs;
     RecordId _cappedFirstRecord;
     AtomicInt64 _cappedSleep;
     AtomicInt64 _cappedSleepMS;


### PR DESCRIPTION
Support online change oplog size by collMod command.

eg:

change maxSize limit

```
var maxSize = 8192;
assert.commandWorked(
        db.runCommand({collMod: coll, cappedSize: maxSize})
        );
```

change maxDocs limit

```
var maxDocs = 10;
assert.commandWorked(
        db.runCommand({collMod: coll, cappedMaxDocs: maxDocs})
        );
```
