### PR TITLE
SERVER-38338 add helpful error ouput to shell

### DIFF
--- a/src/mongo/shell/utils.js
+++ b/src/mongo/shell/utils.js
@@ -849,6 +849,12 @@ shellHelper.it = function() {
     shellPrintHelper(___it___);
 };
 
+shellHelper.mongo = function() {
+    print("You've typed the mongo command within a mongo shell.");
+    print("This is an error.");
+    print("If you meant to run a new mongo shell, please exit the current shell.");
+};
+
 shellHelper.show = function(what) {
     assert(typeof what == "string");
 


### PR DESCRIPTION
This adds some helpful output to the shell if a new user enters `mongo` or `mongo someUri`, rather than `[js] SyntaxError: missing ; before statement @(shell):1:6`