### PR TITLE
SERVER-32873 Fixed Incorrect handling of NumberLong in $pow function

### DIFF
--- a/jstests/aggregation/bugs/server18427.js
+++ b/jstests/aggregation/bugs/server18427.js
@@ -111,7 +111,7 @@ load('jstests/aggregation/extras/utils.js');
     testOp({$pow: [NumberInt("4"), NumberLong("-1")]}, 1 / 4);
     testOp({$pow: [NumberInt("1"), NumberLong("-2")]}, NumberLong("1"));
     testOp({$pow: [NumberInt("-1"), NumberLong("-2")]}, NumberLong("1"));
-
+    testOp({$pow: [NumberLong("-1", NumberLong("-3"))]}, NumberLong("-1"));
     // If result would overflow a long, return a double.
     testOp({$pow: [NumberInt("2"), NumberLong("63")]}, 9223372036854776000);
     // Exact decimal result

--- a/jstests/aggregation/bugs/server18427.js
+++ b/jstests/aggregation/bugs/server18427.js
@@ -111,7 +111,7 @@ load('jstests/aggregation/extras/utils.js');
     testOp({$pow: [NumberInt("4"), NumberLong("-1")]}, 1 / 4);
     testOp({$pow: [NumberInt("1"), NumberLong("-2")]}, NumberLong("1"));
     testOp({$pow: [NumberInt("-1"), NumberLong("-2")]}, NumberLong("1"));
-    testOp({$pow: [NumberLong("-1", NumberLong("-3"))]}, NumberLong("-1"));
+    testOp({$pow: [NumberLong("-1"), NumberLong("-3")]}, NumberLong("-1"));
     // If result would overflow a long, return a double.
     testOp({$pow: [NumberInt("2"), NumberLong("63")]}, 9223372036854776000);
     // Exact decimal result

--- a/src/mongo/db/pipeline/expression.cpp
+++ b/src/mongo/db/pipeline/expression.cpp
@@ -3146,8 +3146,9 @@ Value ExpressionPow::evaluate(const Document& root) const {
     long long result = 1;
     // Use repeated multiplication, since pow() casts args to doubles which could result in loss of
     // precision if arguments are very large.
+    
     for (int i = 0; i < expLong; i++) {
-        result *= baseLong;
+            result *= baseLong;
     }
 
     if (baseType == NumberLong || expType == NumberLong) {

--- a/src/mongo/db/pipeline/expression.cpp
+++ b/src/mongo/db/pipeline/expression.cpp
@@ -74,8 +74,7 @@ static Value serializeConstant(Value val) {
 string Expression::removeFieldPrefix(const string& prefixedField) {
     uassert(16419,
             str::stream() << "field path must not contain embedded null characters"
-                          << prefixedField.find("\0")
-                          << ",",
+                          << prefixedField.find("\0") << ",",
             prefixedField.find('\0') == string::npos);
 
     const char* pPrefixedField = prefixedField.c_str();
@@ -479,13 +478,11 @@ Value ExpressionArrayElemAt::evaluate(const Document& root) const {
             array.isArray());
     uassert(28690,
             str::stream() << getOpName() << "'s second argument must be a numeric value,"
-                          << " but is "
-                          << typeName(indexArg.getType()),
+                          << " but is " << typeName(indexArg.getType()),
             indexArg.numeric());
     uassert(28691,
             str::stream() << getOpName() << "'s second argument must be representable as"
-                          << " a 32-bit integer: "
-                          << indexArg.coerceToDouble(),
+                          << " a 32-bit integer: " << indexArg.coerceToDouble(),
             indexArg.integral());
 
     long long i = indexArg.coerceToLong();
@@ -766,7 +763,7 @@ static const CmpLookup cmpLookup[7] = {
     // CMP is special. Only name is used.
     /* CMP */ {{false, false, false}, ExpressionCompare::CMP, "$cmp"},
 };
-}
+}  // namespace
 
 Value ExpressionCompare::evaluate(const Document& root) const {
     Value pLeft(vpOperand[0]->evaluate(root));
@@ -1020,8 +1017,8 @@ intrusive_ptr<Expression> ExpressionDateFromParts::parse(
             timeZoneElem = arg;
         } else {
             uasserted(40518,
-                      str::stream() << "Unrecognized argument to $dateFromParts: "
-                                    << arg.fieldName());
+                      str::stream()
+                          << "Unrecognized argument to $dateFromParts: " << arg.fieldName());
         }
     }
 
@@ -1181,8 +1178,7 @@ bool ExpressionDateFromParts::evaluateNumberWithinRange(const Document& root,
 
     uassert(40515,
             str::stream() << "'" << fieldName << "' must evaluate to an integer, found "
-                          << typeName(fieldValue.getType())
-                          << " with value "
+                          << typeName(fieldValue.getType()) << " with value "
                           << fieldValue.toString(),
             fieldValue.integral());
 
@@ -1190,11 +1186,7 @@ bool ExpressionDateFromParts::evaluateNumberWithinRange(const Document& root,
 
     uassert(40523,
             str::stream() << "'" << fieldName << "' must evaluate to an integer in the range "
-                          << minValue
-                          << " to "
-                          << maxValue
-                          << ", found "
-                          << *returnValue,
+                          << minValue << " to " << maxValue << ", found " << *returnValue,
             *returnValue >= minValue && *returnValue <= maxValue);
 
     return true;
@@ -1310,8 +1302,8 @@ intrusive_ptr<Expression> ExpressionDateFromString::parse(
             timeZoneElem = arg;
         } else {
             uasserted(40541,
-                      str::stream() << "Unrecognized argument to $dateFromString: "
-                                    << arg.fieldName());
+                      str::stream()
+                          << "Unrecognized argument to $dateFromString: " << arg.fieldName());
         }
     }
 
@@ -1360,8 +1352,7 @@ Value ExpressionDateFromString::evaluate(const Document& root) const {
 
     uassert(40543,
             str::stream() << "$dateFromString requires that 'dateString' be a string, found: "
-                          << typeName(dateString.getType())
-                          << " with value "
+                          << typeName(dateString.getType()) << " with value "
                           << dateString.toString(),
             dateString.getType() == BSONType::String);
     const std::string& dateTimeString = dateString.getString();
@@ -1404,8 +1395,8 @@ intrusive_ptr<Expression> ExpressionDateToParts::parse(
             isoDateElem = arg;
         } else {
             uasserted(40520,
-                      str::stream() << "Unrecognized argument to $dateToParts: "
-                                    << arg.fieldName());
+                      str::stream()
+                          << "Unrecognized argument to $dateToParts: " << arg.fieldName());
         }
     }
 
@@ -1546,8 +1537,8 @@ intrusive_ptr<Expression> ExpressionDateToString::parse(
             timeZoneElem = arg;
         } else {
             uasserted(18534,
-                      str::stream() << "Unrecognized argument to $dateToString: "
-                                    << arg.fieldName());
+                      str::stream()
+                          << "Unrecognized argument to $dateToString: " << arg.fieldName());
         }
     }
 
@@ -1647,9 +1638,7 @@ Value ExpressionDivide::evaluate(const Document& root) const {
     } else {
         uasserted(16609,
                   str::stream() << "$divide only supports numeric types, not "
-                                << typeName(lhs.getType())
-                                << " and "
-                                << typeName(rhs.getType()));
+                                << typeName(lhs.getType()) << " and " << typeName(rhs.getType()));
     }
 }
 
@@ -1983,9 +1972,8 @@ intrusive_ptr<Expression> ExpressionFilter::optimize() {
 }
 
 Value ExpressionFilter::serialize(bool explain) const {
-    return Value(
-        DOC("$filter" << DOC("input" << _input->serialize(explain) << "as" << _varName << "cond"
-                                     << _filter->serialize(explain))));
+    return Value(DOC("$filter" << DOC("input" << _input->serialize(explain) << "as" << _varName
+                                              << "cond" << _filter->serialize(explain))));
 }
 
 Value ExpressionFilter::evaluate(const Document& root) const {
@@ -2372,9 +2360,7 @@ Value ExpressionMod::evaluate(const Document& root) const {
     } else {
         uasserted(16611,
                   str::stream() << "$mod only supports numeric types, not "
-                                << typeName(lhs.getType())
-                                << " and "
-                                << typeName(rhs.getType()));
+                                << typeName(lhs.getType()) << " and " << typeName(rhs.getType()));
     }
 }
 
@@ -2494,15 +2480,12 @@ void uassertIfNotIntegralAndNonNegative(Value val,
                                         StringData argumentName) {
     uassert(40096,
             str::stream() << expressionName << "requires an integral " << argumentName
-                          << ", found a value of type: "
-                          << typeName(val.getType())
-                          << ", with value: "
-                          << val.toString(),
+                          << ", found a value of type: " << typeName(val.getType())
+                          << ", with value: " << val.toString(),
             val.integral());
     uassert(40097,
             str::stream() << expressionName << " requires a nonnegative " << argumentName
-                          << ", found: "
-                          << val.toString(),
+                          << ", found: " << val.toString(),
             val.coerceToInt() >= 0);
 }
 
@@ -3145,19 +3128,19 @@ Value ExpressionPow::evaluate(const Document& root) const {
 
     long long result = 1;
 
-    //When baseLong == -1 and expLong is < 0 the following for loop will never run because expLong
-    //will always be less than 0 so result will always be 1 but the result can potentialy be -1 
-    //ex baselong = -1 expLong = -5  then result should be -1
-    
-    if(baseLong == -1 && expLong < 0) {
+    // When baseLong == -1 and expLong is < 0 the following for loop will never run because expLong
+    // will always be less than 0 so result will always be 1 but the result can potentialy be -1
+    // ex baselong = -1 expLong = -5  then result should be -1
+
+    if (baseLong == -1 && expLong < 0) {
         expLong = expLong % 2 == 0 ? 2 : 1;
     }
 
     // Use repeated multiplication, since pow() casts args to doubles which could result in loss of
     // precision if arguments are very large.
-    
+
     for (int i = 0; i < expLong; i++) {
-            result *= baseLong;
+        result *= baseLong;
     }
 
     if (baseType == NumberLong || expType == NumberLong) {
@@ -3353,7 +3336,7 @@ ValueSet arrayToSet(const Value& val, const ValueComparator& valueComparator) {
     valueSet.insert(array.begin(), array.end());
     return valueSet;
 }
-}
+}  // namespace
 
 /* ----------------------- ExpressionSetDifference ---------------------------- */
 
@@ -3367,13 +3350,11 @@ Value ExpressionSetDifference::evaluate(const Document& root) const {
 
     uassert(17048,
             str::stream() << "both operands of $setDifference must be arrays. First "
-                          << "argument is of type: "
-                          << typeName(lhs.getType()),
+                          << "argument is of type: " << typeName(lhs.getType()),
             lhs.isArray());
     uassert(17049,
             str::stream() << "both operands of $setDifference must be arrays. Second "
-                          << "argument is of type: "
-                          << typeName(rhs.getType()),
+                          << "argument is of type: " << typeName(rhs.getType()),
             rhs.isArray());
 
     ValueSet rhsSet = arrayToSet(rhs, getExpressionContext()->getValueComparator());
@@ -3412,8 +3393,7 @@ Value ExpressionSetEquals::evaluate(const Document& root) const {
         const Value nextEntry = vpOperand[i]->evaluate(root);
         uassert(17044,
                 str::stream() << "All operands of $setEquals must be arrays. One "
-                              << "argument is of type: "
-                              << typeName(nextEntry.getType()),
+                              << "argument is of type: " << typeName(nextEntry.getType()),
                 nextEntry.isArray());
 
         if (i == 0) {
@@ -3451,8 +3431,7 @@ Value ExpressionSetIntersection::evaluate(const Document& root) const {
         }
         uassert(17047,
                 str::stream() << "All operands of $setIntersection must be arrays. One "
-                              << "argument is of type: "
-                              << typeName(nextEntry.getType()),
+                              << "argument is of type: " << typeName(nextEntry.getType()),
                 nextEntry.isArray());
 
         if (i == 0) {
@@ -3499,7 +3478,7 @@ Value setIsSubsetHelper(const vector<Value>& lhs, const ValueSet& rhs) {
     }
     return Value(true);
 }
-}
+}  // namespace
 
 Value ExpressionSetIsSubset::evaluate(const Document& root) const {
     const Value lhs = vpOperand[0]->evaluate(root);
@@ -3507,13 +3486,11 @@ Value ExpressionSetIsSubset::evaluate(const Document& root) const {
 
     uassert(17046,
             str::stream() << "both operands of $setIsSubset must be arrays. First "
-                          << "argument is of type: "
-                          << typeName(lhs.getType()),
+                          << "argument is of type: " << typeName(lhs.getType()),
             lhs.isArray());
     uassert(17042,
             str::stream() << "both operands of $setIsSubset must be arrays. Second "
-                          << "argument is of type: "
-                          << typeName(rhs.getType()),
+                          << "argument is of type: " << typeName(rhs.getType()),
             rhs.isArray());
 
     return setIsSubsetHelper(lhs.getArray(),
@@ -3541,8 +3518,7 @@ public:
 
         uassert(17310,
                 str::stream() << "both operands of $setIsSubset must be arrays. First "
-                              << "argument is of type: "
-                              << typeName(lhs.getType()),
+                              << "argument is of type: " << typeName(lhs.getType()),
                 lhs.isArray());
 
         return setIsSubsetHelper(lhs.getArray(), _cachedRhsSet);
@@ -3564,8 +3540,7 @@ intrusive_ptr<Expression> ExpressionSetIsSubset::optimize() {
         const Value rhs = ec->getValue();
         uassert(17311,
                 str::stream() << "both operands of $setIsSubset must be arrays. Second "
-                              << "argument is of type: "
-                              << typeName(rhs.getType()),
+                              << "argument is of type: " << typeName(rhs.getType()),
                 rhs.isArray());
 
         intrusive_ptr<Expression> optimizedWithConstant(
@@ -3594,8 +3569,7 @@ Value ExpressionSetUnion::evaluate(const Document& root) const {
         }
         uassert(17043,
                 str::stream() << "All operands of $setUnion must be arrays. One argument"
-                              << " is of type: "
-                              << typeName(newEntries.getType()),
+                              << " is of type: " << typeName(newEntries.getType()),
                 newEntries.isArray());
 
         unionedSet.insert(newEntries.getArray().begin(), newEntries.getArray().end());
@@ -3635,18 +3609,15 @@ Value ExpressionSlice::evaluate(const Document& root) const {
 
     uassert(28724,
             str::stream() << "First argument to $slice must be an array, but is"
-                          << " of type: "
-                          << typeName(arrayVal.getType()),
+                          << " of type: " << typeName(arrayVal.getType()),
             arrayVal.isArray());
     uassert(28725,
             str::stream() << "Second argument to $slice must be a numeric value,"
-                          << " but is of type: "
-                          << typeName(arg2.getType()),
+                          << " but is of type: " << typeName(arg2.getType()),
             arg2.numeric());
     uassert(28726,
             str::stream() << "Second argument to $slice can't be represented as"
-                          << " a 32-bit integer: "
-                          << arg2.coerceToDouble(),
+                          << " a 32-bit integer: " << arg2.coerceToDouble(),
             arg2.integral());
 
     const auto& array = arrayVal.getArray();
@@ -3686,13 +3657,11 @@ Value ExpressionSlice::evaluate(const Document& root) const {
 
         uassert(28727,
                 str::stream() << "Third argument to $slice must be numeric, but "
-                              << "is of type: "
-                              << typeName(countVal.getType()),
+                              << "is of type: " << typeName(countVal.getType()),
                 countVal.numeric());
         uassert(28728,
                 str::stream() << "Third argument to $slice can't be represented"
-                              << " as a 32-bit integer: "
-                              << countVal.coerceToDouble(),
+                              << " as a 32-bit integer: " << countVal.coerceToDouble(),
                 countVal.integral());
         uassert(28729,
                 str::stream() << "Third argument to $slice must be positive: "
@@ -3841,14 +3810,12 @@ Value ExpressionSubstrBytes::evaluate(const Document& root) const {
     uassert(16034,
             str::stream() << getOpName()
                           << ":  starting index must be a numeric type (is BSON type "
-                          << typeName(pLower.getType())
-                          << ")",
+                          << typeName(pLower.getType()) << ")",
             (pLower.getType() == NumberInt || pLower.getType() == NumberLong ||
              pLower.getType() == NumberDouble));
     uassert(16035,
             str::stream() << getOpName() << ":  length must be a numeric type (is BSON type "
-                          << typeName(pLength.getType())
-                          << ")",
+                          << typeName(pLength.getType()) << ")",
             (pLength.getType() == NumberInt || pLength.getType() == NumberLong ||
              pLength.getType() == NumberDouble));
 
@@ -3893,8 +3860,7 @@ Value ExpressionSubstrCP::evaluate(const Document& root) const {
     std::string str = inputVal.coerceToString();
     uassert(34450,
             str::stream() << getOpName() << ": starting index must be a numeric type (is BSON type "
-                          << typeName(lowerVal.getType())
-                          << ")",
+                          << typeName(lowerVal.getType()) << ")",
             lowerVal.numeric());
     uassert(34451,
             str::stream() << getOpName()
@@ -3903,8 +3869,7 @@ Value ExpressionSubstrCP::evaluate(const Document& root) const {
             lowerVal.integral());
     uassert(34452,
             str::stream() << getOpName() << ": length must be a numeric type (is BSON type "
-                          << typeName(lengthVal.getType())
-                          << ")",
+                          << typeName(lengthVal.getType()) << ")",
             lengthVal.numeric());
     uassert(34453,
             str::stream() << getOpName()
@@ -4039,8 +4004,8 @@ Value ExpressionSubtract::evaluate(const Document& root) const {
             return Value(lhs.getDate() - Milliseconds(rhs.coerceToLong()));
         } else {
             uasserted(16613,
-                      str::stream() << "cant $subtract a " << typeName(rhs.getType())
-                                    << " from a Date");
+                      str::stream()
+                          << "cant $subtract a " << typeName(rhs.getType()) << " from a Date");
         }
     } else {
         uasserted(16556,
@@ -4399,8 +4364,7 @@ Value ExpressionZip::serialize(bool explain) const {
     }
 
     return Value(DOC("$zip" << DOC("inputs" << Value(serializedInput) << "defaults"
-                                            << Value(serializedDefaults)
-                                            << "useLongestLength"
+                                            << Value(serializedDefaults) << "useLongestLength"
                                             << serializedUseLongestLength)));
 }
 

--- a/src/mongo/db/pipeline/expression.cpp
+++ b/src/mongo/db/pipeline/expression.cpp
@@ -3145,17 +3145,15 @@ Value ExpressionPow::evaluate(const Document& root) const {
 
     long long result = 1;
 
-    // When baseLong == -1 and expLong is < 0 the following for loop will never run because expLong
+    // When 'baseLong' == -1 and 'expLong' is < 0 the following for loop will never run because 'expLong'
     // will always be less than 0 so result will always be 1 but the result can potentialy be -1
-    // ex baselong = -1 expLong = -5  then result should be -1
-
+    // ex: 'baselong' = -1 'expLong' = -5  then result should be -1
     if (baseLong == -1 && expLong < 0) {
         expLong = expLong % 2 == 0 ? 2 : 1;
     }
 
     // Use repeated multiplication, since pow() casts args to doubles which could result in loss of
     // precision if arguments are very large.
-
     for (int i = 0; i < expLong; i++) {
         result *= baseLong;
     }

--- a/src/mongo/db/pipeline/expression.cpp
+++ b/src/mongo/db/pipeline/expression.cpp
@@ -3144,6 +3144,15 @@ Value ExpressionPow::evaluate(const Document& root) const {
     }
 
     long long result = 1;
+
+    //When baseLong == -1 and expLong is < 0 the following for loop will never run because expLong
+    //will always be less than 0 so result will always be 1 but the result can potentialy be -1 
+    //ex baselong = -1 expLong = -5  then result should be -1
+    
+    if(baseLong == -1 && expLong < 0) {
+        expLong = expLong % 2 == 0 ? 2 : 1;
+    }
+
     // Use repeated multiplication, since pow() casts args to doubles which could result in loss of
     // precision if arguments are very large.
     

--- a/src/mongo/db/pipeline/expression.cpp
+++ b/src/mongo/db/pipeline/expression.cpp
@@ -74,7 +74,8 @@ static Value serializeConstant(Value val) {
 string Expression::removeFieldPrefix(const string& prefixedField) {
     uassert(16419,
             str::stream() << "field path must not contain embedded null characters"
-                          << prefixedField.find("\0") << ",",
+                          << prefixedField.find("\0")
+                          << ",",
             prefixedField.find('\0') == string::npos);
 
     const char* pPrefixedField = prefixedField.c_str();
@@ -478,11 +479,13 @@ Value ExpressionArrayElemAt::evaluate(const Document& root) const {
             array.isArray());
     uassert(28690,
             str::stream() << getOpName() << "'s second argument must be a numeric value,"
-                          << " but is " << typeName(indexArg.getType()),
+                          << " but is "
+                          << typeName(indexArg.getType()),
             indexArg.numeric());
     uassert(28691,
             str::stream() << getOpName() << "'s second argument must be representable as"
-                          << " a 32-bit integer: " << indexArg.coerceToDouble(),
+                          << " a 32-bit integer: "
+                          << indexArg.coerceToDouble(),
             indexArg.integral());
 
     long long i = indexArg.coerceToLong();
@@ -763,7 +766,7 @@ static const CmpLookup cmpLookup[7] = {
     // CMP is special. Only name is used.
     /* CMP */ {{false, false, false}, ExpressionCompare::CMP, "$cmp"},
 };
-}  // namespace
+}
 
 Value ExpressionCompare::evaluate(const Document& root) const {
     Value pLeft(vpOperand[0]->evaluate(root));
@@ -1017,8 +1020,8 @@ intrusive_ptr<Expression> ExpressionDateFromParts::parse(
             timeZoneElem = arg;
         } else {
             uasserted(40518,
-                      str::stream()
-                          << "Unrecognized argument to $dateFromParts: " << arg.fieldName());
+                      str::stream() << "Unrecognized argument to $dateFromParts: "
+                                    << arg.fieldName());
         }
     }
 
@@ -1178,7 +1181,8 @@ bool ExpressionDateFromParts::evaluateNumberWithinRange(const Document& root,
 
     uassert(40515,
             str::stream() << "'" << fieldName << "' must evaluate to an integer, found "
-                          << typeName(fieldValue.getType()) << " with value "
+                          << typeName(fieldValue.getType())
+                          << " with value "
                           << fieldValue.toString(),
             fieldValue.integral());
 
@@ -1186,7 +1190,11 @@ bool ExpressionDateFromParts::evaluateNumberWithinRange(const Document& root,
 
     uassert(40523,
             str::stream() << "'" << fieldName << "' must evaluate to an integer in the range "
-                          << minValue << " to " << maxValue << ", found " << *returnValue,
+                          << minValue
+                          << " to "
+                          << maxValue
+                          << ", found "
+                          << *returnValue,
             *returnValue >= minValue && *returnValue <= maxValue);
 
     return true;
@@ -1302,8 +1310,8 @@ intrusive_ptr<Expression> ExpressionDateFromString::parse(
             timeZoneElem = arg;
         } else {
             uasserted(40541,
-                      str::stream()
-                          << "Unrecognized argument to $dateFromString: " << arg.fieldName());
+                      str::stream() << "Unrecognized argument to $dateFromString: "
+                                    << arg.fieldName());
         }
     }
 
@@ -1352,7 +1360,8 @@ Value ExpressionDateFromString::evaluate(const Document& root) const {
 
     uassert(40543,
             str::stream() << "$dateFromString requires that 'dateString' be a string, found: "
-                          << typeName(dateString.getType()) << " with value "
+                          << typeName(dateString.getType())
+                          << " with value "
                           << dateString.toString(),
             dateString.getType() == BSONType::String);
     const std::string& dateTimeString = dateString.getString();
@@ -1395,8 +1404,8 @@ intrusive_ptr<Expression> ExpressionDateToParts::parse(
             isoDateElem = arg;
         } else {
             uasserted(40520,
-                      str::stream()
-                          << "Unrecognized argument to $dateToParts: " << arg.fieldName());
+                      str::stream() << "Unrecognized argument to $dateToParts: "
+                                    << arg.fieldName());
         }
     }
 
@@ -1537,8 +1546,8 @@ intrusive_ptr<Expression> ExpressionDateToString::parse(
             timeZoneElem = arg;
         } else {
             uasserted(18534,
-                      str::stream()
-                          << "Unrecognized argument to $dateToString: " << arg.fieldName());
+                      str::stream() << "Unrecognized argument to $dateToString: "
+                                    << arg.fieldName());
         }
     }
 
@@ -1638,7 +1647,9 @@ Value ExpressionDivide::evaluate(const Document& root) const {
     } else {
         uasserted(16609,
                   str::stream() << "$divide only supports numeric types, not "
-                                << typeName(lhs.getType()) << " and " << typeName(rhs.getType()));
+                                << typeName(lhs.getType())
+                                << " and "
+                                << typeName(rhs.getType()));
     }
 }
 
@@ -1972,8 +1983,9 @@ intrusive_ptr<Expression> ExpressionFilter::optimize() {
 }
 
 Value ExpressionFilter::serialize(bool explain) const {
-    return Value(DOC("$filter" << DOC("input" << _input->serialize(explain) << "as" << _varName
-                                              << "cond" << _filter->serialize(explain))));
+    return Value(
+        DOC("$filter" << DOC("input" << _input->serialize(explain) << "as" << _varName << "cond"
+                                     << _filter->serialize(explain))));
 }
 
 Value ExpressionFilter::evaluate(const Document& root) const {
@@ -2360,7 +2372,9 @@ Value ExpressionMod::evaluate(const Document& root) const {
     } else {
         uasserted(16611,
                   str::stream() << "$mod only supports numeric types, not "
-                                << typeName(lhs.getType()) << " and " << typeName(rhs.getType()));
+                                << typeName(lhs.getType())
+                                << " and "
+                                << typeName(rhs.getType()));
     }
 }
 
@@ -2480,12 +2494,15 @@ void uassertIfNotIntegralAndNonNegative(Value val,
                                         StringData argumentName) {
     uassert(40096,
             str::stream() << expressionName << "requires an integral " << argumentName
-                          << ", found a value of type: " << typeName(val.getType())
-                          << ", with value: " << val.toString(),
+                          << ", found a value of type: "
+                          << typeName(val.getType())
+                          << ", with value: "
+                          << val.toString(),
             val.integral());
     uassert(40097,
             str::stream() << expressionName << " requires a nonnegative " << argumentName
-                          << ", found: " << val.toString(),
+                          << ", found: "
+                          << val.toString(),
             val.coerceToInt() >= 0);
 }
 
@@ -3336,7 +3353,7 @@ ValueSet arrayToSet(const Value& val, const ValueComparator& valueComparator) {
     valueSet.insert(array.begin(), array.end());
     return valueSet;
 }
-}  // namespace
+}
 
 /* ----------------------- ExpressionSetDifference ---------------------------- */
 
@@ -3350,11 +3367,13 @@ Value ExpressionSetDifference::evaluate(const Document& root) const {
 
     uassert(17048,
             str::stream() << "both operands of $setDifference must be arrays. First "
-                          << "argument is of type: " << typeName(lhs.getType()),
+                          << "argument is of type: "
+                          << typeName(lhs.getType()),
             lhs.isArray());
     uassert(17049,
             str::stream() << "both operands of $setDifference must be arrays. Second "
-                          << "argument is of type: " << typeName(rhs.getType()),
+                          << "argument is of type: "
+                          << typeName(rhs.getType()),
             rhs.isArray());
 
     ValueSet rhsSet = arrayToSet(rhs, getExpressionContext()->getValueComparator());
@@ -3393,7 +3412,8 @@ Value ExpressionSetEquals::evaluate(const Document& root) const {
         const Value nextEntry = vpOperand[i]->evaluate(root);
         uassert(17044,
                 str::stream() << "All operands of $setEquals must be arrays. One "
-                              << "argument is of type: " << typeName(nextEntry.getType()),
+                              << "argument is of type: "
+                              << typeName(nextEntry.getType()),
                 nextEntry.isArray());
 
         if (i == 0) {
@@ -3431,7 +3451,8 @@ Value ExpressionSetIntersection::evaluate(const Document& root) const {
         }
         uassert(17047,
                 str::stream() << "All operands of $setIntersection must be arrays. One "
-                              << "argument is of type: " << typeName(nextEntry.getType()),
+                              << "argument is of type: "
+                              << typeName(nextEntry.getType()),
                 nextEntry.isArray());
 
         if (i == 0) {
@@ -3478,7 +3499,7 @@ Value setIsSubsetHelper(const vector<Value>& lhs, const ValueSet& rhs) {
     }
     return Value(true);
 }
-}  // namespace
+}
 
 Value ExpressionSetIsSubset::evaluate(const Document& root) const {
     const Value lhs = vpOperand[0]->evaluate(root);
@@ -3486,11 +3507,13 @@ Value ExpressionSetIsSubset::evaluate(const Document& root) const {
 
     uassert(17046,
             str::stream() << "both operands of $setIsSubset must be arrays. First "
-                          << "argument is of type: " << typeName(lhs.getType()),
+                          << "argument is of type: "
+                          << typeName(lhs.getType()),
             lhs.isArray());
     uassert(17042,
             str::stream() << "both operands of $setIsSubset must be arrays. Second "
-                          << "argument is of type: " << typeName(rhs.getType()),
+                          << "argument is of type: "
+                          << typeName(rhs.getType()),
             rhs.isArray());
 
     return setIsSubsetHelper(lhs.getArray(),
@@ -3518,7 +3541,8 @@ public:
 
         uassert(17310,
                 str::stream() << "both operands of $setIsSubset must be arrays. First "
-                              << "argument is of type: " << typeName(lhs.getType()),
+                              << "argument is of type: "
+                              << typeName(lhs.getType()),
                 lhs.isArray());
 
         return setIsSubsetHelper(lhs.getArray(), _cachedRhsSet);
@@ -3540,7 +3564,8 @@ intrusive_ptr<Expression> ExpressionSetIsSubset::optimize() {
         const Value rhs = ec->getValue();
         uassert(17311,
                 str::stream() << "both operands of $setIsSubset must be arrays. Second "
-                              << "argument is of type: " << typeName(rhs.getType()),
+                              << "argument is of type: "
+                              << typeName(rhs.getType()),
                 rhs.isArray());
 
         intrusive_ptr<Expression> optimizedWithConstant(
@@ -3569,7 +3594,8 @@ Value ExpressionSetUnion::evaluate(const Document& root) const {
         }
         uassert(17043,
                 str::stream() << "All operands of $setUnion must be arrays. One argument"
-                              << " is of type: " << typeName(newEntries.getType()),
+                              << " is of type: "
+                              << typeName(newEntries.getType()),
                 newEntries.isArray());
 
         unionedSet.insert(newEntries.getArray().begin(), newEntries.getArray().end());
@@ -3609,15 +3635,18 @@ Value ExpressionSlice::evaluate(const Document& root) const {
 
     uassert(28724,
             str::stream() << "First argument to $slice must be an array, but is"
-                          << " of type: " << typeName(arrayVal.getType()),
+                          << " of type: "
+                          << typeName(arrayVal.getType()),
             arrayVal.isArray());
     uassert(28725,
             str::stream() << "Second argument to $slice must be a numeric value,"
-                          << " but is of type: " << typeName(arg2.getType()),
+                          << " but is of type: "
+                          << typeName(arg2.getType()),
             arg2.numeric());
     uassert(28726,
             str::stream() << "Second argument to $slice can't be represented as"
-                          << " a 32-bit integer: " << arg2.coerceToDouble(),
+                          << " a 32-bit integer: "
+                          << arg2.coerceToDouble(),
             arg2.integral());
 
     const auto& array = arrayVal.getArray();
@@ -3657,11 +3686,13 @@ Value ExpressionSlice::evaluate(const Document& root) const {
 
         uassert(28727,
                 str::stream() << "Third argument to $slice must be numeric, but "
-                              << "is of type: " << typeName(countVal.getType()),
+                              << "is of type: "
+                              << typeName(countVal.getType()),
                 countVal.numeric());
         uassert(28728,
                 str::stream() << "Third argument to $slice can't be represented"
-                              << " as a 32-bit integer: " << countVal.coerceToDouble(),
+                              << " as a 32-bit integer: "
+                              << countVal.coerceToDouble(),
                 countVal.integral());
         uassert(28729,
                 str::stream() << "Third argument to $slice must be positive: "
@@ -3810,12 +3841,14 @@ Value ExpressionSubstrBytes::evaluate(const Document& root) const {
     uassert(16034,
             str::stream() << getOpName()
                           << ":  starting index must be a numeric type (is BSON type "
-                          << typeName(pLower.getType()) << ")",
+                          << typeName(pLower.getType())
+                          << ")",
             (pLower.getType() == NumberInt || pLower.getType() == NumberLong ||
              pLower.getType() == NumberDouble));
     uassert(16035,
             str::stream() << getOpName() << ":  length must be a numeric type (is BSON type "
-                          << typeName(pLength.getType()) << ")",
+                          << typeName(pLength.getType())
+                          << ")",
             (pLength.getType() == NumberInt || pLength.getType() == NumberLong ||
              pLength.getType() == NumberDouble));
 
@@ -3860,7 +3893,8 @@ Value ExpressionSubstrCP::evaluate(const Document& root) const {
     std::string str = inputVal.coerceToString();
     uassert(34450,
             str::stream() << getOpName() << ": starting index must be a numeric type (is BSON type "
-                          << typeName(lowerVal.getType()) << ")",
+                          << typeName(lowerVal.getType())
+                          << ")",
             lowerVal.numeric());
     uassert(34451,
             str::stream() << getOpName()
@@ -3869,7 +3903,8 @@ Value ExpressionSubstrCP::evaluate(const Document& root) const {
             lowerVal.integral());
     uassert(34452,
             str::stream() << getOpName() << ": length must be a numeric type (is BSON type "
-                          << typeName(lengthVal.getType()) << ")",
+                          << typeName(lengthVal.getType())
+                          << ")",
             lengthVal.numeric());
     uassert(34453,
             str::stream() << getOpName()
@@ -4004,8 +4039,8 @@ Value ExpressionSubtract::evaluate(const Document& root) const {
             return Value(lhs.getDate() - Milliseconds(rhs.coerceToLong()));
         } else {
             uasserted(16613,
-                      str::stream()
-                          << "cant $subtract a " << typeName(rhs.getType()) << " from a Date");
+                      str::stream() << "cant $subtract a " << typeName(rhs.getType())
+                                    << " from a Date");
         }
     } else {
         uasserted(16556,
@@ -4364,7 +4399,8 @@ Value ExpressionZip::serialize(bool explain) const {
     }
 
     return Value(DOC("$zip" << DOC("inputs" << Value(serializedInput) << "defaults"
-                                            << Value(serializedDefaults) << "useLongestLength"
+                                            << Value(serializedDefaults)
+                                            << "useLongestLength"
                                             << serializedUseLongestLength)));
 }
 

--- a/src/mongo/db/pipeline/expression_test.cpp
+++ b/src/mongo/db/pipeline/expression_test.cpp
@@ -2179,11 +2179,7 @@ TEST(ExpressionFromAccumulators, StdDevSamp) {
 }
 
 TEST(ExpressionFromAccumulators, Pow) {
-    assertExpectedResults(
-        "$pow",
-        {
-          {{Value(-1LL), Value(-5LL)}, Value(-1LL)}
-        });
+    assertExpectedResults("$pow", {{{Value(-1LL), Value(-5LL)}, Value(-1LL)}});
 }
 
 namespace FieldPath {

--- a/src/mongo/db/pipeline/expression_test.cpp
+++ b/src/mongo/db/pipeline/expression_test.cpp
@@ -2179,7 +2179,22 @@ TEST(ExpressionFromAccumulators, StdDevSamp) {
 }
 
 TEST(ExpressionFromAccumulators, Pow) {
-    assertExpectedResults("$pow", {{{Value(-1LL), Value(-5LL)}, Value(-1LL)}});
+    assertExpectedResults(
+        "$pow",
+        {
+         {{Value(2), Value(5)}, Value(32)},
+
+         {{Value(-1), Value(-5)}, Value(-1)},
+         {{Value(-1), Value(-4)}, Value(1)},
+         {{Value(-1), Value(-3)}, Value(-1)},
+
+         {{Value(-1LL), Value(0LL)}, Value(1LL)},
+         {{Value(-1LL), Value(-1LL)}, Value(-1LL)},
+         {{Value(-1LL), Value(-2LL)}, Value(1LL)},
+         {{Value(-1LL), Value(-3LL)}, Value(-1LL)},
+         {{Value(-1LL), Value(-4LL)}, Value(1LL)},
+         {{Value(-1LL), Value(-5LL)}, Value(-1LL)},
+        });
 }
 
 namespace FieldPath {

--- a/src/mongo/db/pipeline/expression_test.cpp
+++ b/src/mongo/db/pipeline/expression_test.cpp
@@ -27,7 +27,7 @@
  */
 
 #include "mongo/platform/basic.h"
-
+#include <iostream>
 #include "mongo/bson/bsonmisc.h"
 #include "mongo/config.h"
 #include "mongo/db/jsobj.h"
@@ -2177,6 +2177,15 @@ TEST(ExpressionFromAccumulators, StdDevSamp) {
          {{Value(1LL), Value(2LL), Value(3LL)}, Value(1.0)},
          // $stdDevSamp returns null when no arguments are provided.
          {{}, Value(BSONNULL)}});
+}
+
+TEST(ExpressionFromAccumulators, Power) {
+    std::cout << " \n\n\nMaster \n \n\n\n\n"; 
+    assertExpectedResults(
+        "$pow",
+        {
+          {{Value(-1LL), Value(-5LL)}, Value(-1)}
+        });
 }
 
 namespace FieldPath {

--- a/src/mongo/db/pipeline/expression_test.cpp
+++ b/src/mongo/db/pipeline/expression_test.cpp
@@ -27,6 +27,7 @@
  */
 
 #include "mongo/platform/basic.h"
+
 #include "mongo/bson/bsonmisc.h"
 #include "mongo/config.h"
 #include "mongo/db/jsobj.h"
@@ -2178,23 +2179,20 @@ TEST(ExpressionFromAccumulators, StdDevSamp) {
          {{}, Value(BSONNULL)}});
 }
 
-TEST(ExpressionFromAccumulators, Pow) {
-    assertExpectedResults(
-        "$pow",
-        {
-         {{Value(2), Value(5)}, Value(32)},
+TEST(ExpressionPowTest, NegativeOneRaisedToNegativeOddExponentShouldOutPutNegativeOne) {
+    assertExpectedResults("$pow",
+                          {
+                              {{Value(-1), Value(-1)}, Value(-1)},
+                              {{Value(-1), Value(-2)}, Value(1)},
+                              {{Value(-1), Value(-3)}, Value(-1)},
 
-         {{Value(-1), Value(-5)}, Value(-1)},
-         {{Value(-1), Value(-4)}, Value(1)},
-         {{Value(-1), Value(-3)}, Value(-1)},
-
-         {{Value(-1LL), Value(0LL)}, Value(1LL)},
-         {{Value(-1LL), Value(-1LL)}, Value(-1LL)},
-         {{Value(-1LL), Value(-2LL)}, Value(1LL)},
-         {{Value(-1LL), Value(-3LL)}, Value(-1LL)},
-         {{Value(-1LL), Value(-4LL)}, Value(1LL)},
-         {{Value(-1LL), Value(-5LL)}, Value(-1LL)},
-        });
+                              {{Value(-1LL), Value(0LL)}, Value(1LL)},
+                              {{Value(-1LL), Value(-1LL)}, Value(-1LL)},
+                              {{Value(-1LL), Value(-2LL)}, Value(1LL)},
+                              {{Value(-1LL), Value(-3LL)}, Value(-1LL)},
+                              {{Value(-1LL), Value(-4LL)}, Value(1LL)},
+                              {{Value(-1LL), Value(-5LL)}, Value(-1LL)},
+                          });
 }
 
 namespace FieldPath {

--- a/src/mongo/db/pipeline/expression_test.cpp
+++ b/src/mongo/db/pipeline/expression_test.cpp
@@ -27,7 +27,6 @@
  */
 
 #include "mongo/platform/basic.h"
-#include <iostream>
 #include "mongo/bson/bsonmisc.h"
 #include "mongo/config.h"
 #include "mongo/db/jsobj.h"
@@ -2179,12 +2178,11 @@ TEST(ExpressionFromAccumulators, StdDevSamp) {
          {{}, Value(BSONNULL)}});
 }
 
-TEST(ExpressionFromAccumulators, Power) {
-    std::cout << " \n\n\nMaster \n \n\n\n\n"; 
+TEST(ExpressionFromAccumulators, Pow) {
     assertExpectedResults(
         "$pow",
         {
-          {{Value(-1LL), Value(-5LL)}, Value(-1)}
+          {{Value(-1LL), Value(-5LL)}, Value(-1LL)}
         });
 }
 


### PR DESCRIPTION
  When the user uses the $pow expression and the base is -1 and the exponent is negative as well the expression returns 1 when it should potentially return -1 for example if base = -1 and exponent = -5  the result should be -1 not 1.
       This was happening because the for loop that finds the power has the condition  for(int i= 0; i < expLong; i++) since the expLong is already < 0 this loop doesnt run and by default the result is 1 so 1 is returned.
