### PR TITLE
SERVER-33154 upconvert {query: "foo"} correctly

### DIFF
--- a/jstests/core/profile_find.js
+++ b/jstests/core/profile_find.js
@@ -171,4 +171,11 @@
     profileObj = getLatestProfilerEntry(testDB, profileEntryFilter);
     assert.eq((typeof profileObj.command.$truncated), "string", tojson(profileObj));
     assert.eq(profileObj.command.comment, "profile_find", tojson(profileObj));
+
+    //
+    // Confirm {query: "foo"} appears correctly in the profiler (SERVER-33154)
+    //
+    coll.find({query: "foo"}).itcount();
+    profileObj = getLatestProfilerEntry(testDB, profileEntryFilter);
+    assert.eq(profileObj.command.filter, {query: "foo"}, tojson(profileObj));
 })();

--- a/src/mongo/db/curop.cpp
+++ b/src/mongo/db/curop.cpp
@@ -84,12 +84,12 @@ BSONObj upconvertQueryEntry(const BSONObj& query,
 
     // Extract the query predicate.
     BSONObj filter;
-    if (auto elem = query["query"]) {
+    if (query["query"].isABSONObj()) {
         predicateIsWrapped = true;
-        bob.appendAs(elem, "filter");
-    } else if (auto elem = query["$query"]) {
+        bob.appendAs(query["query"], "filter");
+    } else if (query["$query"].isABSONObj()) {
         predicateIsWrapped = true;
-        bob.appendAs(elem, "filter");
+        bob.appendAs(query["$query"], "filter");
     } else if (!query.isEmpty()) {
         bob.append("filter", query);
     }


### PR DESCRIPTION
I believe the `jsCore_compatibility` evergreen task should exercise the buggy legacy path.