### PR TITLE
SERVER-31942 Truncate test lifecycle JIRA issue description

### DIFF
--- a/buildscripts/tests/test_update_test_lifecycle.py
+++ b/buildscripts/tests/test_update_test_lifecycle.py
@@ -1010,14 +1010,14 @@ class TestJiraIssueCreator(unittest.TestCase):
         self.assertEqual(expected, desc)
 
     def test_truncate_description(self):
-        desc = "a" * (JiraIssueCreator._MAX_DESCRIPTION_SIZE - 1)
-        self.assertTrue(desc == JiraIssueCreator._truncate_description(desc))
+        desc = "a" * (update_test_lifecycle.JiraIssueCreator._MAX_DESCRIPTION_SIZE - 1)
+        self.assertTrue(desc == update_test_lifecycle.JiraIssueCreator._truncate_description(desc))
        
         desc += "a"
-        self.assertTrue(desc == JiraIssueCreator._truncate_description(desc))
+        self.assertTrue(desc == update_test_lifecycle.JiraIssueCreator._truncate_description(desc))
 
         desc += "a"
-        self.assertTrue(len(desc) <= len(JiraIssueCreator._truncate_description(desc)))
+        self.assertTrue(len(update_test_lifecycle.JiraIssueCreator._truncate_description(desc)) <= update_test_lifecycle.JiraIssueCreator._MAX_DESCRIPTION_SIZE)
 
 class TestTagsConfigWithChangelog(unittest.TestCase):
     def setUp(self):

--- a/buildscripts/tests/test_update_test_lifecycle.py
+++ b/buildscripts/tests/test_update_test_lifecycle.py
@@ -1009,6 +1009,15 @@ class TestJiraIssueCreator(unittest.TestCase):
         expected = "_None_"
         self.assertEqual(expected, desc)
 
+    def test_truncate_description(self):
+        desc = "a" * (JiraIssueCreator._MAX_DESCRIPTION_SIZE - 1)
+        self.assertTrue(desc == JiraIssueCreator._truncate_description(desc))
+       
+        desc += "a"
+        self.assertTrue(desc == JiraIssueCreator._truncate_description(desc))
+
+        desc += "a"
+        self.assertTrue(len(desc) <= len(JiraIssueCreator._truncate_description(desc)))
 
 class TestTagsConfigWithChangelog(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
When the update_test_lifecycle task sees changes in unreliable tests, it
creates a JIRA issue before committing the changes.The description of
the issue contains the tag changes and if there are many of them the
description text size can exceed the allowed limit for the field
(32,767 characters).

When that happens the task fails and the changes are not committed.

Instead we should truncate the description when its size exceeds the
allowed limit.