### PR TITLE
Add missing error code in central list of error codes

### DIFF
--- a/src/mongo/base/error_codes.err
+++ b/src/mongo/base/error_codes.err
@@ -269,6 +269,7 @@ error_code("ShardKeyTooBig", 13334);
 error_code("StaleConfig", 13388, extra="StaleConfigInfo");
 error_code("DatabaseDifferCase", 13297);
 error_code("OBSOLETE_PrepareConfigsFailed", 13104);
+error_code("SortExceedMemoryLimitNoDiskUseAllowed", 16819);
 
 # Group related errors into classes, can be checked against ErrorCodes::isXXXClassName methods.
 error_class("NetworkError", ["HostUnreachable", "HostNotFound", "NetworkTimeout", "SocketException"])


### PR DESCRIPTION
Just got an error code that is not on the main list. I think it should be added.