### PR TITLE
Fix  fortify source warning

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -2480,8 +2480,20 @@ def doConfigure(myenv):
             context.Result(ret)
             return ret
 
+        def CheckForGlibcDefinesFortify(context):
+            test_body="""
+            #ifndef _FORTIFY_SOURCE
+            #error
+            #endif
+            """
+            context.Message('Checking for predefined _FORTIFY_SOURCE...')
+            ret = context.TryCompile(textwrap.dedent(test_body), ".c")
+            context.Result(ret)
+            return ret
+
         conf = Configure(myenv, help=False, custom_tests = {
             'CheckForFortify': CheckForGlibcKnownToSupportFortify,
+            'CheckForFortifyDefined': CheckForGlibcDefinesFortify,
         })
 
         # Fortify only possibly makes sense on POSIX systems, and we know that clang is not a valid
@@ -2490,6 +2502,10 @@ def doConfigure(myenv):
         # http://lists.llvm.org/pipermail/cfe-dev/2015-November/045852.html
         #
         if env.TargetOSIs('posix') and not env.ToolchainIs('clang') and conf.CheckForFortify():
+            if conf.CheckForFortifyDefined():
+                conf.env.Prepend(
+                    CPPFLAGS='-U_FORTIFY_SOURCE'
+                )
             conf.env.Append(
                 CPPDEFINES=[
                     ('_FORTIFY_SOURCE', 2),


### PR DESCRIPTION
Fixes problem with warnings when _FORTIFIED_SOURCE is already defined by the compiler by undefining it on the command line before defining it again.