### PR TITLE
Fix for negative Date timezone offsets 

### DIFF
--- a/src/mongo/shell/types.js
+++ b/src/mongo/shell/types.js
@@ -46,7 +46,7 @@ Date.prototype.tojson = function() {
     // var ofsmin = this.getTimezoneOffset();
     // if (ofsmin != 0){
     //     ofs = ofsmin > 0 ? '-' : '+'; // This is correct
-    //     ofs += (ofsmin/60).zeroPad(2)
+    //     ofs += Math.abs(ofsmin/60).zeroPad(2)
     //     ofs += (ofsmin%60).zeroPad(2)
     // }
     return 'ISODate("' + year + '-' + month + '-' + date + 'T' + hour + ':' + minute + ':' + sec +


### PR DESCRIPTION
When uncommented this `// print a non-UTC time` block and changed `var UTC = '';` got invalid timezone offsets like: `ISODate("2016-11-14T00:00:00+-100")`. This makes Date be displayed as `ISODate("2016-11-14T00:00:00+0100")`