### PR TITLE
Fix server-33111 spurious split dwarf builds

### DIFF
--- a/src/third_party/scons-3.0.4/scons-local-3.0.4/SCons/Builder.py
+++ b/src/third_party/scons-3.0.4/scons-local-3.0.4/SCons/Builder.py
@@ -563,6 +563,15 @@ class BuilderBase(object):
 
         tlist, slist = self._create_nodes(env, target, source)
 
+        # If there is more than one target ensure that if we need to reset
+        # the implicit list to new scan of dependency all targets implicit lists
+        # are cleared. (SERVER-33111)
+        if len(tlist) > 1:
+            # print("Builder:_execute():Tlist > 1 -> %s"%[str(t) for t in tlist])
+            for t in tlist:
+                t.attributes.target_peers = tlist
+
+
         # Check for errors with the specified target/source lists.
         _node_errors(self, env, tlist, slist)
 

--- a/src/third_party/scons-3.0.4/scons-local-3.0.4/SCons/Builder.py
+++ b/src/third_party/scons-3.0.4/scons-local-3.0.4/SCons/Builder.py
@@ -569,7 +569,7 @@ class BuilderBase(object):
         if len(tlist) > 1:
             # print("Builder:_execute():Tlist > 1 -> %s"%[str(t) for t in tlist])
             for t in tlist:
-                t.attributes.target_peers = tlist
+                t.target_peers = tlist
 
 
         # Check for errors with the specified target/source lists.

--- a/src/third_party/scons-3.0.4/scons-local-3.0.4/SCons/Node/__init__.py
+++ b/src/third_party/scons-3.0.4/scons-local-3.0.4/SCons/Node/__init__.py
@@ -783,6 +783,11 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
         # waiting for this Node to be built.
         for parent in self.waiting_parents:
             parent.implicit = None
+            try:
+                for peer in parent.attributes.target_peers:
+                    peer.implicit = None
+            except AttributeError as e:
+                pass
 
         self.clear()
 

--- a/src/third_party/scons-3.0.4/scons-local-3.0.4/SCons/Node/__init__.py
+++ b/src/third_party/scons-3.0.4/scons-local-3.0.4/SCons/Node/__init__.py
@@ -529,6 +529,7 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
 
     __slots__ = ['sources',
                  'sources_set',
+                 'target_peers', 
                  '_specific_sources',
                  'depends',
                  'depends_set',
@@ -784,7 +785,7 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
         for parent in self.waiting_parents:
             parent.implicit = None
             try:
-                for peer in parent.attributes.target_peers:
+                for peer in parent.target_peers:
                     peer.implicit = None
             except AttributeError as e:
                 pass


### PR DESCRIPTION
    - Fix spurious rebuilds on second build for cases where builder has > 1 target and the source file
      is generated. This was causing the > 1th target to not have it's implicit list cleared when the source
      file was actually built, leaving an implicit list similar to follows for 2nd and higher target
              ['/usr/bin/python', 'xxx', 'yyy', 'zzz']
      This was getting persisted to SConsign and on rebuild it would be corrected to be similar to this
              ['zzz', 'yyy', 'xxx', '/usr/bin/python']
      Which would trigger a rebuild because the order changed.
      The fix involved added logic to mark all shared targets as peers and then ensure they're implicit
      list is all cleared together.
