### PR TITLE
SERVER-8164 ISODate returns incorrect values for dates of than 100 years

### DIFF
--- a/jstests/core/isodate.js
+++ b/jstests/core/isodate.js
@@ -1,0 +1,48 @@
+var tests = 
+[
+    {
+        input: '0001-01-01T00:00:00Z',
+        expected: {
+            year: 1,
+            month: 0,
+            day: 1,
+            hour: 0,
+            minute: 0,
+            second: 0,
+        },
+    },
+    {
+        input: '2001-02-03T12:34:56',
+        expected: {
+            year: 2001,
+            month: 1,
+            day: 3,
+            hour: 12,
+            minute: 34,
+            second: 56,
+        },
+    },
+    {
+        input: '1969-06-07T00:00:00',
+        expected: {
+            year: 2001,
+            month: 1,
+            day: 3,
+            hour: 12,
+            minute: 34,
+            second: 56,
+        },
+    },
+];
+
+for (var i = 0; i < tests.length; i ++) {
+    var test = tests[i];
+    var d = ISODate(test.input);
+
+    assert.eq(test.expected.year, d.getFullYear(), `for input '${test.input}' expected year ${test.expected.year}, got ${d.getFullYear()}`);
+    assert.eq(test.expected.month, d.getMonth(), `for input '${test.input}' expected month ${test.month.year}, got ${d.getMonth()}`);
+    assert.eq(test.expected.day, d.getDay(), `for input '${test.input}' expected day ${test.day.year}, got ${d.getDay()}`);
+    assert.eq(test.expected.hour, d.getHours(), `for input '${test.input}' expected hour ${test.day.hour}, got ${d.getHours()}`);
+    assert.eq(test.expected.minute, d.getMinutes(), `for input '${test.input}' expected minute ${test.day.year}, got ${d.getMinutes()}`);
+    assert.eq(test.expected.second, d.getSeconds(), `for input '${test.input}' expected second ${test.day.year}, got ${d.getSeconds()}`);
+}

--- a/src/mongo/shell/types.js
+++ b/src/mongo/shell/types.js
@@ -65,6 +65,14 @@ ISODate = function(isoDateStr) {
         throw Error("invalid ISO date");
 
     var year = parseInt(res[1], 10) || 1970;  // this should always be present
+    // If the year < 100, then we add 100 years and take it off later, because the Date.UTC constructor
+    // assumes that if the year is less than 100, then it should be 19xx, e.g. 1901 for 1.
+    // Given the regular expression ensures that years are 4 digits long (i.e. have to have leading
+    // zeroes), a year of 0000-0099 is intentional, not accidental.
+    var applyYearOffset = year < 100;
+    if (applyYearOffset) {
+        year += 100;
+    }
     var month = (parseInt(res[2], 10) || 1) - 1;
     var date = parseInt(res[3], 10) || 0;
     var hour = parseInt(res[5], 10) || 0;
@@ -105,7 +113,15 @@ ISODate = function(isoDateStr) {
         time += ofs;
     }
 
-    return new Date(time);
+    var rv = new Date(time);
+
+    if (applyYearOffset) {
+        var currentYear = rv.getUTCFullYear();
+        currentYear -= 100;
+        rv.setUTCFullYear(currentYear);
+    }
+
+    return rv;
 };
 
 // Regular Expression


### PR DESCRIPTION
The ISODate incorrectly parses dates such as:

```
0001-01-01T00:00:00Z
0002-01-01T00:00:00Z
...
0099-01-01T00:00:00Z
```

If you insert data via the MongoDB shell:

```
> use test
switched to db test
> db.tests.insert({ d: ISODate('0001-01-01T00:00:00Z') })
WriteResult({ "nInserted" : 1 })
> db.tests.findOne()
{
	"_id" : ObjectId("598ed923e9d74c3320ec1b39"),
	"d" : ISODate("1901-01-01T00:00:00Z")
}
```

The expectation is that `d` has a year value of 0001, not 1901.