### PR TITLE
Ignore codereview.rc in source control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,6 @@ CMakeLists.txt
 DriverInclude.wxs
 
 compile_commands.json
+
+# Rietveld code review config
+codereview.rc


### PR DESCRIPTION
This lets server team engineers add a `codereview.rc` file to the base of the mongo repository. For example, I have
```
CC=serverteam-query@10gen.com
```
so that the Query Team is automatically CC'd on each new code review.