### PR TITLE
add & to make mongod process run on background

### DIFF
--- a/rpm/init.d-mongod
+++ b/rpm/init.d-mongod
@@ -66,7 +66,7 @@ start()
   ulimit -u 64000
 
   echo -n $"Starting mongod: "
-  daemon --user "$MONGO_USER" --check $mongod "$NUMACTL $mongod $OPTIONS >/dev/null 2>&1"
+  daemon --user "$MONGO_USER" --check $mongod "$NUMACTL $mongod $OPTIONS >/dev/null 2>&1 &"
   RETVAL=$?
   echo
   [ $RETVAL -eq 0 ] && touch /var/lock/subsys/mongod


### PR DESCRIPTION
for now when you run `systemctl start mongod` the script will hold the shell.(tested on CentOS 7)
