### PR TITLE
SERVER-32809 Fix typo in config_server_test_fixture.cpp

### DIFF
--- a/src/mongo/s/config_server_test_fixture.cpp
+++ b/src/mongo/s/config_server_test_fixture.cpp
@@ -243,7 +243,7 @@ Status ConfigServerTestFixture::deleteToConfigCollection(OperationContext* opCtx
                                                          const NamespaceString& ns,
                                                          const BSONObj& doc,
                                                          const bool multi) {
-    auto deleteReponse = getConfigShard()->runCommand(opCtx,
+    auto deleteResponse = getConfigShard()->runCommand(opCtx,
                                                       kReadPref,
                                                       ns.db().toString(),
                                                       [&]() {
@@ -261,7 +261,7 @@ Status ConfigServerTestFixture::deleteToConfigCollection(OperationContext* opCtx
 
 
     BatchedCommandResponse batchResponse;
-    auto status = Shard::CommandResponse::processBatchWriteResponse(deleteReponse, &batchResponse);
+    auto status = Shard::CommandResponse::processBatchWriteResponse(deleteResponse, &batchResponse);
     return status;
 }
 


### PR DESCRIPTION
## Summary
I've reopened https://github.com/mongodb/mongo/pull/1208

I fixed typo in config_server_test_fixture.cpp

reponse  → response

Ticket url https://jira.mongodb.org/browse/SERVER-32809?focusedCommentId=1781053&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1781053

