### PR TITLE
SERVER-25192 Handle null properties in Object.extend

### DIFF
--- a/src/mongo/shell/types.js
+++ b/src/mongo/shell/types.js
@@ -251,7 +251,7 @@ Array.stdDev = function(arr) {
 Object.extend = function(dst, src, deep) {
     for (var k in src) {
         var v = src[k];
-        if (deep && typeof(v) == "object") {
+        if (deep && typeof(v) == "object" && v !== null) {
             if (v.constructor === ObjectId) {  // convert ObjectId properly
                 eval("v = " + tojson(v));
             } else if ("floatApprox" in v) {  // convert NumberLong properly


### PR DESCRIPTION
Ran into this issue adapting mongo-perf to run some internal bench marks. A query op such as this:

```
ops : [
  { op: "find",
    ns: "app-test.emails",
    query: {
      accountId: "12345-67890-12345-67890",
      _type: { $ne: null }
    }
  }
]
```

produces the following error:

```
Error running test [object Object]: Cannot use 'in' operator to search for 'floatApprox' in null:TypeError: Cannot use 'in' operator to search for 'floatApprox' in null
at Function.Object.extend (src/mongo/shell/types.js:228:34)
at Function.Object.extend (src/mongo/shell/types.js:231:28)
at Function.Object.extend (src/mongo/shell/types.js:231:28)
at util/utils.js:86:29
at Array.forEach (native)
at runTest (util/utils.js:82:14)
at runTests (util/utils.js:369:38)
at mongoPerfRunTests (util/utils.js:421:19)
at (shell):1:1
```


The issue is that in javascript:
```
[00:09:51] tim@Timo:~/src/mongo $ node
> typeof(null)
'object'
>
```

and the code being modified in the PR is trying to deep copy an object, verifying the property is an object by using `typeof()`.