### PR TITLE
Fix typo in example output on mongotop man page

### DIFF
--- a/debian/mongotop.1
+++ b/debian/mongotop.1
@@ -529,7 +529,7 @@ This command produces the following output:
 local.system.namespaces      0ms     0ms      0ms
    local.system.replset      0ms     0ms      0ms
 
-                     ns    total    read    write          2014\-12\-19T15:47:01\-05:00
+                     ns    total    read    write          2014\-12\-19T15:32:16\-05:00
      admin.system.roles      0ms     0ms      0ms
    admin.system.version      0ms     0ms      0ms
                local.me      0ms     0ms      0ms


### PR DESCRIPTION
Example output shows mongotop reporting every 15 minutes instead of 15 seconds.