### PR TITLE
Make string.cpp compatible with boost 1.62

### DIFF
--- a/src/mongo/db/fts/unicode/string.cpp
+++ b/src/mongo/db/fts/unicode/string.cpp
@@ -30,6 +30,7 @@
 
 #include <algorithm>
 #include <boost/algorithm/searching/boyer_moore.hpp>
+#include <boost/version.hpp>
 
 #include "mongo/db/fts/unicode/byte_vector.h"
 #include "mongo/platform/bits.h"
@@ -273,8 +274,13 @@ bool String::substrMatch(const std::string& str,
     auto needle = caseFoldAndStripDiacritics(&needleBuf, find, options, cfMode);
 
     // Case sensitive and diacritic sensitive.
+#if BOOST_VERSION < 106200
     return boost::algorithm::boyer_moore_search(
                haystack.begin(), haystack.end(), needle.begin(), needle.end()) != haystack.end();
+#else
+    return boost::algorithm::boyer_moore_search(
+               haystack.begin(), haystack.end(), needle.begin(), needle.end()) != std::make_pair(haystack.end(), haystack.end());
+#endif
 }
 
 }  // namespace unicode


### PR DESCRIPTION
Add a conditional for boost > 1.62 compatibility, boyer_moore_search
now returns an std::pair. Fixes https://jira.mongodb.org/browse/SERVER-31119