### PR TITLE
SERVER-19507 scan all keys in index for distinct key

### DIFF
--- a/jstests/core/distinct_multikey_index.js
+++ b/jstests/core/distinct_multikey_index.js
@@ -1,0 +1,32 @@
+(function() {
+    "use strict";
+
+    load("jstests/libs/analyze_plan.js");
+
+    var t = db.distinct_multikey_index;
+
+    t.drop();
+    for (var i = 0; i < 10; i++) {
+        t.save({a: 1, b: 1});
+        t.save({a: 1, b: 2});
+        t.save({a: 2, b: 1});
+        t.save({a: 2, b: 3});
+    }
+    t.createIndex({a: 1, b: 1});
+
+    var explain = t.distinct('b', {a: 1}).explain("executionStats");
+    assert.commandWorked(explain);
+    assert(planHasStage(explain.queryPlanner.winningPlan, "DISTINCT_SCAN"));
+    assert(planHasState(explain.queryPlanner.winningPlan, "PROJECTION"));
+    assert.eq(2, explain.executionStats.nReturned);
+
+    var stage = getPlanStage(explain.queryPlanner.winningPlan, "DISTINCT_SCAN");
+    assert.eq({a: 1, b: 1}, stage.keyPattern);
+    assert.eq("a_1_b_1", stage.indexName);
+    assert.eq(false, stage.isMultiKey);
+    assert.eq(false, stage.isUnique);
+    assert.eq(false, stage.isSparse);
+    assert.eq(false, stage.isPartial);
+    assert.eq(1, stage.indexVersion);
+    assert("indexBounds" in stage);
+})();

--- a/src/mongo/db/query/get_executor.cpp
+++ b/src/mongo/db/query/get_executor.cpp
@@ -1137,6 +1137,10 @@ bool getDistinctNodeIndex(const std::vector<IndexEntry>& indices,
         if (indices[i].multikey && isDottedField) {
             continue;
         }
+        // Skip indices where the first key is not field
+        if (indices[i].keyPattern.firstElementFieldName() != field) {
+            continue;
+        }
         int nFields = indices[i].keyPattern.nFields();
         // Pick the index with the lowest number of fields.
         if (nFields < minFields) {

--- a/src/mongo/db/query/get_executor.cpp
+++ b/src/mongo/db/query/get_executor.cpp
@@ -1352,9 +1352,7 @@ bool turnIxscanIntoDistinctIxscan(QuerySolution* soln, const string& field) {
     distinctNode->direction = indexScanNode->direction;
     distinctNode->bounds = indexScanNode->bounds;
 
-    // Figure out which field we're skipping to the next value of.  TODO: We currently only
-    // try to distinct-hack when there is an index prefixed by the field we're distinct-ing
-    // over.  Consider removing this code if we stick with that policy.
+    // Figure out which field we're skipping to the next value of.
     distinctNode->fieldNo = 0;
     BSONObjIterator it(indexScanNode->index.keyPattern);
     while (it.more()) {
@@ -1431,9 +1429,7 @@ StatusWith<unique_ptr<PlanExecutor>> getExecutorDistinct(OperationContext* txn,
     while (ii.more()) {
         const IndexDescriptor* desc = ii.next();
         IndexCatalogEntry* ice = ii.catalogEntry(desc);
-        // The distinct hack can work if any field is in the index but it's not always clear
-        // if it's a win unless it's the first field.
-        if (desc->keyPattern().firstElement().fieldName() == parsedDistinct->getKey()) {
+        if (desc->keyPattern().hasField(parsedDistinct->getKey())) {
             plannerParams.indices.push_back(IndexEntry(desc->keyPattern(),
                                                        desc->getAccessMethodName(),
                                                        desc->isMultikey(txn),

--- a/src/mongo/db/query/get_executor.cpp
+++ b/src/mongo/db/query/get_executor.cpp
@@ -1137,7 +1137,7 @@ bool getDistinctNodeIndex(const std::vector<IndexEntry>& indices,
         if (indices[i].multikey && isDottedField) {
             continue;
         }
-        // Skip indices where the first key is not field
+        // Skip indices where the first key is not field.
         if (indices[i].keyPattern.firstElementFieldName() != field) {
             continue;
         }

--- a/src/mongo/dbtests/query_stage_distinct.cpp
+++ b/src/mongo/dbtests/query_stage_distinct.cpp
@@ -236,6 +236,73 @@ public:
     }
 };
 
+class QueryStageDistinctCompoundIndex : public DistinctBase {
+public:
+    void run() {
+        // insert documents with a: 1 and b: 1
+        for (size_t i = 0; i < 1000; ++i) {
+            insert(BSON("a" << 1 << "b" << 1));
+        }
+        // insert documents with a: 1 and b: 2
+        for (size_t i = 0; i < 1000; ++i) {
+            insert(BSON("a" << 1 << "b" << 2));
+        }
+        // insert documents with a: 2 and b: 1
+        for (size_t i = 0; i < 1000; ++i) {
+            insert(BSON("a" << 2 << "b" << 1));
+        }
+        // insert documents with a: 2 and b: 3
+        for (size_t i = 0; i < 1000; ++i) {
+            insert(BSON("a" << 2 << "b" << 3));
+        }
+
+        addIndex(BSON("a" << 1 << "b" << 1));
+
+        AutoGetCollectionForRead ctx(&_txn, ns());
+        Collection* coll = ctx.getCollection();
+
+        std::vector<IndexDescriptor*> indices;
+        coll->getIndexCatalog()->findIndexesByKeyPattern(&_txn, BSON("a" << 1 << "b" << 1), false, &indices);
+        verify(indices.size() == 1);
+
+        DistinctParams params;
+        params.descriptor = indices[0];
+        verify(params.descriptor);
+
+        params.direction = 1;
+        params.fieldNo = 1;
+        params.bounds.isSimpleRange = false;
+
+        OrderedIntervalList a_oil{"a"};
+        a_oil.intervals.push_back(IndexBoundsBuilder::allValues());
+        params.bounds.fields.push_back(a_oil);
+
+        OrderedIntervalList b_oil{"b"};
+        b_oil.intervals.push_back(IndexBoundsBuilder::allValues());
+        params.bounds.fields.push_back(b_oil);
+
+        WorkingSet ws;
+        DistinctScan distinct(&_txn, params, &ws);
+
+        WorkingSetID wsid;
+        PlanStage::StageState state;
+
+        std::vector<int> seen;
+
+        while (PlanStage::IS_EOF != (state = distinct.work(&wsid))) {
+            if (PlanStage::ADVANCED == state) {
+                seen.push_back(getIntFieldDotted(ws, wsid, "b"));
+            }
+        }
+
+        ASSERT_EQUALS(4U, seen.size());
+        ASSERT_EQUALS(1, seen[0]);
+        ASSERT_EQUALS(2, seen[1]);
+        ASSERT_EQUALS(1, seen[2]);
+        ASSERT_EQUALS(3, seen[3]);
+    }
+};
+
 // XXX: add a test case with bounds where skipping to the next key gets us a result that's not
 // valid w.r.t. our query.
 
@@ -246,6 +313,7 @@ public:
     void setupTests() {
         add<QueryStageDistinctBasic>();
         add<QueryStageDistinctMultiKey>();
+        add<QueryStageDistinctCompoundIndex>();
     }
 };
 

--- a/src/mongo/dbtests/query_stage_distinct.cpp
+++ b/src/mongo/dbtests/query_stage_distinct.cpp
@@ -263,23 +263,23 @@ public:
 
         std::vector<IndexDescriptor*> indices;
         coll->getIndexCatalog()->findIndexesByKeyPattern(&_txn, BSON("a" << 1 << "b" << 1), false, &indices);
-        verify(indices.size() == 1);
+        ASSERT_EQ(1U, indices.size());
 
         DistinctParams params;
         params.descriptor = indices[0];
-        verify(params.descriptor);
+        ASSERT_TRUE(params.descriptor);
 
         params.direction = 1;
         params.fieldNo = 1;
         params.bounds.isSimpleRange = false;
 
-        OrderedIntervalList a_oil{"a"};
-        a_oil.intervals.push_back(IndexBoundsBuilder::allValues());
-        params.bounds.fields.push_back(a_oil);
+        OrderedIntervalList aOil{"a"};
+        aOil.intervals.push_back(IndexBoundsBuilder::allValues());
+        params.bounds.fields.push_back(aOil);
 
-        OrderedIntervalList b_oil{"b"};
-        b_oil.intervals.push_back(IndexBoundsBuilder::allValues());
-        params.bounds.fields.push_back(b_oil);
+        OrderedIntervalList bOil{"b"};
+        bOil.intervals.push_back(IndexBoundsBuilder::allValues());
+        params.bounds.fields.push_back(bOil);
 
         WorkingSet ws;
         DistinctScan distinct(&_txn, params, &ws);
@@ -290,6 +290,8 @@ public:
         std::vector<int> seen;
 
         while (PlanStage::IS_EOF != (state = distinct.work(&wsid))) {
+            ASSERT_NE(PlanStage::FAILURE, state);
+            ASSERT_NE(PlanStage::DEAD, state);
             if (PlanStage::ADVANCED == state) {
                 seen.push_back(getIntFieldDotted(ws, wsid, "b"));
             }


### PR DESCRIPTION
The distinct hack can also be applied when the distinct command key is not the first key in the index. The corresponding JIRA ticket gives one such example.