### PR TITLE
Use the overrided environment when generating compile_command.json

### DIFF
--- a/site_scons/site_tools/compilation_db.py
+++ b/site_scons/site_tools/compilation_db.py
@@ -51,7 +51,8 @@ def makeEmitCompilationDbEntry(comstr):
             source=[],
             __COMPILATIONDB_UTARGET=target,
             __COMPILATIONDB_USOURCE=source,
-            __COMPILATIONDB_UACTION=user_action)
+            __COMPILATIONDB_UACTION=user_action,
+            __COMPILATIONDB_ENV=env)
 
         # TODO: Technically, these next two lines should not be required: it should be fine to
         # cache the entries. However, they don't seem to update properly. Since they are quick
@@ -70,7 +71,7 @@ def CompilationDbEntryAction(target, source, env, **kw):
     command = env['__COMPILATIONDB_UACTION'].strfunction(
         target=env['__COMPILATIONDB_UTARGET'],
         source=env['__COMPILATIONDB_USOURCE'],
-        env=env)
+        env=env['__COMPILATIONDB_ENV'],)
 
     entry = {
         "directory": env.Dir('#').abspath,


### PR DESCRIPTION
When the compilation_db scons emitter saved compilation database
entried it always used the "global" environment which might not match
the compilation command line actually used to build the target.

That meant that using eg.:

env.Library("foo", ["foo.cpp"], CXXFLAGS=["-Dfoo"])

Would not write the extra "-Dfoo" flag actually used to build the foo
library to the compile_commands.json file.

Instead save the environment used to generate the target and use that
when writing the compile_command.json entry.

This probably won't benefit the mongodb project (at least for now), but this should be more correct I hope.