### PR TITLE
ssl_manager.cpp: fix build with gcc 7 and -fpermissive

### DIFF
--- a/src/mongo/util/net/ssl_manager.cpp
+++ b/src/mongo/util/net/ssl_manager.cpp
@@ -782,7 +782,7 @@ public:
      *
      * Returns a DERToken which consists of the (tag, length, value) tuple.
      */
-    static StatusWith<DERToken> parse(ConstDataRange cdr, size_t* outLength);
+    static StatusWith<DERToken> parse(ConstDataRange cdr, uint64_t* outLength);
 
 private:
     DERType _type{DERType::EndOfContent};
@@ -799,7 +799,7 @@ struct DataType::Handler<DERToken> {
                        size_t length,
                        size_t* advanced,
                        std::ptrdiff_t debug_offset) {
-        size_t outLength;
+        uint64_t outLength;
 
         auto swPair = DERToken::parse(ConstDataRange(ptr, length), &outLength);
 
@@ -844,7 +844,7 @@ StatusWith<std::string> readDERString(ConstDataRangeCursor& cdc) {
 }
 
 
-StatusWith<DERToken> DERToken::parse(ConstDataRange cdr, size_t* outLength) {
+StatusWith<DERToken> DERToken::parse(ConstDataRange cdr, uint64_t* outLength) {
     const size_t kTagLength = 1;
     const size_t kTagLengthAndInitialLengthByteLength = kTagLength + 1;
 


### PR DESCRIPTION
Change prototype of DERToken::parse function from
parse(ConstDataRange cdr, size_t* outLength);
to parse(ConstDataRange cdr, uint64_t* outLength);

Otherwise, we got the following error:

src/mongo/util/net/ssl_manager.cpp: In static member function 'static mongo::StatusWith<mongo::{anonymous}::DERToken> mongo::{anonymous}::DERToken::parse(mongo::ConstDataRange, size_t*)':
src/mongo/util/net/ssl_manager.cpp:575:79: error: invalid conversion from 'size_t* {aka unsigned int*}' to 'long unsigned int*' [-fpermissive]
  if (mongoUnsignedAddOverflow64(tagAndLengthByteCount, derLength, outLength) ||

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>