### PR TITLE
SERVER-27438 Prevent mongos from dropping legacy $comment meta-operator

### DIFF
--- a/jstests/libs/profiler.js
+++ b/jstests/libs/profiler.js
@@ -15,3 +15,12 @@ function getProfilerProtocolStringForCommand(conn) {
 
     return "op_command";
 }
+
+// Throws an assertion if the profiler does not contain exactly one entry matching <filter>.
+// Optional arguments <errorMsgFilter> and <errorMsgProj> limit profiler output if this asserts.
+function profilerHasSingleMatchingEntryOrThrow(inputDb, filter, errorMsgFilter, errorMsgProj) {
+    assert.eq(inputDb.system.profile.find(filter).itcount(),
+              1,
+              "Expected exactly one op matching: " + tojson(filter) + " in profiler " +
+                  tojson(inputDb.system.profile.find(errorMsgFilter, errorMsgProj).toArray()));
+}

--- a/jstests/sharding/mongos_query_comment.js
+++ b/jstests/sharding/mongos_query_comment.js
@@ -1,0 +1,79 @@
+/**
+ * Test that a legacy query via mongos retains the $comment query meta-operator when transformed
+ * into a find command for the shards. In addition, verify that the find command comment parameter
+ * and query operator are passed to the shards correctly, and that an attempt to attach a non-string
+ * comment to the find command fails.
+ */
+(function() {
+    "use strict";
+
+    // For profilerHasSingleMatchingEntryOrThrow.
+    load("jstests/libs/profiler.js");
+
+    const st = new ShardingTest({name: "mongos_comment_test", mongos: 1, shards: 1});
+
+    const shard = st.shard0;
+    const mongos = st.s;
+
+    // Need references to the database via both mongos and mongod so that we can enable profiling &
+    // test queries on the shard.
+    const mongosDB = mongos.getDB("mongos_comment");
+    const shardDB = shard.getDB("mongos_comment");
+
+    assert.commandWorked(mongosDB.dropDatabase());
+
+    const mongosColl = mongosDB.test;
+    const shardColl = shardDB.test;
+
+    const collNS = mongosColl.getFullName();
+
+    for (let i = 0; i < 5; ++i) {
+        assert.writeOK(mongosColl.insert({_id: i, a: i}));
+    }
+
+    // The profiler will be used to verify that comments are present on the shard.
+    assert.commandWorked(shardDB.setProfilingLevel(2));
+    const profiler = shardDB.system.profile;
+
+    //
+    // Set legacy read mode for the mongos and shard connections.
+    //
+    mongosDB.getMongo().forceReadMode("legacy");
+    shardDB.getMongo().forceReadMode("legacy");
+
+    // TEST CASE: A legacy string $comment meta-operator is propagated to the shards via mongos.
+    assert.eq(mongosColl.find({$query: {a: 1}, $comment: "TEST"}).itcount(), 1);
+    profilerHasSingleMatchingEntryOrThrow(shardDB,
+                                          {op: "query", ns: collNS, "query.comment": "TEST"});
+
+    // TEST CASE: A legacy BSONObj $comment is converted to a string and propagated via mongos.
+    assert.eq(mongosColl.find({$query: {a: 1}, $comment: {c: 2, d: {e: "TEST"}}}).itcount(), 1);
+    profilerHasSingleMatchingEntryOrThrow(
+        shardDB, {op: "query", ns: collNS, "query.comment": "{ c: 2.0, d: { e: \"TEST\" } }"});
+
+    // TEST CASE: Legacy BSONObj $comment is NOT converted to a string when issued on the mongod.
+    assert.eq(shardColl.find({$query: {a: 1}, $comment: {c: 3, d: {e: "TEST"}}}).itcount(), 1);
+    profilerHasSingleMatchingEntryOrThrow(
+        shardDB, {op: "query", ns: collNS, "query.comment": {c: 3, d: {e: "TEST"}}});
+
+    //
+    // Revert to "commands" read mode for the find command test cases below.
+    //
+    mongosDB.getMongo().forceReadMode("commands");
+    shardDB.getMongo().forceReadMode("commands");
+
+    // TEST CASE: Verify that string find.comment and non-string find.filter.$comment propagate.
+    assert.eq(mongosColl.find({a: 1, $comment: {b: "TEST"}}).comment("TEST").itcount(), 1);
+    profilerHasSingleMatchingEntryOrThrow(
+        shardDB,
+        {op: "query", ns: collNS, "query.comment": "TEST", "query.filter.$comment": {b: "TEST"}});
+
+    // TEST CASE: Verify that find command with a non-string comment parameter is rejected.
+    assert.commandFailedWithCode(
+        mongosDB.runCommand(
+            {"find": mongosColl.getName(), "filter": {a: 1}, "comment": {b: "TEST"}}),
+        9,
+        "Non-string find command comment did not return an error.");
+
+    st.stop();
+})();

--- a/src/mongo/db/query/query_request.h
+++ b/src/mongo/db/query/query_request.h
@@ -393,6 +393,16 @@ public:
      */
     static StatusWith<std::unique_ptr<QueryRequest>> fromLegacyQueryMessage(const QueryMessage& qm);
 
+    /**
+     * Parse the provided legacy query object and parameters to construct a QueryRequest.
+     */
+    static StatusWith<std::unique_ptr<QueryRequest>> fromLegacyQueryForTest(NamespaceString nss,
+                                                                            const BSONObj& queryObj,
+                                                                            const BSONObj& proj,
+                                                                            int ntoskip,
+                                                                            int ntoreturn,
+                                                                            int queryOptions);
+
 private:
     Status init(int ntoskip,
                 int ntoreturn,

--- a/src/mongo/db/query/query_request_test.cpp
+++ b/src/mongo/db/query/query_request_test.cpp
@@ -1304,5 +1304,28 @@ TEST(QueryRequestTest, ConvertToAggregationWithCollationSucceeds) {
     ASSERT_BSONOBJ_EQ(ar.getValue().getCollation(), BSON("f" << 1));
 }
 
+TEST(QueryRequestTest, ParseFromLegacyObjMetaOpComment) {
+    BSONObj queryObj = fromjson(
+        "{$query: {a: 1},"
+        "$comment: {b: 2, c: {d: 'ParseFromLegacyObjMetaOpComment'}}}");
+    const NamespaceString nss("test.testns");
+    unique_ptr<QueryRequest> qr(
+        assertGet(QueryRequest::fromLegacyQueryForTest(nss, queryObj, BSONObj(), 0, 0, 0)));
+
+    // Ensure that legacy comment meta-operator is parsed to a string comment
+    ASSERT_EQ(qr->getComment(), "{ b: 2, c: { d: \"ParseFromLegacyObjMetaOpComment\" } }");
+}
+
+TEST(QueryRequestTest, ParseFromLegacyStringMetaOpComment) {
+    BSONObj queryObj = fromjson(
+        "{$query: {a: 1},"
+        "$comment: 'ParseFromLegacyStringMetaOpComment'}");
+    const NamespaceString nss("test.testns");
+    unique_ptr<QueryRequest> qr(
+        assertGet(QueryRequest::fromLegacyQueryForTest(nss, queryObj, BSONObj(), 0, 0, 0)));
+
+    ASSERT_EQ(qr->getComment(), "ParseFromLegacyStringMetaOpComment");
+}
+
 }  // namespace mongo
 }  // namespace


### PR DESCRIPTION
This patch ensures that a mongos will not omit a legacy query's $comment meta-operator when forwarding the query to the shards.

- Adds code to handle the presence of a $comment meta-operator in query_request.cpp and an accompanying integration test.
- Adds a new method for testing the legacy query path and relevant unit tests.