### PR TITLE
SERVER-32343 due to "dbtests" runs in a shared environment we can observe "update"…

### DIFF
--- a/src/mongo/dbtests/updatetests.cpp
+++ b/src/mongo/dbtests/updatetests.cpp
@@ -43,6 +43,9 @@
 #include "mongo/db/lasterror.h"
 #include "mongo/db/ops/update.h"
 #include "mongo/dbtests/dbtests.h"
+#include "mongo/db/repl/replication_coordinator_global.h"
+#include "mongo/db/repl/replication_coordinator_mock.h"
+#include <mongo/db/repl/repl_settings.h>
 
 namespace UpdateTests {
 
@@ -58,6 +61,11 @@ class ClientBase {
 public:
     ClientBase() : _client(&_opCtx) {
         mongo::LastError::get(_opCtx.getClient()).reset();
+        repl::ReplSettings replSettings;
+        replSettings.setOplogSizeBytes(10 * 1024 * 1024);
+        replSettings.setMaster(true);
+        setGlobalReplicationCoordinator(
+                new repl::ReplicationCoordinatorMock(_opCtx.getServiceContext(), replSettings));
     }
     virtual ~ClientBase() {
         mongo::LastError::get(_opCtx.getClient()).reset();

--- a/src/mongo/dbtests/updatetests.cpp
+++ b/src/mongo/dbtests/updatetests.cpp
@@ -43,9 +43,6 @@
 #include "mongo/db/lasterror.h"
 #include "mongo/db/ops/update.h"
 #include "mongo/dbtests/dbtests.h"
-#include "mongo/db/repl/replication_coordinator_global.h"
-#include "mongo/db/repl/replication_coordinator_mock.h"
-#include <mongo/db/repl/repl_settings.h>
 
 namespace UpdateTests {
 
@@ -61,11 +58,6 @@ class ClientBase {
 public:
     ClientBase() : _client(&_opCtx) {
         mongo::LastError::get(_opCtx.getClient()).reset();
-        repl::ReplSettings replSettings;
-        replSettings.setOplogSizeBytes(10 * 1024 * 1024);
-        replSettings.setMaster(true);
-        setGlobalReplicationCoordinator(
-                new repl::ReplicationCoordinatorMock(_opCtx.getServiceContext(), replSettings));
     }
     virtual ~ClientBase() {
         mongo::LastError::get(_opCtx.getClient()).reset();


### PR DESCRIPTION
before fix:
```
2017-12-11T10:54:50.865+0300 I -        [testsuite] rollback                       | tests:   54 | fails:   24 | assert calls:          0 | time secs: 14.951
        RollbackTests::RenameCollection<false, false, false>    Expected ::mongo::Status::OK() == (renameCollection(&opCtx, source, target)) (OK  == NotMaster Not primary while renaming collection unittests.rollback_rename_collection_src to unittests.rollback_rename_collection_dest) @src/mongo/dbtests/rollbacktests.cpp:254
        RollbackTests::RenameCollection<false, false, true>     Expected ::mongo::Status::OK() == (renameCollection(&opCtx, source, target)) (OK  == NotMaster Not primary while renaming collection unittests.rollback_rename_collection_src to unittests.rollback_rename_collection_dest) @src/mongo/dbtests/rollbacktests.cpp:254
        RollbackTests::RenameCollection<false, true, false>     Expected ::mongo::Status::OK() == (renameCollection(&opCtx, source, target)) (OK  == NotMaster Not primary while renaming collection unittests.rollback_rename_collection_src to unittests.rollback_rename_collection_dest) @src/mongo/dbtests/rollbacktests.cpp:254
        RollbackTests::RenameCollection<false, true, true>      Expected ::mongo::Status::OK() == (renameCollection(&opCtx, source, target)) (OK  == NotMaster Not primary while renaming collection unittests.rollback_rename_collection_src to unittests.rollback_rename_collection_dest) @src/mongo/dbtests/rollbacktests.cpp:254
        RollbackTests::RenameCollection<true, false, false>     Expected ::mongo::Status::OK() == (renameCollection(&opCtx, source, target)) (OK  == NotMaster Not primary while renaming collection unittests.rollback_rename_collection_src to unittests.rollback_rename_collection_dest) @src/mongo/dbtests/rollbacktests.cpp:254
        RollbackTests::RenameCollection<true, false, true>      Expected ::mongo::Status::OK() == (renameCollection(&opCtx, source, target)) (OK  == NotMaster Not primary while renaming collection unittests.rollback_rename_collection_src to unittests.rollback_rename_collection_dest) @src/mongo/dbtests/rollbacktests.cpp:254
        RollbackTests::RenameCollection<true, true, false>      Expected ::mongo::Status::OK() == (renameCollection(&opCtx, source, target)) (OK  == NotMaster Not primary while renaming collection unittests.rollback_rename_collection_src to unittests.rollback_rename_collection_dest) @src/mongo/dbtests/rollbacktests.cpp:254
        RollbackTests::RenameCollection<true, true, true>       Expected ::mongo::Status::OK() == (renameCollection(&opCtx, source, target)) (OK  == NotMaster Not primary while renaming collection unittests.rollback_rename_collection_src to unittests.rollback_rename_collection_dest) @src/mongo/dbtests/rollbacktests.cpp:254
        RollbackTests::RenameDropTargetCollection<false, false, false>  Expected ::mongo::Status::OK() == (dropCollection(&opCtx, target, result, {}, DropCollectionSystemCollectionMode::kDisallowSystemCollectionDrops)) (OK  == NotMaster Not primary while dropping collection unittests.rollback_rename_droptarget_collection_dest) @src/mongo/dbtests/rollback
tests.cpp:329
        RollbackTests::RenameDropTargetCollection<false, false, true>   Expected ::mongo::Status::OK() == (dropCollection(&opCtx, target, result, {}, DropCollectionSystemCollectionMode::kDisallowSystemCollectionDrops)) (OK  == NotMaster Not primary while dropping collection unittests.rollback_rename_droptarget_collection_dest) @src/mongo/dbtests/rollback
tests.cpp:329
        RollbackTests::RenameDropTargetCollection<false, true, false>   Expected ::mongo::Status::OK() == (dropCollection(&opCtx, target, result, {}, DropCollectionSystemCollectionMode::kDisallowSystemCollectionDrops)) (OK  == NotMaster Not primary while dropping collection unittests.rollback_rename_droptarget_collection_dest) @src/mongo/dbtests/rollback
tests.cpp:329
        RollbackTests::RenameDropTargetCollection<false, true, true>    Expected ::mongo::Status::OK() == (dropCollection(&opCtx, target, result, {}, DropCollectionSystemCollectionMode::kDisallowSystemCollectionDrops)) (OK  == NotMaster Not primary while dropping collection unittests.rollback_rename_droptarget_collection_dest) @src/mongo/dbtests/rollback
tests.cpp:329
        RollbackTests::RenameDropTargetCollection<true, false, false>   Expected ::mongo::Status::OK() == (dropCollection(&opCtx, target, result, {}, DropCollectionSystemCollectionMode::kDisallowSystemCollectionDrops)) (OK  == NotMaster Not primary while dropping collection unittests.rollback_rename_droptarget_collection_dest) @src/mongo/dbtests/rollback
tests.cpp:329
        RollbackTests::RenameDropTargetCollection<true, false, true>    Expected ::mongo::Status::OK() == (dropCollection(&opCtx, target, result, {}, DropCollectionSystemCollectionMode::kDisallowSystemCollectionDrops)) (OK  == NotMaster Not primary while dropping collection unittests.rollback_rename_droptarget_collection_dest) @src/mongo/dbtests/rollback
tests.cpp:329
        RollbackTests::RenameDropTargetCollection<true, true, false>    Expected ::mongo::Status::OK() == (dropCollection(&opCtx, target, result, {}, DropCollectionSystemCollectionMode::kDisallowSystemCollectionDrops)) (OK  == NotMaster Not primary while dropping collection unittests.rollback_rename_droptarget_collection_dest) @src/mongo/dbtests/rollback
tests.cpp:329
        RollbackTests::RenameDropTargetCollection<true, true, true>     Expected ::mongo::Status::OK() == (dropCollection(&opCtx, target, result, {}, DropCollectionSystemCollectionMode::kDisallowSystemCollectionDrops)) (OK  == NotMaster Not primary while dropping collection unittests.rollback_rename_droptarget_collection_dest) @src/mongo/dbtests/rollback
tests.cpp:329
        RollbackTests::ReplaceCollection<false, false>  Expected ::mongo::Status::OK() == (dropCollection(&opCtx, nss, result, {}, DropCollectionSystemCollectionMode::kDisallowSystemCollectionDrops)) (OK  == NotMaster Not primary while dropping collection unittests.rollback_replace_collection) @src/mongo/dbtests/rollbacktests.cpp:393
        RollbackTests::ReplaceCollection<false, true>   Expected ::mongo::Status::OK() == (dropCollection(&opCtx, nss, result, {}, DropCollectionSystemCollectionMode::kDisallowSystemCollectionDrops)) (OK  == NotMaster Not primary while dropping collection unittests.rollback_replace_collection) @src/mongo/dbtests/rollbacktests.cpp:393
        RollbackTests::ReplaceCollection<true, false>   Expected ::mongo::Status::OK() == (dropCollection(&opCtx, nss, result, {}, DropCollectionSystemCollectionMode::kDisallowSystemCollectionDrops)) (OK  == NotMaster Not primary while dropping collection unittests.rollback_replace_collection) @src/mongo/dbtests/rollbacktests.cpp:393
        RollbackTests::ReplaceCollection<true, true>    Expected ::mongo::Status::OK() == (dropCollection(&opCtx, nss, result, {}, DropCollectionSystemCollectionMode::kDisallowSystemCollectionDrops)) (OK  == NotMaster Not primary while dropping collection unittests.rollback_replace_collection) @src/mongo/dbtests/rollbacktests.cpp:393
        RollbackTests::CreateDropCollection<false, false>       Expected ::mongo::Status::OK() == (dropCollection(&opCtx, nss, result, {}, DropCollectionSystemCollectionMode::kDisallowSystemCollectionDrops)) (OK  == NotMaster Not primary while dropping collection unittests.rollback_create_drop_collection) @src/mongo/dbtests/rollbacktests.cpp:452
        RollbackTests::CreateDropCollection<false, true>        Expected ::mongo::Status::OK() == (dropCollection(&opCtx, nss, result, {}, DropCollectionSystemCollectionMode::kDisallowSystemCollectionDrops)) (OK  == NotMaster Not primary while dropping collection unittests.rollback_create_drop_collection) @src/mongo/dbtests/rollbacktests.cpp:452
        RollbackTests::CreateDropCollection<true, false>        Expected ::mongo::Status::OK() == (dropCollection(&opCtx, nss, result, {}, DropCollectionSystemCollectionMode::kDisallowSystemCollectionDrops)) (OK  == NotMaster Not primary while dropping collection unittests.rollback_create_drop_collection) @src/mongo/dbtests/rollbacktests.cpp:452
        RollbackTests::CreateDropCollection<true, true> Expected ::mongo::Status::OK() == (dropCollection(&opCtx, nss, result, {}, DropCollectionSystemCollectionMode::kDisallowSystemCollectionDrops)) (OK  == NotMaster Not primary while dropping collection unittests.rollback_create_drop_collection) @src/mongo/dbtests/rollbacktests.cpp:452
2017-12-11T10:54:50.866+0300 I -        [testsuite] sock                           | tests:    1 | fails:    0 | assert calls:          0 | time secs:  0.005
2017-12-11T10:54:50.866+0300 I -        [testsuite] threading                      | tests:    5 | fails:    0 | assert calls:          0 | time secs: 10.150
2017-12-11T10:54:50.866+0300 I -        [testsuite] warning: log line attempted (16kB) over max size (10kB), printing beginning and end ... update                         | tests:  113 | fails:  108 | assert calls:          0 | time secs:  0.230
        UpdateTests::ModId       std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::ModId
        UpdateTests::ModNonmodMix        std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::ModNonmodMix
        UpdateTests::InvalidMod  std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::InvalidMod
        UpdateTests::ModNotFirst         std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::ModNotFirst
        UpdateTests::ModDuplicateFieldSpec       std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::ModDuplicateFieldSpec
        UpdateTests::IncNonNumber        std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::IncNonNumber
        UpdateTests::PushAllNonArray     std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::PushAllNonArray
        UpdateTests::PullAllNonArray     std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::PullAllNonArray
        UpdateTests::IncTargetNonNumber  std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::IncTargetNonNumber
        UpdateTests::SetNum      std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::SetNum
        UpdateTests::SetString   std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::SetString
        UpdateTests::SetStringDifferentLength    std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::SetStringDifferentLength
        UpdateTests::SetStringToNum      std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::SetStringToNum
        UpdateTests::SetStringToNumInPlace       std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::SetStringToNumInPlace
        UpdateTests::SetOnInsertFromEmpty        std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::SetOnInsertFromEmpty
        UpdateTests::SetOnInsertFromNonExistent  std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::SetOnInsertFromNonExistent
        UpdateTests::SetOnInsertFromNonExistentWithQuery         std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::SetOnInsertFromNonExistentWithQuery
        UpdateTests::SetOnInsertFromNonExistentWithQueryOverField        std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::SetOnInsertFromNonExistentWithQueryOverField
        UpdateTests::SetOnInsertMissingField     std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::SetOnInsertMissingField
        UpdateTests::SetOnInsertExisting         std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::SetOnInsertExisting
        UpdateTests::SetOnInsertMixed    std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::SetOnInsertMixed
        UpdateTests::SetOnInsertMissingParent    std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::SetOnInsertMissingParent
        UpdateTests::ModDott .......... ouble
        UpdateTests::PushSortInvalidSortSort     std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::PushSortInvalidSortSort
        UpdateTests::PushSortInvalidSortSortOrder        std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::PushSortInvalidSortSortOrder
        UpdateTests::PushSortInvertedSortAndSlice        std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::PushSortInvertedSortAndSlice
        UpdateTests::PushSortInvalidDuplicatedSort       std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::PushSortInvalidDuplicatedSort
        UpdateTests::CantIncParent       std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::CantIncParent
        UpdateTests::DontDropEmpty       std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::DontDropEmpty
        UpdateTests::InsertInEmpty       std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::InsertInEmpty
        UpdateTests::IndexParentOfMod    std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::IndexParentOfMod
        UpdateTests::PreserveIdWithIndex         std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::PreserveIdWithIndex
        UpdateTests::CheckNoMods         std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::CheckNoMods
        UpdateTests::UpdateMissingToNull         std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::UpdateMissingToNull
        UpdateTests::TwoModsWithinDuplicatedField        std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::TwoModsWithinDuplicatedField
        UpdateTests::ThreeModsWithinDuplicatedField      std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::ThreeModsWithinDuplicatedField
        UpdateTests::TwoModsBeforeExistingField  std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::TwoModsBeforeExistingField
        UpdateTests::basic::inc1         std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::basic::inc1
        UpdateTests::basic::inc3         std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::basic::inc3
        UpdateTests::basic::inc4         std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::basic::inc4
        UpdateTests::basic::inc5         std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::basic::inc5
        UpdateTests::basic::inc6         std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::basic::inc6
        UpdateTests::basic::bit1         std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::basic::bit1
        UpdateTests::basic::unset        std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::basic::unset
        UpdateTests::basic::setswitchint         std::exception: Not-master error during fire-and-forget command processing in test UpdateTests::basic::setswitchint
2017-12-11T10:54:50.867+0300 I -        [testsuite] validate_tests                 | tests:   24 | fails:    2 | assert calls:          0 | time secs:  5.005
        ValidateTests::ValidatePartialIndexOnCollectionWithNonIndexableFields<false, false>     Expected statement dbtests::createIndexFromSpec(&_opCtx, coll->ns().ns(), ((::mongo::BSONObjBuilder(64) << "name" << "partial_index" << "ns" << coll->ns().ns() << "key" << ((::mongo::BSONObjBuilder(64) << "x" << "2dsphere").obj()) << "v" << static_cast<int>(kIndexVersion) << "background" << false << "partialFilterExpression" << ((::mongo::BSONObjBuilder(64) << "a" << ((::mongo::BSONObjBuilder(64) << "$eq" << 2).obj())).obj())).obj())) .transitional_ignore() to throw AssertionException but it threw nothing. @src/mongo/dbtests/validate_tests.cpp:712
        ValidateTests::ValidatePartialIndexOnCollectionWithNonIndexableFields<false, true>      Expected statement dbtests::createIndexFromSpec(&_opCtx, coll->ns().ns(), ((::mongo::BSONObjBuilder(64) << "name" << "partial_index" << "ns" << coll->ns().ns() << "key" << ((::mongo::BSONObjBuilder(64) << "x" << "2dsphere").obj()) << "v" << static_cast<int>(kIndexVersion) << "background" << false << "partialFilterExpression" << ((::mongo::BSONObjBuilder(64) << "a" << ((::mongo::BSONObjBuilder(64) << "$eq" << 2).obj())).obj())).obj())) .transitional_ignore() to throw AssertionException but it threw nothing. @src/mongo/dbtests/validate_tests.cpp:712
2017-12-11T10:54:50.867+0300 I -        [testsuite] TOTALS                         | tests: 1141 | fails:  134 | assert calls:          0 | time secs: 188.940
2017-12-11T10:54:50.867+0300 I -        [testsuite] Failing tests:
2017-12-11T10:54:50.867+0300 I -        [testsuite]      rollback/RollbackTests::RenameCollection<false, false, false> Failed
2017-12-11T10:54:50.867+0300 I -        [testsuite]      rollback/RollbackTests::RenameCollection<false, false, true> Failed
2017-12-11T10:54:50.867+0300 I -        [testsuite]      rollback/RollbackTests::RenameCollection<false, true, false> Failed
2017-12-11T10:54:50.867+0300 I -        [testsuite]      rollback/RollbackTests::RenameCollection<false, true, true> Failed
2017-12-11T10:54:50.867+0300 I -        [testsuite]      rollback/RollbackTests::RenameCollection<true, false, false> Failed
2017-12-11T10:54:50.867+0300 I -        [testsuite]      rollback/RollbackTests::RenameCollection<true, false, true> Failed
2017-12-11T10:54:50.868+0300 I -        [testsuite]      rollback/RollbackTests::RenameCollection<true, true, false> Failed
2017-12-11T10:54:50.868+0300 I -        [testsuite]      rollback/RollbackTests::RenameCollection<true, true, true> Failed
2017-12-11T10:54:50.868+0300 I -        [testsuite]      rollback/RollbackTests::RenameDropTargetCollection<false, false, false> Failed
2017-12-11T10:54:50.868+0300 I -        [testsuite]      rollback/RollbackTests::RenameDropTargetCollection<false, false, true> Failed
2017-12-11T10:54:50.868+0300 I -        [testsuite]      rollback/RollbackTests::RenameDropTargetCollection<false, true, false> Failed
2017-12-11T10:54:50.868+0300 I -        [testsuite]      rollback/RollbackTests::RenameDropTargetCollection<false, true, true> Failed
2017-12-11T10:54:50.868+0300 I -        [testsuite]      rollback/RollbackTests::RenameDropTargetCollection<true, false, false> Failed
2017-12-11T10:54:50.868+0300 I -        [testsuite]      rollback/RollbackTests::RenameDropTargetCollection<true, false, true> Failed
2017-12-11T10:54:50.868+0300 I -        [testsuite]      rollback/RollbackTests::RenameDropTargetCollection<true, true, false> Failed
2017-12-11T10:54:50.868+0300 I -        [testsuite]      rollback/RollbackTests::RenameDropTargetCollection<true, true, true> Failed
2017-12-11T10:54:50.868+0300 I -        [testsuite]      rollback/RollbackTests::ReplaceCollection<false, false> Failed
2017-12-11T10:54:50.868+0300 I -        [testsuite]      rollback/RollbackTests::ReplaceCollection<false, true> Failed
2017-12-11T10:54:50.869+0300 I -        [testsuite]      rollback/RollbackTests::ReplaceCollection<true, false> Failed
2017-12-11T10:54:50.869+0300 I -        [testsuite]      rollback/RollbackTests::ReplaceCollection<true, true> Failed
2017-12-11T10:54:50.869+0300 I -        [testsuite]      rollback/RollbackTests::CreateDropCollection<false, false> Failed
2017-12-11T10:54:50.869+0300 I -        [testsuite]      rollback/RollbackTests::CreateDropCollection<false, true> Failed
2017-12-11T10:54:50.869+0300 I -        [testsuite]      rollback/RollbackTests::CreateDropCollection<true, false> Failed
2017-12-11T10:54:50.869+0300 I -        [testsuite]      rollback/RollbackTests::CreateDropCollection<true, true> Failed
2017-12-11T10:54:50.869+0300 I -        [testsuite]      update/UpdateTests::ModId Failed
2017-12-11T10:54:50.869+0300 I -        [testsuite]      update/UpdateTests::ModNonmodMix Failed
2017-12-11T10:54:50.869+0300 I -        [testsuite]      update/UpdateTests::InvalidMod Failed
2017-12-11T10:54:50.869+0300 I -        [testsuite]      update/UpdateTests::ModNotFirst Failed
2017-12-11T10:54:50.869+0300 I -        [testsuite]      update/UpdateTests::ModDuplicateFieldSpec Failed
2017-12-11T10:54:50.869+0300 I -        [testsuite]      update/UpdateTests::IncNonNumber Failed
2017-12-11T10:54:50.869+0300 I -        [testsuite]      update/UpdateTests::PushAllNonArray Failed
2017-12-11T10:54:50.869+0300 I -        [testsuite]      update/UpdateTests::PullAllNonArray Failed
2017-12-11T10:54:50.869+0300 I -        [testsuite]      update/UpdateTests::IncTargetNonNumber Failed
2017-12-11T10:54:50.870+0300 I -        [testsuite]      update/UpdateTests::SetNum Failed
2017-12-11T10:54:50.870+0300 I -        [testsuite]      update/UpdateTests::SetString Failed
2017-12-11T10:54:50.870+0300 I -        [testsuite]      update/UpdateTests::SetStringDifferentLength Failed
2017-12-11T10:54:50.870+0300 I -        [testsuite]      update/UpdateTests::SetStringToNum Failed
2017-12-11T10:54:50.870+0300 I -        [testsuite]      update/UpdateTests::SetStringToNumInPlace Failed
2017-12-11T10:54:50.870+0300 I -        [testsuite]      update/UpdateTests::SetOnInsertFromEmpty Failed
2017-12-11T10:54:50.870+0300 I -        [testsuite]      update/UpdateTests::SetOnInsertFromNonExistent Failed
2017-12-11T10:54:50.870+0300 I -        [testsuite]      update/UpdateTests::SetOnInsertFromNonExistentWithQuery Failed
2017-12-11T10:54:50.870+0300 I -        [testsuite]      update/UpdateTests::SetOnInsertFromNonExistentWithQueryOverField Failed
2017-12-11T10:54:50.870+0300 I -        [testsuite]      update/UpdateTests::SetOnInsertMissingField Failed
2017-12-11T10:54:50.870+0300 I -        [testsuite]      update/UpdateTests::SetOnInsertExisting Failed
2017-12-11T10:54:50.870+0300 I -        [testsuite]      update/UpdateTests::SetOnInsertMixed Failed
2017-12-11T10:54:50.870+0300 I -        [testsuite]      update/UpdateTests::SetOnInsertMissingParent Failed
2017-12-11T10:54:50.870+0300 I -        [testsuite]      update/UpdateTests::ModDotted Failed
2017-12-11T10:54:50.870+0300 I -        [testsuite]      update/UpdateTests::SetInPlaceDotted Failed
2017-12-11T10:54:50.871+0300 I -        [testsuite]      update/UpdateTests::SetRecreateDotted Failed
2017-12-11T10:54:50.871+0300 I -        [testsuite]      update/UpdateTests::SetMissingDotted Failed
2017-12-11T10:54:50.871+0300 I -        [testsuite]      update/UpdateTests::SetAdjacentDotted Failed
2017-12-11T10:54:50.871+0300 I -        [testsuite]      update/UpdateTests::IncMissing Failed
2017-12-11T10:54:50.871+0300 I -        [testsuite]      update/UpdateTests::MultiInc Failed
2017-12-11T10:54:50.871+0300 I -        [testsuite]      update/UpdateTests::UnorderedNewSet Failed
2017-12-11T10:54:50.871+0300 I -        [testsuite]      update/UpdateTests::UnorderedNewSetAdjacent Failed
2017-12-11T10:54:50.871+0300 I -        [testsuite]      update/UpdateTests::ArrayEmbeddedSet Failed
2017-12-11T10:54:50.871+0300 I -        [testsuite]      update/UpdateTests::AttemptEmbedInExistingNum Failed
2017-12-11T10:54:50.871+0300 I -        [testsuite]      update/UpdateTests::AttemptEmbedConflictsWithOtherSet Failed
2017-12-11T10:54:50.871+0300 I -        [testsuite]      update/UpdateTests::ModMasksEmbeddedConflict Failed
2017-12-11T10:54:50.871+0300 I -        [testsuite]      update/UpdateTests::ModOverwritesExistingObject Failed
2017-12-11T10:54:50.871+0300 I -        [testsuite]      update/UpdateTests::InvalidEmbeddedSet Failed
2017-12-11T10:54:50.871+0300 I -        [testsuite]      update/UpdateTests::UpsertMissingEmbedded Failed
2017-12-11T10:54:50.872+0300 I -        [testsuite]      update/UpdateTests::Push Failed
2017-12-11T10:54:50.872+0300 I -        [testsuite]      update/UpdateTests::PushInvalidEltType Failed
2017-12-11T10:54:50.872+0300 I -        [testsuite]      update/UpdateTests::PushConflictsWithOtherMod Failed
2017-12-11T10:54:50.872+0300 I -        [testsuite]      update/UpdateTests::PushFromNothing Failed
2017-12-11T10:54:50.872+0300 I -        [testsuite]      update/UpdateTests::PushFromEmpty Failed
2017-12-11T10:54:50.872+0300 I -        [testsuite]      update/UpdateTests::PushInsideNothing Failed
2017-12-11T10:54:50.872+0300 I -        [testsuite]      update/UpdateTests::CantPushInsideOtherMod Failed
2017-12-11T10:54:50.872+0300 I -        [testsuite]      update/UpdateTests::CantPushTwice Failed
2017-12-11T10:54:50.872+0300 I -        [testsuite]      update/UpdateTests::SetEncapsulationConflictsWithExistingType Failed
2017-12-11T10:54:50.872+0300 I -        [testsuite]      update/UpdateTests::CantPushToParent Failed
2017-12-11T10:54:50.872+0300 I -        [testsuite]      update/UpdateTests::PushEachSimple Failed
2017-12-11T10:54:50.872+0300 I -        [testsuite]      update/UpdateTests::PushEachFromEmpty Failed
2017-12-11T10:54:50.872+0300 I -        [testsuite]      update/UpdateTests::PushSliceBelowFull Failed
2017-12-11T10:54:50.872+0300 I -        [testsuite]      update/UpdateTests::PushSliceReachedFullExact Failed
2017-12-11T10:54:50.872+0300 I -        [testsuite]      update/UpdateTests::PushSliceReachedFullWithEach Failed
2017-12-11T10:54:50.873+0300 I -        [testsuite]      update/UpdateTests::PushSliceReachedFullWithBoth Failed
2017-12-11T10:54:50.873+0300 I -        [testsuite]      update/UpdateTests::PushSliceToZero Failed
2017-12-11T10:54:50.873+0300 I -        [testsuite]      update/UpdateTests::PushSliceToZeroFromNothing Failed
2017-12-11T10:54:50.873+0300 I -        [testsuite]      update/UpdateTests::PushSliceFromNothing Failed
2017-12-11T10:54:50.873+0300 I -        [testsuite]      update/UpdateTests::PushSliceLongerThanSliceFromNothing Failed
2017-12-11T10:54:50.873+0300 I -        [testsuite]      update/UpdateTests::PushSliceFromEmpty Failed
2017-12-11T10:54:50.873+0300 I -        [testsuite]      update/UpdateTests::PushSliceLongerThanSliceFromEmpty Failed
2017-12-11T10:54:50.873+0300 I -        [testsuite]      update/UpdateTests::PushSliceTwoFields Failed
2017-12-11T10:54:50.873+0300 I -        [testsuite]      update/UpdateTests::PushSliceAndNormal Failed
2017-12-11T10:54:50.873+0300 I -        [testsuite]      update/UpdateTests::PushSliceTwoFieldsConflict Failed
2017-12-11T10:54:50.873+0300 I -        [testsuite]      update/UpdateTests::PushSliceAndNormalConflict Failed
2017-12-11T10:54:50.873+0300 I -        [testsuite]      update/UpdateTests::PushSliceInvalidEachType Failed
2017-12-11T10:54:50.874+0300 I -        [testsuite]      update/UpdateTests::PushSliceInvalidSliceType Failed
2017-12-11T10:54:50.874+0300 I -        [testsuite]      update/UpdateTests::PushSliceInvalidSliceValue Failed
2017-12-11T10:54:50.874+0300 I -        [testsuite]      update/UpdateTests::PushSliceInvalidSliceDouble Failed
2017-12-11T10:54:50.874+0300 I -        [testsuite]      update/UpdateTests::PushSliceValidSliceDouble Failed
2017-12-11T10:54:50.874+0300 I -        [testsuite]      update/UpdateTests::PushSliceInvalidSlice Failed
2017-12-11T10:54:50.874+0300 I -        [testsuite]      update/UpdateTests::PushSortBelowFull Failed
2017-12-11T10:54:50.874+0300 I -        [testsuite]      update/UpdateTests::PushSortReachedFullExact Failed
2017-12-11T10:54:50.874+0300 I -        [testsuite]      update/UpdateTests::PushSortReachedFullWithBoth Failed
2017-12-11T10:54:50.874+0300 I -        [testsuite]      update/UpdateTests::PushSortToZero Failed
2017-12-11T10:54:50.874+0300 I -        [testsuite]      update/UpdateTests::PushSortToZeroFromNothing Failed
2017-12-11T10:54:50.874+0300 I -        [testsuite]      update/UpdateTests::PushSortFromNothing Failed
2017-12-11T10:54:50.875+0300 I -        [testsuite]      update/UpdateTests::PushSortLongerThanSliceFromNothing Failed
2017-12-11T10:54:50.875+0300 I -        [testsuite]      update/UpdateTests::PushSortFromEmpty Failed
2017-12-11T10:54:50.875+0300 I -        [testsuite]      update/UpdateTests::PushSortLongerThanSliceFromEmpty Failed
2017-12-11T10:54:50.875+0300 I -        [testsuite]      update/UpdateTests::PushSortInvalidSortPattern Failed
2017-12-11T10:54:50.875+0300 I -        [testsuite]      update/UpdateTests::PushSortInvalidEachType Failed
2017-12-11T10:54:50.875+0300 I -        [testsuite]      update/UpdateTests::PushSortInvalidSortType Failed
2017-12-11T10:54:50.875+0300 I -        [testsuite]      update/UpdateTests::PushSortInvalidSortValue Failed
2017-12-11T10:54:50.875+0300 I -        [testsuite]      update/UpdateTests::PushSortInvalidSortDouble Failed
2017-12-11T10:54:50.875+0300 I -        [testsuite]      update/UpdateTests::PushSortValidSortDouble Failed
2017-12-11T10:54:50.876+0300 I -        [testsuite]      update/UpdateTests::PushSortInvalidSortSort Failed
2017-12-11T10:54:50.876+0300 I -        [testsuite]      update/UpdateTests::PushSortInvalidSortSortOrder Failed
2017-12-11T10:54:50.876+0300 I -        [testsuite]      update/UpdateTests::PushSortInvertedSortAndSlice Failed
2017-12-11T10:54:50.876+0300 I -        [testsuite]      update/UpdateTests::PushSortInvalidDuplicatedSort Failed
2017-12-11T10:54:50.876+0300 I -        [testsuite]      update/UpdateTests::CantIncParent Failed
2017-12-11T10:54:50.876+0300 I -        [testsuite]      update/UpdateTests::DontDropEmpty Failed
2017-12-11T10:54:50.876+0300 I -        [testsuite]      update/UpdateTests::InsertInEmpty Failed
2017-12-11T10:54:50.876+0300 I -        [testsuite]      update/UpdateTests::IndexParentOfMod Failed
2017-12-11T10:54:50.876+0300 I -        [testsuite]      update/UpdateTests::PreserveIdWithIndex Failed
2017-12-11T10:54:50.876+0300 I -        [testsuite]      update/UpdateTests::CheckNoMods Failed
2017-12-11T10:54:50.876+0300 I -        [testsuite]      update/UpdateTests::UpdateMissingToNull Failed
2017-12-11T10:54:50.877+0300 I -        [testsuite]      update/UpdateTests::TwoModsWithinDuplicatedField Failed
2017-12-11T10:54:50.877+0300 I -        [testsuite]      update/UpdateTests::ThreeModsWithinDuplicatedField Failed
2017-12-11T10:54:50.877+0300 I -        [testsuite]      update/UpdateTests::TwoModsBeforeExistingField Failed
2017-12-11T10:54:50.877+0300 I -        [testsuite]      update/UpdateTests::basic::inc1 Failed
2017-12-11T10:54:50.877+0300 I -        [testsuite]      update/UpdateTests::basic::inc2 Failed
2017-12-11T10:54:50.877+0300 I -        [testsuite]      update/UpdateTests::basic::inc3 Failed
2017-12-11T10:54:50.877+0300 I -        [testsuite]      update/UpdateTests::basic::inc4 Failed
2017-12-11T10:54:50.877+0300 I -        [testsuite]      update/UpdateTests::basic::inc5 Failed
2017-12-11T10:54:50.878+0300 I -        [testsuite]      update/UpdateTests::basic::inc6 Failed
2017-12-11T10:54:50.878+0300 I -        [testsuite]      update/UpdateTests::basic::bit1 Failed
2017-12-11T10:54:50.878+0300 I -        [testsuite]      update/UpdateTests::basic::unset Failed
2017-12-11T10:54:50.878+0300 I -        [testsuite]      update/UpdateTests::basic::setswitchint Failed
2017-12-11T10:54:50.878+0300 I -        [testsuite]      validate_tests/ValidateTests::ValidatePartialIndexOnCollectionWithNonIndexableFields<false, false> Failed
2017-12-11T10:54:50.878+0300 I -        [testsuite]      validate_tests/ValidateTests::ValidatePartialIndexOnCollectionWithNonIndexableFields<false, true> Failed
2017-12-11T10:54:50.878+0300 I -        [testsuite] FAILURE - 134 tests in 3 suites failed
2017-12-11T10:54:50.886+0300 I STORAGE  [WTOplogJournalThread] oplog journal thread loop shutting down
2017-12-11T10:54:50.891+0300 I STORAGE  [testsuite] WiredTigerKVEngine shutting down
2017-12-11T10:54:51.362+0300 I STORAGE  [testsuite] shutdown: removing fs lock...
2017-12-11T10:54:51.362+0300 I CONTROL  [testsuite] shutting down with code:17
```

after fix:
```
2017-12-11T13:37:32.779+0300 I STORAGE  [testsuite] Finishing collection drop for unittests.validate_tests (22febe0f-a76b-4644-85f9-65e580e9bb32).
2017-12-11T13:37:32.840+0300 I -        [testsuite] 	 DONE running tests
2017-12-11T13:37:32.840+0300 I -        [testsuite] **************************************************
2017-12-11T13:37:32.841+0300 I -        [testsuite] CommandTests                   | tests:    1 | fails:    0 | assert calls:          0 | time secs:  0.154
2017-12-11T13:37:32.841+0300 I -        [testsuite] CursorManagerTest              | tests:   16 | fails:    0 | assert calls:          0 | time secs:  0.016
2017-12-11T13:37:32.841+0300 I -        [testsuite] CursorManagerTestCustomOpCtx   | tests:    5 | fails:    0 | assert calls:          0 | time secs:  0.000
2017-12-11T13:37:32.841+0300 I -        [testsuite] DocumentSourceCursorTest       | tests:   14 | fails:    0 | assert calls:          0 | time secs:  1.335
2017-12-11T13:37:32.841+0300 I -        [testsuite] ExtensionsCallbackRealTest     | tests:   14 | fails:    0 | assert calls:          0 | time secs:  2.301
2017-12-11T13:37:32.841+0300 I -        [testsuite] IndexAccessMethodSetDifference | tests:   11 | fails:    0 | assert calls:          0 | time secs:  0.000
2017-12-11T13:37:32.841+0300 I -        [testsuite] InsertTest                     | tests:    3 | fails:    0 | assert calls:          0 | time secs:  0.002
2017-12-11T13:37:32.841+0300 I -        [testsuite] MockDBClientConnTest           | tests:   19 | fails:    0 | assert calls:          0 | time secs:  0.307
2017-12-11T13:37:32.841+0300 I -        [testsuite] MockReplicaSetTest             | tests:   13 | fails:    0 | assert calls:          0 | time secs:  0.005
2017-12-11T13:37:32.841+0300 I -        [testsuite] MultikeyPathsTest              | tests:    6 | fails:    0 | assert calls:          0 | time secs:  1.012
2017-12-11T13:37:32.841+0300 I -        [testsuite] PlanExecutorSnapshotTest       | tests:    2 | fails:    0 | assert calls:          0 | time secs:  0.213
2017-12-11T13:37:32.841+0300 I -        [testsuite] PlanExecutorTest               | tests:    7 | fails:    0 | assert calls:          0 | time secs:  0.888
2017-12-11T13:37:32.842+0300 I -        [testsuite] QueryStageCollectionScan       | tests:    8 | fails:    0 | assert calls:          0 | time secs:  0.911
2017-12-11T13:37:32.842+0300 I -        [testsuite] QueryStageEnsureSortedTest     | tests:    9 | fails:    0 | assert calls:          0 | time secs:  0.006
2017-12-11T13:37:32.842+0300 I -        [testsuite] QueryStageMultiPlanTest        | tests:    6 | fails:    0 | assert calls:          0 | time secs:  3.573
2017-12-11T13:37:32.842+0300 I -        [testsuite] QueryStageNearTest             | tests:    2 | fails:    0 | assert calls:          0 | time secs:  0.000
2017-12-11T13:37:32.842+0300 I -        [testsuite] QueryStageSubplanTest          | tests:   10 | fails:    0 | assert calls:          0 | time secs:  2.366
2017-12-11T13:37:32.842+0300 I -        [testsuite] ReplicaSetMonitorTest          | tests:    2 | fails:    0 | assert calls:          0 | time secs:  0.013
2017-12-11T13:37:32.842+0300 I -        [testsuite] ReplicaSetTest                 | tests:    3 | fails:    0 | assert calls:          0 | time secs:  0.338
2017-12-11T13:37:32.842+0300 I -        [testsuite] SortKeyGeneratorStageTest      | tests:   17 | fails:    0 | assert calls:          0 | time secs:  0.002
2017-12-11T13:37:32.842+0300 I -        [testsuite] StorageTimestampTests          | tests:    7 | fails:    0 | assert calls:          0 | time secs:  0.695
2017-12-11T13:37:32.842+0300 I -        [testsuite] TwoNodeWithTags                | tests:    2 | fails:    0 | assert calls:          0 | time secs:  0.002
2017-12-11T13:37:32.842+0300 I -        [testsuite] basic                          | tests:   16 | fails:    0 | assert calls:          0 | time secs: 12.724
2017-12-11T13:37:32.842+0300 I -        [testsuite] client                         | tests:   16 | fails:    0 | assert calls:          0 | time secs:  3.112
2017-12-11T13:37:32.843+0300 I -        [testsuite] commands                       | tests:   11 | fails:    0 | assert calls:          0 | time secs:  1.526
2017-12-11T13:37:32.843+0300 I -        [testsuite] count                          | tests:    4 | fails:    0 | assert calls:          0 | time secs:  0.691
2017-12-11T13:37:32.843+0300 I -        [testsuite] deferred_writer_tests          | tests:    6 | fails:    0 | assert calls:          0 | time secs:  1.232
2017-12-11T13:37:32.843+0300 I -        [testsuite] directclient                   | tests:    8 | fails:    0 | assert calls:          0 | time secs:  0.559
2017-12-11T13:37:32.843+0300 I -        [testsuite] executor_registry              | tests:    5 | fails:    0 | assert calls:          0 | time secs:  1.725
2017-12-11T13:37:32.843+0300 I -        [testsuite] gle                            | tests:    3 | fails:    0 | assert calls:          0 | time secs:  0.096
2017-12-11T13:37:32.843+0300 I -        [testsuite] indexcatalogtests              | tests:    2 | fails:    0 | assert calls:          0 | time secs:  0.406
2017-12-11T13:37:32.843+0300 I -        [testsuite] indexupdate                    | tests:   25 | fails:    0 | assert calls:          0 | time secs:  5.093
2017-12-11T13:37:32.843+0300 I -        [testsuite] js                             | tests:  102 | fails:    0 | assert calls:          0 | time secs: 26.364
2017-12-11T13:37:32.843+0300 I -        [testsuite] jsobj                          | tests:   88 | fails:    0 | assert calls:          0 | time secs:  1.443
2017-12-11T13:37:32.843+0300 I -        [testsuite] json                           | tests:  250 | fails:    0 | assert calls:          0 | time secs:  0.025
2017-12-11T13:37:32.843+0300 I -        [testsuite] logical_sessions               | tests:    3 | fails:    0 | assert calls:          0 | time secs:  3.218
2017-12-11T13:37:32.844+0300 I -        [testsuite] matcher                        | tests:   15 | fails:    0 | assert calls:          0 | time secs:  0.643
2017-12-11T13:37:32.844+0300 I -        [testsuite] mmap                           | tests:    0 | fails:    0 | assert calls:          0 | time secs:  0.000
2017-12-11T13:37:32.844+0300 I -        [testsuite] namespace                      | tests:    4 | fails:    0 | assert calls:          0 | time secs:  0.000
2017-12-11T13:37:32.844+0300 I -        [testsuite] oplogstart                     | tests:    2 | fails:    0 | assert calls:          0 | time secs:  0.264
2017-12-11T13:37:32.844+0300 I -        [testsuite] pdfile                         | tests:    4 | fails:    0 | assert calls:          0 | time secs:  0.133
2017-12-11T13:37:32.844+0300 I -        [testsuite] query                          | tests:   52 | fails:    0 | assert calls:          0 | time secs: 12.481
2017-12-11T13:37:32.844+0300 I -        [testsuite] query_plan_ranking             | tests:   12 | fails:    0 | assert calls:          0 | time secs: 25.110
2017-12-11T13:37:32.844+0300 I -        [testsuite] query_stage_and                | tests:   19 | fails:    0 | assert calls:          0 | time secs:  4.804
2017-12-11T13:37:32.844+0300 I -        [testsuite] query_stage_cached_plan        | tests:    2 | fails:    0 | assert calls:          0 | time secs:  0.471
2017-12-11T13:37:32.844+0300 I -        [testsuite] query_stage_count              | tests:    7 | fails:    0 | assert calls:          0 | time secs:  2.072
2017-12-11T13:37:32.844+0300 I -        [testsuite] query_stage_count_scan         | tests:   11 | fails:    0 | assert calls:          0 | time secs:  1.928
2017-12-11T13:37:32.844+0300 I -        [testsuite] query_stage_delete             | tests:    3 | fails:    0 | assert calls:          0 | time secs:  0.400
2017-12-11T13:37:32.845+0300 I -        [testsuite] query_stage_distinct           | tests:    3 | fails:    0 | assert calls:          0 | time secs:  1.628
2017-12-11T13:37:32.845+0300 I -        [testsuite] query_stage_fetch              | tests:    2 | fails:    0 | assert calls:          0 | time secs:  0.264
2017-12-11T13:37:32.845+0300 I -        [testsuite] query_stage_ixscan             | tests:    5 | fails:    0 | assert calls:          0 | time secs:  0.789
2017-12-11T13:37:32.845+0300 I -        [testsuite] query_stage_keep               | tests:    2 | fails:    0 | assert calls:          0 | time secs:  0.274
2017-12-11T13:37:32.845+0300 I -        [testsuite] query_stage_limit_skip         | tests:    1 | fails:    0 | assert calls:          0 | time secs:  0.022
2017-12-11T13:37:32.845+0300 I -        [testsuite] query_stage_merge_sort_test    | tests:   10 | fails:    0 | assert calls:          0 | time secs:  4.799
2017-12-11T13:37:32.845+0300 I -        [testsuite] query_stage_sort               | tests:   10 | fails:    0 | assert calls:          0 | time secs:  3.735
2017-12-11T13:37:32.845+0300 I -        [testsuite] query_stage_tests              | tests:    5 | fails:    0 | assert calls:          0 | time secs:  1.222
2017-12-11T13:37:32.845+0300 I -        [testsuite] query_stage_update             | tests:    5 | fails:    0 | assert calls:          0 | time secs:  0.611
2017-12-11T13:37:32.845+0300 I -        [testsuite] remove                         | tests:    1 | fails:    0 | assert calls:          0 | time secs:  0.000
2017-12-11T13:37:32.845+0300 I -        [testsuite] repl                           | tests:   53 | fails:    0 | assert calls:          0 | time secs: 23.546
2017-12-11T13:37:32.845+0300 I -        [testsuite] rollback                       | tests:   54 | fails:    0 | assert calls:          0 | time secs: 15.492
2017-12-11T13:37:32.846+0300 I -        [testsuite] sock                           | tests:    1 | fails:    0 | assert calls:          0 | time secs:  0.003
2017-12-11T13:37:32.846+0300 I -        [testsuite] threading                      | tests:    5 | fails:    0 | assert calls:          0 | time secs: 10.263
2017-12-11T13:37:32.846+0300 I -        [testsuite] update                         | tests:  113 | fails:    0 | assert calls:          0 | time secs: 14.640
2017-12-11T13:37:32.846+0300 I -        [testsuite] validate_tests                 | tests:   24 | fails:    0 | assert calls:          0 | time secs:  8.179
2017-12-11T13:37:32.846+0300 I -        [testsuite] TOTALS                         | tests: 1141 | fails:    0 | assert calls:          0 | time secs: 206.126
2017-12-11T13:37:32.846+0300 I -        [testsuite] SUCCESS - All tests in all suites passed
2017-12-11T13:37:32.856+0300 I STORAGE  [WTOplogJournalThread] oplog journal thread loop shutting down
2017-12-11T13:37:32.857+0300 I STORAGE  [testsuite] WiredTigerKVEngine shutting down
2017-12-11T13:37:33.320+0300 I STORAGE  [testsuite] shutdown: removing fs lock...
2017-12-11T13:37:33.321+0300 I CONTROL  [testsuite] shutting down with code:0
```