### PR TITLE
SERVER-27693 implemented commands to access diagnostic.data files

### DIFF
--- a/buildscripts/resmokeconfig/suites/sharded_collections_jscore_passthrough.yml
+++ b/buildscripts/resmokeconfig/suites/sharded_collections_jscore_passthrough.yml
@@ -19,6 +19,8 @@ selector:
     - jstests/core/dbhash.js  # dbhash.
     - jstests/core/dbhash2.js  # dbhash.
     - jstests/core/diagdata.js # Command not supported in mongos
+    - jstests/core/diagdata2.js # Command not supported in mongos
+    - jstests/core/diagdata3.js # Command not supported in mongos
     - jstests/core/dropdb_race.js  # syncdelay.
     - jstests/core/evalb.js  # profiling.
     - jstests/core/fsync.js  # uses fsync.

--- a/buildscripts/resmokeconfig/suites/sharding_jscore_passthrough.yml
+++ b/buildscripts/resmokeconfig/suites/sharding_jscore_passthrough.yml
@@ -19,6 +19,8 @@ selector:
     - jstests/core/dbhash.js  # dbhash.
     - jstests/core/dbhash2.js  # dbhash.
     - jstests/core/diagdata.js # Command not supported in mongos
+    - jstests/core/diagdata2.js # Command not supported in mongos
+    - jstests/core/diagdata3.js # Command not supported in mongos
     - jstests/core/dropdb_race.js  # syncdelay.
     - jstests/core/evalb.js  # profiling.
     - jstests/core/fsync.js  # uses fsync.

--- a/jstests/auth/lib/commands_lib.js
+++ b/jstests/auth/lib/commands_lib.js
@@ -2705,6 +2705,42 @@ var authCommandsLib = {
           ]
         },
         {
+          testname: "getDiagnosticDataFiles",
+          command: {getDiagnosticDataFiles: 1},
+          skipSharded: true,
+          testcases: [
+              {
+                runOnDb: adminDbName,
+                roles: roles_monitoring,
+                privileges: [
+                    {resource: {cluster: true}, actions: ["serverStatus"]},
+                    {resource: {cluster: true}, actions: ["replSetGetStatus"]},
+                    {resource: {db: "local", collection: "oplog.rs"}, actions: ["collStats"]},
+                ]
+              },
+              {runOnDb: firstDbName, roles: {}},
+              {runOnDb: secondDbName, roles: {}}
+          ]
+        },
+        {
+          testname: "getDiagnosticDataFromFile",
+          command: {getDiagnosticDataFromFile: 1},
+          skipSharded: true,
+          testcases: [
+              {
+                runOnDb: adminDbName,
+                roles: roles_monitoring,
+                privileges: [
+                    {resource: {cluster: true}, actions: ["serverStatus"]},
+                    {resource: {cluster: true}, actions: ["replSetGetStatus"]},
+                    {resource: {db: "local", collection: "oplog.rs"}, actions: ["collStats"]},
+                ]
+              },
+              {runOnDb: firstDbName, roles: {}},
+              {runOnDb: secondDbName, roles: {}}
+          ]
+        },
+        {
           testname: "getLastError",
           command: {getLastError: 1},
           testcases: [

--- a/jstests/core/diagdata2.js
+++ b/jstests/core/diagdata2.js
@@ -1,0 +1,28 @@
+// Test that verifies getDiagnosticDataFiles returns FTDC data files
+
+(function() {
+    "use strict";
+
+    // Verify we require admin database
+    assert.commandFailed(db.diagdata.runCommand("getDiagnosticDataFiles"));
+
+    // We need to retry a few times if run this test immediately after mongod is started as FTDC may
+    // not have run yet so it may have no files.
+    var foundFiles = false;
+
+    for (var i = 0; i < 60; ++i) {
+        var result = db.adminCommand("getDiagnosticDataFiles");
+        assert.commandWorked(result);
+
+        var data = result.data;
+        //Check for the metrics.interim file it should be present with a good probability
+        if (data.indexOf("metrics.interim") > -1) {
+            foundFiles = true;
+        } else {
+            // Wait a little longer for FTDC to start
+            sleep(500);
+        }
+    }
+    assert(foundFiles,
+           "getDiagnosticDataFiles failed to return files, is FTDC running?");
+})();

--- a/jstests/core/diagdata3.js
+++ b/jstests/core/diagdata3.js
@@ -1,0 +1,33 @@
+// Test that verifies getDiagnosticDataFromFile returns FTDC data
+
+(function() {
+    "use strict";
+
+    // Verify we require admin database
+    assert.commandFailed(db.diagdata.runCommand("getDiagnosticDataFromFile"));
+
+    // We need to retry a few times if run this test immediately after mongod is started as FTDC may
+    // not have run yet.
+    var foundGoodDocument = false;
+
+    for (var i = 0; i < 60; ++i) {
+        var result = db.adminCommand("getDiagnosticDataFromFile");
+        assert.commandWorked(result);
+
+        //Check the first result document
+        var data = result.data[0];
+
+        if (!data.hasOwnProperty("start")) {
+            // Wait a little longer for FTDC to start
+            sleep(500);
+        } else {
+            // Check for a few common properties to ensure we got data
+            assert(data.hasOwnProperty("serverStatus"),
+                   "does not have 'serverStatus' in '" + tojson(data) + "'");
+            assert(data.hasOwnProperty("end"), "does not have 'end' in '" + tojson(data) + "'");
+            foundGoodDocument = true;
+        }
+    }
+    assert(foundGoodDocument,
+           "getDiagnosticDataFromFile failed to return a non-empty command, is FTDC running?");
+})();

--- a/jstests/core/views/views_all_commands.js
+++ b/jstests/core/views/views_all_commands.js
@@ -223,6 +223,8 @@
         },
         getCmdLineOpts: {skip: isUnrelated},
         getDiagnosticData: {skip: isUnrelated},
+        getDiagnosticDataFiles: {skip: isUnrelated},
+        getDiagnosticDataFromFile: {skip: isUnrelated},
         getLastError: {skip: isUnrelated},
         getLog: {skip: isUnrelated},
         getMore: {

--- a/src/mongo/db/ftdc/ftdc_commands.cpp
+++ b/src/mongo/db/ftdc/ftdc_commands.cpp
@@ -28,12 +28,16 @@
 
 #include "mongo/platform/basic.h"
 
+#include <boost/filesystem.hpp>
+
 #include "mongo/base/init.h"
+#include "mongo/bson/util/bson_extract.h"
 #include "mongo/db/auth/action_type.h"
 #include "mongo/db/auth/authorization_session.h"
 #include "mongo/db/client.h"
 #include "mongo/db/commands.h"
 #include "mongo/db/ftdc/controller.h"
+#include "mongo/db/ftdc/file_reader.h"
 #include "mongo/db/jsobj.h"
 #include "mongo/db/operation_context.h"
 
@@ -102,10 +106,276 @@ public:
     }
 };
 
+
 Command* ftdcCommand;
 
 MONGO_INITIALIZER(CreateDiagnosticDataCommand)(InitializerContext* context) {
     ftdcCommand = new GetDiagnosticDataCommand();
+
+    return Status::OK();
+}
+
+/**
+ * Get the content of an FTDC data file
+ *
+ * The command can dump the content of an ftdc archive file.
+ *
+ */
+class GetDiagnosticDataFromFileCommand final : public Command {
+public:
+    GetDiagnosticDataFromFileCommand() : Command("getDiagnosticDataFromFile") {}
+
+    bool adminOnly() const override {
+        return true;
+    }
+
+    void help(std::stringstream& help) const override {
+        help << "get diagnostic data from file";
+    }
+
+    bool slaveOk() const override {
+        return true;
+    }
+
+    bool supportsWriteConcern(const BSONObj& cmd) const override {
+        return false;
+    }
+
+    Status checkAuthForCommand(Client* client,
+                               const std::string& dbname,
+                               const BSONObj& cmdObj) override {
+
+        if (!AuthorizationSession::get(client)->isAuthorizedForActionsOnResource(
+                ResourcePattern::forClusterResource(), ActionType::serverStatus)) {
+            return Status(ErrorCodes::Unauthorized, "Unauthorized");
+        }
+
+        if (!AuthorizationSession::get(client)->isAuthorizedForActionsOnResource(
+                ResourcePattern::forClusterResource(), ActionType::replSetGetStatus)) {
+            return Status(ErrorCodes::Unauthorized, "Unauthorized");
+        }
+
+        if (!AuthorizationSession::get(client)->isAuthorizedForActionsOnResource(
+                ResourcePattern::forExactNamespace(NamespaceString("local", "oplog.rs")),
+                ActionType::collStats)) {
+            return Status(ErrorCodes::Unauthorized, "Unauthorized");
+        }
+
+        return Status::OK();
+    }
+
+    bool run(OperationContext* txn,
+             const std::string& db,
+             BSONObj& cmdObj,
+             int options,
+             std::string& errmsg,
+             BSONObjBuilder& result) override {
+
+        /*
+        * Handle the input parameters
+        * filename : actually the filename of the archive we would like to handle
+        * skip, limit : skip and limit as like any
+        * showOutput: turn off data output generation to check filesize in records for example.
+        * startDate: start date of data output generation
+        * endDate: end date of data output generation
+        */
+
+        std::string dbPath;
+        std::string filePath;
+
+        long long skip, limit;
+        bool showOutput;
+        BSONElement startDateFilter;
+        BSONElement endDateFilter;
+        BSONObj fieldList;
+
+        // TODO: this seems dangerous, what is when there is no storage key here? Is that possible?
+        uassertStatusOK(bsonExtractStringFieldWithDefault(
+            serverGlobalParams.parsedOpts.getObjectField("storage"),
+            "dbPath",
+            "/opt/data",
+            &dbPath));
+
+        uassertStatusOK(
+            bsonExtractStringFieldWithDefault(cmdObj, "filename", "metrics.interim", &filePath));
+        // TODO: check the value a bit better, not to have any bad affect.
+        std::size_t foundPos = filePath.find('/');
+        if (foundPos != std::string::npos) {
+            result.append("errmsg", "/ not allowed in the filename");
+            return false;
+        }
+
+        uassertStatusOK(
+            bsonExtractBooleanFieldWithDefault(cmdObj, "showOutput", true, &showOutput));
+        uassertStatusOK(bsonExtractIntegerFieldWithDefault(cmdObj, "skip", 0, &skip));
+        uassertStatusOK(bsonExtractIntegerFieldWithDefault(cmdObj, "limit", 100, &limit));
+
+        /*
+        *   Extract dates
+        *
+        *   startDate  defaults to ISODate("1970-01-01T00:00:00Z")
+        *   endDate    should be checked if it is ISODate("1970-01-01T00:00:00Z") should be set
+        *              to Date.now() as nothing can be there for the future
+        */
+
+        Status statussdf = bsonExtractTypedField(cmdObj, "startDate", Date, &startDateFilter);
+        if (!statussdf.isOK()) {
+            bsonExtractTypedField(BSON("dateepoch" << Date_t::fromMillisSinceEpoch(0)),
+                                  "dateepoch",
+                                  Date,
+                                  &startDateFilter);
+        }
+
+        Status statusedf = bsonExtractTypedField(cmdObj, "endDate", Date, &endDateFilter);
+        if (!statusedf.isOK()) {
+            bsonExtractTypedField(BSON("datenow" << DATENOW), "datenow", Date, &endDateFilter);
+        }
+
+        try {
+            FTDCFileReader reader;
+            std::stringstream ss;
+            ss << dbPath << "/diagnostic.data/" << filePath;
+
+            boost::filesystem::path p(ss.str());
+            reader.open(p);
+
+            int docsNumber = 0, matchedDocsNumber = 0;
+            BSONArrayBuilder list;
+            auto sw = reader.hasNext();
+            while (sw.isOK() && sw.getValue() && (limit == 0 || matchedDocsNumber < (skip + limit))) {
+                BSONObj oneEntry = std::get<1>(reader.next()).getOwned();
+                Date_t entryEndDate = oneEntry.getField("end").Date();
+                if (entryEndDate > startDateFilter.Date() &&
+                    entryEndDate < endDateFilter.Date()) {
+                    matchedDocsNumber++;
+                    if (showOutput && matchedDocsNumber > skip) {
+                        list.append(oneEntry);
+                    }
+                }
+                sw = reader.hasNext();
+                docsNumber++;
+            }
+
+            result.append("data", list.arr());
+            result.append("numDocumentsRead", docsNumber);
+            result.append("numDocumentsMatched", matchedDocsNumber);
+            result.append("startDateFilter", startDateFilter.Date());
+            result.append("endDateFilter", endDateFilter.Date());
+            result.append("skip", skip);
+            result.append("limit", limit);
+
+        } catch (std::exception e) {
+            result.append("errmsg", "Problem occured during the process");
+            return false;
+        }
+
+        return true;
+    }
+};
+
+Command* ftdcFromFileCommand;
+
+MONGO_INITIALIZER(CreateDiagnosticDataFromFileCommand)(InitializerContext* context) {
+    ftdcFromFileCommand = new GetDiagnosticDataFromFileCommand();
+
+    return Status::OK();
+}
+
+/**
+ * Get the list of FTDC archive files in diagnostic.data directory.
+ *
+ */
+class GetDiagnosticDataFilesCommand final : public Command {
+public:
+    GetDiagnosticDataFilesCommand() : Command("getDiagnosticDataFiles") {}
+
+    bool adminOnly() const override {
+        return true;
+    }
+
+    void help(std::stringstream& help) const override {
+        help << "get the list of diagnostic data archive files";
+    }
+
+    bool slaveOk() const override {
+        return true;
+    }
+
+    bool supportsWriteConcern(const BSONObj& cmd) const override {
+        return false;
+    }
+
+    Status checkAuthForCommand(Client* client,
+                               const std::string& dbname,
+                               const BSONObj& cmdObj) override {
+
+        if (!AuthorizationSession::get(client)->isAuthorizedForActionsOnResource(
+                ResourcePattern::forClusterResource(), ActionType::serverStatus)) {
+            return Status(ErrorCodes::Unauthorized, "Unauthorized");
+        }
+
+        if (!AuthorizationSession::get(client)->isAuthorizedForActionsOnResource(
+                ResourcePattern::forClusterResource(), ActionType::replSetGetStatus)) {
+            return Status(ErrorCodes::Unauthorized, "Unauthorized");
+        }
+
+        if (!AuthorizationSession::get(client)->isAuthorizedForActionsOnResource(
+                ResourcePattern::forExactNamespace(NamespaceString("local", "oplog.rs")),
+                ActionType::collStats)) {
+            return Status(ErrorCodes::Unauthorized, "Unauthorized");
+        }
+
+        return Status::OK();
+    }
+
+    bool run(OperationContext* txn,
+             const std::string& db,
+             BSONObj& cmdObj,
+             int options,
+             std::string& errmsg,
+             BSONObjBuilder& result) override {
+
+        std::string dbPath;
+        bsonExtractStringFieldWithDefault(serverGlobalParams.parsedOpts.getObjectField("storage"),
+                                          "dbPath",
+                                          "/opt/data",
+                                          &dbPath);
+
+        try {
+            std::stringstream ss;
+            ss << dbPath << "/diagnostic.data/";
+
+            boost::filesystem::path p(ss.str());
+            boost::filesystem::directory_iterator di(p);
+            std::vector<std::string> files;
+
+            for (; di != boost::filesystem::directory_iterator(); di++) {
+                boost::filesystem::directory_entry& de = *di;
+                std::string f = de.path().filename().string();
+                files.emplace_back(f);
+            }
+            std::sort(files.begin(), files.end());
+
+            BSONArrayBuilder list;
+
+            for (auto f : files) {
+                list.append(f);
+            }
+
+            result.append("data", list.arr());
+        } catch (std::exception e) {
+            result.append("errmsg", "Problem occured during the process");
+            return false;
+        }
+        return true;
+    }
+};
+
+
+Command* ftdcGetArchiveFilesCommand;
+
+MONGO_INITIALIZER(CreateDiagnosticDataArchiveListCommand)(InitializerContext* context) {
+    ftdcGetArchiveFilesCommand = new GetDiagnosticDataFilesCommand();
 
     return Status::OK();
 }


### PR DESCRIPTION
Hi,

Implemented two commands with tests (a bit more in jira described). Reused the test js from getDiagnosticData command, and most of the implementation is from the ftdc_test.cpp assuming it is ok, after some hours of debugging.

I followed the implementation from the getdiagnosticdata commands pull request. 

I think these commands can be useful for debugging/investigating problems.

Formatted the code with clang formatter. 
Please have a look, 
Best, 
Attila
