### PR TITLE
[SERVER-30376] Remove extra hyphens in error msg

### DIFF
--- a/src/mongo/util/options_parser/options_parser.cpp
+++ b/src/mongo/util/options_parser/options_parser.cpp
@@ -722,7 +722,7 @@ Status OptionsParser::parseCommandLine(const OptionSection& options,
         }
     } catch (po::multiple_occurrences& e) {
         StringBuilder sb;
-        sb << "Error parsing command line:  Multiple occurrences of option \"--"
+        sb << "Error parsing command line:  Multiple occurrences of option \""
            << e.get_option_name() << "\"";
         return Status(ErrorCodes::BadValue, sb.str());
     } catch (po::error& e) {


### PR DESCRIPTION
There are two extra hyphens being appended when there shouldn't be
as in the following:

$ ./mongod --storageEngine mmapv1 --storageEngine emphemeralForTest
--storageEngine wiredTiger
Error parsing command line:  Multiple occurrences of option
"----storageEngine"
try './mongod --help' for more information

To remediate the issue, simply remove the extra hyphens from the output
statement.