### PR TITLE
SERVER-30166 Replace string with explicit std::string. Enables compul…

### DIFF
--- a/src/mongo/db/matcher/expression_leaf.cpp
+++ b/src/mongo/db/matcher/expression_leaf.cpp
@@ -202,7 +202,7 @@ void ComparisonMatchExpression::debugString(StringBuilder& debug, int level) con
 }
 
 void ComparisonMatchExpression::serialize(BSONObjBuilder* out) const {
-    string opString = "";
+    std::string opString = "";
     switch (matchType()) {
         case LT:
             opString = "$lt";
@@ -884,7 +884,7 @@ void BitTestMatchExpression::debugString(StringBuilder& debug, int level) const 
 }
 
 void BitTestMatchExpression::serialize(BSONObjBuilder* out) const {
-    string opString = "";
+    std::string opString = "";
 
     switch (matchType()) {
         case BITS_ALL_SET:

--- a/src/mongo/db/repl/master_slave.cpp
+++ b/src/mongo/db/repl/master_slave.cpp
@@ -168,7 +168,7 @@ BSONObj ReplSource::jsobj() {
 
     BSONObjBuilder dbsNextPassBuilder;
     int n = 0;
-    for (set<string>::iterator i = addDbNextPass.begin(); i != addDbNextPass.end(); i++) {
+    for (set<std::string>::iterator i = addDbNextPass.begin(); i != addDbNextPass.end(); i++) {
         n++;
         dbsNextPassBuilder.appendBool(*i, 1);
     }
@@ -177,7 +177,7 @@ BSONObj ReplSource::jsobj() {
 
     BSONObjBuilder incompleteCloneDbsBuilder;
     n = 0;
-    for (set<string>::iterator i = incompleteCloneDbs.begin(); i != incompleteCloneDbs.end(); i++) {
+    for (set<std::string>::iterator i = incompleteCloneDbs.begin(); i != incompleteCloneDbs.end(); i++) {
         n++;
         incompleteCloneDbsBuilder.appendBool(*i, 1);
     }
@@ -187,8 +187,8 @@ BSONObj ReplSource::jsobj() {
     return b.obj();
 }
 
-void ReplSource::ensureMe(OperationContext* txn) {
-    string myname = getHostName();
+void ReplSource::ensureMe(OperationContext* opCtx) {
+    std::string myname = getHostName();
 
     // local.me is an identifier for a server for getLastError w:2+
     bool exists = Helpers::getSingleton(txn, "local.me", _me);
@@ -377,11 +377,9 @@ public:
         out->push_back(Privilege(ResourcePattern::forClusterResource(), actions));
     }
 
-    virtual bool run(OperationContext* txn,
-                     const string& ns,
-                     BSONObj& cmdObj,
-                     int options,
-                     string& errmsg,
+    virtual bool run(OperationContext* opCtx,
+                     const std::string& ns,
+                     const BSONObj& cmdObj,
                      BSONObjBuilder& result) {
         HandshakeArgs handshake;
         Status status = handshake.initialize(cmdObj);
@@ -398,7 +396,7 @@ public:
 } handshakeCmd;
 
 bool replHandshake(DBClientConnection* conn, const OID& myRID) {
-    string myname = getHostName();
+    std::string myname = getHostName();
 
     BSONObjBuilder cmd;
     cmd.append("handshake", myRID);
@@ -450,7 +448,7 @@ void ReplSource::forceResync(OperationContext* txn, const char* requester) {
         BSONElement e = i.next();
         if (e.eoo())
             break;
-        string name = e.embeddedObject().getField("name").valuestr();
+        std::string name = e.embeddedObject().getField("name").valuestr();
         if (!e.embeddedObject().getBoolField("empty")) {
             if (name != "local") {
                 if (only.empty() || only == name) {
@@ -481,7 +479,7 @@ Status ReplSource::_updateIfDoneWithInitialSync() {
     return Status::OK();
 }
 
-void ReplSource::resyncDrop(OperationContext* txn, const string& dbName) {
+void ReplSource::resyncDrop(OperationContext* opCtx, const std::string& dbName) {
     log() << "resync: dropping database " << dbName;
     invariant(txn->lockState()->isW());
 
@@ -531,13 +529,13 @@ void ReplSource::resync(OperationContext* txn, const std::string& dbName) {
 
 static DatabaseIgnorer ___databaseIgnorer;
 
-void DatabaseIgnorer::doIgnoreUntilAfter(const string& db, const Timestamp& futureOplogTime) {
+void DatabaseIgnorer::doIgnoreUntilAfter(const std::string& db, const Timestamp& futureOplogTime) {
     if (futureOplogTime > _ignores[db]) {
         _ignores[db] = futureOplogTime;
     }
 }
 
-bool DatabaseIgnorer::ignoreAt(const string& db, const Timestamp& currentOplogTime) {
+bool DatabaseIgnorer::ignoreAt(const std::string& db, const Timestamp& currentOplogTime) {
     if (_ignores[db].isNull()) {
         return false;
     }
@@ -627,7 +625,7 @@ bool ReplSource::handleDuplicateDbName(OperationContext* txn,
 
     // The database is present on the master and no conflicting databases
     // are present on the master.  Drop any local conflicts.
-    for (set<string>::const_iterator i = duplicates.begin(); i != duplicates.end(); ++i) {
+    for (set<std::string>::const_iterator i = duplicates.begin(); i != duplicates.end(); ++i) {
         ___databaseIgnorer.doIgnoreUntilAfter(*i, lastTime);
         incompleteCloneDbs.erase(*i);
         addDbNextPass.erase(*i);
@@ -826,10 +824,10 @@ void ReplSource::_sync_pullOpLog_applyOperation(OperationContext* txn,
 }
 
 void ReplSource::syncToTailOfRemoteLog() {
-    string _ns = ns();
+    std::string _ns = ns();
     BSONObjBuilder b;
     if (!only.empty()) {
-        b.appendRegex("ns", string("^") + pcrecpp::RE::QuoteMeta(only));
+        b.appendRegex("ns", std::string("^") + pcrecpp::RE::QuoteMeta(only));
     }
     BSONObj last = oplogReader.findOne(_ns.c_str(), Query(b.done()).sort(BSON("$natural" << -1)));
     if (!last.isEmpty()) {
@@ -877,7 +875,7 @@ public:
 */
 int ReplSource::_sync_pullOpLog(OperationContext* txn, int& nApplied) {
     int okResultCode = restartSyncAfterSleep;
-    string ns = string("local.oplog.$") + sourceName();
+    std::string ns = std::string("local.oplog.$") + sourceName();
     LOG(2) << "sync_pullOpLog " << ns << " syncedTo:" << syncedTo.toStringLong() << '\n';
 
     bool tailing = true;
@@ -897,7 +895,7 @@ int ReplSource::_sync_pullOpLog(OperationContext* txn, int& nApplied) {
                 BSONElement e = i.next();
                 if (e.eoo())
                     break;
-                string name = e.embeddedObject().getField("name").valuestr();
+                std::string name = e.embeddedObject().getField("name").valuestr();
                 if (!e.embeddedObject().getBoolField("empty")) {
                     if (name != "local") {
                         if (only.empty() || only == name) {
@@ -921,7 +919,7 @@ int ReplSource::_sync_pullOpLog(OperationContext* txn, int& nApplied) {
         if (!only.empty()) {
             // note we may here skip a LOT of data table scanning, a lot of work for the master.
             // maybe append "\\." here?
-            query.appendRegex("ns", string("^") + pcrecpp::RE::QuoteMeta(only));
+            query.appendRegex("ns", std::string("^") + pcrecpp::RE::QuoteMeta(only));
         }
         BSONObj queryObj = query.done();
         // e.g. queryObj = { ts: { $gte: syncedTo } }
@@ -940,7 +938,7 @@ int ReplSource::_sync_pullOpLog(OperationContext* txn, int& nApplied) {
 
     // show any deferred database creates from a previous pass
     {
-        set<string>::iterator i = addDbNextPass.begin();
+        set<std::string>::iterator i = addDbNextPass.begin();
         if (i != addDbNextPass.end()) {
             BSONObjBuilder b;
             b.append("ns", *i + '.');
@@ -984,7 +982,7 @@ int ReplSource::_sync_pullOpLog(OperationContext* txn, int& nApplied) {
         BSONObj op = oplogReader.nextSafe();
         BSONElement ts = op.getField("ts");
         if (ts.type() != Date && ts.type() != bsonTimestamp) {
-            string err = op.getStringField("$err");
+            std::string err = op.getStringField("$err");
             if (!err.empty()) {
                 // 13051 is "tailable cursor requested on non capped collection"
                 if (op.getIntField("code") == 13051) {
@@ -1152,7 +1150,7 @@ int ReplSource::sync(OperationContext* txn, int& nApplied) {
 
     // FIXME Handle cases where this db isn't on default port, or default port is spec'd in
     // hostName.
-    if ((string("localhost") == hostName || string("127.0.0.1") == hostName) &&
+    if ((std::string("localhost") == hostName || std::string("127.0.0.1") == hostName) &&
         serverGlobalParams.port == ServerGlobalParams::DefaultDBPort) {
         log() << "can't sync from self (localhost). sources configuration may be wrong." << endl;
         sleepsecs(5);
@@ -1297,8 +1295,8 @@ static void replMain(OperationContext* txn) {
         if (s) {
             stringstream ss;
             ss << "sleep " << s << " sec before next pass";
-            string msg = ss.str();
-            if (!serverGlobalParams.quiet)
+            std::string msg = ss.str();
+            if (!serverGlobalParams.quiet.load())
                 log() << msg << endl;
             ReplInfo r(msg.c_str());
             sleepsecs(s);

--- a/src/mongo/shell/bench.cpp
+++ b/src/mongo/shell/bench.cpp
@@ -674,7 +674,7 @@ void BenchRunWorker::generateLoadOnConnection(DBClientBase* conn) {
     invariant(bsonTemplateEvaluator.setId(_id) == BsonTemplateEvaluator::StatusSuccess);
 
     if (_config->username != "") {
-        string errmsg;
+        std::string errmsg;
         if (!conn->auth("admin", _config->username, _config->password, errmsg)) {
             uasserted(15931, "Authenticating to connection for _benchThread failed: " + errmsg);
         }
@@ -918,7 +918,7 @@ void BenchRunWorker::generateLoadOnConnection(DBClientBase* conn) {
 
                             if (!result["err"].eoo() && result["err"].type() == String &&
                                 (_config->throwGLE || op.throwGLE))
-                                throw DBException((string) "From benchRun GLE" +
+                                throw DBException((std::string) "From benchRun GLE" +
                                                       causedBy(result["err"].String()),
                                                   result["code"].eoo() ? 0 : result["code"].Int());
                         }
@@ -984,7 +984,7 @@ void BenchRunWorker::generateLoadOnConnection(DBClientBase* conn) {
 
                             if (!result["err"].eoo() && result["err"].type() == String &&
                                 (_config->throwGLE || op.throwGLE))
-                                throw DBException((string) "From benchRun GLE" +
+                                throw DBException((std::string) "From benchRun GLE" +
                                                       causedBy(result["err"].String()),
                                                   result["code"].eoo() ? 0 : result["code"].Int());
                         }
@@ -1031,7 +1031,7 @@ void BenchRunWorker::generateLoadOnConnection(DBClientBase* conn) {
 
                             if (!result["err"].eoo() && result["err"].type() == String &&
                                 (_config->throwGLE || op.throwGLE))
-                                throw DBException((string) "From benchRun GLE " +
+                                throw DBException((std::string) "From benchRun GLE " +
                                                       causedBy(result["err"].String()),
                                                   result["code"].eoo() ? 0 : result["code"].Int());
                         }
@@ -1133,7 +1133,7 @@ void BenchRunWorker::run() {
     try {
         std::unique_ptr<DBClientBase> conn(_config->createConnection());
         if (!_config->username.empty()) {
-            string errmsg;
+            std::string errmsg;
             if (!conn->auth("admin", _config->username, _config->password, errmsg)) {
                 uasserted(15932, "Authenticating to connection for benchThread failed: " + errmsg);
             }
@@ -1165,7 +1165,7 @@ void BenchRunner::start() {
         std::unique_ptr<DBClientBase> conn(_config->createConnection());
         // Must authenticate to admin db in order to run serverStatus command
         if (_config->username != "") {
-            string errmsg;
+            std::string errmsg;
             if (!conn->auth("admin", _config->username, _config->password, errmsg)) {
                 uasserted(
                     16704,
@@ -1201,7 +1201,7 @@ void BenchRunner::stop() {
     {
         std::unique_ptr<DBClientBase> conn(_config->createConnection());
         if (_config->username != "") {
-            string errmsg;
+            std::string errmsg;
             // this can only fail if admin access was revoked since start of run
             if (!conn->auth("admin", _config->username, _config->password, errmsg)) {
                 uasserted(


### PR DESCRIPTION
Replaces string with std::string in several files so it will build when using --using-system-pcre with libpcre 8.41.

This is currently preventing Mongo from build in gentoo linux (See https://bugs.gentoo.org/show_bug.cgi?id=625148)