### PR TITLE
SERVER-30768: Backport to v3.4

### DIFF
--- a/jstests/sharding/lagged_config_secondary.js
+++ b/jstests/sharding/lagged_config_secondary.js
@@ -36,7 +36,7 @@
         testDB.user.find({}).maxTimeMS(15000).itcount();
     });
 
-    assert.eq(ErrorCodes.ExceededTimeLimit, exception.code);
+    assert(ErrorCodes.isExceededTimeLimitError(exception.code));
 
     var msg = 'Command on database config timed out waiting for read concern to be satisfied.';
     assert.soon(function() {

--- a/src/mongo/base/error_codes.err
+++ b/src/mongo/base/error_codes.err
@@ -244,3 +244,5 @@ error_class("WriteConcernError", ["WriteConcernFailed",
                                   "UnknownReplWriteConcern",
                                   "CannotSatisfyWriteConcern"])
 error_class("ShutdownError", ["ShutdownInProgress", "InterruptedAtShutdown"])
+
+error_class("ExceededTimeLimitError", ["ExceededTimeLimit", "NetworkInterfaceExceededTimeLimit"])

--- a/src/mongo/db/s/balancer/migration_manager_test.cpp
+++ b/src/mongo/db/s/balancer/migration_manager_test.cpp
@@ -1014,7 +1014,7 @@ TEST_F(MigrationManagerTest, RemoteCallErrorConversionToOperationFailed) {
         chunk2,
         kShardId3,
         false,
-        Status(ErrorCodes::ExceededTimeLimit,
+        Status(ErrorCodes::NetworkInterfaceExceededTimeLimit,
                "RemoteCallErrorConversionToOperationFailedCheck generated error."));
 
     // Run the MigrationManager code.

--- a/src/mongo/executor/connection_pool_asio_integration_test.cpp
+++ b/src/mongo/executor/connection_pool_asio_integration_test.cpp
@@ -175,7 +175,7 @@ TEST(ConnectionPoolASIO, ConnSetupTimeout) {
         deferred.emplace(std::move(resp));
     });
 
-    ASSERT_EQ(deferred.get().status.code(), ErrorCodes::ExceededTimeLimit);
+    ASSERT_EQ(deferred.get().status.code(), ErrorCodes::NetworkInterfaceExceededTimeLimit);
 }
 
 /**

--- a/src/mongo/executor/network_interface_asio.cpp
+++ b/src/mongo/executor/network_interface_asio.cpp
@@ -290,10 +290,7 @@ Status NetworkInterfaceASIO::startCommand(const TaskExecutor::CallbackHandle& cb
             Status status = wasPreviouslyCanceled
                 ? Status(ErrorCodes::CallbackCanceled, "Callback canceled")
                 : swConn.getStatus();
-            if (status.code() == ErrorCodes::NetworkInterfaceExceededTimeLimit) {
-                status = Status(ErrorCodes::ExceededTimeLimit, status.reason());
-            }
-            if (status.code() == ErrorCodes::ExceededTimeLimit) {
+            if (ErrorCodes::isExceededTimeLimitError(status.code())) {
                 _numTimedOutOps.fetchAndAdd(1);
             }
             if (status.code() != ErrorCodes::CallbackCanceled) {

--- a/src/mongo/executor/network_interface_asio_command.cpp
+++ b/src/mongo/executor/network_interface_asio_command.cpp
@@ -287,8 +287,7 @@ void NetworkInterfaceASIO::_completeOperation(AsyncOp* op, ResponseStatus resp) 
         op->_timeoutAlarm->cancel();
     }
 
-    if (resp.status.code() == ErrorCodes::ExceededTimeLimit ||
-        resp.status.code() == ErrorCodes::NetworkInterfaceExceededTimeLimit) {
+    if (ErrorCodes::isExceededTimeLimitError(resp.status.code())) {
         _numTimedOutOps.fetchAndAdd(1);
     }
 

--- a/src/mongo/executor/network_interface_asio_integration_test.cpp
+++ b/src/mongo/executor/network_interface_asio_integration_test.cpp
@@ -65,7 +65,7 @@ TEST_F(NetworkInterfaceASIOIntegrationFixture, Timeouts) {
                                             << "none"
                                             << "secs"
                                             << 10),
-                               ErrorCodes::ExceededTimeLimit,
+                               ErrorCodes::NetworkInterfaceExceededTimeLimit,
                                Milliseconds(100));
 
     // Run a sleep command that should return before we hit the ASIO timeout.
@@ -179,7 +179,7 @@ TEST_F(NetworkInterfaceASIOIntegrationFixture, StressTest) {
             expectedResults[i] = ErrorCodes::OK;
             StressTestOp::runCompleteOp(this, cb);
         } else if (r < .99) {
-            expectedResults[i] = ErrorCodes::ExceededTimeLimit;
+            expectedResults[i] = ErrorCodes::NetworkInterfaceExceededTimeLimit;
             StressTestOp::runTimeoutOp(this, cb);
         } else {
             // Just a sprinkling of long ops, to mitigate connection pool contention
@@ -228,7 +228,7 @@ TEST_F(NetworkInterfaceASIOIntegrationFixture, HookHangs) {
     startNet(std::move(options));
 
     assertCommandFailsOnClient(
-        "admin", BSON("ping" << 1), ErrorCodes::ExceededTimeLimit, Seconds(1));
+        "admin", BSON("ping" << 1), ErrorCodes::NetworkInterfaceExceededTimeLimit, Seconds(1));
 }
 
 }  // namespace

--- a/src/mongo/executor/network_interface_asio_operation.cpp
+++ b/src/mongo/executor/network_interface_asio_operation.cpp
@@ -198,13 +198,6 @@ void NetworkInterfaceASIO::AsyncOp::finish(ResponseStatus&& rs) {
     LOG(2) << "Request " << _request.id << " finished with response: "
            << redact(rs.isOK() ? rs.data.toString() : rs.status.toString());
 
-    // Our own internally generated time outs have a different error code to allow us to retry
-    // internal timeouts.  But the outside world (and our tests) still expect the one true
-    // ExceededTimeLimit, so we convert back here so they get what they expect.
-    if (!rs.isOK() && rs.status.code() == ErrorCodes::NetworkInterfaceExceededTimeLimit) {
-        rs.status = Status(ErrorCodes::ExceededTimeLimit, rs.status.reason());
-    }
-
     // Calling the completion handler may invalidate state in this op, so do it last.
     _onFinish(rs);
 }

--- a/src/mongo/executor/network_interface_asio_test.cpp
+++ b/src/mongo/executor/network_interface_asio_test.cpp
@@ -325,7 +325,7 @@ TEST_F(NetworkInterfaceASIOTest, TimeoutWithNetworkError) {
 
     // Wait for op to complete, assert that timeout had precedence.
     auto& result = deferred.get();
-    ASSERT_EQ(ErrorCodes::ExceededTimeLimit, result.status);
+    ASSERT_EQ(ErrorCodes::NetworkInterfaceExceededTimeLimit, result.status);
     ASSERT(result.elapsedMillis);
     assertNumOps(0u, 1u, 1u, 0u);
 }
@@ -394,7 +394,7 @@ TEST_F(NetworkInterfaceASIOTest, AsyncOpTimeout) {
     }
 
     auto& result = deferred.get();
-    ASSERT_EQ(ErrorCodes::ExceededTimeLimit, result.status);
+    ASSERT_EQ(ErrorCodes::NetworkInterfaceExceededTimeLimit, result.status);
     ASSERT(result.elapsedMillis);
     assertNumOps(0u, 1u, 1u, 0u);
 }

--- a/src/mongo/s/client/shard.cpp
+++ b/src/mongo/s/client/shard.cpp
@@ -97,7 +97,7 @@ bool Shard::shouldErrorBePropagated(ErrorCodes::Error code) {
     return std::find(RemoteCommandRetryScheduler::kAllRetriableErrors.begin(),
                      RemoteCommandRetryScheduler::kAllRetriableErrors.end(),
                      code) == RemoteCommandRetryScheduler::kAllRetriableErrors.end() &&
-        code != ErrorCodes::ExceededTimeLimit;
+        code != ErrorCodes::NetworkInterfaceExceededTimeLimit;
 }
 
 Shard::Shard(const ShardId& id) : _id(id) {}

--- a/src/mongo/s/client/shard_remote.cpp
+++ b/src/mongo/s/client/shard_remote.cpp
@@ -140,9 +140,7 @@ void ShardRemote::updateReplSetMonitor(const HostAndPort& remoteHost,
         _targeter->markHostNotMaster(remoteHost, remoteCommandStatus);
     } else if (ErrorCodes::isNetworkError(remoteCommandStatus.code())) {
         _targeter->markHostUnreachable(remoteHost, remoteCommandStatus);
-    } else if (remoteCommandStatus == ErrorCodes::NotMasterOrSecondary) {
-        _targeter->markHostUnreachable(remoteHost, remoteCommandStatus);
-    } else if (remoteCommandStatus == ErrorCodes::ExceededTimeLimit) {
+    } else if (remoteCommandStatus == ErrorCodes::NetworkInterfaceExceededTimeLimit) {
         _targeter->markHostUnreachable(remoteHost, remoteCommandStatus);
     }
 }
@@ -228,7 +226,7 @@ Shard::HostWithResponse ShardRemote::_runCommand(OperationContext* txn,
     updateReplSetMonitor(host.getValue(), swResponse.status);
 
     if (!swResponse.isOK()) {
-        if (swResponse.status.compareCode(ErrorCodes::ExceededTimeLimit)) {
+       if (ErrorCodes::isExceededTimeLimitError(swResponse.status.code())) {
             LOG(0) << "Operation timed out with status " << redact(swResponse.status);
         }
         return Shard::HostWithResponse(host.getValue(), swResponse.status);
@@ -362,7 +360,7 @@ StatusWith<Shard::QueryResponse> ShardRemote::_exhaustiveFindOnConfig(
     updateReplSetMonitor(host.getValue(), status);
 
     if (!status.isOK()) {
-        if (status.compareCode(ErrorCodes::ExceededTimeLimit)) {
+        if (ErrorCodes::isExceededTimeLimitError(status.code())) {
             LOG(0) << "Operation timed out " << causedBy(status);
         }
         return status;


### PR DESCRIPTION
Hi Mongo,

I went ahead and ported the fix for [SERVER-30768](https://jira.mongodb.org/browse/SERVER-30768) to v3.4. If there's any reason this can't / shouldn't go in, I'd love to hear about that too!

Thanks,
Greg