### PR TITLE
Support prefix match for full-text search

### DIFF
--- a/src/mongo/db/exec/text.cpp
+++ b/src/mongo/db/exec/text.cpp
@@ -103,12 +103,16 @@ unique_ptr<PlanStage> TextStage::buildTextTree(OperationContext* opCtx,
 
         ixparams.bounds.startKey = FTSIndexFormat::getIndexKey(
             MAX_WEIGHT, term, _params.indexPrefix, _params.spec.getTextIndexVersion());
+
+        string term_end = term;
+        term_end[term_end.size() - 1]++;          // increment last character key code of search term for End-Key
         ixparams.bounds.endKey = FTSIndexFormat::getIndexKey(
-            0, term, _params.indexPrefix, _params.spec.getTextIndexVersion());
-        ixparams.bounds.boundInclusion = BoundInclusion::kIncludeBothStartAndEndKeys;
+            MAX_WEIGHT, term_end, _params.indexPrefix, _params.spec.getTextIndexVersion());
+        ixparams.bounds.endKeyInclusive = false;  // End key is not inclusive (endKey is artificially generated)      
+      
         ixparams.bounds.isSimpleRange = true;
         ixparams.descriptor = _params.index;
-        ixparams.direction = -1;
+        ixparams.direction = 1;
 
         textScorer->addChild(make_unique<IndexScan>(opCtx, ixparams, ws, nullptr));
     }


### PR DESCRIPTION
Add range search feature on full text search (original version has only exact match)

For CJK language, mongodb does not support stemmer for full text search.
Also not easy to implement stemmer for those language (Especially Korean).
So we usually use N-gram parser for full text search not supported mongodb yet.

Fortunately in Korean, we use space character between words and Korean(and also Japanese) use only suffix not prefix. So we can use mongodb full text search if mongodb support prefix match in fulltext. So I propose this simple feature.

>> Match range of original fulltext search
    * '한글' <= match_range <= '한글'
    * '테스트' <= match_range <= '테스트'
    * '이성' <= match_range <= '이성'
    * '한' <= match_range <= '한'

>> Match range of patched fulltext search
    * '한글' <= match_range < '한긁'
    * '테스트' <= match_range < '테스특'
    * '이성' <= match_range < '이섲'
    * '한' <= match_range < '핝'

I hope user can control this search mode (exact or prefix match) by query parameter or internal parameter.

