### PR TITLE
SERVER-32148 Update oplog.cpp & sync_tail_test.cpp

### DIFF
--- a/src/mongo/db/repl/oplog.cpp
+++ b/src/mongo/db/repl/oplog.cpp
@@ -901,8 +901,9 @@ std::map<std::string, ApplyOpMetadata> opsMap = {
          BSONObj& cmd,
          const OpTime& opTime,
          OplogApplication::Mode mode) -> Status {
-         return convertToCapped(opCtx, parseUUIDorNs(opCtx, ns, ui, cmd), cmd["size"].number());
-     }}},
+          return convertToCapped(opCtx, parseUUIDorNs(opCtx, ns, ui, cmd), cmd["size"].number());
+      },
+      {ErrorCodes::NamespaceNotFound}}},
     {"emptycapped",
      {[](OperationContext* opCtx,
          const char* ns,
@@ -910,8 +911,9 @@ std::map<std::string, ApplyOpMetadata> opsMap = {
          BSONObj& cmd,
          const OpTime& opTime,
          OplogApplication::Mode mode) -> Status {
-         return emptyCapped(opCtx, parseUUIDorNs(opCtx, ns, ui, cmd));
-     }}},
+          return emptyCapped(opCtx, parseUUIDorNs(opCtx, ns, ui, cmd));
+      },
+      {ErrorCodes::NamespaceNotFound}}},
 };
 
 }  // namespace

--- a/src/mongo/db/repl/sync_tail_test.cpp
+++ b/src/mongo/db/repl/sync_tail_test.cpp
@@ -1815,34 +1815,37 @@ TEST_F(SyncTailTest, DropDatabaseSucceedsInRecovering) {
 }
 
 TEST_F(IdempotencyTest, EmptyCappedNamespaceNotFound) {
-    // Create a dummy namespace string.
-    auto ns = NamespaceString("foo.bar");
+    // Create a BSON "emptycapped" command.
+    auto emptyCappedCmd = BSON("emptycapped" << nss.coll());
 
-    AutoGetCollectionForReadCommand autoColl(_opCtx.get(), ns);
+    // Create an "emptycapped" oplog entry.
+    auto emptyCappedOp = makeCommandOplogEntry(nextOpTime(), nss, emptyCappedCmd);
+
+    // Ensure that the returned status code signals a failure.
+    ASSERT_NOT_OK(runOpInitialSync(emptyCappedOp));
+
+    AutoGetCollectionForReadCommand autoColl(_opCtx.get(), nss);
 
     // Ensure that autoColl.getCollection() and autoColl.getDb() are both null.
     ASSERT_FALSE(autoColl.getCollection());
     ASSERT_FALSE(autoColl.getDb());
-
-    // Create a BSON "emptycapped" command.
-    auto emptyCappedCmd = BSON("emptycapped" << ns.coll());
-    auto emptyCappedOp = makeCommandOplogEntry(nextOpTime(), ns, emptyCappedCmd);
-    ASSERT_NOT_OK(runOpInitialSync(emptyCappedOp));
 }
 
 TEST_F(IdempotencyTest, ConvertToCappedNamespaceNotFound) {
-    // Create a dummy namespace string.
-    auto ns = NamespaceString("foo.bar");
-    AutoGetCollectionForReadCommand autoColl(_opCtx.get(), ns);
+    // Create a BSON "convertToCapped" command.
+    auto convertToCappedCmd = BSON("convertToCapped" << nss.coll());
+
+    // Create a "convertToCapped" oplog entry.
+    auto convertToCappedOp = makeCommandOplogEntry(nextOpTime(), nss, convertToCappedCmd);
+
+    // Ensure that the returned status code signals a failure.
+    ASSERT_NOT_OK(runOpInitialSync(convertToCappedOp));
+
+    AutoGetCollectionForReadCommand autoColl(_opCtx.get(), nss);
 
     // Ensure that autoColl.getCollection() and autoColl.getDb() are both null.
     ASSERT_FALSE(autoColl.getCollection());
     ASSERT_FALSE(autoColl.getDb());
-
-    // Create a BSON "converToCapped" command.
-    auto convertToCappedCmd = BSON("convertToCapped" << ns.coll());
-    auto convertToCappedOp = makeCommandOplogEntry(nextOpTime(), ns, convertToCappedCmd);
-    ASSERT_NOT_OK(runOpInitialSync(convertToCappedOp));
 }
 
 }  // namespace

--- a/src/mongo/db/repl/sync_tail_test.cpp
+++ b/src/mongo/db/repl/sync_tail_test.cpp
@@ -1814,6 +1814,37 @@ TEST_F(SyncTailTest, DropDatabaseSucceedsInRecovering) {
     ASSERT_OK(runOpSteadyState(op));
 }
 
+TEST_F(IdempotencyTest, EmptyCappedNamespaceNotFound) {
+    // Create a dummy namespace string.
+    auto ns = NamespaceString("foo.bar");
+
+    AutoGetCollectionForReadCommand autoColl(_opCtx.get(), ns);
+
+    // Ensure that autoColl.getCollection() and autoColl.getDb() are both null.
+    ASSERT_FALSE(autoColl.getCollection());
+    ASSERT_FALSE(autoColl.getDb());
+
+    // Create a BSON "emptycapped" command.
+    auto emptyCappedCmd = BSON("emptycapped" << ns.coll());
+    auto emptyCappedOp = makeCommandOplogEntry(nextOpTime(), ns, emptyCappedCmd);
+    ASSERT_NOT_OK(runOpInitialSync(emptyCappedOp));
+}
+
+TEST_F(IdempotencyTest, ConvertToCappedNamespaceNotFound) {
+    // Create a dummy namespace string.
+    auto ns = NamespaceString("foo.bar");
+    AutoGetCollectionForReadCommand autoColl(_opCtx.get(), ns);
+
+    // Ensure that autoColl.getCollection() and autoColl.getDb() are both null.
+    ASSERT_FALSE(autoColl.getCollection());
+    ASSERT_FALSE(autoColl.getDb());
+
+    // Create a BSON "converToCapped" command.
+    auto convertToCappedCmd = BSON("convertToCapped" << ns.coll());
+    auto convertToCappedOp = makeCommandOplogEntry(nextOpTime(), ns, convertToCappedCmd);
+    ASSERT_NOT_OK(runOpInitialSync(convertToCappedOp));
+}
+
 }  // namespace
 }  // namespace repl
 }  // namespace mongo


### PR DESCRIPTION
We should make "NameSpaceNotFound" an accetable error for "emptyCapped"
and "convertToCapped".