### PR TITLE
SERVER-37583: Refactored mms package structure

### DIFF
--- a/etc/cloud_nightly.yml
+++ b/etc/cloud_nightly.yml
@@ -21,9 +21,7 @@ tasks:
         cd mms/scripts
         ./init_virtualenv.sh ${workdir} 'no-om'
         VIRTUAL_ENV_DISABLE_PROMPT=true source venv-activate
-        cd evergreen
-        sleep ${compile_wait_duration_seconds}
-        ./mongo_cloud_nightly/generate_cloud_nightly.py > ${workdir}/cloud_nightly.json
+        generate_cloud_nightly > "${workdir}/cloud_nightly.json"
   - command: s3.put
     params:
       aws_key: ${aws_key}
@@ -34,6 +32,12 @@ tasks:
       content_type: application/json
       display_name: "Generated tasks (cloud_nightly.json)"
       permissions: private
+  - command: shell.exec
+    params:
+      shell: bash
+      script: |
+        set -ex
+        sleep ${compile_wait_duration_seconds}
   - command: generate.tasks
     params:
       files:


### PR DESCRIPTION
The virtual environment we create now has a setup.py that sets up the scripts like generate_cloud_nightly.py as command line tools and includes them in PATH when you're inside the virtualenv. From the server perspective that means we can now refactor or structure these scripts however we want as long as `generate_cloud_nightly` is still in PATH, it could be written in anything.

Also move sleep til after tasks JSON is created and uploaded, so it can be debugged during the sleep if desired.