### PR TITLE
Update SConstruct - Add support for portable compiler naming standards on Unix

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -630,7 +630,7 @@ def decide_platform_tools():
         # we only support MS toolchain on windows
         return ['msvc', 'mslink', 'mslib', 'masm']
     elif mongo_platform.is_running_os('linux', 'solaris'):
-        return ['gcc', 'g++', 'gnulink', 'ar', 'gas']
+        return ['cc', 'c++', 'gnulink', 'ar', 'gas']
     elif mongo_platform.is_running_os('darwin'):
         return ['gcc', 'g++', 'applelink', 'ar', 'libtool', 'as', 'xcode']
     else:


### PR DESCRIPTION
This new setting adds support for building from either gcc or clang, since the two compilers support portable command naming (`cc` and `c++`).

This way not only GCC users can compile mongodb code, but also LLVM users.