### PR TITLE
SERVER-37198 Add test for $arrayToObject behaviour with duplicate keys

### DIFF
--- a/jstests/aggregation/expressions/arrayToObject.js
+++ b/jstests/aggregation/expressions/arrayToObject.js
@@ -110,4 +110,9 @@
 
     assert.writeOK(coll.insert({_id: 25, expanded: NaN}));
     assertErrorCode(coll, [{$match: {_id: 25}}, array_to_object_expr], 40386);
+
+    // check that if duplicate keys exist, the value of the first key is used
+    assert.writeOK(coll.insert({ _id: 26, expanded: [["duplicate", 1], ["duplicate", 2]] }));
+    result = coll.aggregate([{ $match: { _id: 26 } }, array_to_object_expr]).toArray();
+    assert.eq(result, [{ _id: 26, collapsed: { "duplicate": 1 } }]);
 }());


### PR DESCRIPTION
According to the [documentation](https://docs.mongodb.com/manual/reference/operator/aggregation/arrayToObject/#behavior), when $arrayToObject encounters duplicate keys, it takes the value from the first key. This commit adds a test for this behaviour.