### PR TITLE
SERVER-40131 Incorrect format string in Windows stacktrace generator

### DIFF
--- a/src/mongo/util/stacktrace_windows.cpp
+++ b/src/mongo/util/stacktrace_windows.cpp
@@ -220,7 +220,7 @@ static void getsymbolAndOffset(HANDLE process,
     std::string symbolString(symbolInfo->Name);
     static const size_t bufferSize = 32;
     std::unique_ptr<char[]> symbolOffset(new char[bufferSize]);
-    _snprintf(symbolOffset.get(), bufferSize, "+0x%llux", displacement64);
+    _snprintf(symbolOffset.get(), bufferSize, "+0x%llx", displacement64);
     symbolString += symbolOffset.get();
     returnedSymbolAndOffset->swap(symbolString);
 }


### PR DESCRIPTION
Fixed a bad format string in _nsprintf. Mark Benvenuto reviewed and said to issue a PR.