### PR TITLE
[SERVER-32813] Fix typos in config_server_test_fixture.cpp and dpml_error_codes.c

### DIFF
--- a/src/mongo/s/config_server_test_fixture.cpp
+++ b/src/mongo/s/config_server_test_fixture.cpp
@@ -243,7 +243,7 @@ Status ConfigServerTestFixture::deleteToConfigCollection(OperationContext* opCtx
                                                          const NamespaceString& ns,
                                                          const BSONObj& doc,
                                                          const bool multi) {
-    auto deleteReponse = getConfigShard()->runCommand(opCtx,
+    auto deleteResponse = getConfigShard()->runCommand(opCtx,
                                                       kReadPref,
                                                       ns.db().toString(),
                                                       [&]() {
@@ -261,7 +261,7 @@ Status ConfigServerTestFixture::deleteToConfigCollection(OperationContext* opCtx
 
 
     BatchedCommandResponse batchResponse;
-    auto status = Shard::CommandResponse::processBatchWriteResponse(deleteReponse, &batchResponse);
+    auto status = Shard::CommandResponse::processBatchWriteResponse(deleteResponse, &batchResponse);
     return status;
 }
 

--- a/src/third_party/IntelRDFPMathLib20U1/LIBRARY/float128/dpml_error_codes.c
+++ b/src/third_party/IntelRDFPMathLib20U1/LIBRARY/float128/dpml_error_codes.c
@@ -420,8 +420,8 @@
 
     /*
      * At this point, any platform specific modifications to the default
-     * reponses can be made in the manner described above by using any of
-     * the DEFINE_REPONSE, DEFAULT_RESPONSE and DEFAULT_NO_ERROR macros.  
+     * responses can be made in the manner described above by using any of
+     * the DEFINE_RESPONSE, DEFAULT_RESPONSE and DEFAULT_NO_ERROR macros.  
      */
 
 #   if (OP_SYSTEM == osf) || (OP_SYSTEM == vms) || (OP_SYSTEM == linux)


### PR DESCRIPTION
## Summary
I found some typos in files as below.

```
src/mongo/s/config_server_test_fixture.cpp
src/third_party/IntelRDFPMathLib20U1/LIBRARY/float128/dpml_error_codes.c
```

reponse  → response

