### PR TITLE
SERVER-36039 Fix build for LibreSSL 2.7 (adopted parts of OpenSSL 1.1 API).

### DIFF
--- a/src/mongo/crypto/sha_block_openssl.cpp
+++ b/src/mongo/crypto/sha_block_openssl.cpp
@@ -44,7 +44,7 @@
 #include <openssl/hmac.h>
 #include <openssl/sha.h>
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
 namespace {
 // Copies of OpenSSL after 1.1.0 define new EVP digest routines. We must
 // polyfill used definitions to interact with older OpenSSL versions.

--- a/src/mongo/util/net/ssl_manager_openssl.cpp
+++ b/src/mongo/util/net/ssl_manager_openssl.cpp
@@ -169,7 +169,7 @@ IMPLEMENT_ASN1_ENCODE_FUNCTIONS_const_fname(ASN1_SEQUENCE_ANY, ASN1_SET_ANY, ASN
 #endif // MONGO_CONFIG_NEEDS_ASN1_ANY_DEFINITIONS
 // clang-format on
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000fL)
 // Copies of OpenSSL after 1.1.0 define new functions for interaction with
 // X509 structure. We must polyfill used definitions to interact with older
 // OpenSSL versions.


### PR DESCRIPTION
Stumbled over this while building 3.6.5 (could be back-ported easily, not sure how the mongodb project handles this).