### PR TITLE
SERVER-32233 Ensure electionId is increasing per iteration

### DIFF
--- a/src/mongo/client/replica_set_monitor_test.cpp
+++ b/src/mongo/client/replica_set_monitor_test.cpp
@@ -999,20 +999,21 @@ TEST(ReplicaSetMonitorTests, NewPrimaryWithMaxElectionId) {
 
         refresher.receivedIsMaster(basicSeeds[i],
                                    -1,
-                                   BSON("setName"
-                                        << "name"
-                                        << "ismaster"
-                                        << true
-                                        << "secondary"
-                                        << false
-                                        << "hosts"
-                                        << BSON_ARRAY("a"
-                                                      << "b"
-                                                      << "c")
-                                        << "electionId"
-                                        << OID::gen()
-                                        << "ok"
-                                        << true));
+                                   BSON(
+                                       "setName"
+                                       << "name"
+                                       << "ismaster"
+                                       << true
+                                       << "secondary"
+                                       << false
+                                       << "hosts"
+                                       << BSON_ARRAY("a"
+                                                     << "b"
+                                                     << "c")
+                                       << "electionId"
+                                       << OID::fromTerm(i)  // electionId must increase every cycle.
+                                       << "ok"
+                                       << true));
 
         // Ensure the set primary is the host we just got a reply from
         HostAndPort currentPrimary = state->getMatchingHost(primaryOnly);


### PR DESCRIPTION
NewPrimaryWithMaxElectionId test should ensure that electionId is increasing
per iteration.

The problem is that the test assumes that OID generated per iteration is
increasing. And this assumption is based on the fact that OID::gen
constructs a value based on the return value from time(). However, there
is no guarantee that time() will consistently be returning values that
increases over time.

Use OID::fromTerm() in place of OID::gen().