### PR TITLE
Fix md5 decider win32 server-41129

### DIFF
--- a/src/third_party/scons-3.0.4/scons-local-3.0.4/SCons/Node/FS.py
+++ b/src/third_party/scons-3.0.4/scons-local-3.0.4/SCons/Node/FS.py
@@ -3347,6 +3347,11 @@ class File(Base):
 
         # First try the simple name for node
         c_str = str(self)
+        df = dmap.get(c_str, None)
+        if df:
+            return df
+
+        # If not found swap alstep for sep (\ -> /) and try again
         if os.altsep:
             c_str = c_str.replace(os.sep, os.altsep)
         df = dmap.get(c_str, None)
@@ -3406,6 +3411,7 @@ class File(Base):
             except AttributeError:
                 pass
             return False
+
         return self.changed_content(target, prev_ni)
 
     def changed_timestamp_newer(self, target, prev_ni):

--- a/src/third_party/scons-3.0.4/scons-local-3.0.4/SCons/Node/__init__.py
+++ b/src/third_party/scons-3.0.4/scons-local-3.0.4/SCons/Node/__init__.py
@@ -50,6 +50,12 @@ import collections
 import copy
 from itertools import chain
 
+try:
+    from itertools import zip_longest
+except ImportError:
+    from itertools import izip_longest as zip_longest
+
+
 import SCons.Debug
 from SCons.Debug import logInstanceCreation
 import SCons.Executor
@@ -1672,9 +1678,16 @@ class Node(object, with_metaclass(NoSlotsPyPy)):
                     lines.append("`%s' changed\n" % stringify(k))
 
         if len(lines) == 0 and old_bkids != new_bkids:
-            lines.append("the dependency order changed:\n" +
-                         "%sold: %s\n" % (' '*15, list(map(stringify, old_bkids))) +
-                         "%snew: %s\n" % (' '*15, list(map(stringify, new_bkids))))
+            lines.append("the dependency order changed:\n")
+            lines.append("->Sources\n")
+            for (o,n) in zip_longest(old.bsources, new.bsources, fillvalue=None):
+                lines.append("Old:%s\tNew:%s\n"%(o,n))
+            lines.append("->Depends\n")
+            for (o,n) in zip_longest(old.bdepends, new.bdepends, fillvalue=None):
+                lines.append("Old:%s\tNew:%s\n"%(o,n))
+            lines.append("->Implicit\n")
+            for (o,n) in zip_longest(old.bimplicit, new.bimplicit, fillvalue=None):
+                lines.append("Old:%s\tNew:%s\n"%(o,n)) 
 
         if len(lines) == 0:
             def fmt_with_title(title, strlines):


### PR DESCRIPTION
The logic wasn't attempting to first compare windows native path "\" separated with stored dependency list.

Also included some enhanced --debug=explain logic which is in SCons current master.