### PR TITLE
set umask=0027 in systemd service unit

### DIFF
--- a/debian/mongod.service
+++ b/debian/mongod.service
@@ -6,6 +6,7 @@ Documentation=https://docs.mongodb.org/manual
 [Service]
 User=mongodb
 Group=mongodb
+UMask=0027
 ExecStart=/usr/bin/mongod --config /etc/mongod.conf
 PIDFile=/var/run/mongodb/mongod.pid
 # file size


### PR DESCRIPTION
Set UMask=0027 in debian/mongod.service so that database files are created with no permissions for "other" users.