### PR TITLE
if we are forcing fork, then systemd unit needs to enforce it

### DIFF
--- a/rpm/mongod.service
+++ b/rpm/mongod.service
@@ -7,7 +7,7 @@ Documentation=https://docs.mongodb.org/manual
 User=mongod
 Group=mongod
 Environment="OPTIONS=-f /etc/mongod.conf"
-ExecStart=/usr/bin/mongod $OPTIONS
+ExecStart=/usr/bin/mongod --fork --pidfilepath /var/run/mongodb/mongod.pid $OPTIONS
 ExecStartPre=/usr/bin/mkdir -p /var/run/mongodb
 ExecStartPre=/usr/bin/chown mongod:mongod /var/run/mongodb
 ExecStartPre=/usr/bin/chmod 0755 /var/run/mongodb


### PR DESCRIPTION
commit 3607059 introduced a default fork option, but it has not
been enforced in the command line. Since fork is enforced in the
systemd unit and ignores the configuration file, if the config
file has fork disabled (default value) then the unit will not
start properly. This is problematic for situations where a config
file is being managed by an external system like ansible