### PR TITLE
Allow PowerShell to connect using TLS 1.2

### DIFF
--- a/src/mongo/installer/compass/Install-Compass.ps1.in
+++ b/src/mongo/installer/compass/Install-Compass.ps1.in
@@ -36,7 +36,7 @@ try {
     
     # Default PowerShell SecurityProtocol does not support Tls1.2 (required by domain)
     if ([Net.ServicePointManager]::SecurityProtocol.ToString() -NotMatch "Tls12") {
-        [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12 
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 
     }
     Invoke-WebRequest -Uri $CompassUrl -OutFile $CompassExe
 

--- a/src/mongo/installer/compass/Install-Compass.ps1.in
+++ b/src/mongo/installer/compass/Install-Compass.ps1.in
@@ -33,6 +33,11 @@ Remove-Item $CompassExe -ErrorAction:Ignore
 
 try {
     Write-Output "Downloading Compass from $CompassUrl"
+    
+    # Default PowerShell SecurityProtocol does not support Tls1.2 (required by domain)
+    if ([Net.ServicePointManager]::SecurityProtocol.ToString() -NotMatch "Tls12") {
+        [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12 
+    }
     Invoke-WebRequest -Uri $CompassUrl -OutFile $CompassExe
 
     Write-Output "Installing Compass"


### PR DESCRIPTION
By default powershell does not connect via TLS 1.2. Allow it if it isn't already configured.

This fixes an issue where checking "Install Compass" on the MongoDB installer does not install compass on Windows machines.