### PR TITLE
Add a missing quote to error message.

### DIFF
--- a/src/mongo/client/read_preference.cpp
+++ b/src/mongo/client/read_preference.cpp
@@ -89,7 +89,7 @@ StatusWith<ReadPreference> parseReadPreferenceMode(StringData prefStr) {
                                 << kPrimaryOnly
                                 << "', '"
                                 << kPrimaryPreferred
-                                << "', "
+                                << "', '"
                                 << kSecondaryOnly
                                 << "', '"
                                 << kSecondaryPreferred


### PR DESCRIPTION
Before:

       Could not parse $readPreference mode ''. Only the modes 'primary', 'primaryPreferred', secondary', 'secondaryPreferred', and 'nearest' are supported. (9)

Note missing quote prior to "secondary".