### PR TITLE
Fix error in command example in mongorestore.1 man

### DIFF
--- a/debian/mongorestore.1
+++ b/debian/mongorestore.1
@@ -631,7 +631,7 @@ through standard input, as in the following example:
 .sp
 .nf
 .ft C
-zcat /opt/backup/mongodump\-2014\-12\-03/accounts.people.bson.gz | mongorestore \-\-collection people \-\-db accounts
+zcat /opt/backup/mongodump\-2014\-12\-03/accounts.people.bson.gz | mongorestore \-\-collection people \-\-db accounts \-
 .ft P
 .fi
 .UNINDENT


### PR DESCRIPTION
The trailing slash argument is missing in mongorestore command example in debian mans.