### PR TITLE
SERVER-24948: add nameOnly option to listDatabases

### DIFF
--- a/jstests/core/dbadmin.js
+++ b/jstests/core/dbadmin.js
@@ -10,6 +10,9 @@ t.save( { x : 1 } );
 var res = db._adminCommand( "listDatabases" );
 assert( res.databases && res.databases.length > 0 , "listDatabases 1 " + tojson(res) );
 
+var res = db.adminCommand( {listDatabases: 1, nameOnly: true} );
+assert( res.databases && res.databases.length > 0 && res.nameOnly , "listDatabases 1 " + tojson(res) );
+
 var now = new Date();
 var x = db._adminCommand( "ismaster" );
 assert( x.ismaster , "ismaster failed: " + tojson( x ) );

--- a/src/mongo/client/dbclient.cpp
+++ b/src/mongo/client/dbclient.cpp
@@ -680,7 +680,7 @@ list<string> DBClientWithCommands::getDatabaseNames() {
     BSONObj info;
     uassert(10005,
             "listdatabases failed",
-            runCommand("admin", BSON("listDatabases" << 1), info, QueryOption_SlaveOk));
+            runCommand("admin", BSON("listDatabases" << 1 << "nameOnly" << true), info, QueryOption_SlaveOk));
     uassert(10006, "listDatabases.databases not array", info["databases"].type() == Array);
 
     list<string> names;

--- a/src/mongo/db/commands/list_databases.cpp
+++ b/src/mongo/db/commands/list_databases.cpp
@@ -79,6 +79,13 @@ public:
              int,
              string& errmsg,
              BSONObjBuilder& result) {
+    
+        bool nameOnly = false;
+        BSONElement nameOnlyElt = jsobj["nameOnly"];
+        if (!nameOnlyElt.eoo() && nameOnlyElt.trueValue()) {
+            nameOnly = true;
+        }
+
         vector<string> dbNames;
         StorageEngine* storageEngine = getGlobalServiceContext()->getGlobalStorageEngine();
         storageEngine->listDatabases(&dbNames);
@@ -104,7 +111,7 @@ public:
                 const DatabaseCatalogEntry* entry = db->getDatabaseCatalogEntry();
                 invariant(entry);
 
-                int64_t size = entry->sizeOnDisk(txn);
+                int64_t size = nameOnly ? 0 : entry->sizeOnDisk(txn);
                 b.append("sizeOnDisk", static_cast<double>(size));
                 totalSize += size;
 
@@ -118,6 +125,9 @@ public:
 
         result.append("databases", dbInfos);
         result.append("totalSize", double(totalSize));
+        if (nameOnly) {
+            result.append("nameOnly", nameOnly);
+        }
         return true;
     }
 } cmdListDatabases;


### PR DESCRIPTION
Add 'nameOnly' option to listDatabases command, using this option in initial sync to avoid socket timeout when listDatabases.
