### PR TITLE
SERVER-23398 Fixed. Allowing read sharding data from config replica

### DIFF
--- a/src/mongo/client/replica_set_monitor.cpp
+++ b/src/mongo/client/replica_set_monitor.cpp
@@ -76,7 +76,7 @@ const double socketTimeoutSecs = 5;
 // Intentionally chosen to compare worse than all known latencies.
 const int64_t unknownLatency = numeric_limits<int64_t>::max();
 
-const ReadPreferenceSetting kPrimaryOnlyReadPreference(ReadPreference::PrimaryOnly, TagSet());
+const ReadPreferenceSetting kPrimaryOnlyReadPreference(ReadPreference::PrimaryPreferred, TagSet());
 const Milliseconds kFindHostMaxBackOffTime(500);
 
 // TODO: Move to ReplicaSetMonitorManager

--- a/src/mongo/db/server_options.h
+++ b/src/mongo/db/server_options.h
@@ -80,6 +80,7 @@ struct ServerGlobalParams {
 
     std::string logpath;            // Path to log file, if logging to a file; otherwise, empty.
     bool logAppend = false;         // True if logging to a file in append mode.
+    bool allowInconsistentConfigReads = false;  // True if it is allowed to read config data from config replica set nodes other than Primary
     bool logRenameOnRotate = true;  // True if logging should rename log files on rotate
     bool logWithSyslog = false;     // True if logging to syslog; must not be set if logpath is set.
     int syslogFacility;             // Facility used when appending messages to the syslog.

--- a/src/mongo/db/server_options_helpers.cpp
+++ b/src/mongo/db/server_options_helpers.cpp
@@ -246,6 +246,13 @@ Status addGeneralServerOptions(moe::OptionSection* options) {
                                "syslog facility used for mongodb syslog message");
 
 #endif  // _WIN32
+
+    options->addOptionChaining("allowInconsistentConfigReads",
+                               "allowInconsistentConfigReads",
+                               moe::Switch,
+                               "allow to read config data from config replica set nodes other than Primary");
+
+
     options->addOptionChaining("systemLog.logAppend",
                                "logappend",
                                moe::Switch,
@@ -934,6 +941,10 @@ Status storeServerOptions(const moe::Environment& params, const std::vector<std:
 
     if (params.count("systemLog.logAppend") && params["systemLog.logAppend"].as<bool>() == true) {
         serverGlobalParams.logAppend = true;
+    }
+
+    if (params.count("allowInconsistentConfigReads") && params["allowInconsistentConfigReads"].as<bool>() == true) {
+        serverGlobalParams.allowInconsistentConfigReads = true;
     }
 
     if (params.count("systemLog.logRotate")) {

--- a/src/mongo/s/catalog/replset/catalog_manager_replica_set.cpp
+++ b/src/mongo/s/catalog/replset/catalog_manager_replica_set.cpp
@@ -1485,7 +1485,7 @@ bool CatalogManagerReplicaSet::runUserManagementWriteCommand(OperationContext* t
 
     auto response = Grid::get(txn)->shardRegistry()->getConfigShard()->runCommand(
         txn,
-        ReadPreferenceSetting{ReadPreference::PrimaryOnly},
+        ReadPreferenceSetting{ReadPreference::PrimaryPreferred},
         dbname,
         cmdToRun,
         Shard::RetryPolicy::kNotIdempotent);

--- a/src/mongo/s/client/shard_remote.cpp
+++ b/src/mongo/s/client/shard_remote.cpp
@@ -316,7 +316,8 @@ StatusWith<Shard::QueryResponse> ShardRemote::_exhaustiveFindOnConfig(
     BSONObj readConcernObj;
     {
         const repl::ReadConcernArgs readConcern{grid.configOpTime(),
-                                                repl::ReadConcernLevel::kMajorityReadConcern};
+            (serverGlobalParams.allowInconsistentConfigReads) ? repl::ReadConcernLevel::kLocalReadConcern : repl::ReadConcernLevel::kMajorityReadConcern};
+
         BSONObjBuilder bob;
         readConcern.appendInfo(&bob);
         readConcernObj =


### PR DESCRIPTION
Allowing read sharding data from any config replica nodes rather than Primary only.