### PR TITLE
SERVER-39195 Fix getUserDir to not solely rely on env var HOME

### DIFF
--- a/src/mongo/shell/shell_utils.cpp
+++ b/src/mongo/shell/shell_utils.cpp
@@ -49,6 +49,7 @@
 #include "mongo/util/quick_exit.h"
 #include "mongo/util/text.h"
 #include "mongo/util/version.h"
+#include <pwd.h>
 
 namespace mongo {
 
@@ -100,10 +101,14 @@ BSONElement singleArg(const BSONObj& args) {
 }
 
 const char* getUserDir() {
+  const char* homedir;
 #ifdef _WIN32
     return getenv("USERPROFILE");
 #else
-    return getenv("HOME");
+    if((homedir = getenv("HOME")) == NULL) {
+      homedir = getpwuid(geteuid())->pw_dir;
+    };
+    return homedir;
 #endif
 }
 


### PR DESCRIPTION
Shell should not rely solely on env var HOME. It's very often not set at all when launching scripts e.g from cron or other apps. This causes shell to output a warning that it could not save .dbshell and thus making it very hard to parse output from shell as it would result in malformed JSON when retrieving data.
This change won't fix that kind of behaviour on MacOS as users settings are not kept in /etc/passwd so getpwuid() can't be used for this purpose.