### PR TITLE
Some extreme case, internal page can never be evicted

### DIFF
--- a/src/third_party/wiredtiger/src/evict/evict_lru.c
+++ b/src/third_party/wiredtiger/src/evict/evict_lru.c
@@ -1392,7 +1392,7 @@ __evict_walk_file(WT_SESSION_IMPL *session, uint32_t queue_index, u_int *slotp)
 		/* Limit internal pages to 50% unless we get aggressive. */
 		if (WT_PAGE_IS_INTERNAL(page) &&
 		    !FLD_ISSET(cache->state, WT_EVICT_PASS_AGGRESSIVE) &&
-		    internal_pages >= (int)(evict - start) / 2)
+		    internal_pages >= (int)(end - start) / 2)
 			continue;
 
 fast:		/* If the page can't be evicted, give up. */


### PR DESCRIPTION
This might be extreme case, But looks like this happens to me.

If __wt_tree_walk_count() return only internal page(btree->evict_ref),
expression "internal_pages >= (int)(evict - start) / 2)" always be true and internal page never can be evicted because both "evict" and "internal_pages" var are never changed.

So I think we should change "evict" to "end".