### PR TITLE
SERVER-30283 Update topology_coordinator's .h and .cpp files

### DIFF
--- a/src/mongo/db/repl/topology_coordinator.cpp
+++ b/src/mongo/db/repl/topology_coordinator.cpp
@@ -109,9 +109,6 @@ int indexOfIterator(const std::vector<T>& vec, typename std::vector<T>::const_it
     return static_cast<int>(it - vec.begin());
 }
 
-// Maximum number of retries for a failed heartbeat.
-const int kMaxHeartbeatRetries = 2;
-
 /**
  * Returns true if the only up heartbeats are auth errors.
  */
@@ -908,9 +905,8 @@ std::pair<ReplSetHeartbeatArgs, Milliseconds> TopologyCoordinator::prepareHeartb
     Date_t now, const std::string& ourSetName, const HostAndPort& target) {
     PingStats& hbStats = _pings[target];
     Milliseconds alreadyElapsed = now - hbStats.getLastHeartbeatStartDate();
-    if (!_rsConfig.isInitialized() || (hbStats.noMoreRetries() == true) ||		    
-       (alreadyElapsed >= _rsConfig.getHeartbeatTimeoutPeriodMillis())
-        ) {
+    if (!_rsConfig.isInitialized() || (hbStats.hasFailed()) ||
+        (alreadyElapsed >= _rsConfig.getHeartbeatTimeoutPeriodMillis())) {
         // This is either the first request ever for "target", or the heartbeat timeout has
         // passed, so we're starting a "new" heartbeat.
         hbStats.start(now);
@@ -947,9 +943,8 @@ std::pair<ReplSetHeartbeatArgsV1, Milliseconds> TopologyCoordinator::prepareHear
     Date_t now, const std::string& ourSetName, const HostAndPort& target) {
     PingStats& hbStats = _pings[target];
     Milliseconds alreadyElapsed(now.asInt64() - hbStats.getLastHeartbeatStartDate().asInt64());
-    if (!_rsConfig.isInitialized() || (hbStats.noMoreRetries() == true) ||
-        (alreadyElapsed >= _rsConfig.getHeartbeatTimeoutPeriodMillis())
-        ) {
+    if ((!_rsConfig.isInitialized()) || (hbStats.hasFailed()) ||
+        (alreadyElapsed >= _rsConfig.getHeartbeatTimeoutPeriodMillis())) {
         // This is either the first request ever for "target", or the heartbeat timeout has
         // passed, so we're starting a "new" heartbeat.
         hbStats.start(now);
@@ -1026,10 +1021,7 @@ HeartbeatResponseAction TopologyCoordinator::processHeartbeatResponse(
     const Milliseconds alreadyElapsed = now - hbStats.getLastHeartbeatStartDate();
     Date_t nextHeartbeatStartDate;
     // Determine next heartbeat start time.
-    if ((hbStats.getNumFailuresSinceLastStart() <= kMaxHeartbeatRetries) &&
-        (hbStats.getGoodHeartbeatReceived() == false) &&
-        (alreadyElapsed < _rsConfig.getHeartbeatTimeoutPeriod())
-        ) {
+    if ((!hbStats.hasFailed()) && (alreadyElapsed < _rsConfig.getHeartbeatTimeoutPeriod())) {
         // There are still retries left, let's use one.
         nextHeartbeatStartDate = now;
     } else {
@@ -1096,13 +1088,12 @@ HeartbeatResponseAction TopologyCoordinator::processHeartbeatResponse(
     if (!hbResponse.isOK()) {
         if (isUnauthorized) {
             hbData.setAuthIssue(now);
-        } else if ((hbStats.noMoreRetries() == true) ||
-                   (alreadyElapsed >= _rsConfig.getHeartbeatTimeoutPeriod())
-                   ) {
+        } else if ((hbStats.hasFailed()) ||
+                   (alreadyElapsed >= _rsConfig.getHeartbeatTimeoutPeriod())) {
             hbData.setDownValues(now, hbResponse.getStatus().reason());
         } else {
-            LOG(3) << "Bad heartbeat response from " << target << "; trying again; Retries left: "
-                   << (kMaxHeartbeatRetries - hbStats.getNumFailuresSinceLastStart()) << "; "
+            LOG(3) << "Bad heartbeat response from " << target
+                   << "; trying again; Retries left: " << (hbStats.retriesLeft()) << "; "
                    << alreadyElapsed << " have already elapsed";
         }
     } else {

--- a/src/mongo/db/repl/topology_coordinator.cpp
+++ b/src/mongo/db/repl/topology_coordinator.cpp
@@ -149,10 +149,11 @@ void appendOpTime(BSONObjBuilder* bob,
 void TopologyCoordinator::PingStats::start(Date_t now) {
     _lastHeartbeatStartDate = now;
     _numFailuresSinceLastStart = 0;
+    _goodHeartbeatReceived = false;
 }
 
 void TopologyCoordinator::PingStats::hit(Milliseconds millis) {
-    _numFailuresSinceLastStart = std::numeric_limits<int>::max();
+    _goodHeartbeatReceived = true;
     ++count;
 
     value = value == UninitializedPing ? millis : Milliseconds((value * 4 + millis) / 5);
@@ -907,9 +908,9 @@ std::pair<ReplSetHeartbeatArgs, Milliseconds> TopologyCoordinator::prepareHeartb
     Date_t now, const std::string& ourSetName, const HostAndPort& target) {
     PingStats& hbStats = _pings[target];
     Milliseconds alreadyElapsed = now - hbStats.getLastHeartbeatStartDate();
-    if (!_rsConfig.isInitialized() ||
-        (hbStats.getNumFailuresSinceLastStart() > kMaxHeartbeatRetries) ||
-        (alreadyElapsed >= _rsConfig.getHeartbeatTimeoutPeriodMillis())) {
+    if (!_rsConfig.isInitialized() || (hbStats.noMoreRetries() == true) ||		    
+       (alreadyElapsed >= _rsConfig.getHeartbeatTimeoutPeriodMillis())
+        ) {
         // This is either the first request ever for "target", or the heartbeat timeout has
         // passed, so we're starting a "new" heartbeat.
         hbStats.start(now);
@@ -946,9 +947,9 @@ std::pair<ReplSetHeartbeatArgsV1, Milliseconds> TopologyCoordinator::prepareHear
     Date_t now, const std::string& ourSetName, const HostAndPort& target) {
     PingStats& hbStats = _pings[target];
     Milliseconds alreadyElapsed(now.asInt64() - hbStats.getLastHeartbeatStartDate().asInt64());
-    if (!_rsConfig.isInitialized() ||
-        (hbStats.getNumFailuresSinceLastStart() > kMaxHeartbeatRetries) ||
-        (alreadyElapsed >= _rsConfig.getHeartbeatTimeoutPeriodMillis())) {
+    if (!_rsConfig.isInitialized() || (hbStats.noMoreRetries() == true) ||
+        (alreadyElapsed >= _rsConfig.getHeartbeatTimeoutPeriodMillis())
+        ) {
         // This is either the first request ever for "target", or the heartbeat timeout has
         // passed, so we're starting a "new" heartbeat.
         hbStats.start(now);
@@ -1025,8 +1026,10 @@ HeartbeatResponseAction TopologyCoordinator::processHeartbeatResponse(
     const Milliseconds alreadyElapsed = now - hbStats.getLastHeartbeatStartDate();
     Date_t nextHeartbeatStartDate;
     // Determine next heartbeat start time.
-    if (hbStats.getNumFailuresSinceLastStart() <= kMaxHeartbeatRetries &&
-        alreadyElapsed < _rsConfig.getHeartbeatTimeoutPeriod()) {
+    if ((hbStats.getNumFailuresSinceLastStart() <= kMaxHeartbeatRetries) &&
+        (hbStats.getGoodHeartbeatReceived() == false) &&
+        (alreadyElapsed < _rsConfig.getHeartbeatTimeoutPeriod())
+        ) {
         // There are still retries left, let's use one.
         nextHeartbeatStartDate = now;
     } else {
@@ -1093,8 +1096,9 @@ HeartbeatResponseAction TopologyCoordinator::processHeartbeatResponse(
     if (!hbResponse.isOK()) {
         if (isUnauthorized) {
             hbData.setAuthIssue(now);
-        } else if (hbStats.getNumFailuresSinceLastStart() > kMaxHeartbeatRetries ||
-                   alreadyElapsed >= _rsConfig.getHeartbeatTimeoutPeriod()) {
+        } else if ((hbStats.noMoreRetries() == true) ||
+                   (alreadyElapsed >= _rsConfig.getHeartbeatTimeoutPeriod())
+                   ) {
             hbData.setDownValues(now, hbResponse.getStatus().reason());
         } else {
             LOG(3) << "Bad heartbeat response from " << target << "; trying again; Retries left: "

--- a/src/mongo/db/repl/topology_coordinator.h
+++ b/src/mongo/db/repl/topology_coordinator.h
@@ -52,6 +52,9 @@ class ReplSetConfig;
 class TagSubgroup;
 struct MemberState;
 
+// Maximum number of retries for a failed heartbeat.
+const int kMaxHeartbeatRetries = 2;
+
 /**
  * Replication Topology Coordinator
  *
@@ -1046,7 +1049,7 @@ public:
      * last call to start(). Otherwise, returns false.
      */
     bool hasFailed() const {
-        return (_numFailuresSinceLastStart > _kMaxHeartbeatRetries) ||
+        return (_numFailuresSinceLastStart > kMaxHeartbeatRetries) ||
             (_goodHeartbeatReceived == true);
     }
 
@@ -1054,14 +1057,12 @@ public:
      * Gets the number of retries left for a failed heartbeat.
      */
     int retriesLeft() const {
-        return _kMaxHeartbeatRetries - _numFailuresSinceLastStart;
+        return kMaxHeartbeatRetries - _numFailuresSinceLastStart;
     }
 
 private:
     static constexpr Milliseconds UninitializedPing{-1};
 
-    // Maximum number of retries for a failed heartbeat.
-    int _kMaxHeartbeatRetries = 2;
     unsigned int count = 0;
     Milliseconds value = UninitializedPing;
     Date_t _lastHeartbeatStartDate;

--- a/src/mongo/db/repl/topology_coordinator.h
+++ b/src/mongo/db/repl/topology_coordinator.h
@@ -1041,38 +1041,27 @@ public:
     }
 
     /**
-     * Gets the number of failures since start() was last called.
-     *
-     * This value is incremented by calls to miss() and cleared by calls to start().
-     * 
+     * Returns true if the number of failed heartbeats has exceeded the max number
+     * of heartbeat retries or if a good heartbeat has been received since the
+     * last call to start(). Otherwise, returns false.
      */
-    int getNumFailuresSinceLastStart() const {
-        return _numFailuresSinceLastStart;
+    bool hasFailed() const {
+        return (_numFailuresSinceLastStart > _kMaxHeartbeatRetries) ||
+            (_goodHeartbeatReceived == true);
     }
 
     /**
-     * Gets a flag that indicates whether the number of failed heartbeats has
-     * exceeded the max number of heartbeat retries or whether a good
-     * heartbeat has been received since the last call to start(). 
+     * Gets the number of retries left for a failed heartbeat.
      */
-    bool noMoreRetries() const {
-        return _numFailuresSinceLastStart > 2 || _goodHeartbeatReceived == true;
-    }
-	
-    /**
-     * Gets a flag that indicates whether a good heartbeat was received
-     * since the last call to start().
-     *
-     * This value is set to false on calls to start() and set to true on
-     * call to hit().
-     */
-    bool getGoodHeartbeatReceived() const {
-        return _goodHeartbeatReceived;
+    int retriesLeft() const {
+        return _kMaxHeartbeatRetries - _numFailuresSinceLastStart;
     }
 
 private:
     static constexpr Milliseconds UninitializedPing{-1};
 
+    // Maximum number of retries for a failed heartbeat.
+    int _kMaxHeartbeatRetries = 2;
     unsigned int count = 0;
     Milliseconds value = UninitializedPing;
     Date_t _lastHeartbeatStartDate;

--- a/src/mongo/db/repl/topology_coordinator.h
+++ b/src/mongo/db/repl/topology_coordinator.h
@@ -1043,11 +1043,31 @@ public:
     /**
      * Gets the number of failures since start() was last called.
      *
-     * This value is incremented by calls to miss(), cleared by calls to start() and
-     * set to the maximum possible value by calls to hit().
+     * This value is incremented by calls to miss() and cleared by calls to start().
+     * 
      */
     int getNumFailuresSinceLastStart() const {
         return _numFailuresSinceLastStart;
+    }
+
+    /**
+     * Gets a flag that indicates whether the number of failed heartbeats has
+     * exceeded the max number of heartbeat retries or whether a good
+     * heartbeat has been received since the last call to start(). 
+     */
+    bool noMoreRetries() const {
+        return _numFailuresSinceLastStart > 2 || _goodHeartbeatReceived == true;
+    }
+	
+    /**
+     * Gets a flag that indicates whether a good heartbeat was received
+     * since the last call to start().
+     *
+     * This value is set to false on calls to start() and set to true on
+     * call to hit().
+     */
+    bool getGoodHeartbeatReceived() const {
+        return _goodHeartbeatReceived;
     }
 
 private:
@@ -1057,6 +1077,7 @@ private:
     Milliseconds value = UninitializedPing;
     Date_t _lastHeartbeatStartDate;
     int _numFailuresSinceLastStart = std::numeric_limits<int>::max();
+    bool _goodHeartbeatReceived = false;
 };
 
 //


### PR DESCRIPTION
PingStats, defined in topology_coordinator.cpp, is a data structure used
to track statistics about replication heartbeat messages. It has a
variable called _numFailuresSinceLastStart, which keeps track of failed
heartbeat attempts. When a good heartbeat response comes back, this
variable is set to std::numeric_limits<int>max(), presumably as an easy
way for this value to always be larger than others in certain
comparisons. In the case that we actually get back a good hearbeat
response (PingStats::hit) and then a failed heartbeat response from the
same node (PingStats::miss), we will actually overflow this
_numFailuresSinceLastStart variable. The integer max function should
not be used to determine if a good heartbeat response was received.

To remediate the issue, a field named _goodHeartbeatReceived was
added to PingStats to indicate whether a good heartbeat response
(PingStats::hit) was received since the last start
(PingStats::start). The assignment statement responsible for the
potential overflow is then replaced by a new assignment statement
that sets _goodHeartbeatReceived to true when a good heartbeat
response comes back.

Resolves: SERVER-30283