### PR TITLE
Allow specifying sample rate of slow queries

### DIFF
--- a/jstests/auth/lib/commands_lib.js
+++ b/jstests/auth/lib/commands_lib.js
@@ -3586,6 +3586,26 @@ var authCommandsLib = {
           ]
         },
         {
+          testname: "profileSetSampleRate",
+          command: {profile: -1, sampleRate: 0.5},
+          skipSharded: true,
+          testcases: [
+              {
+                runOnDb: firstDbName,
+                roles: roles_dbAdmin,
+                privileges:
+                    [{resource: {db: firstDbName, collection: ""}, actions: ["enableProfiler"]}]
+              },
+              {
+                runOnDb: secondDbName,
+                roles: roles_dbAdminAny,
+                privileges: [
+                    {resource: {db: secondDbName, collection: ""}, actions: ["enableProfiler"]}
+                ]
+              }
+          ]
+        },
+        {
           testname: "renameCollection_sameDb",
           command: {renameCollection: firstDbName + ".x", to: firstDbName + ".y", dropTarget: true},
           setup: function(db) {

--- a/jstests/core/profile_sampling.js
+++ b/jstests/core/profile_sampling.js
@@ -1,0 +1,49 @@
+// Confirms that the number of profiled operations is consistent with the sampleRate, if set.
+
+(function () {
+    "use strict";
+
+    // Use a special db to support running other tests in parallel.
+    var profileDB = db.getSisterDB("profile_sampling");
+    var username = "jstests_profile_sampling_user";
+
+    var coll = profileDB.profile_sampling;
+
+    profileDB.dropDatabase();
+
+    var origprof = 0;
+    try {
+        origprof = profileDB.setProfilingLevel(0).was;
+        profileDB.system.profile.drop();
+        assert.eq(0, profileDB.system.profile.count());
+
+        profileDB.createCollection(coll.getName());
+        assert.writeOK(coll.insert({x: 1}));
+
+        assert.commandWorked(profileDB.setProfilingLevel(2, {sampleRate: 0}));
+
+        assert.neq(null, coll.findOne({x: 1}));
+        assert.eq(1, coll.find({x: 1}).count());
+        assert.writeOK(coll.update({x: 1}, {$inc: {a: 1}}));
+
+        profileDB.setProfilingLevel(0);
+
+        profileDB.system.profile.find().forEach(printjson);
+        assert.eq(0, profileDB.system.profile.count());
+
+        profileDB.system.profile.drop();
+        assert.commandWorked(profileDB.setProfilingLevel(2, {sampleRate: 0.5}));
+
+        // This should generate about 500 profile log entries.
+        for (var i = 0; i < 500; i++) {
+            assert.neq(null, coll.findOne({x: 1}));
+            assert.writeOK(coll.update({x: 1}, {$inc: {a: 1}}));
+        }
+
+        profileDB.setProfilingLevel(0);
+
+        assert.between(10, profileDB.system.profile.count(), 990);
+    } finally {
+        profileDB.setProfilingLevel(origprof);
+    }
+}());

--- a/src/mongo/bson/util/bson_extract.cpp
+++ b/src/mongo/bson/util/bson_extract.cpp
@@ -185,6 +185,18 @@ Status bsonExtractDoubleField(const BSONObj& object, StringData fieldName, doubl
     return Status::OK();
 }
 
+Status bsonExtractDoubleFieldWithDefault(const BSONObj& object,
+                                         StringData fieldName,
+                                         double defaultValue,
+                                         double* out) {
+    Status status = bsonExtractDoubleField(object, fieldName, out);
+    if (status == ErrorCodes::NoSuchKey) {
+        *out = defaultValue;
+        status = Status::OK();
+    }
+    return status;
+}
+
 Status bsonExtractIntegerFieldWithDefault(const BSONObj& object,
                                           StringData fieldName,
                                           long long defaultValue,

--- a/src/mongo/bson/util/bson_extract.h
+++ b/src/mongo/bson/util/bson_extract.h
@@ -158,6 +158,21 @@ Status bsonExtractIntegerFieldWithDefault(const BSONObj& object,
                                           long long* out);
 
 /**
+ * Finds a double-precision floating point element named "fieldName" in "object".
+ *
+ * If a field named "fieldName" is present, and is a double, stores the value of the field into
+ * "*out". If no field named fieldName is present, sets "*out" to "defaultValue". In these cases,
+ * returns Status::OK().
+ *
+ * If "fieldName" is present more than once, behavior is undefined. If the found field is not a
+ * double, returns ErrorCodes::TypeMismatch.
+ */
+Status bsonExtractDoubleFieldWithDefault(const BSONObj& object,
+                                         StringData fieldName,
+                                         double defaultValue,
+                                         double* out);
+
+/**
  * Finds a std::string element named "fieldName" in "object".
  *
  * If a field named "fieldName" is present, and is a string, stores the value of the field into

--- a/src/mongo/db/assemble_response.cpp
+++ b/src/mongo/db/assemble_response.cpp
@@ -628,13 +628,17 @@ void assembleResponse(OperationContext* txn,
         .incrementGlobalLatencyStats(
             txn, currentOp.totalTimeMicros(), currentOp.getReadWriteType());
 
-    if (shouldLogOpDebug || debug.executionTimeMicros > logThresholdMs * 1000LL) {
+    const bool shouldSample = serverGlobalParams.sampleRate == 1.0 ?
+        true :
+        c.getPrng().nextCanonicalDouble() < serverGlobalParams.sampleRate;
+
+    if (shouldLogOpDebug || (shouldSample && debug.executionTimeMicros > logThresholdMs * 1000LL)) {
         Locker::LockerInfo lockerInfo;
         txn->lockState()->getLockerInfo(&lockerInfo);
         log() << debug.report(&c, currentOp, lockerInfo.stats);
     }
 
-    if (currentOp.shouldDBProfile()) {
+    if (shouldSample && currentOp.shouldDBProfile()) {
         // Performance profiling is on
         if (txn->lockState()->isReadLocked()) {
             LOG(1) << "note: not profiling because recursive read lock";

--- a/src/mongo/db/commands/dbcommands.cpp
+++ b/src/mongo/db/commands/dbcommands.cpp
@@ -39,6 +39,7 @@
 #include "mongo/base/status_with.h"
 #include "mongo/bson/simple_bsonobj_comparator.h"
 #include "mongo/bson/util/builder.h"
+#include "mongo/bson/util/bson_extract.h"
 #include "mongo/db/audit.h"
 #include "mongo/db/auth/action_set.h"
 #include "mongo/db/auth/action_type.h"
@@ -349,7 +350,7 @@ public:
                                        const BSONObj& cmdObj) {
         AuthorizationSession* authzSession = AuthorizationSession::get(client);
 
-        if (cmdObj.firstElement().numberInt() == -1 && !cmdObj.hasField("slowms")) {
+        if (cmdObj.firstElement().numberInt() == -1 && !cmdObj.hasField("slowms") && !cmdObj.hasField("sampleRate")) {
             // If you just want to get the current profiling level you can do so with just
             // read access to system.profile, even if you can't change the profiling level.
             if (authzSession->isAuthorizedForActionsOnResource(
@@ -393,6 +394,7 @@ public:
 
         result.append("was", db ? db->getProfilingLevel() : serverGlobalParams.defaultProfile);
         result.append("slowms", serverGlobalParams.slowMS);
+        result.append("sampleRate", serverGlobalParams.sampleRate);
 
         if (!readOnly) {
             if (!db) {
@@ -407,6 +409,11 @@ public:
         if (slow.isNumber()) {
             serverGlobalParams.slowMS = slow.numberInt();
         }
+
+        double newSampleRate;
+        uassertStatusOK(bsonExtractDoubleFieldWithDefault(cmdObj, "sampleRate"_sd, serverGlobalParams.sampleRate, &newSampleRate));
+        uassert(ErrorCodes::BadValue, "sampleRate must be between 0.0 and 1.0 inclusive", newSampleRate >= 0.0 && newSampleRate <= 1.0);
+        serverGlobalParams.sampleRate = newSampleRate;
 
         if (!status.isOK()) {
             errmsg = status.reason();

--- a/src/mongo/db/mongod_options.cpp
+++ b/src/mongo/db/mongod_options.cpp
@@ -146,6 +146,13 @@ Status addMongodOptions(moe::OptionSection* options) {
                            "value of slow for profile and console log")
         .setDefault(moe::Value(100));
 
+    general_options
+        .addOptionChaining("operationProfiling.slowOpSampleRate",
+                           "sampleRate",
+                           moe::Double,
+                           "fraction of slow ops to include in the profile and console log")
+        .setDefault(moe::Value(1.0));
+
     general_options.addOptionChaining("profile", "profile", moe::Int, "0=off 1=slow, 2=all")
         .setSources(moe::SourceAllLegacy);
 
@@ -1042,6 +1049,10 @@ Status storeMongodOptions(const moe::Environment& params) {
 
     if (params.count("operationProfiling.slowOpThresholdMs")) {
         serverGlobalParams.slowMS = params["operationProfiling.slowOpThresholdMs"].as<int>();
+    }
+
+    if (params.count("operationProfiling.slowOpSampleRate")) {
+        serverGlobalParams.sampleRate = params["operationProfiling.slowOpSampleRate"].as<double>();
     }
 
     if (params.count("storage.syncPeriodSecs")) {

--- a/src/mongo/db/ops/write_ops_exec.cpp
+++ b/src/mongo/db/ops/write_ops_exec.cpp
@@ -109,13 +109,17 @@ void finishCurOp(OperationContext* txn, CurOp* curOp) {
         const bool logSlow = executionTimeMicros >
             (serverGlobalParams.slowMS + curOp->getExpectedLatencyMs()) * 1000LL;
 
-        if (logAll || logSlow) {
+        const bool shouldSample = serverGlobalParams.sampleRate == 1.0 ?
+            true :
+            txn->getClient()->getPrng().nextCanonicalDouble() < serverGlobalParams.sampleRate;
+
+        if (logAll || (shouldSample && logSlow)) {
             Locker::LockerInfo lockerInfo;
             txn->lockState()->getLockerInfo(&lockerInfo);
             log() << curOp->debug().report(txn->getClient(), *curOp, lockerInfo.stats);
         }
 
-        if (curOp->shouldDBProfile()) {
+        if (shouldSample && curOp->shouldDBProfile()) {
             profile(txn, CurOp::get(txn)->getNetworkOp());
         }
     } catch (const DBException& ex) {

--- a/src/mongo/db/server_options.h
+++ b/src/mongo/db/server_options.h
@@ -65,6 +65,7 @@ struct ServerGlobalParams {
 
     int defaultProfile = 0;                // --profile
     int slowMS = 100;                      // --time in ms that is "slow"
+    double sampleRate = 1.0;               // --samplerate rate at which to sample slow queries
     int defaultLocalThresholdMillis = 15;  // --localThreshold in ms to consider a node local
     bool moveParanoia = false;             // for move chunk paranoia
 

--- a/src/mongo/shell/db.js
+++ b/src/mongo/shell/db.js
@@ -548,20 +548,33 @@ var DB;
     /**
      * <p> Set profiling level for your db.  Profiling gathers stats on query performance. </p>
      *
-     * <p>Default is off, and resets to off on a database restart -- so if you want it on,
-     *    turn it on periodically. </p>
+     * <p>Default is off, and resets to off on a database restart
+     *    unless you specify the --profile command line argument </p>
+     *
+     * <p>Options:</p>
+     *
+     * <ul>
+     *
+     * <li>slowms: threshold in milliseconds for slow operations. If
+     *     the profiling level is set to 1, only operations that take
+     *     longer than this value are logged.</li>
+     *
+     * <li>sampleRate: ratio of operations to sample. Must be between
+     *     0.0 and 1.0 (inclusive). If specified, a random sample is
+     *     taken of operations that would otherwise be profiled.</li>
+     *
+     * </ul>
      *
      *  <p>Levels :</p>
      *   <ul>
      *    <li>0=off</li>
-     *    <li>1=log very slow operations; optional argument slowms specifies slowness threshold</li>
+     *    <li>1=log very slow operations; specifying the option slowms sets the threshold</li>
      *    <li>2=log all</li>
      *  @param {String} level Desired level of profiling
-     *  @param {String} slowms For slow logging, query duration that counts as slow (default 100ms)
+     *  @param {Object} options Object with options. Options are listed above
      *  @return SOMETHING_FIXME or null on error
      */
-    DB.prototype.setProfilingLevel = function(level, slowms) {
-
+    DB.prototype.setProfilingLevel = function(level, options) {
         if (level < 0 || level > 2) {
             var errorText = "input level " + level + " is out of range [0..2]";
             var errorObject = new Error(errorText);
@@ -570,8 +583,11 @@ var DB;
         }
 
         var cmd = {profile: level};
-        if (isNumber(slowms))
-            cmd["slowms"] = slowms;
+        if (isNumber(options)) {
+            cmd.slowms = options;
+        } else {
+            cmd = Object.extend(cmd, options);
+        }
         return assert.commandWorked(this._dbCommand(cmd));
     };
 


### PR DESCRIPTION
Ideally, we'd like to be able to set a lower slowms threshold so that we can get a broader sample of queries being run against our databases. However, dropping the threshold low enough to get useful data results in an unacceptable amount of load.

This allows us to drop the threshold, but only capture a fraction of queries.

(We're currently running with a similar patch backported to an older MongoDB version in production, and it's been very helpful for analyzing query traffic)
