### PR TITLE
[SERVER-7716] change DBClientWithCommands count() to take a Query instead of a BSON object

### DIFF
--- a/src/mongo/client/dbclient.cpp
+++ b/src/mongo/client/dbclient.cpp
@@ -323,8 +323,10 @@ bool DBClientWithCommands::runPseudoCommand(StringData db,
 }
 
 unsigned long long DBClientWithCommands::count(
-    const string& myns, const BSONObj& query, int options, int limit, int skip) {
-    BSONObj cmd = _countCmd(myns, query, options, limit, skip);
+    const string& myns, const Query& query, int options, int limit, int skip) {
+    const BSONObj query_obj = query.isComplex() ? query.obj["query"].embeddedObject() : BSONObj();
+
+    const BSONObj cmd = _countCmd(myns, query_obj, options, limit, skip);
     BSONObj res;
     if (!runCommand(nsToDatabase(myns), cmd, res, options))
         uasserted(11010, string("count fails:") + res.toString());
@@ -334,6 +336,7 @@ unsigned long long DBClientWithCommands::count(
 BSONObj DBClientWithCommands::_countCmd(
     const string& myns, const BSONObj& query, int options, int limit, int skip) {
     NamespaceString ns(myns);
+
     BSONObjBuilder b;
     b.append("count", ns.coll());
     b.append("query", query);

--- a/src/mongo/client/dbclientinterface.h
+++ b/src/mongo/client/dbclientinterface.h
@@ -524,7 +524,7 @@ public:
         throws UserAssertion if database returns an error
     */
     virtual unsigned long long count(const std::string& ns,
-                                     const BSONObj& query = BSONObj(),
+                                     const Query& query = Query(),
                                      int options = 0,
                                      int limit = 0,
                                      int skip = 0);

--- a/src/mongo/db/dbdirectclient.h
+++ b/src/mongo/db/dbdirectclient.h
@@ -82,7 +82,7 @@ public:
     virtual void say(Message& toSend, bool isRetry = false, std::string* actualServer = 0);
 
     virtual unsigned long long count(const std::string& ns,
-                                     const BSONObj& query = BSONObj(),
+                                     const Query& query = Query(),
                                      int options = 0,
                                      int limit = 0,
                                      int skip = 0);


### PR DESCRIPTION
Changed signature of mongo::DBClientWithCommands::count function and its dependent classes for complex queries handles.