### PR TITLE
SERVER-23273 Allow MmapV1ExtentManager::recordNeedsFetch to be overridable

### DIFF
--- a/src/mongo/db/storage/mmap_v1/mmap_v1_extent_manager.h
+++ b/src/mongo/db/storage/mmap_v1/mmap_v1_extent_manager.h
@@ -125,7 +125,7 @@ public:
      */
     MmapV1RecordHeader* recordForV1(const DiskLoc& loc) const;
 
-    std::unique_ptr<RecordFetcher> recordNeedsFetch(const DiskLoc& loc) const final;
+    std::unique_ptr<RecordFetcher> recordNeedsFetch(const DiskLoc& loc) const;
 
     /**
      * @param loc - has to be for a specific MmapV1RecordHeader (not an Extent)


### PR DESCRIPTION
@GeertBosch 