### PR TITLE
fixbug SERVER-31687: Missing minvalid in sync source cause oplog full table scan all the time

### DIFF
--- a/src/mongo/db/repl/oplogreader.h
+++ b/src/mongo/db/repl/oplogreader.h
@@ -107,6 +107,8 @@ public:
 
     void tailingQuery(const char* ns, const BSONObj& query);
 
+    void tailingQueryOne(const char* ns, const BSONObj& query);
+
     void tailingQueryGTE(const char* ns, Timestamp t);
 
     bool more() {


### PR DESCRIPTION
See details in [SERVER-31687](https://jira.mongodb.org/browse/SERVER-31687)

`$lte` condition may cause the oplog full scan, so we should just use `$gte`, and compare in the client side.