### PR TITLE
[SERVER-32436] Add virtual destructor to DurableViewCatalog

### DIFF
--- a/src/mongo/db/views/durable_view_catalog.h
+++ b/src/mongo/db/views/durable_view_catalog.h
@@ -65,6 +65,7 @@ public:
                         const BSONObj& view) = 0;
     virtual void remove(OperationContext* opCtx, const NamespaceString& name) = 0;
     virtual const std::string& getName() const = 0;
+    virtual ~DurableViewCatalog() = default;
 };
 
 /**


### PR DESCRIPTION
A user upgraded his or her compiler and noticed the following warning:

'mongo::DurableViewCatalog' has virtual functions but non-virtual destructor

To resolve this issue, add an inline virtual destructor to the
DurableViewCatalog class header file.