### PR TITLE
[SERVER-32259] Update wiredtiger_util.cpp

### DIFF
--- a/src/mongo/db/storage/wiredtiger/wiredtiger_util.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_util.cpp
@@ -87,7 +87,7 @@ void WiredTigerUtil::fetchTypeAndSourceURI(OperationContext* opCtx,
     invariant(colon != string::npos);
     colgroupUri += tableUri.substr(colon);
     StatusWith<std::string> colgroupResult = getMetadata(opCtx, colgroupUri);
-    invariant(colgroupResult.isOK());
+    invariantOK(colgroupResult.getStatus());
     WiredTigerConfigParser parser(colgroupResult.getValue());
 
     WT_CONFIG_ITEM typeItem;


### PR DESCRIPTION
WiredTigerUtil::fetchTypeAndSourceURI() is using
invariant(colgroupResult.isOK()) instead of
invariantOK(colgroupResult.getStatus()). This means that if the
invariant ever fires, we don't know what the bad Status actually was.