### PR TITLE
Visual C++ workaround

### DIFF
--- a/src/mongo/util/lru_cache.h
+++ b/src/mongo/util/lru_cache.h
@@ -131,7 +131,7 @@ public:
      */
     const_iterator cfind(const K& key) const {
         auto it = this->_map.find(key);
-        return (it == this->_map.end()) ? this->end() : it->second;
+        return (it == this->_map.end()) ? this->end() : const_iterator(it->second);
     }
 
     /**


### PR DESCRIPTION
Workaround to allow building MongoDB with /Zc:ternary on (implied by /permissive-) under existing STL sources. Explicit cast can be removed once Visual C++ std::list stops using inheritance between const and modifiable iterators.

Jira ticket: https://jira.mongodb.org/browse/SERVER-28890 

Visual C++ compiler team is improving conformance of conditional operator for the upcoming VS2017 Update 1 release (15.3). The improvements will be available under a switch, but they will also be implied by the /permissive- switch. Our QA team currently builds regularly MongoDB as a part of RWC suite and so far MongoDB been clean under /permissive-. There is one place right now that will fail to compile under upcoming /Zc:ternary:

mongo\src\mongo\util\lru_cache.h(134):
```C++
const_iterator cfind(const K& key) const {
    auto it = this->_map.find(key); 
    return (it == this->_map.end()) ? this->end() : it->second; // << Line 134
} 
```
The problem is not so much in the code itself as other compilers are able to compile it without problems, but in our STL implementation that currently uses inheritance between mutable and const iterators. Stephan acknowledged the library team is planning to get rid of this trick and replace it with conformant implementation in the next major breaking release, but it's not going to happen anytime soon, while as is the above statement is ambiguous (according to the standard; note other compilers would have complained as well should they've been using our STL implementation).
We would like to ask you guys to patch the above code with an explicit cast to resolve the ambiguity caused by our current iterator implementation as following (pull request is following):

```C++
const_iterator cfind(const K& key) const {
    auto it = this->_map.find(key); 
    return (it == this->_map.end()) ? this->end() : const_iterator(it->second); // << Line 134
} 
```
This would allow us to keep building MongoDB clean under /permissive- for validating compiler changes.

Thank you!
Yuriy