### PR TITLE
init.d: fix broken anchor links to recommended ulimit settings

### DIFF
--- a/debian/init.d
+++ b/debian/init.d
@@ -126,7 +126,7 @@ running() {
 
 start_server() {
             # Recommended ulimit values for mongod or mongos
-            # See http://docs.mongodb.org/manual/reference/ulimit/#recommended-settings
+            # See http://docs.mongodb.org/manual/reference/ulimit/#recommended-ulimit-settings
             #
             ulimit -f unlimited
             ulimit -t unlimited

--- a/debian/mongod.upstart
+++ b/debian/mongod.upstart
@@ -1,7 +1,7 @@
 # Ubuntu upstart file at /etc/init/mongod.conf
 
 # Recommended ulimit values for mongod or mongos
-# See http://docs.mongodb.org/manual/reference/ulimit/#recommended-settings
+# See http://docs.mongodb.org/manual/reference/ulimit/#recommended-ulimit-settings
 #
 limit fsize unlimited unlimited
 limit cpu unlimited unlimited

--- a/rpm/init.d-mongod
+++ b/rpm/init.d-mongod
@@ -50,7 +50,7 @@ start()
   fi
 
   # Recommended ulimit values for mongod or mongos
-  # See http://docs.mongodb.org/manual/reference/ulimit/#recommended-settings
+  # See http://docs.mongodb.org/manual/reference/ulimit/#recommended-ulimit-settings
   #
   ulimit -f unlimited
   ulimit -t unlimited

--- a/rpm/init.d-mongod.suse
+++ b/rpm/init.d-mongod.suse
@@ -57,7 +57,7 @@ start()
   fi
 
   # Recommended ulimit values for mongod or mongos
-  # See http://docs.mongodb.org/manual/reference/ulimit/#recommended-settings
+  # See http://docs.mongodb.org/manual/reference/ulimit/#recommended-ulimit-settings
   #
   ulimit -f unlimited
   ulimit -t unlimited


### PR DESCRIPTION
This fixes the broken anchor link in all of the init scripts so that it jumps to the correct section for `ulimit` settings.