### PR TITLE
SERVER-9306 support Invisible index in MongoDB

### DIFF
--- a/jstests/core/hidden_index.js
+++ b/jstests/core/hidden_index.js
@@ -1,0 +1,114 @@
+// Test expected behavior for hidden indexes. A hidden index is invisible to the query planner so
+// it will not be used in planning. It is handled in the same way as other indexes by the index
+// catalog and for TTL purposes.
+
+(function () {
+    'use strict';
+    load("jstests/libs/analyze_plan.js");  // For getPlanStages.
+    const testtab = db["hidden_index"];
+
+    function usedIndex(query) {
+	const explain = assert.commandWorked(testtab.find(query).explain());
+	const ixScans = getPlanStages(explain.queryPlanner.winningPlan, "IXSCAN");
+	return ixScans.length === 1;
+    }
+
+    function HiddenCheckTest(query, index_type, wildcard) {
+	let index_name;
+	if (wildcard)
+	    index_name = 'a.$**_' + index_type;
+	else
+	    index_name = 'a_' + index_type;
+
+	testtab.dropIndexes();
+	if (wildcard)
+	    assert.commandWorked(testtab.createIndex({"a.$**": index_type}));
+	else
+	    assert.commandWorked(testtab.createIndex({"a": index_type}));
+	
+	assert.eq(testtab.getIndexes()[1].hidden, undefined);
+	assert(usedIndex(query));
+	
+	assert.commandWorked(testtab.hideIndex(index_name));
+	assert(testtab.getIndexes()[1].hidden);
+	if (index_type === "text") {
+	    // errmsg: error processing query: ns=test.hidden_indexTree: TEXT : query=java,
+	    // language=english, caseSensitive=0, diacriticSensitive=0,
+	    // tag=NULL\nSort: {}\nProj: {}\n planner returned error ::
+	    // caused by :: need exactly one text index for $text query
+	    assert.throws(() => {testtab.find(query).explain();});
+	    return;
+	}
+	assert(!usedIndex(query));
+	
+	assert.commandWorked(testtab.unhideIndex(index_name));
+	assert.eq(testtab.getIndexes()[1].hidden, undefined);
+	assert(usedIndex(query));
+	
+	assert.commandWorked(testtab.dropIndex(index_name));
+
+	if (wildcard)
+	    assert.commandWorked(testtab.createIndex({"a.$**": index_type}, {hidden: true}));
+	else
+	    assert.commandWorked(testtab.createIndex({"a": index_type}, {hidden: true}));
+
+	assert(testtab.getIndexes()[1].hidden);
+	assert(!usedIndex(query));
+    }
+
+    
+    // Normal index testing.
+    HiddenCheckTest({a: 1}, 1);
+    // GEO index testing.
+    HiddenCheckTest({a: { $geoWithin :
+			  { $geometry :
+			    { type : "Polygon" ,
+                              coordinates : [ [
+                                  [ 0 , 0 ] ,
+                                  [ 3 , 6 ] ,
+                                  [ 6 , 1 ] ,
+                                  [ 0 , 0 ]
+                              ] ]
+			    } } } }, "2dsphere");
+
+    // Fts index.
+    HiddenCheckTest({ $text: { $search: "java" } }, "text");
+
+    // Wildcard index.
+    HiddenCheckTest({"a.f": 1}, 1, true);
+
+    // Hidden index on capped collection.
+    assert(testtab.drop());
+    assert.commandWorked(db.createCollection("hidden_index", {capped: true, size: 100}));
+    HiddenCheckTest({a: 1}, 1);
+    
+    // Can't hide index on system index.
+    const systemtab = db.getSiblingDB('admin').system.version;
+    assert.commandWorked(systemtab.createIndex({a: 1}));
+    assert.commandFailedWithCode(systemtab.hideIndex("a_1"), 2);
+    assert.commandWorked(systemtab.dropIndex("a_1"));
+    assert.commandFailedWithCode(systemtab.createIndex({a: 1}, {hidden: true}), 2);
+
+    // Can't hide _id index.
+    assert.commandFailed(testtab.hideIndex("_id_"));
+
+    // We can change ttl index and hide info at the same time.
+    assert.commandWorked(testtab.dropIndexes());
+    assert.commandWorked(testtab.createIndex({"tm": 1}, {expireAfterSeconds: 10}));
+    assert.eq(testtab.getIndexes()[1].hidden, undefined);
+    assert.eq(testtab.getIndexes()[1].expireAfterSeconds, 10);
+
+    db.runCommand({"collMod": testtab.getName(), "index": {"name": "tm_1",
+							   "expireAfterSeconds": 1,
+							   "hidden": true
+							  }});
+    assert(testtab.getIndexes()[1].hidden);
+    assert.eq(testtab.getIndexes()[1].expireAfterSeconds, 1);
+
+    // Hidden index is only allowed with FCV 4.4.
+    assert.commandWorked(db.adminCommand({setFeatureCompatibilityVersion: "4.2"}));
+    assert.commandFailedWithCode(testtab.createIndex({b: 1}, {hidden: true}), 31449);
+    assert.commandWorked(testtab.createIndex({b: 1}));
+    assert.commandFailedWithCode(testtab.hideIndex("b_1"), 2);
+    assert.commandWorked(testtab.unhideIndex("tm_1"));
+})();

--- a/jstests/noPassthrough/ttl_hidden_index.js
+++ b/jstests/noPassthrough/ttl_hidden_index.js
@@ -1,0 +1,26 @@
+// Make sure the TTL index still work after we hide it
+(function() {
+"use strict";
+let runner = MongoRunner.runMongod({setParameter: "ttlMonitorSleepSecs=1"});
+let coll = runner.getDB("test").ttl_hiddenl_index;
+coll.drop();
+
+// Create TTL index.
+assert.commandWorked(coll.ensureIndex({x: 1}, {expireAfterSeconds: 0}));
+let now = new Date();
+assert.commandWorked(coll.insert({x: now}));
+assert.commandWorked(coll.insert({x: now}));
+
+assert.commandWorked(coll.hide_index("x_1"));
+// Wait for the TTL monitor to run at least twice (in case we weren't finished setting up our
+// collection when it ran the first time).
+var ttlPass = coll.getDB().serverStatus().metrics.ttl.passes;
+assert.soon(function() {
+    return coll.getDB().serverStatus().metrics.ttl.passes >= ttlPass + 2;
+}, "TTL monitor didn't run before timing out.");
+
+assert.eq(coll.count(), 0, "We should get 0 documents after TTL monitor run");
+    
+MongoRunner.stopMongod(runner);
+    
+});

--- a/src/mongo/db/auth/auth_op_observer.cpp
+++ b/src/mongo/db/auth/auth_op_observer.cpp
@@ -114,11 +114,11 @@ void AuthOpObserver::onCollMod(OperationContext* opCtx,
                                OptionalCollectionUUID uuid,
                                const BSONObj& collModCmd,
                                const CollectionOptions& oldCollOptions,
-                               boost::optional<TTLCollModInfo> ttlInfo) {
+                               boost::optional<IndexCollModInfo> indexInfo) {
     const auto cmdNss = nss.getCommandNS();
 
     // Create the 'o' field object.
-    const auto cmdObj = makeCollModCmdObj(collModCmd, oldCollOptions, ttlInfo);
+    const auto cmdObj = makeCollModCmdObj(collModCmd, oldCollOptions, indexInfo);
 
     AuthorizationManager::get(opCtx->getServiceContext())
         ->logOp(opCtx, "c", cmdNss, cmdObj, nullptr);

--- a/src/mongo/db/auth/auth_op_observer.h
+++ b/src/mongo/db/auth/auth_op_observer.h
@@ -113,7 +113,7 @@ public:
                    OptionalCollectionUUID uuid,
                    const BSONObj& collModCmd,
                    const CollectionOptions& oldCollOptions,
-                   boost::optional<TTLCollModInfo> ttlInfo) final;
+                   boost::optional<IndexCollModInfo> indexInfo) final;
 
     void onDropDatabase(OperationContext* opCtx, const std::string& dbName) final;
 

--- a/src/mongo/db/catalog/coll_mod.cpp
+++ b/src/mongo/db/catalog/coll_mod.cpp
@@ -69,6 +69,7 @@ MONGO_FAIL_POINT_DEFINE(assertAfterIndexUpdate);
 struct CollModRequest {
     const IndexDescriptor* idx = nullptr;
     BSONElement indexExpireAfterSeconds = {};
+    BSONElement indexHidden = {};
     BSONElement viewPipeLine = {};
     std::string viewOn = {};
     BSONElement collValidator = {};
@@ -125,14 +126,19 @@ StatusWith<CollModRequest> parseCollModRequest(OperationContext* opCtx,
             }
 
             cmr.indexExpireAfterSeconds = indexObj["expireAfterSeconds"];
-            if (cmr.indexExpireAfterSeconds.eoo()) {
-                return Status(ErrorCodes::InvalidOptions, "no expireAfterSeconds field");
+            cmr.indexHidden = indexObj["hidden"];
+
+            if (cmr.indexExpireAfterSeconds.eoo() && cmr.indexHidden.eoo()) {
+                return Status(ErrorCodes::InvalidOptions, "no expireAfterSeconds or hidden field");
             }
-            if (!cmr.indexExpireAfterSeconds.isNumber()) {
+            if (!cmr.indexExpireAfterSeconds.eoo() && !cmr.indexExpireAfterSeconds.isNumber()) {
                 return Status(ErrorCodes::InvalidOptions,
                               "expireAfterSeconds field must be a number");
             }
-
+            if (!cmr.indexHidden.eoo() && !cmr.indexHidden.isBoolean()) {
+                return Status(ErrorCodes::InvalidOptions,
+                              "hidden field must be a boolean");
+            }
             if (!indexName.empty()) {
                 cmr.idx = coll->getIndexCatalog()->findIndexByName(opCtx, indexName);
                 if (!cmr.idx) {
@@ -161,15 +167,16 @@ StatusWith<CollModRequest> parseCollModRequest(OperationContext* opCtx,
                 cmr.idx = indexes[0];
             }
 
-            BSONElement oldExpireSecs = cmr.idx->infoObj().getField("expireAfterSeconds");
-            if (oldExpireSecs.eoo()) {
-                return Status(ErrorCodes::InvalidOptions, "no expireAfterSeconds field to update");
+            if (!cmr.indexExpireAfterSeconds.eoo()) {
+                BSONElement oldExpireSecs = cmr.idx->infoObj().getField("expireAfterSeconds");
+                if (oldExpireSecs.eoo()) {
+                    return Status(ErrorCodes::InvalidOptions, "no expireAfterSeconds field to update");
+                }
+                if (!oldExpireSecs.isNumber()) {
+                    return Status(ErrorCodes::InvalidOptions,
+                                  "existing expireAfterSeconds field is not a number");
+                }
             }
-            if (!oldExpireSecs.isNumber()) {
-                return Status(ErrorCodes::InvalidOptions,
-                              "existing expireAfterSeconds field is not a number");
-            }
-
         } else if (fieldName == "validator" && !isView) {
             // Save this to a variable to avoid reading the atomic variable multiple times.
             const auto currentFCV = serverGlobalParams.featureCompatibility.getVersion();
@@ -250,13 +257,25 @@ class CollModResultChange : public RecoveryUnit::Change {
 public:
     CollModResultChange(const BSONElement& oldExpireSecs,
                         const BSONElement& newExpireSecs,
+                        const BSONElement& oldHidden,
+                        const BSONElement& newHidden,
                         BSONObjBuilder* result)
-        : _oldExpireSecs(oldExpireSecs), _newExpireSecs(newExpireSecs), _result(result) {}
+        : _oldExpireSecs(oldExpireSecs), _newExpireSecs(newExpireSecs),
+          _oldHidden(oldHidden), _newHidden(newHidden),
+          _result(result) {
+    }
 
     void commit(boost::optional<Timestamp>) override {
         // add the fields to BSONObjBuilder result
-        _result->appendAs(_oldExpireSecs, "expireAfterSeconds_old");
-        _result->appendAs(_newExpireSecs, "expireAfterSeconds_new");
+        if (!_oldExpireSecs.eoo()) {
+            _result->appendAs(_oldExpireSecs, "expireAfterSeconds_old");
+            _result->appendAs(_newExpireSecs, "expireAfterSeconds_new");
+        }
+        if (!_newHidden.eoo()) {
+            bool oldValue = _oldHidden.eoo() ? false : _oldHidden.booleanSafe();
+            _result->append("hidden_old", oldValue);
+            _result->appendAs(_newHidden, "hidden_new");
+        }
     }
 
     void rollback() override {}
@@ -264,6 +283,8 @@ public:
 private:
     const BSONElement _oldExpireSecs;
     const BSONElement _newExpireSecs;
+    const BSONElement _oldHidden;
+    const BSONElement _newHidden;
     BSONObjBuilder* _result;
 };
 
@@ -324,6 +345,21 @@ Status _collModInternal(OperationContext* opCtx,
     const CollModRequest cmrOld = statusW.getValue();
     CollModRequest cmrNew = statusW.getValue();
 
+    if (!cmrOld.indexHidden.eoo()) {
+
+        if(serverGlobalParams.featureCompatibility.isVersionInitialized() &&
+           serverGlobalParams.featureCompatibility.getVersion() <
+           ServerGlobalParams::FeatureCompatibility::Version::kFullyUpgradedTo44 &&
+           cmrOld.indexHidden.booleanSafe()
+           ) {
+            return Status(ErrorCodes::BadValue, "Hidden indexes can only be created with FCV 4.4");
+        }
+       if (coll->ns().isSystem())
+           return Status(ErrorCodes::BadValue, "Can't hide index on system collection");
+       if (cmrOld.idx->isIdIndex())
+           return Status(ErrorCodes::BadValue, "can't hide _id index");
+    }
+
     return writeConflictRetry(opCtx, "collMod", nss.ns(), [&] {
         WriteUnitOfWork wunit(opCtx);
 
@@ -360,40 +396,66 @@ Status _collModInternal(OperationContext* opCtx,
         CollectionOptions oldCollOptions =
             DurableCatalog::get(opCtx)->getCollectionOptions(opCtx, coll->getCatalogId());
 
-        boost::optional<TTLCollModInfo> ttlInfo;
+        boost::optional<IndexCollModInfo> indexCollModInfo;
 
         // Handle collMod operation type appropriately.
 
-        // TTLIndex
-        if (!cmrOld.indexExpireAfterSeconds.eoo()) {
-            BSONElement newExpireSecs = cmrOld.indexExpireAfterSeconds;
-            BSONElement oldExpireSecs = cmrOld.idx->infoObj().getField("expireAfterSeconds");
+        if (!cmrOld.indexExpireAfterSeconds.eoo() || !cmrOld.indexHidden.eoo()) {
+            BSONElement newExpireSecs = {};
+            BSONElement oldExpireSecs = {};
+            BSONElement newHidden = {};
+            BSONElement oldHidden = {};
+            // TTL Index
+            if (!cmrOld.indexExpireAfterSeconds.eoo()) {
+                newExpireSecs = cmrOld.indexExpireAfterSeconds;
+                oldExpireSecs = cmrOld.idx->infoObj().getField("expireAfterSeconds");
+                if (SimpleBSONElementComparator::kInstance.evaluate(oldExpireSecs != newExpireSecs)) {
+                    // Change the value of "expireAfterSeconds" on disk.
+                    DurableCatalog::get(opCtx)->updateTTLSetting(opCtx,
+                                                                 coll->getCatalogId(),
+                                                                 cmrOld.idx->indexName(),
+                                                                 newExpireSecs.safeNumberLong());
+                }
+            }
 
-            if (SimpleBSONElementComparator::kInstance.evaluate(oldExpireSecs != newExpireSecs)) {
-                // Change the value of "expireAfterSeconds" on disk.
-                DurableCatalog::get(opCtx)->updateTTLSetting(opCtx,
-                                                             coll->getCatalogId(),
-                                                             cmrOld.idx->indexName(),
-                                                             newExpireSecs.safeNumberLong());
-
-                // Notify the index catalog that the definition of this index changed. This will
-                // invalidate the idx pointer in cmrOld. On rollback of this WUOW, the idx pointer
-                // in cmrNew will be invalidated and the idx pointer in cmrOld will be valid again.
-                cmrNew.idx = coll->getIndexCatalog()->refreshEntry(opCtx, cmrOld.idx);
-                opCtx->recoveryUnit()->registerChange(
-                    std::make_unique<CollModResultChange>(oldExpireSecs, newExpireSecs, result));
-
-                if (MONGO_unlikely(assertAfterIndexUpdate.shouldFail())) {
-                    LOGV2(20307, "collMod - assertAfterIndexUpdate fail point enabled.");
-                    uasserted(50970, "trigger rollback after the index update");
+            // User wants to hide or unhide index.
+            if (!cmrOld.indexHidden.eoo()) {
+                newHidden = cmrOld.indexHidden;
+                oldHidden = cmrOld.idx->infoObj().getField("hidden");
+                // make sure when we set it to false, we can remove the hidden field from catalog
+                if ((!oldHidden.eoo() && !oldHidden.booleanSafe())
+                    || SimpleBSONElementComparator::kInstance.evaluate(oldHidden != newHidden)) {
+                    DurableCatalog::get(opCtx)->updateHiddenSetting(opCtx,
+                                                                    coll->getCatalogId(),
+                                                                    cmrOld.idx->indexName(),
+                                                                    newHidden.booleanSafe());
                 }
             }
 
 
-            // Save previous TTL index expiration.
-            ttlInfo = TTLCollModInfo{Seconds(newExpireSecs.safeNumberLong()),
-                                     Seconds(oldExpireSecs.safeNumberLong()),
-                                     cmrNew.idx->indexName()};
+            indexCollModInfo = IndexCollModInfo{cmrOld.indexExpireAfterSeconds.eoo() ?
+                                                boost::optional<Seconds>() : Seconds(newExpireSecs.safeNumberLong()),
+                                                cmrOld.indexExpireAfterSeconds.eoo() ?
+                                                boost::optional<Seconds>() : Seconds(oldExpireSecs.safeNumberLong()),
+                                                cmrOld.indexHidden.eoo() ?
+                                                boost::optional<bool>() :  newHidden.booleanSafe(),
+                                                cmrOld.indexHidden.eoo() ?
+                                                boost::optional<bool>() :  oldHidden.booleanSafe(),
+                                                cmrNew.idx->indexName()};
+
+            // Notify the index catalog that the definition of this index changed. This will
+            // invalidate the idx pointer in cmrOld. On rollback of this WUOW, the idx pointer
+            // in cmrNew will be invalidated and the idx pointer in cmrOld will be valid again.
+            cmrNew.idx = coll->getIndexCatalog()->refreshEntry(opCtx, cmrOld.idx);
+            opCtx->recoveryUnit()->registerChange(
+                                                  std::make_unique<CollModResultChange>(oldExpireSecs, newExpireSecs,
+                                                                                        oldHidden, newHidden,
+                                                                                        result));
+
+            if (MONGO_unlikely(assertAfterIndexUpdate.shouldFail())) {
+                LOGV2(20307, "collMod - assertAfterIndexUpdate fail point enabled.");
+                uasserted(50970, "trigger rollback after the index update");
+            }
         }
 
         // The Validator, ValidationAction and ValidationLevel are already parsed and must be OK.
@@ -410,8 +472,11 @@ Status _collModInternal(OperationContext* opCtx,
 
         // Only observe non-view collMods, as view operations are observed as operations on the
         // system.views collection.
+
         auto* const opObserver = opCtx->getServiceContext()->getOpObserver();
-        opObserver->onCollMod(opCtx, nss, coll->uuid(), oplogEntryObj, oldCollOptions, ttlInfo);
+        opObserver->onCollMod(
+            opCtx, nss, coll->uuid(), oplogEntryObj, oldCollOptions, indexCollModInfo);
+
 
         wunit.commit();
         return Status::OK();

--- a/src/mongo/db/commands/create_indexes.cpp
+++ b/src/mongo/db/commands/create_indexes.cpp
@@ -161,6 +161,8 @@ StatusWith<std::vector<BSONObj>> parseAndValidateIndexSpecs(
                     // entry with a '*' as an index name means "drop all indexes in this
                     // collection".  We disallow creation of such indexes to avoid this conflict.
                     return {ErrorCodes::BadValue, "The index name '*' is not valid."};
+                } else if (ns.isSystem() && !indexSpec[IndexDescriptor::kHiddenFieldName].eoo()) {
+                    return {ErrorCodes::BadValue, "Can't hide index on system collection"};
                 }
 
                 indexSpecs.push_back(std::move(indexSpec));

--- a/src/mongo/db/create_indexes.idl
+++ b/src/mongo/db/create_indexes.idl
@@ -50,6 +50,9 @@ structs:
       unique:
         type: bool
         optional: true
+      hidden:
+        type: bool
+        optional: true
       partialFilterExpression:
         type: object
         optional: true

--- a/src/mongo/db/free_mon/free_mon_op_observer.h
+++ b/src/mongo/db/free_mon/free_mon_op_observer.h
@@ -113,7 +113,7 @@ public:
                    OptionalCollectionUUID uuid,
                    const BSONObj& collModCmd,
                    const CollectionOptions& oldCollOptions,
-                   boost::optional<TTLCollModInfo> ttlInfo) final {}
+                   boost::optional<IndexCollModInfo> indexInfo) final {}
 
     void onDropDatabase(OperationContext* opCtx, const std::string& dbName) final {}
 

--- a/src/mongo/db/index/index_descriptor.cpp
+++ b/src/mongo/db/index/index_descriptor.cpp
@@ -61,6 +61,7 @@ void populateOptionsMap(std::map<StringData, BSONElement>& theMap, const BSONObj
                 IndexDescriptor::kBackgroundFieldName ||  // this is a creation time option only
             fieldName == IndexDescriptor::kDropDuplicatesFieldName ||  // this is now ignored
             fieldName == IndexDescriptor::kSparseFieldName ||          // checked specially
+            fieldName == IndexDescriptor::kHiddenFieldName || // not considered for equivalence
             fieldName == IndexDescriptor::kUniqueFieldName             // check specially
         ) {
             continue;
@@ -93,6 +94,7 @@ constexpr StringData IndexDescriptor::kSparseFieldName;
 constexpr StringData IndexDescriptor::kStorageEngineFieldName;
 constexpr StringData IndexDescriptor::kTextVersionFieldName;
 constexpr StringData IndexDescriptor::kUniqueFieldName;
+constexpr StringData IndexDescriptor::kHiddenFieldName;
 constexpr StringData IndexDescriptor::kWeightsFieldName;
 
 IndexDescriptor::IndexDescriptor(Collection* collection,
@@ -109,6 +111,7 @@ IndexDescriptor::IndexDescriptor(Collection* collection,
       _isIdIndex(isIdIndexPattern(_keyPattern)),
       _sparse(infoObj[IndexDescriptor::kSparseFieldName].trueValue()),
       _unique(_isIdIndex || infoObj[kUniqueFieldName].trueValue()),
+      _hidden(infoObj[kHiddenFieldName].trueValue()),
       _partial(!infoObj[kPartialFilterExprFieldName].eoo()),
       _cachedEntry(nullptr) {
     BSONElement e = _infoObj[IndexDescriptor::kIndexVersionFieldName];

--- a/src/mongo/db/index/index_descriptor.h
+++ b/src/mongo/db/index/index_descriptor.h
@@ -82,6 +82,7 @@ public:
     static constexpr StringData kStorageEngineFieldName = "storageEngine"_sd;
     static constexpr StringData kTextVersionFieldName = "textIndexVersion"_sd;
     static constexpr StringData kUniqueFieldName = "unique"_sd;
+    static constexpr StringData kHiddenFieldName = "hidden"_sd;
     static constexpr StringData kWeightsFieldName = "weights"_sd;
 
     /**
@@ -174,6 +175,10 @@ public:
         return _unique;
     }
 
+    bool hidden() const {
+        return _hidden;
+    }
+
     // Is this index sparse?
     bool isSparse() const {
         return _sparse;
@@ -251,6 +256,7 @@ private:
     bool _isIdIndex;
     bool _sparse;
     bool _unique;
+    bool _hidden;
     bool _partial;
     IndexVersion _version;
     BSONObj _collation;

--- a/src/mongo/db/op_observer.h
+++ b/src/mongo/db/op_observer.h
@@ -60,9 +60,11 @@ struct OplogUpdateEntryArgs {
         : updateArgs(std::move(updateArgs)), nss(std::move(nss)), uuid(std::move(uuid)) {}
 };
 
-struct TTLCollModInfo {
-    Seconds expireAfterSeconds;
-    Seconds oldExpireAfterSeconds;
+struct IndexCollModInfo {
+    boost::optional<Seconds> expireAfterSeconds;
+    boost::optional<Seconds> oldExpireAfterSeconds;
+    boost::optional<bool> hidden;
+    boost::optional<bool> oldHidden;
     std::string indexName;
 };
 
@@ -211,7 +213,7 @@ public:
                            OptionalCollectionUUID uuid,
                            const BSONObj& collModCmd,
                            const CollectionOptions& oldCollOptions,
-                           boost::optional<TTLCollModInfo> ttlInfo) = 0;
+                           boost::optional<IndexCollModInfo> indexInfo) = 0;
     virtual void onDropDatabase(OperationContext* opCtx, const std::string& dbName) = 0;
 
     /**

--- a/src/mongo/db/op_observer_impl.cpp
+++ b/src/mongo/db/op_observer_impl.cpp
@@ -659,7 +659,7 @@ void OpObserverImpl::onCollMod(OperationContext* opCtx,
                                OptionalCollectionUUID uuid,
                                const BSONObj& collModCmd,
                                const CollectionOptions& oldCollOptions,
-                               boost::optional<TTLCollModInfo> ttlInfo) {
+                               boost::optional<IndexCollModInfo> indexInfo) {
 
     if (!nss.isSystemDotProfile()) {
         // do not replicate system.profile modifications
@@ -667,16 +667,22 @@ void OpObserverImpl::onCollMod(OperationContext* opCtx,
         // Create the 'o2' field object. We save the old collection metadata and TTL expiration.
         BSONObjBuilder o2Builder;
         o2Builder.append("collectionOptions_old", oldCollOptions.toBSON());
-        if (ttlInfo) {
-            auto oldExpireAfterSeconds = durationCount<Seconds>(ttlInfo->oldExpireAfterSeconds);
-            o2Builder.append("expireAfterSeconds_old", oldExpireAfterSeconds);
+        if (indexInfo) {
+            if (indexInfo->oldExpireAfterSeconds) {
+                auto oldExpireAfterSeconds = durationCount<Seconds>(indexInfo->oldExpireAfterSeconds.get());
+                o2Builder.append("expireAfterSeconds_old", oldExpireAfterSeconds);
+            }
+            if (indexInfo->oldHidden) {
+                auto oldHidden = indexInfo->oldHidden.get();
+                o2Builder.append("hidden_old", oldHidden);
+            }
         }
 
         MutableOplogEntry oplogEntry;
         oplogEntry.setOpType(repl::OpTypeEnum::kCommand);
         oplogEntry.setNss(nss.getCommandNS());
         oplogEntry.setUuid(uuid);
-        oplogEntry.setObject(makeCollModCmdObj(collModCmd, oldCollOptions, ttlInfo));
+        oplogEntry.setObject(makeCollModCmdObj(collModCmd, oldCollOptions, indexInfo));
         oplogEntry.setObject2(o2Builder.done());
         logOperation(opCtx, &oplogEntry);
     }

--- a/src/mongo/db/op_observer_impl.h
+++ b/src/mongo/db/op_observer_impl.h
@@ -102,7 +102,7 @@ public:
                    OptionalCollectionUUID uuid,
                    const BSONObj& collModCmd,
                    const CollectionOptions& oldCollOptions,
-                   boost::optional<TTLCollModInfo> ttlInfo) final;
+                   boost::optional<IndexCollModInfo> indexInfo) final;
     void onDropDatabase(OperationContext* opCtx, const std::string& dbName) final;
     repl::OpTime onDropCollection(OperationContext* opCtx,
                                   const NamespaceString& collectionName,

--- a/src/mongo/db/op_observer_impl_test.cpp
+++ b/src/mongo/db/op_observer_impl_test.cpp
@@ -273,16 +273,16 @@ TEST_F(OpObserverTest, CollModWithCollectionOptionsAndTTLInfo) {
     oldCollOpts.validationLevel = "strict";
     oldCollOpts.validationAction = "error";
 
-    TTLCollModInfo ttlInfo;
-    ttlInfo.expireAfterSeconds = Seconds(10);
-    ttlInfo.oldExpireAfterSeconds = Seconds(5);
-    ttlInfo.indexName = "name_of_index";
+    IndexCollModInfo indexInfo;
+    indexInfo.expireAfterSeconds = Seconds(10);
+    indexInfo.oldExpireAfterSeconds = Seconds(5);
+    indexInfo.indexName = "name_of_index";
 
     // Write to the oplog.
     {
         AutoGetDb autoDb(opCtx.get(), nss.db(), MODE_X);
         WriteUnitOfWork wunit(opCtx.get());
-        opObserver.onCollMod(opCtx.get(), nss, uuid, collModCmd, oldCollOpts, ttlInfo);
+        opObserver.onCollMod(opCtx.get(), nss, uuid, collModCmd, oldCollOpts, indexInfo);
         wunit.commit();
     }
 
@@ -296,8 +296,8 @@ TEST_F(OpObserverTest, CollModWithCollectionOptionsAndTTLInfo) {
                        << "validationAction"
                        << "warn"
                        << "index"
-                       << BSON("name" << ttlInfo.indexName << "expireAfterSeconds"
-                                      << durationCount<Seconds>(ttlInfo.expireAfterSeconds)));
+                       << BSON("name" << indexInfo.indexName << "expireAfterSeconds"
+                               << durationCount<Seconds>(indexInfo.expireAfterSeconds.get())));
     ASSERT_BSONOBJ_EQ(oExpected, o);
 
     // Ensure that the old collection metadata was saved.
@@ -306,7 +306,7 @@ TEST_F(OpObserverTest, CollModWithCollectionOptionsAndTTLInfo) {
         BSON("collectionOptions_old"
              << BSON("validationLevel" << oldCollOpts.validationLevel << "validationAction"
                                        << oldCollOpts.validationAction)
-             << "expireAfterSeconds_old" << durationCount<Seconds>(ttlInfo.oldExpireAfterSeconds));
+             << "expireAfterSeconds_old" << durationCount<Seconds>(indexInfo.oldExpireAfterSeconds.get()));
 
     ASSERT_BSONOBJ_EQ(o2Expected, o2);
 }

--- a/src/mongo/db/op_observer_noop.h
+++ b/src/mongo/db/op_observer_noop.h
@@ -98,7 +98,7 @@ public:
                    OptionalCollectionUUID uuid,
                    const BSONObj& collModCmd,
                    const CollectionOptions& oldCollOptions,
-                   boost::optional<TTLCollModInfo> ttlInfo) override {}
+                   boost::optional<IndexCollModInfo> indexInfo) override {}
     void onDropDatabase(OperationContext* opCtx, const std::string& dbName) override {}
     repl::OpTime onDropCollection(OperationContext* opCtx,
                                   const NamespaceString& collectionName,

--- a/src/mongo/db/op_observer_registry.h
+++ b/src/mongo/db/op_observer_registry.h
@@ -175,10 +175,10 @@ public:
                    OptionalCollectionUUID uuid,
                    const BSONObj& collModCmd,
                    const CollectionOptions& oldCollOptions,
-                   boost::optional<TTLCollModInfo> ttlInfo) override {
+                   boost::optional<IndexCollModInfo> indexInfo) override {
         ReservedTimes times{opCtx};
         for (auto& o : _observers)
-            o->onCollMod(opCtx, nss, uuid, collModCmd, oldCollOptions, ttlInfo);
+            o->onCollMod(opCtx, nss, uuid, collModCmd, oldCollOptions, indexInfo);
     }
 
     void onDropDatabase(OperationContext* const opCtx, const std::string& dbName) override {

--- a/src/mongo/db/op_observer_util.cpp
+++ b/src/mongo/db/op_observer_util.cpp
@@ -42,21 +42,25 @@ namespace mongo {
  */
 BSONObj makeCollModCmdObj(const BSONObj& collModCmd,
                           const CollectionOptions& oldCollOptions,
-                          boost::optional<TTLCollModInfo> ttlInfo) {
+                          boost::optional<IndexCollModInfo> indexInfo) {
     BSONObjBuilder cmdObjBuilder;
-    std::string ttlIndexFieldName = "index";
+    std::string indexFieldName = "index";
 
     // Add all fields from the original collMod command.
     for (auto elem : collModCmd) {
         // We normalize all TTL collMod oplog entry objects to use the index name, even if the
         // command used an index key pattern.
-        if (elem.fieldNameStringData() == ttlIndexFieldName && ttlInfo) {
-            BSONObjBuilder ttlIndexObjBuilder;
-            ttlIndexObjBuilder.append("name", ttlInfo->indexName);
-            ttlIndexObjBuilder.append("expireAfterSeconds",
-                                      durationCount<Seconds>(ttlInfo->expireAfterSeconds));
+        if (elem.fieldNameStringData() == indexFieldName && indexInfo) {
+            BSONObjBuilder indexObjBuilder;
+            indexObjBuilder.append("name", indexInfo->indexName);
+            if (indexInfo->expireAfterSeconds)
+                indexObjBuilder.append("expireAfterSeconds",
+                                          durationCount<Seconds>(indexInfo->expireAfterSeconds.get()));
+            if (indexInfo->hidden)
+                indexObjBuilder.append("hidden",
+                                          indexInfo->hidden.get());
 
-            cmdObjBuilder.append(ttlIndexFieldName, ttlIndexObjBuilder.obj());
+            cmdObjBuilder.append(indexFieldName, indexObjBuilder.obj());
         } else {
             cmdObjBuilder.append(elem);
         }

--- a/src/mongo/db/op_observer_util.h
+++ b/src/mongo/db/op_observer_util.h
@@ -36,5 +36,5 @@
 namespace mongo {
 BSONObj makeCollModCmdObj(const BSONObj& collModCmd,
                           const CollectionOptions& oldCollOptions,
-                          boost::optional<TTLCollModInfo> ttlInfo);
+                          boost::optional<IndexCollModInfo> indexInfo);
 }  // namespace mongo

--- a/src/mongo/db/query/get_executor.cpp
+++ b/src/mongo/db/query/get_executor.cpp
@@ -247,6 +247,10 @@ void fillOutPlannerParams(OperationContext* opCtx,
         collection->getIndexCatalog()->getIndexIterator(opCtx, false);
     while (ii->more()) {
         const IndexCatalogEntry* ice = ii->next();
+
+        // Skip the addition of hidden indexes to prevent use in query planning.
+        if (ice->descriptor()->hidden())
+            continue;
         plannerParams->indices.push_back(
             indexEntryFromIndexCatalogEntry(opCtx, *ice, canonicalQuery));
     }
@@ -1436,6 +1440,10 @@ QueryPlannerParams fillOutPlannerParamsForDistinct(OperationContext* opCtx,
     while (ii->more()) {
         const IndexCatalogEntry* ice = ii->next();
         const IndexDescriptor* desc = ice->descriptor();
+
+        // Skip the addition of hidden indexes to prevent use in query planning.
+        if (desc->hidden())
+            continue;
         if (desc->keyPattern().hasField(parsedDistinct.getKey())) {
             if (!mayUnwindArrays &&
                 isAnyComponentOfPathMultikey(desc->keyPattern(),

--- a/src/mongo/db/s/config_server_op_observer.h
+++ b/src/mongo/db/s/config_server_op_observer.h
@@ -114,7 +114,7 @@ public:
                    OptionalCollectionUUID uuid,
                    const BSONObj& collModCmd,
                    const CollectionOptions& oldCollOptions,
-                   boost::optional<TTLCollModInfo> ttlInfo) override {}
+                   boost::optional<IndexCollModInfo> indexInfo) override {}
 
     void onDropDatabase(OperationContext* opCtx, const std::string& dbName) override {}
 

--- a/src/mongo/db/s/shard_server_op_observer.cpp
+++ b/src/mongo/db/s/shard_server_op_observer.cpp
@@ -47,6 +47,7 @@
 #include "mongo/db/s/shard_identity_rollback_notifier.h"
 #include "mongo/db/s/sharding_initialization_mongod.h"
 #include "mongo/db/s/sharding_state.h"
+#include "mongo/db/s/operation_sharding_state.h"
 #include "mongo/db/s/type_shard_identity.h"
 #include "mongo/logv2/log.h"
 #include "mongo/s/balancer_configuration.h"
@@ -493,7 +494,7 @@ void ShardServerOpObserver::onCollMod(OperationContext* opCtx,
                                       OptionalCollectionUUID uuid,
                                       const BSONObj& collModCmd,
                                       const CollectionOptions& oldCollOptions,
-                                      boost::optional<TTLCollModInfo> ttlInfo) {
+                                      boost::optional<IndexCollModInfo> indexInfo) {
     abortOngoingMigrationIfNeeded(opCtx, nss);
 };
 

--- a/src/mongo/db/s/shard_server_op_observer.h
+++ b/src/mongo/db/s/shard_server_op_observer.h
@@ -114,7 +114,7 @@ public:
                    OptionalCollectionUUID uuid,
                    const BSONObj& collModCmd,
                    const CollectionOptions& oldCollOptions,
-                   boost::optional<TTLCollModInfo> ttlInfo) override;
+                   boost::optional<IndexCollModInfo> indexInfo) override;
 
     void onDropDatabase(OperationContext* opCtx, const std::string& dbName) override {}
 

--- a/src/mongo/db/storage/bson_collection_catalog_entry.cpp
+++ b/src/mongo/db/storage/bson_collection_catalog_entry.cpp
@@ -120,6 +120,26 @@ void BSONCollectionCatalogEntry::IndexMetaData::updateTTLSetting(long long newEx
     spec = b.obj();
 }
 
+
+void BSONCollectionCatalogEntry::IndexMetaData::updateHiddenSetting(bool hidden) {
+    // If hidden == false, we remove this field from catalog rather than add a field with false.
+    // or else, the old binary can't startup due to the unknown field.
+    BSONObjBuilder b;
+    for (BSONObjIterator bi(spec); bi.more();) {
+        BSONElement e = bi.next();
+        if (e.fieldNameStringData() == "hidden") {
+            continue;
+        }
+        b.append(e);
+    }
+
+    if (hidden) {
+        b.append("hidden", hidden);
+    }
+    spec = b.obj();
+}
+
+
 // --------------------------
 
 int BSONCollectionCatalogEntry::MetaData::findIndexOffset(StringData name) const {

--- a/src/mongo/db/storage/bson_collection_catalog_entry.h
+++ b/src/mongo/db/storage/bson_collection_catalog_entry.h
@@ -64,6 +64,8 @@ public:
 
         void updateTTLSetting(long long newExpireSeconds);
 
+        void updateHiddenSetting(bool hidden);
+
         std::string name() const {
             return spec["name"].String();
         }

--- a/src/mongo/db/storage/durable_catalog.h
+++ b/src/mongo/db/storage/durable_catalog.h
@@ -151,6 +151,15 @@ public:
                                   StringData idxName,
                                   long long newExpireSeconds) = 0;
 
+    /*
+     * Hide or unhide the given index. A hidden index will not be considered for use by the
+     * query planner.
+     */
+    virtual void updateHiddenSetting(OperationContext* opCtx,
+                                        RecordId catalogId,
+                                        StringData idxName,
+                                        bool hidden) = 0;
+
     /** Compares the UUID argument to the UUID obtained from the metadata. Returns true if they are
      * equal, false otherwise.
      */

--- a/src/mongo/db/storage/durable_catalog_impl.cpp
+++ b/src/mongo/db/storage/durable_catalog_impl.cpp
@@ -931,6 +931,19 @@ void DurableCatalogImpl::updateTTLSetting(OperationContext* opCtx,
     putMetaData(opCtx, catalogId, md);
 }
 
+void DurableCatalogImpl::updateHiddenSetting(OperationContext* opCtx,
+                                                RecordId catalogId,
+                                                StringData idxName,
+                                                bool hidden) {
+
+    BSONCollectionCatalogEntry::MetaData md = getMetaData(opCtx, catalogId);
+    int offset = md.findIndexOffset(idxName);
+    invariant(offset >= 0);
+    md.indexes[offset].updateHiddenSetting(hidden);
+    putMetaData(opCtx, catalogId, md);
+}
+
+
 bool DurableCatalogImpl::isEqualToMetadataUUID(OperationContext* opCtx,
                                                RecordId catalogId,
                                                OptionalCollectionUUID uuid) {

--- a/src/mongo/db/storage/durable_catalog_impl.h
+++ b/src/mongo/db/storage/durable_catalog_impl.h
@@ -124,6 +124,11 @@ public:
                           StringData idxName,
                           long long newExpireSeconds);
 
+    void updateHiddenSetting(OperationContext* opCtx,
+                             RecordId catalogId,
+                             StringData idxName,
+                             bool hidden);
+
     bool isEqualToMetadataUUID(OperationContext* opCtx,
                                RecordId catalogId,
                                OptionalCollectionUUID uuid);

--- a/src/mongo/shell/collection.js
+++ b/src/mongo/shell/collection.js
@@ -60,6 +60,10 @@ DBCollection.prototype.help = function() {
     print("\tdb." + shortName + ".drop() drop the collection");
     print("\tdb." + shortName + ".dropIndex(index) - e.g. db." + shortName +
           ".dropIndex( \"indexName\" ) or db." + shortName + ".dropIndex( { \"indexKey\" : 1 } )");
+    print("\tdb." + shortName + ".hideIndex(index) - e.g. db." + shortName +
+          ".hideIndex( \"indexName\" ) or db." + shortName + ".hideIndex( { \"indexKey\" : 1 } )");
+    print("\tdb." + shortName + ".unhideIndex(index) - e.g. db." + shortName +
+          ".unhideIndex( \"indexName\" ) or db." + shortName + ".unhideIndex( { \"indexKey\" : 1 } )");
     print("\tdb." + shortName + ".dropIndexes()");
     print("\tdb." + shortName +
           ".ensureIndex(keypattern[,options]) - DEPRECATED, use createIndex() instead");
@@ -873,6 +877,38 @@ DBCollection.prototype.dropIndex = function(index) {
     var res = this._dbCommand("dropIndexes", {index: index});
     return res;
 };
+
+
+/**
+ * Hide an index from the query planner.
+ */
+DBCollection.prototype._hiddenIndex = function(index, hidden) {
+    assert(index, "please specify index to hide");
+
+    // Need an extra check for array because 'Array' is an 'object', but not every 'object' is an
+    // 'Array'.
+    var indexField = {};
+    if (typeof index == "string") {
+	indexField = {name: index, hidden: hidden};
+    } else if (typeof index == "object") {
+	indexField = { keyPattern: index, hidden: hidden};
+    } else {
+        throw new Error(
+	    "Index must be either the index name or the index specification document");
+    }
+    var cmd = {"collMod": this._shortName, index: indexField};
+    var res = this._db.runCommand(cmd);
+    return res;
+};
+
+DBCollection.prototype.hideIndex = function(index) {
+    return this._hiddenIndex(index, true);
+}
+
+DBCollection.prototype.unhideIndex = function(index) {
+    return this._hiddenIndex(index, false);
+}
+
 
 DBCollection.prototype.getCollection = function(subName) {
     return this._db.getCollection(this._shortName + "." + subName);


### PR DESCRIPTION
Hi:
   This pull request is about  https://jira.mongodb.org/browse/SERVER-9306 and https://jira.mongodb.org/browse/SERVER-26589
   
   The user story of this feature is something like this:
1. DBA want to drop an index
2. DBA is not confident enough to know if the index is not need at all.
3. The table is huge so recreating the index after drop will take a long time.
 
  In this situation,  we can make the index `invisible` for the following few days,   which means mongodb will still maintain index for the following data change but the optimizer will not use it any more.
If we found the index is still needed,  we can simple rollback our change quickly by making it visible again.   If we found the index is not needed for the following N days,  we can drop it safely.
 
The reason why “indexStats” command in MongoDB 3.2 is not perfect for this user case is that the optimizer may choose a wrong index, so it will still show the index is in use but in fact it can be and should be dropped.
 
Here is an overview for this feature:
 ```
> for(var i = 0; i<10000; i++) { db.i.save({a: i})}
> db.i.createIndex({a: 1})
{
                "createdCollectionAutomatically" : false,
                "numIndexesBefore" : 1,
                "numIndexesAfter" : 2,
                "ok" : 1
}
 
> db.i.getIndices()
[
                {
                                "v" : 2,
                                "key" : {
                                                "_id" : 1
                                },
                                "name" : "_id_",
                                "ns" : "zhifan.i",
                                "invisible" : false
                },
                {
                                "v" : 2,
                                "key" : {
                                                "a" : 1
                                },
                                "name" : "a_1",
                                "ns" : "zhifan.i",
                                "invisible" : false
                }
]
 
> db.i.find({a: 100}).explain()
{
                "queryPlanner" : {
                                "plannerVersion" : 1,
                                "namespace" : "zhifan.i",
                                "indexFilterSet" : false,
                                "parsedQuery" : {
                                                "a" : {
                                                                "$eq" : 100
                                                }
                                },
                                "winningPlan" : {
                                                "stage" : "FETCH",
                                                "inputStage" : {
                                                                "stage" : "IXSCAN",
                                                                "keyPattern" : {
                                                                                "a" : 1
                                                                },
                                                                "indexName" : "a_1",
                                                                "isMultiKey" : false,
                                                                "multiKeyPaths" : {
                                                                                "a" : [ ]
                                                                },
                                                                "isUnique" : false,
                                                                "isSparse" : false,
                                                                "isPartial" : false,
                                                                "indexVersion" : 2,
                                                                "direction" : "forward",
                                                                "indexBounds" : {
                                                                                "a" : [
                                                                                                "[100.0, 100.0]"
                                                                                ]
                                                                }
                                                }
                                },
                                "rejectedPlans" : [ ]
                },
                "serverInfo" : {
                                "host" : "zhifan-dev16",
                                "port" : 27017,
                                "version" : "3.7.0-353-g2307b7a",
                                "gitVersion" : "2307b7ae2495b4b1c0caa0a83d7be1323b975fe4"
                },
                "ok" : 1
}
 
> db.runCommand({"collMod": "i", "index": {"name": "a_1", "invisible": true}})
{ "invisible_old" : false, "invisible_new" : true, "ok" : 1 }
> db.i.find({a: 100}).explain()
{
                "queryPlanner" : {
                                "plannerVersion" : 1,
                                "namespace" : "zhifan.i",
                                "indexFilterSet" : false,
                                "parsedQuery" : {
                                                "a" : {
                                                                "$eq" : 100
                                                }
                                },
                                "winningPlan" : {
                                                "stage" : "COLLSCAN",
                                                "filter" : {
                                                                "a" : {
                                                                                "$eq" : 100
                                                                }
                                                },
                                                "direction" : "forward"
                                },
                                "rejectedPlans" : [ ]
                },
                "serverInfo" : {
                                "host" : "zhifan-dev16",
                                "port" : 27017,
                                "version" : "3.7.0-353-g2307b7a",
                                "gitVersion" : "2307b7ae2495b4b1c0caa0a83d7be1323b975fe4"
                },
                "ok" : 1
}
> db.runCommand({"collMod": "i", "index": {"name": "a_1", "invisible": false}})
{ "invisible_old" : true, "invisible_new" : false, "ok" : 1 }
> db.i.find({a: 100}).explain()
{
                "queryPlanner" : {
                                "plannerVersion" : 1,
                                "namespace" : "zhifan.i",
                                "indexFilterSet" : false,
                                "parsedQuery" : {
                                                "a" : {
                                                                "$eq" : 100
                                                }
                                },
                                "winningPlan" : {
                                                "stage" : "FETCH",
                                                "inputStage" : {
                                                                "stage" : "IXSCAN",
                                                                "keyPattern" : {
                                                                                "a" : 1
                                                                },
                                                                "indexName" : "a_1",
                                                                "isMultiKey" : false,
                                                                "multiKeyPaths" : {
                                                                                "a" : [ ]
                                                                },
                                                                "isUnique" : false,
                                                                "isSparse" : false,
                                                                "isPartial" : false,
                                                                "indexVersion" : 2,
                                                                "direction" : "forward",
                                                                "indexBounds" : {
                                                                                "a" : [
                                                                                                "[100.0, 100.0]"
                                                                                ]
                                                                }
                                                }
                                },
                                "rejectedPlans" : [ ]
                },
                "serverInfo" : {
                                "host" : "zhifan-dev16",
                                "port" : 27017,
                                "version" : "3.7.0-353-g2307b7a",
                                "gitVersion" : "2307b7ae2495b4b1c0caa0a83d7be1323b975fe4"
                },
                "ok" : 1
}
 ```
all the existing test case are passed  with `python buildscripts/resmoke.py jstests/core/*.js` and code is formated with `python buildscripts/clang_format.py format`