### PR TITLE
Fix start-stop-daemon stop issue

### DIFF
--- a/debian/init.d
+++ b/debian/init.d
@@ -155,8 +155,7 @@ stop_server() {
 # Stop the process using the wrapper
             start-stop-daemon --stop --quiet --pidfile $PIDFILE \
                         --retry 300 \
-                        --user $DAEMONUSER \
-                        --exec $DAEMON
+                        --user $DAEMONUSER
             errcode=$?
         return $errcode
 }


### PR DESCRIPTION
Fix `No /usr/bin/mongod found running; none killed.` error when using `service mongod stop`