### PR TITLE
SCons 3.0.4 Resolve failing --config=force

### DIFF
--- a/src/third_party/scons-3.0.4/scons-local-3.0.4/SCons/Node/__init__.py
+++ b/src/third_party/scons-3.0.4/scons-local-3.0.4/SCons/Node/__init__.py
@@ -1486,7 +1486,7 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
                     result = True
             except DeciderNeedsNode as e:
                 if e.decider(self, prev_ni, node=node):
-                    if t: Trace(': %s changed' % child)
+                    if t: Trace(': in DeciderNeedsNode logic %s changed' % child)
                     result = True
 
         if self.has_builder():


### PR DESCRIPTION
Due to configure custom decider which is only used when config=force which calls the normal decider, but wasn't yet handling exception DeciderNeedsNode.