### PR TITLE
Scons build fixes for a smaller build

### DIFF
--- a/src/mongo/SConscript
+++ b/src/mongo/SConscript
@@ -513,10 +513,13 @@ env.Alias("tools", "#/" + add_exe("mongobridge"))
 installBinary( env, "mongod" )
 installBinary( env, "mongos" )
 
+core_alias_binaries = [ add_exe( "mongod" ), add_exe( "mongos" ) ]
+
 if shellEnv is not None:
     installBinary( shellEnv, "mongo" )
+    core_alias_binaries += [ add_exe( "mongo" ) ]
 
-env.Alias( "core", [ '#/%s' % b for b in [ add_exe( "mongo" ), add_exe( "mongod" ), add_exe( "mongos" ) ] ] )
+env.Alias( "core", [ '#/%s' % b for b in  core_alias_binaries] )
 
 # Stage the top-level mongodb banners
 distsrc = env.Dir('#distsrc')

--- a/src/mongo/s/SConscript
+++ b/src/mongo/s/SConscript
@@ -309,6 +309,7 @@ env.Library(
     ],
     LIBDEPS=[
         "coreshard",
+        "local_sharding_info",
         "$BUILD_DIR/mongo/db/commands/core",
         "$BUILD_DIR/mongo/db/concurrency/lock_manager",
         "$BUILD_DIR/mongo/db/query/query",


### PR DESCRIPTION
I'm trying to perform a no-js engine build, and no mongo command. I've hit two issues:

serveronly target was underlinked, failing to find a reference to local_sharding_info.

core target referenced mongo executable, when it was not going to be built.

Below fixes both of the above issues on the v3.4 branch.