### PR TITLE
SERVER-25717 Allow for negative $push indexes.

### DIFF
--- a/src/mongo/db/ops/modifier_push.cpp
+++ b/src/mongo/db/ops/modifier_push.cpp
@@ -546,7 +546,11 @@ Status ModifierPush::apply() const {
 
     // Handle negative starting positions as a distance from the end of the array.
     if (_startPosition < 0) {
-        _preparedState->startPosition = size_t(_preparedState->arrayPreModSize + _startPosition);
+        if (_preparedState->arrayPreModSize + _startPosition < 0) {
+            _preparedState->startPosition = 0;
+        } else {
+            _preparedState->startPosition = size_t(_preparedState->arrayPreModSize + _startPosition);
+        }
     } else {
         _preparedState->startPosition = size_t(_startPosition);
     }

--- a/src/mongo/db/ops/modifier_push.cpp
+++ b/src/mongo/db/ops/modifier_push.cpp
@@ -546,7 +546,7 @@ Status ModifierPush::apply() const {
 
     // Handle negative starting positions as a distance from the end of the array.
     if (_startPosition < 0) {
-        if (_preparedState->arrayPreModSize + _startPosition < 0) {
+        if (size_t(abs(_startPosition)) > _preparedState->arrayPreModSize) {
             _preparedState->startPosition = 0;
         } else {
             _preparedState->startPosition = size_t(_preparedState->arrayPreModSize + _startPosition);

--- a/src/mongo/db/ops/modifier_push.h
+++ b/src/mongo/db/ops/modifier_push.h
@@ -110,7 +110,7 @@ private:
     bool _slicePresent;
     int64_t _slice;
     bool _sortPresent;
-    size_t _startPosition;
+    int _startPosition;
 
     PatternElementCmp _sort;
 


### PR DESCRIPTION
It is now possible to issue `$push` updates with negative `$position` indexes. These will be treated as an offset from the end of the array.  Ref: the [associated JIRA ticket](https://jira.mongodb.org/browse/SERVER-25717).

For example, given the following document:

``` js
{acl: [
    {grant: true, user: "amcgregor"},
    {grant: true, user: "bdole"},
    {grant: false}
]}
```

Issuing the following update:

``` js
{$push: {acl: {$each: [{grant: true, user: "algore"}], $position: -1}}}
```

Will result in:

``` js
{acl: [
    {grant: true, user: "amcgregor"},
    {grant: true, user: "bdole"},
    {grant: true, user: "algore"},
    {grant: false}
]}
```

This matches Python list manipulation semantics.

Tests have not been updated, range checking should probably be put in there somewhere (or may be covered by the "32-bit integer" test above the modified prep section), and the approach used may be terrible given that this is the first C++ code I've touched in 10 years.
