### PR TITLE
change log message for CRL loading

### DIFF
--- a/src/mongo/util/net/ssl_manager.cpp
+++ b/src/mongo/util/net/ssl_manager.cpp
@@ -1056,8 +1056,8 @@ bool SSLManager::_setupCRL(SSL_CTX* context, const std::string& crlFile) {
                 << getSSLErrorMessage(ERR_get_error());
         return false;
     }
-    log() << "ssl imported " << status << " revoked certificate" << ((status == 1) ? "" : "s")
-          << " from the revocation list.";
+    log() << "ssl imported " << status << " revoked certificate list"
+          << ((status == 1) ? "" : "s") << " from the CRL file.";
     return true;
 }
 


### PR DESCRIPTION
The log message from _setupCRL was misleading.  It is not the number of revoked certificates that X509_load_crl_file returns.  It is the number of CRLs (X509_CRL structures) that it successfully loads that it returns.

https://github.com/openssl/openssl/blob/c0452248ea1a59a41023a4765ef7d9825e80a62b/crypto/x509/by_file.c

http://www.umich.edu/~x509/ssleay/x509_crls.html
  