### PR TITLE
SERVER-4785 maintain slowms at database level

### DIFF
--- a/jstests/core/hidden_index.js
+++ b/jstests/core/hidden_index.js
@@ -1,0 +1,45 @@
+var rsTest = new ReplSetTest({ nodes: 2 });
+rsTest.startSet({ oplogSize: 1000  });
+rsTest.initiate();
+rsTest.awaitSecondaryNodes();
+
+
+var primary = rsTest.getPrimary();
+var secondary = rsTest.getSecondary();
+secondary.setSlaveOk();
+
+var testtab = primary.getDB("test").hidden_index_tab;
+var testtabsec = secondary.getDB("test").hidden_index_tab;
+
+testtab.createIndex({a: 1});
+testtab.createIndex({b: 1}, {hidden: true});
+
+var res = testtab.find({a: 1}).explain()
+assert.eq(res.queryPlanner.winningPlan.inputStage.stage, "IXSCAN");
+res = testtab.find({b: 1}).explain()
+assert.eq(res.queryPlanner.winningPlan.stage, "COLLSCAN");
+sleep(1000);
+
+
+res = testtabsec.find({a: 1}).explain()
+assert.eq(res.queryPlanner.winningPlan.inputStage.stage, "IXSCAN");
+res = testtabsec.find({b: 1}).explain()
+assert.eq(res.queryPlanner.winningPlan.stage, "COLLSCAN");
+
+
+testtab.hiddenIndex("a_1");
+testtab.unhiddenIndex({b: 1});
+
+res = testtab.find({a: 1}).explain()
+assert.eq(res.queryPlanner.winningPlan.stage, "COLLSCAN");
+res = testtab.find({b: 1}).explain()
+assert.eq(res.queryPlanner.winningPlan.inputStage.stage, "IXSCAN");
+sleep(1000);
+
+res = testtabsec.find({a: 1}).explain()
+assert.eq(res.queryPlanner.winningPlan.stage, "COLLSCAN");
+res = testtabsec.find({b: 1}).explain()
+assert.eq(res.queryPlanner.winningPlan.inputStage.stage, "IXSCAN");
+
+
+rsTest.stopSet();

--- a/src/mongo/db/auth/auth_op_observer.cpp
+++ b/src/mongo/db/auth/auth_op_observer.cpp
@@ -114,11 +114,11 @@ void AuthOpObserver::onCollMod(OperationContext* opCtx,
                                OptionalCollectionUUID uuid,
                                const BSONObj& collModCmd,
                                const CollectionOptions& oldCollOptions,
-                               boost::optional<TTLCollModInfo> ttlInfo) {
+                               boost::optional<IndexCollModInfo> indexInfo) {
     const auto cmdNss = nss.getCommandNS();
 
     // Create the 'o' field object.
-    const auto cmdObj = makeCollModCmdObj(collModCmd, oldCollOptions, ttlInfo);
+    const auto cmdObj = makeCollModCmdObj(collModCmd, oldCollOptions, indexInfo);
 
     AuthorizationManager::get(opCtx->getServiceContext())
         ->logOp(opCtx, "c", cmdNss, cmdObj, nullptr);

--- a/src/mongo/db/auth/auth_op_observer.h
+++ b/src/mongo/db/auth/auth_op_observer.h
@@ -113,7 +113,7 @@ public:
                    OptionalCollectionUUID uuid,
                    const BSONObj& collModCmd,
                    const CollectionOptions& oldCollOptions,
-                   boost::optional<TTLCollModInfo> ttlInfo) final;
+                   boost::optional<IndexCollModInfo> indexInfo) final;
 
     void onDropDatabase(OperationContext* opCtx, const std::string& dbName) final;
 

--- a/src/mongo/db/create_indexes.idl
+++ b/src/mongo/db/create_indexes.idl
@@ -50,6 +50,9 @@ structs:
       unique:
         type: bool
         optional: true
+      hidden:
+        type: bool
+        optional: true
       partialFilterExpression:
         type: object
         optional: true

--- a/src/mongo/db/free_mon/free_mon_op_observer.h
+++ b/src/mongo/db/free_mon/free_mon_op_observer.h
@@ -113,7 +113,7 @@ public:
                    OptionalCollectionUUID uuid,
                    const BSONObj& collModCmd,
                    const CollectionOptions& oldCollOptions,
-                   boost::optional<TTLCollModInfo> ttlInfo) final {}
+                   boost::optional<IndexCollModInfo> indexInfo) final {}
 
     void onDropDatabase(OperationContext* opCtx, const std::string& dbName) final {}
 

--- a/src/mongo/db/index/index_descriptor.cpp
+++ b/src/mongo/db/index/index_descriptor.cpp
@@ -62,6 +62,7 @@ void populateOptionsMap(std::map<StringData, BSONElement>& theMap, const BSONObj
                 IndexDescriptor::kBackgroundFieldName ||  // this is a creation time option only
             fieldName == IndexDescriptor::kDropDuplicatesFieldName ||  // this is now ignored
             fieldName == IndexDescriptor::kSparseFieldName ||          // checked specially
+            fieldName == IndexDescriptor::kHiddenFieldName || // not considered for equivalence
             fieldName == IndexDescriptor::kUniqueFieldName             // check specially
         ) {
             continue;
@@ -94,6 +95,7 @@ constexpr StringData IndexDescriptor::kSparseFieldName;
 constexpr StringData IndexDescriptor::kStorageEngineFieldName;
 constexpr StringData IndexDescriptor::kTextVersionFieldName;
 constexpr StringData IndexDescriptor::kUniqueFieldName;
+constexpr StringData IndexDescriptor::kHiddenFieldName;
 constexpr StringData IndexDescriptor::kWeightsFieldName;
 
 IndexDescriptor::IndexDescriptor(Collection* collection,
@@ -110,6 +112,7 @@ IndexDescriptor::IndexDescriptor(Collection* collection,
       _isIdIndex(isIdIndexPattern(_keyPattern)),
       _sparse(infoObj[IndexDescriptor::kSparseFieldName].trueValue()),
       _unique(_isIdIndex || infoObj[kUniqueFieldName].trueValue()),
+      _hidden(infoObj[kHiddenFieldName].trueValue()),
       _partial(!infoObj[kPartialFilterExprFieldName].eoo()),
       _cachedEntry(nullptr) {
     BSONElement e = _infoObj[IndexDescriptor::kIndexVersionFieldName];

--- a/src/mongo/db/index/index_descriptor.h
+++ b/src/mongo/db/index/index_descriptor.h
@@ -82,6 +82,7 @@ public:
     static constexpr StringData kStorageEngineFieldName = "storageEngine"_sd;
     static constexpr StringData kTextVersionFieldName = "textIndexVersion"_sd;
     static constexpr StringData kUniqueFieldName = "unique"_sd;
+    static constexpr StringData kHiddenFieldName = "hidden"_sd;
     static constexpr StringData kWeightsFieldName = "weights"_sd;
 
     /**
@@ -174,6 +175,10 @@ public:
         return _unique;
     }
 
+    bool hidden() const {
+        return _hidden;
+    }
+
     // Is this index sparse?
     bool isSparse() const {
         return _sparse;
@@ -251,6 +256,7 @@ private:
     bool _isIdIndex;
     bool _sparse;
     bool _unique;
+    bool _hidden;
     bool _partial;
     IndexVersion _version;
     BSONObj _collation;

--- a/src/mongo/db/op_observer.h
+++ b/src/mongo/db/op_observer.h
@@ -60,9 +60,11 @@ struct OplogUpdateEntryArgs {
         : updateArgs(std::move(updateArgs)), nss(std::move(nss)), uuid(std::move(uuid)) {}
 };
 
-struct TTLCollModInfo {
-    Seconds expireAfterSeconds;
-    Seconds oldExpireAfterSeconds;
+struct IndexCollModInfo {
+    boost::optional<Seconds> expireAfterSeconds;
+    boost::optional<Seconds> oldExpireAfterSeconds;
+    boost::optional<bool> hidden;
+    boost::optional<bool> oldHidden;
     std::string indexName;
 };
 
@@ -207,7 +209,7 @@ public:
                            OptionalCollectionUUID uuid,
                            const BSONObj& collModCmd,
                            const CollectionOptions& oldCollOptions,
-                           boost::optional<TTLCollModInfo> ttlInfo) = 0;
+                           boost::optional<IndexCollModInfo> indexInfo) = 0;
     virtual void onDropDatabase(OperationContext* opCtx, const std::string& dbName) = 0;
 
     /**

--- a/src/mongo/db/op_observer_impl.cpp
+++ b/src/mongo/db/op_observer_impl.cpp
@@ -642,7 +642,7 @@ void OpObserverImpl::onCollMod(OperationContext* opCtx,
                                OptionalCollectionUUID uuid,
                                const BSONObj& collModCmd,
                                const CollectionOptions& oldCollOptions,
-                               boost::optional<TTLCollModInfo> ttlInfo) {
+                               boost::optional<IndexCollModInfo> indexInfo) {
 
     if (!nss.isSystemDotProfile()) {
         // do not replicate system.profile modifications
@@ -650,16 +650,22 @@ void OpObserverImpl::onCollMod(OperationContext* opCtx,
         // Create the 'o2' field object. We save the old collection metadata and TTL expiration.
         BSONObjBuilder o2Builder;
         o2Builder.append("collectionOptions_old", oldCollOptions.toBSON());
-        if (ttlInfo) {
-            auto oldExpireAfterSeconds = durationCount<Seconds>(ttlInfo->oldExpireAfterSeconds);
-            o2Builder.append("expireAfterSeconds_old", oldExpireAfterSeconds);
+        if (indexInfo) {
+            if (indexInfo->oldExpireAfterSeconds) {
+                auto oldExpireAfterSeconds = durationCount<Seconds>(indexInfo->oldExpireAfterSeconds.get());
+                o2Builder.append("expireAfterSeconds_old", oldExpireAfterSeconds);
+            }
+            if (indexInfo->oldHidden) {
+                auto oldHidden = indexInfo->oldHidden.get();
+                o2Builder.append("hidden_old", oldHidden);
+            }
         }
 
         MutableOplogEntry oplogEntry;
         oplogEntry.setOpType(repl::OpTypeEnum::kCommand);
         oplogEntry.setNss(nss.getCommandNS());
         oplogEntry.setUuid(uuid);
-        oplogEntry.setObject(makeCollModCmdObj(collModCmd, oldCollOptions, ttlInfo));
+        oplogEntry.setObject(makeCollModCmdObj(collModCmd, oldCollOptions, indexInfo));
         oplogEntry.setObject2(o2Builder.done());
         logOperation(opCtx, &oplogEntry);
     }

--- a/src/mongo/db/op_observer_impl.h
+++ b/src/mongo/db/op_observer_impl.h
@@ -102,7 +102,7 @@ public:
                    OptionalCollectionUUID uuid,
                    const BSONObj& collModCmd,
                    const CollectionOptions& oldCollOptions,
-                   boost::optional<TTLCollModInfo> ttlInfo) final;
+                   boost::optional<IndexCollModInfo> indexInfo) final;
     void onDropDatabase(OperationContext* opCtx, const std::string& dbName) final;
     repl::OpTime onDropCollection(OperationContext* opCtx,
                                   const NamespaceString& collectionName,

--- a/src/mongo/db/op_observer_impl_test.cpp
+++ b/src/mongo/db/op_observer_impl_test.cpp
@@ -273,16 +273,16 @@ TEST_F(OpObserverTest, CollModWithCollectionOptionsAndTTLInfo) {
     oldCollOpts.validationLevel = "strict";
     oldCollOpts.validationAction = "error";
 
-    TTLCollModInfo ttlInfo;
-    ttlInfo.expireAfterSeconds = Seconds(10);
-    ttlInfo.oldExpireAfterSeconds = Seconds(5);
-    ttlInfo.indexName = "name_of_index";
+    IndexCollModInfo indexInfo;
+    indexInfo.expireAfterSeconds = Seconds(10);
+    indexInfo.oldExpireAfterSeconds = Seconds(5);
+    indexInfo.indexName = "name_of_index";
 
     // Write to the oplog.
     {
         AutoGetDb autoDb(opCtx.get(), nss.db(), MODE_X);
         WriteUnitOfWork wunit(opCtx.get());
-        opObserver.onCollMod(opCtx.get(), nss, uuid, collModCmd, oldCollOpts, ttlInfo);
+        opObserver.onCollMod(opCtx.get(), nss, uuid, collModCmd, oldCollOpts, indexInfo);
         wunit.commit();
     }
 
@@ -296,8 +296,8 @@ TEST_F(OpObserverTest, CollModWithCollectionOptionsAndTTLInfo) {
                        << "validationAction"
                        << "warn"
                        << "index"
-                       << BSON("name" << ttlInfo.indexName << "expireAfterSeconds"
-                                      << durationCount<Seconds>(ttlInfo.expireAfterSeconds)));
+                       << BSON("name" << indexInfo.indexName << "expireAfterSeconds"
+                               << durationCount<Seconds>(indexInfo.expireAfterSeconds.get())));
     ASSERT_BSONOBJ_EQ(oExpected, o);
 
     // Ensure that the old collection metadata was saved.
@@ -306,7 +306,7 @@ TEST_F(OpObserverTest, CollModWithCollectionOptionsAndTTLInfo) {
         BSON("collectionOptions_old"
              << BSON("validationLevel" << oldCollOpts.validationLevel << "validationAction"
                                        << oldCollOpts.validationAction)
-             << "expireAfterSeconds_old" << durationCount<Seconds>(ttlInfo.oldExpireAfterSeconds));
+             << "expireAfterSeconds_old" << durationCount<Seconds>(indexInfo.oldExpireAfterSeconds.get()));
 
     ASSERT_BSONOBJ_EQ(o2Expected, o2);
 }

--- a/src/mongo/db/op_observer_noop.h
+++ b/src/mongo/db/op_observer_noop.h
@@ -98,7 +98,7 @@ public:
                    OptionalCollectionUUID uuid,
                    const BSONObj& collModCmd,
                    const CollectionOptions& oldCollOptions,
-                   boost::optional<TTLCollModInfo> ttlInfo) override {}
+                   boost::optional<IndexCollModInfo> indexInfo) override {}
     void onDropDatabase(OperationContext* opCtx, const std::string& dbName) override {}
     repl::OpTime onDropCollection(OperationContext* opCtx,
                                   const NamespaceString& collectionName,

--- a/src/mongo/db/op_observer_registry.h
+++ b/src/mongo/db/op_observer_registry.h
@@ -175,10 +175,10 @@ public:
                    OptionalCollectionUUID uuid,
                    const BSONObj& collModCmd,
                    const CollectionOptions& oldCollOptions,
-                   boost::optional<TTLCollModInfo> ttlInfo) override {
+                   boost::optional<IndexCollModInfo> indexInfo) override {
         ReservedTimes times{opCtx};
         for (auto& o : _observers)
-            o->onCollMod(opCtx, nss, uuid, collModCmd, oldCollOptions, ttlInfo);
+            o->onCollMod(opCtx, nss, uuid, collModCmd, oldCollOptions, indexInfo);
     }
 
     void onDropDatabase(OperationContext* const opCtx, const std::string& dbName) override {

--- a/src/mongo/db/op_observer_util.cpp
+++ b/src/mongo/db/op_observer_util.cpp
@@ -42,21 +42,25 @@ namespace mongo {
  */
 BSONObj makeCollModCmdObj(const BSONObj& collModCmd,
                           const CollectionOptions& oldCollOptions,
-                          boost::optional<TTLCollModInfo> ttlInfo) {
+                          boost::optional<IndexCollModInfo> indexInfo) {
     BSONObjBuilder cmdObjBuilder;
-    std::string ttlIndexFieldName = "index";
+    std::string indexFieldName = "index";
 
     // Add all fields from the original collMod command.
     for (auto elem : collModCmd) {
         // We normalize all TTL collMod oplog entry objects to use the index name, even if the
         // command used an index key pattern.
-        if (elem.fieldNameStringData() == ttlIndexFieldName && ttlInfo) {
-            BSONObjBuilder ttlIndexObjBuilder;
-            ttlIndexObjBuilder.append("name", ttlInfo->indexName);
-            ttlIndexObjBuilder.append("expireAfterSeconds",
-                                      durationCount<Seconds>(ttlInfo->expireAfterSeconds));
+        if (elem.fieldNameStringData() == indexFieldName && indexInfo) {
+            BSONObjBuilder indexObjBuilder;
+            indexObjBuilder.append("name", indexInfo->indexName);
+            if (indexInfo->expireAfterSeconds)
+                indexObjBuilder.append("expireAfterSeconds",
+                                          durationCount<Seconds>(indexInfo->expireAfterSeconds.get()));
+            if (indexInfo->hidden)
+                indexObjBuilder.append("hidden",
+                                          indexInfo->hidden.get());
 
-            cmdObjBuilder.append(ttlIndexFieldName, ttlIndexObjBuilder.obj());
+            cmdObjBuilder.append(indexFieldName, indexObjBuilder.obj());
         } else {
             cmdObjBuilder.append(elem);
         }

--- a/src/mongo/db/op_observer_util.h
+++ b/src/mongo/db/op_observer_util.h
@@ -36,5 +36,5 @@
 namespace mongo {
 BSONObj makeCollModCmdObj(const BSONObj& collModCmd,
                           const CollectionOptions& oldCollOptions,
-                          boost::optional<TTLCollModInfo> ttlInfo);
+                          boost::optional<IndexCollModInfo> indexInfo);
 }  // namespace mongo

--- a/src/mongo/db/query/get_executor.cpp
+++ b/src/mongo/db/query/get_executor.cpp
@@ -242,6 +242,9 @@ void fillOutPlannerParams(OperationContext* opCtx,
         collection->getIndexCatalog()->getIndexIterator(opCtx, false);
     while (ii->more()) {
         const IndexCatalogEntry* ice = ii->next();
+
+        if (ice->descriptor()->hidden())
+            continue;
         plannerParams->indices.push_back(
             indexEntryFromIndexCatalogEntry(opCtx, *ice, canonicalQuery));
     }
@@ -1392,6 +1395,8 @@ QueryPlannerParams fillOutPlannerParamsForDistinct(OperationContext* opCtx,
     while (ii->more()) {
         const IndexCatalogEntry* ice = ii->next();
         const IndexDescriptor* desc = ice->descriptor();
+        if (desc->hidden())
+            continue;
         if (desc->keyPattern().hasField(parsedDistinct.getKey())) {
             if (!mayUnwindArrays &&
                 isAnyComponentOfPathMultikey(desc->keyPattern(),

--- a/src/mongo/db/s/config_server_op_observer.h
+++ b/src/mongo/db/s/config_server_op_observer.h
@@ -114,7 +114,7 @@ public:
                    OptionalCollectionUUID uuid,
                    const BSONObj& collModCmd,
                    const CollectionOptions& oldCollOptions,
-                   boost::optional<TTLCollModInfo> ttlInfo) override {}
+                   boost::optional<IndexCollModInfo> indexInfo) override {}
 
     void onDropDatabase(OperationContext* opCtx, const std::string& dbName) override {}
 

--- a/src/mongo/db/s/shard_server_op_observer.cpp
+++ b/src/mongo/db/s/shard_server_op_observer.cpp
@@ -469,7 +469,7 @@ void ShardServerOpObserver::onCollMod(OperationContext* opCtx,
                                       OptionalCollectionUUID uuid,
                                       const BSONObj& collModCmd,
                                       const CollectionOptions& oldCollOptions,
-                                      boost::optional<TTLCollModInfo> ttlInfo) {
+                                      boost::optional<IndexCollModInfo> indexInfo) {
     abortOngoingMigration(opCtx, nss);
 };
 

--- a/src/mongo/db/s/shard_server_op_observer.h
+++ b/src/mongo/db/s/shard_server_op_observer.h
@@ -114,7 +114,7 @@ public:
                    OptionalCollectionUUID uuid,
                    const BSONObj& collModCmd,
                    const CollectionOptions& oldCollOptions,
-                   boost::optional<TTLCollModInfo> ttlInfo) override;
+                   boost::optional<IndexCollModInfo> indexInfo) override;
 
     void onDropDatabase(OperationContext* opCtx, const std::string& dbName) override {}
 

--- a/src/mongo/db/storage/bson_collection_catalog_entry.cpp
+++ b/src/mongo/db/storage/bson_collection_catalog_entry.cpp
@@ -120,6 +120,26 @@ void BSONCollectionCatalogEntry::IndexMetaData::updateTTLSetting(long long newEx
     spec = b.obj();
 }
 
+
+void BSONCollectionCatalogEntry::IndexMetaData::updateHiddenSetting(bool hidden) {
+    // if hidden == true, we remove this field from mddata rather than add a field with false value.
+    // or else, the old binary can't startup due to the unknown field
+    BSONObjBuilder b;
+    for (BSONObjIterator bi(spec); bi.more();) {
+        BSONElement e = bi.next();
+        if (e.fieldNameStringData() == "hidden") {
+            continue;
+        }
+        b.append(e);
+    }
+
+    if (hidden) {
+        b.append("hidden", hidden);
+    }
+    spec = b.obj();
+}
+
+
 // --------------------------
 
 int BSONCollectionCatalogEntry::MetaData::findIndexOffset(StringData name) const {

--- a/src/mongo/db/storage/bson_collection_catalog_entry.h
+++ b/src/mongo/db/storage/bson_collection_catalog_entry.h
@@ -64,6 +64,8 @@ public:
 
         void updateTTLSetting(long long newExpireSeconds);
 
+        void updateHiddenSetting(bool hidden);
+
         std::string name() const {
             return spec["name"].String();
         }

--- a/src/mongo/db/storage/durable_catalog.h
+++ b/src/mongo/db/storage/durable_catalog.h
@@ -151,6 +151,11 @@ public:
                                   StringData idxName,
                                   long long newExpireSeconds) = 0;
 
+    virtual void updateHiddenSetting(OperationContext* opCtx,
+                                        RecordId catalogId,
+                                        StringData idxName,
+                                        bool hidden) = 0;
+
     /** Compares the UUID argument to the UUID obtained from the metadata. Returns true if they are
      * equal, false otherwise.
      */

--- a/src/mongo/db/storage/durable_catalog_impl.cpp
+++ b/src/mongo/db/storage/durable_catalog_impl.cpp
@@ -904,6 +904,19 @@ void DurableCatalogImpl::updateTTLSetting(OperationContext* opCtx,
     putMetaData(opCtx, catalogId, md);
 }
 
+void DurableCatalogImpl::updateHiddenSetting(OperationContext* opCtx,
+                                                RecordId catalogId,
+                                                StringData idxName,
+                                                bool hidden) {
+
+    BSONCollectionCatalogEntry::MetaData md = getMetaData(opCtx, catalogId);
+    int offset = md.findIndexOffset(idxName);
+    invariant(offset >= 0);
+    md.indexes[offset].updateHiddenSetting(hidden);
+    putMetaData(opCtx, catalogId, md);
+}
+
+
 bool DurableCatalogImpl::isEqualToMetadataUUID(OperationContext* opCtx,
                                                RecordId catalogId,
                                                OptionalCollectionUUID uuid) {

--- a/src/mongo/db/storage/durable_catalog_impl.h
+++ b/src/mongo/db/storage/durable_catalog_impl.h
@@ -124,6 +124,11 @@ public:
                           StringData idxName,
                           long long newExpireSeconds);
 
+    void updateHiddenSetting(OperationContext* opCtx,
+                             RecordId catalogId,
+                             StringData idxName,
+                             bool hidden);
+
     bool isEqualToMetadataUUID(OperationContext* opCtx,
                                RecordId catalogId,
                                OptionalCollectionUUID uuid);

--- a/src/mongo/shell/collection.js
+++ b/src/mongo/shell/collection.js
@@ -60,6 +60,10 @@ DBCollection.prototype.help = function() {
     print("\tdb." + shortName + ".drop() drop the collection");
     print("\tdb." + shortName + ".dropIndex(index) - e.g. db." + shortName +
           ".dropIndex( \"indexName\" ) or db." + shortName + ".dropIndex( { \"indexKey\" : 1 } )");
+    print("\tdb." + shortName + ".hiddenIndex(index) - e.g. db." + shortName +
+          ".hiddenIndex( \"indexName\" ) or db." + shortName + ".hiddenIndex( { \"indexKey\" : 1 } )");
+    print("\tdb." + shortName + ".unhiddenIndex(index) - e.g. db." + shortName +
+          ".unhiddenIndex( \"indexName\" ) or db." + shortName + ".unhiddenIndex( { \"indexKey\" : 1 } )");
     print("\tdb." + shortName + ".dropIndexes()");
     print("\tdb." + shortName +
           ".ensureIndex(keypattern[,options]) - DEPRECATED, use createIndex() instead");
@@ -873,6 +877,38 @@ DBCollection.prototype.dropIndex = function(index) {
     var res = this._dbCommand("dropIndexes", {index: index});
     return res;
 };
+
+
+/**
+ * Hidden an index
+ */
+DBCollection.prototype._hiddenIndex = function(index, hidden) {
+    assert(index, "need to specify index to dropIndex");
+
+    // Need an extra check for array because 'Array' is an 'object', but not every 'object' is an
+    // 'Array'.
+    var indexField = {};
+    if (typeof index == "string") {
+	indexField = {name: index, hidden: hidden};
+    } else if (typeof index == "object") {
+	indexField = { keyPattern: index, hidden: hidden};
+    } else {
+        throw new Error(
+            "The index to drop must be either the index name or the index specification document");
+    }
+    var cmd = {"collMod": this._shortName, index: indexField};
+    var res = this._db.runCommand(cmd);
+    return res;
+};
+
+DBCollection.prototype.hiddenIndex = function(index) {
+    return this._hiddenIndex(index, true);
+}
+
+DBCollection.prototype.unhiddenIndex = function(index) {
+    return this._hiddenIndex(index, false);
+}
+
 
 DBCollection.prototype.getCollection = function(subName) {
     return this._db.getCollection(this._shortName + "." + subName);


### PR DESCRIPTION
See issue at https://jira.mongodb.org/browse/SERVER-4785 and https://jira.mongodb.org/browse/SERVER-18946 


Here is the test result.


zhifan@zhifan-dev16:~/github/mongo$ ./mongo
> db.getProfilingStatus()
{ "was" : 0, "slowms" : 100, "sampleRate" : 1 }
> db.setProfilingLevel(0, 1)
{ "was" : 0, "slowms" : 100, "sampleRate" : 1, "ok" : 1 }
> db.getProfilingStatus()
{ "was" : 0, "slowms" : 1, "sampleRate" : 1 }
> for(var i =0; i<10000; i++) {db.test.save({'i': i})}
WriteResult({ "nInserted" : 1 })
> use test2
switched to db test2
> db.getProfilingStatus()
{ "was" : 0, "slowms" : 100, "sampleRate" : 1 } . -- test 2: still 100
> for(var i =0; i<10000; i++) {db.test.save({'i': i})}
WriteResult({ "nInserted" : 1 })


as a result:  we capture the slow queries from test database but not for test2 database.

`
2017-12-26T13:38:32.678+0800 I COMMAND  [conn1] command test.test appName: "MongoDB Shell" command: insert { insert: "test", ordered: true, $db: "test" } ninserted:1 keysInserted:1 numYields:0 reslen:29 locks:{ Global: { acquireCount: { r: 3, w: 1 } }, Database: { acquireCount: { w: 1, R: 1 } }, Collection: { acquireCount: { w: 1 } } } protocol:op_msg 3ms

`

  