### PR TITLE
SERVER-33871 - Stricter systemd .service settings

### DIFF
--- a/debian/mongod.service
+++ b/debian/mongod.service
@@ -23,6 +23,12 @@ LimitMEMLOCK=infinity
 # total threads (user+kernel)
 TasksMax=infinity
 TasksAccounting=false
+# read-only /usr, /boot, /etc
+ProtectSystem=full
+# inaccessible /home, /root and /run/user
+ProtectHome=true
+# remove CAP_SYS_PTRACE kernel capability
+CapabilityBoundingSet=~CAP_SYS_PTRACE
 
 # Recommended limits for for mongod as specified in
 # http://docs.mongodb.org/manual/reference/ulimit/#recommended-settings

--- a/rpm/mongod.service
+++ b/rpm/mongod.service
@@ -29,6 +29,13 @@ LimitMEMLOCK=infinity
 # total threads (user+kernel)
 TasksMax=infinity
 TasksAccounting=false
+# read-only /usr, /boot, /etc
+ProtectSystem=full
+# inaccessible /home, /root and /run/user
+ProtectHome=true
+# remove CAP_SYS_PTRACE kernel capability
+CapabilityBoundingSet=~CAP_SYS_PTRACE
+
 # Recommended limits for for mongod as specified in
 # http://docs.mongodb.org/manual/reference/ulimit/#recommended-settings
 


### PR DESCRIPTION
Stricter `systemd` .service settings.
Using `ProtectSystem`, `ProtectHome` and removing the `CAP_SYS_PTRACE` capability.

Tested on Ubuntu and Centos.

Short version at https://github.com/konstruktoid/hardening/blob/master/systemd.adoc#unit-configuration and official documentation http://0pointer.de/public/systemd-man/systemd.exec.html.