### PR TITLE
SERVER-11947 Regular expressions in boolean expressions in $group and $project

### DIFF
--- a/src/mongo/db/matcher/expression_leaf.cpp
+++ b/src/mongo/db/matcher/expression_leaf.cpp
@@ -31,7 +31,6 @@
 #include "mongo/db/matcher/expression_leaf.h"
 
 #include <cmath>
-#include <pcrecpp.h>
 
 #include "mongo/bson/bsonelement_comparator.h"
 #include "mongo/bson/bsonmisc.h"
@@ -43,6 +42,7 @@
 #include "mongo/db/query/collation/collator_interface.h"
 #include "mongo/stdx/memory.h"
 #include "mongo/util/mongoutils/str.h"
+#include "mongo/util/pcrecpp_util.h"
 
 namespace mongo {
 
@@ -228,24 +228,6 @@ void ComparisonMatchExpression::serialize(BSONObjBuilder* out) const {
 
 // ---------------
 
-// TODO: move
-inline pcrecpp::RE_Options flags2options(const char* flags) {
-    pcrecpp::RE_Options options;
-    options.set_utf8(true);
-    while (flags && *flags) {
-        if (*flags == 'i')
-            options.set_caseless(true);
-        else if (*flags == 'm')
-            options.set_multiline(true);
-        else if (*flags == 'x')
-            options.set_extended(true);
-        else if (*flags == 's')
-            options.set_dotall(true);
-        flags++;
-    }
-    return options;
-}
-
 RegexMatchExpression::RegexMatchExpression() : LeafMatchExpression(REGEX) {}
 
 RegexMatchExpression::~RegexMatchExpression() {}
@@ -284,7 +266,7 @@ Status RegexMatchExpression::init(StringData path, StringData regex, StringData 
 
     _regex = regex.toString();
     _flags = options.toString();
-    _re.reset(new pcrecpp::RE(_regex.c_str(), flags2options(_flags.c_str())));
+    _re.reset(new pcrecpp::RE(_regex.c_str(), mongo::flags2options(_flags.c_str())));
 
     return setPath(path);
 }

--- a/src/mongo/db/pipeline/SConscript
+++ b/src/mongo/db/pipeline/SConscript
@@ -49,6 +49,7 @@ env.Library(
         'field_path',
         '$BUILD_DIR/mongo/base',
         '$BUILD_DIR/mongo/util/intrusive_counter',
+        '$BUILD_DIR/third_party/shim_pcrecpp',
         ]
     )
 

--- a/src/mongo/db/pipeline/document_value_test.cpp
+++ b/src/mongo/db/pipeline/document_value_test.cpp
@@ -807,7 +807,6 @@ class Regex {
 public:
     void run() {
         Value value = fromBson(fromjson("{'':/abc/}"));
-        ASSERT_EQUALS(string("abc"), value.getRegex());
         ASSERT_EQUALS(RegEx, value.getType());
         assertRoundTrips(value);
     }
@@ -1665,6 +1664,38 @@ private:
     }
 };
 
+class RegexMatches {
+public:
+    void run() {
+        // RegEx matching against Symbol/String
+        Value regexValue = Value(BSONRegEx("[abc][123]", "i"));
+        Value symbolValueMatch(BSONSymbol("b2"));
+        Value symbolValueNoMatch(BSONSymbol("b9"));
+        Value stringValueMatch = Value("C1"_sd);
+        Value stringValueNoMatch = Value("A4"_sd);
+
+        assertNotMatches(regexValue, symbolValueNoMatch);
+        assertNotMatches(regexValue, stringValueNoMatch);
+        assertMatches(regexValue, symbolValueMatch);
+        assertMatches(regexValue, stringValueMatch);
+    }
+
+private:
+    void assertMatches(const Value& a, const Value& b) {
+        mongo::unittest::log() << "testing match of " << b.toString() << " against "
+                               << a.toString();
+        ASSERT_TRUE(ValueComparator().evaluate(a == b));
+        ASSERT_TRUE(ValueComparator().evaluate(b == a));
+    }
+
+    void assertNotMatches(const Value& a, const Value& b) {
+        mongo::unittest::log() << "testing match of " << b.toString() << " against "
+                               << a.toString();
+        ASSERT_FALSE(ValueComparator().evaluate(a == b));
+        ASSERT_FALSE(ValueComparator().evaluate(b == a));
+    }
+};
+
 class SubFields {
 public:
     void run() {
@@ -1807,6 +1838,7 @@ public:
         add<Value::AddToBsonObj>();
         add<Value::AddToBsonArray>();
         add<Value::Compare>();
+        add<Value::RegexMatches>();
         add<Value::SubFields>();
         add<Value::SerializationOfMissingForSorter>();
     }

--- a/src/mongo/db/pipeline/value.cpp
+++ b/src/mongo/db/pipeline/value.cpp
@@ -124,18 +124,6 @@ void ValueStorage::putVector(const RCVector* vec) {
     putRefCountable(vec);
 }
 
-void ValueStorage::putRegEx(const BSONRegEx& re) {
-    const size_t patternLen = re.pattern.size();
-    const size_t flagsLen = re.flags.size();
-    const size_t totalLen = patternLen + 1 /*middle NUL*/ + flagsLen;
-
-    // Need to copy since putString doesn't support scatter-gather.
-    std::unique_ptr<char[]> buf(new char[totalLen]);
-    re.pattern.copyTo(buf.get(), true);
-    re.flags.copyTo(buf.get() + patternLen + 1, false);  // no NUL
-    putString(StringData(buf.get(), totalLen));
-}
-
 Document ValueStorage::getDocument() const {
     if (!genericRCPtr)
         return Document();
@@ -353,7 +341,8 @@ BSONObjBuilder& operator<<(BSONObjBuilderValueStream& builder, const Value& val)
         case Code:
             return builder << BSONCode(val.getStringData());
         case RegEx:
-            return builder << BSONRegEx(val.getRegex(), val.getRegexFlags());
+            return builder << BSONRegEx(val._storage.getRegex()->pattern,
+                                        val._storage.getRegex()->flags);
 
         case DBRef:
             return builder << BSONDBRef(val._storage.getDBRef()->ns, val._storage.getDBRef()->oid);
@@ -699,8 +688,17 @@ int Value::compare(const Value& rL,
     int ret = lType == rType ? 0  // fast-path common case
                              : cmp(canonicalizeBSONType(lType), canonicalizeBSONType(rType));
 
-    if (ret)
+    if (ret) {
+        // Handle cmp(Regex, String|Symbol) and vice versa
+        if ((lType == RegEx && (rType == Symbol || rType == String)) ||
+            (rType == RegEx && (lType == Symbol || lType == String))) {
+            intrusive_ptr<const RCRegex> regex = (lType == RegEx ? rL : rR)._storage.getRegex();
+            std::string str = (lType == RegEx ? rR : rL).getStringData().toString();
+            pcrecpp::StringPiece data(str.c_str(), str.size());
+            return regex->re.PartialMatch(data) == true ? 0 : ret;
+        }
         return ret;
+    }
 
     switch (lType) {
         // Order of types is the same as in compareElementValues() to make it easier to verify
@@ -845,8 +843,17 @@ int Value::compare(const Value& rL,
             return rL.getStringData().compare(rR.getStringData());
         }
 
-        case RegEx:  // same as String in this impl but keeping order same as compareElementValues
-            return rL.getStringData().compare(rR.getStringData());
+        case RegEx: {  // same as String in this impl but keeping order same as compareElementValues
+
+            intrusive_ptr<const RCRegex> l = rL._storage.getRegex();
+            intrusive_ptr<const RCRegex> r = rR._storage.getRegex();
+
+            ret = l->pattern.compare(r->pattern);
+            if (ret)
+                return ret;
+
+            return l->flags.compare(r->flags);
+        }
 
         case CodeWScope: {
             intrusive_ptr<const RCCodeWScope> l = rL._storage.getCodeWScope();
@@ -971,8 +978,9 @@ void Value::hash_combine(size_t& seed,
         }
 
         case RegEx: {
-            StringData sd = getStringData();
-            MurmurHash3_x86_32(sd.rawData(), sd.size(), seed, &seed);
+            intrusive_ptr<const RCRegex> regex = _storage.getRegex();
+            SimpleStringDataComparator::kInstance.hash_combine(seed, regex->pattern);
+            SimpleStringDataComparator::kInstance.hash_combine(seed, regex->flags);
             break;
         }
 
@@ -1074,7 +1082,6 @@ bool Value::integral() const {
 size_t Value::getApproximateSize() const {
     switch (getType()) {
         case Code:
-        case RegEx:
         case Symbol:
         case BinData:
         case String:
@@ -1094,6 +1101,10 @@ size_t Value::getApproximateSize() const {
             }
             return size;
         }
+
+        case RegEx:
+            return sizeof(Value) + sizeof(RCRegex) + _storage.getRegex()->pattern.size() +
+                _storage.getRegex()->flags.size() + sizeof(pcrecpp::RE);
 
         case CodeWScope:
             return sizeof(Value) + sizeof(RCCodeWScope) + _storage.getCodeWScope()->code.size() +
@@ -1143,7 +1154,8 @@ ostream& operator<<(ostream& out, const Value& val) {
         case String:
             return out << '"' << val.getString() << '"';
         case RegEx:
-            return out << '/' << val.getRegex() << '/' << val.getRegexFlags();
+            return out << '/' << val._storage.getRegex()->pattern << '/'
+                       << val._storage.getRegex()->flags;
         case Symbol:
             return out << "Symbol(\"" << val.getSymbol() << "\")";
         case Code:
@@ -1253,10 +1265,12 @@ void Value::serializeForSorter(BufBuilder& buf) const {
             break;
         }
 
-        case RegEx:
-            buf.appendStr(getRegex(), /*NUL byte*/ true);
-            buf.appendStr(getRegexFlags(), /*NUL byte*/ true);
+        case RegEx: {
+            intrusive_ptr<const RCRegex> regex = _storage.getRegex();
+            buf.appendStr(regex->pattern, /*NUL byte*/ true);
+            buf.appendStr(regex->flags, /*NUL byte*/ true);
             break;
+        }
 
         case Object:
             getDocument().serializeForSorter(buf);

--- a/src/mongo/db/pipeline/value.h
+++ b/src/mongo/db/pipeline/value.h
@@ -409,18 +409,6 @@ inline Timestamp Value::getTimestamp() const {
     return Timestamp(_storage.timestampValue);
 }
 
-inline const char* Value::getRegex() const {
-    verify(getType() == RegEx);
-    return _storage.getString().rawData();  // this is known to be NUL terminated
-}
-inline const char* Value::getRegexFlags() const {
-    verify(getType() == RegEx);
-    const char* pattern = _storage.getString().rawData();  // this is known to be NUL terminated
-    const char* flags = pattern + strlen(pattern) + 1;     // first byte after pattern's NUL
-    dassert(flags + strlen(flags) == pattern + _storage.getString().size());
-    return flags;
-}
-
 inline std::string Value::getSymbol() const {
     verify(getType() == Symbol);
     return _storage.getString().toString();

--- a/src/mongo/shell/bench.cpp
+++ b/src/mongo/shell/bench.cpp
@@ -35,7 +35,6 @@
 #include "mongo/shell/bench.h"
 
 #include <iostream>
-#include <pcrecpp.h>
 
 #include "mongo/client/dbclientcursor.h"
 #include "mongo/db/namespace_string.h"
@@ -47,6 +46,7 @@
 #include "mongo/stdx/thread.h"
 #include "mongo/util/log.h"
 #include "mongo/util/md5.h"
+#include "mongo/util/pcrecpp_util.h"
 #include "mongo/util/time_support.h"
 #include "mongo/util/timer.h"
 #include "mongo/util/version.h"
@@ -54,24 +54,6 @@
 // ---------------------------------
 // ---- benchmarking system --------
 // ---------------------------------
-
-// TODO:  Maybe extract as library to avoid code duplication?
-namespace {
-inline pcrecpp::RE_Options flags2options(const char* flags) {
-    pcrecpp::RE_Options options;
-    options.set_utf8(true);
-    while (flags && *flags) {
-        if (*flags == 'i')
-            options.set_caseless(true);
-        else if (*flags == 'm')
-            options.set_multiline(true);
-        else if (*flags == 'x')
-            options.set_extended(true);
-        flags++;
-    }
-    return options;
-}
-}
 
 namespace mongo {
 
@@ -459,22 +441,22 @@ void BenchRunConfig::initializeFromBson(const BSONObj& args) {
             const char* regex = arg.regex();
             const char* flags = arg.regexFlags();
             trapPattern =
-                std::shared_ptr<pcrecpp::RE>(new pcrecpp::RE(regex, flags2options(flags)));
+                std::shared_ptr<pcrecpp::RE>(new pcrecpp::RE(regex, mongo::flags2options(flags)));
         } else if (name == "noTrapPattern") {
             const char* regex = arg.regex();
             const char* flags = arg.regexFlags();
             noTrapPattern =
-                std::shared_ptr<pcrecpp::RE>(new pcrecpp::RE(regex, flags2options(flags)));
+                std::shared_ptr<pcrecpp::RE>(new pcrecpp::RE(regex, mongo::flags2options(flags)));
         } else if (name == "watchPattern") {
             const char* regex = arg.regex();
             const char* flags = arg.regexFlags();
             watchPattern =
-                std::shared_ptr<pcrecpp::RE>(new pcrecpp::RE(regex, flags2options(flags)));
+                std::shared_ptr<pcrecpp::RE>(new pcrecpp::RE(regex, mongo::flags2options(flags)));
         } else if (name == "noWatchPattern") {
             const char* regex = arg.regex();
             const char* flags = arg.regexFlags();
             noWatchPattern =
-                std::shared_ptr<pcrecpp::RE>(new pcrecpp::RE(regex, flags2options(flags)));
+                std::shared_ptr<pcrecpp::RE>(new pcrecpp::RE(regex, mongo::flags2options(flags)));
         } else if (name == "ops") {
             // iterate through the objects in ops
             // create an BenchRunOp per

--- a/src/mongo/util/pcrecpp_util.h
+++ b/src/mongo/util/pcrecpp_util.h
@@ -1,0 +1,53 @@
+// "mongo/util/pcrecpp_util.h"
+
+/**
+ * Copyright (C) 2016 MongoDB Inc.
+ *
+ * This program is free software: you can redistribute it and/or  modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * As a special exception, the copyright holders give permission to link the
+ * code of portions of this program with the OpenSSL library under certain
+ * conditions as described in each individual source file and distribute
+ * linked combinations including the program with the OpenSSL library. You
+ * must comply with the GNU Affero General Public License in all respects
+ * for all of the code used other than as permitted herein. If you modify
+ * file(s) with this exception, you may extend this exception to your
+ * version of the file(s), but you are not obligated to do so. If you do not
+ * wish to do so, delete this exception statement from your version. If you
+ * delete this exception statement from all source files in the program,
+ * then also delete it in the license file.
+ */
+
+#pragma once
+
+#include <pcrecpp.h>
+
+namespace mongo {
+
+inline pcrecpp::RE_Options flags2options(const char* flags) {
+    pcrecpp::RE_Options options;
+    options.set_utf8(true);
+    while (flags && *flags) {
+        if (*flags == 'i')
+            options.set_caseless(true);
+        else if (*flags == 'm')
+            options.set_multiline(true);
+        else if (*flags == 'x')
+            options.set_extended(true);
+        else if (*flags == 's')
+            options.set_dotall(true);
+        flags++;
+    }
+    return options;
+}
+}


### PR DESCRIPTION
Add support for RegEx Values matching String or Symbol Values in the aggregation pipeline.  This enables the use of regular expressions as part of boolean expressions (such as in a $switch or $cond) in the $group or $project stage of the aggregation pipeline.  Moved flags2options code to a central location.