### PR TITLE
Possibility to mute shell's compatibility infos

### DIFF
--- a/src/mongo/shell/mongo.js
+++ b/src/mongo/shell/mongo.js
@@ -280,7 +280,7 @@ Mongo.prototype.writeMode = function() {
     if (this.hasWriteCommands()) {
         // good with whatever is already set
     } else if (this._writeMode == "commands") {
-        print("Cannot use commands write mode, degrading to compatibility mode");
+        chatty("Cannot use commands write mode, degrading to compatibility mode");
         this._writeMode = "compatibility";
     }
 
@@ -330,7 +330,7 @@ Mongo.prototype.readMode = function() {
             if (hasReadCommands) {
                 this._readMode = "commands";
             } else {
-                print("Cannot use 'commands' readMode, degrading to 'legacy' mode");
+                chatty("Cannot use 'commands' readMode, degrading to 'legacy' mode");
                 this._readMode = "legacy";
             }
         } catch (e) {


### PR DESCRIPTION
MongoDB shell produces warnings when newer shell is connected to old database version. For example:

```
Cannot use 'commands' readMode, degrading to 'legacy' mode
```

These infos can be muted with `--quiet` option, because there is not much user can do about it anyway. 
