### PR TITLE
SERVER-27976 Do not accept unknown argument for the explain command.

### DIFF
--- a/jstests/core/explain_invalid_arguments.js
+++ b/jstests/core/explain_invalid_arguments.js
@@ -16,7 +16,7 @@ explain = db.runCommand({
   verosity: "executionStats"
 });
 assert.commandFailedWithCode(explain, ErrorCodes.InvalidOptions);
-assert.eq("explain does not support 'verosity' argument(s).", explain.errmsg);
+assert.eq("explain does not support 'verosity' argument.", explain.errmsg);
 
 explain = db.runCommand({
   explain: { find: collName },
@@ -24,7 +24,15 @@ explain = db.runCommand({
   foo: 1
 });
 assert.commandFailedWithCode(explain, ErrorCodes.InvalidOptions);
-assert.eq("explain does not support 'foo' argument(s).", explain.errmsg);
+assert.eq("explain does not support 'foo' argument.", explain.errmsg);
+
+explain = db.runCommand({
+  explain: { find: collName },
+  foo: 1,
+  bar: 1
+});
+assert.commandFailedWithCode(explain, ErrorCodes.InvalidOptions);
+assert.eq("explain does not support 'foo' argument.", explain.errmsg);
 
 explain = db.runCommand({
   explain: { find: collName },
@@ -33,7 +41,7 @@ explain = db.runCommand({
   bar: 1
 });
 assert.commandFailedWithCode(explain, ErrorCodes.InvalidOptions);
-assert.eq("explain does not support 'foo', 'bar' argument(s).", explain.errmsg);
+assert.eq("explain does not support 'foo' argument.", explain.errmsg);
 
 explain = db.runCommand({
   explain: { find: collName },
@@ -41,4 +49,4 @@ explain = db.runCommand({
   bar: 1
 });
 assert.commandFailedWithCode(explain, ErrorCodes.InvalidOptions);
-assert.eq("explain does not support 'bar' argument(s).", explain.errmsg);
+assert.eq("explain does not support 'bar' argument.", explain.errmsg);

--- a/jstests/core/explain_invalid_arguments.js
+++ b/jstests/core/explain_invalid_arguments.js
@@ -1,0 +1,44 @@
+// Tests for validating arguments of the explain command.
+
+var collName = "jstests_explain_invalid_arguments";
+var t = db[collName];
+t.drop();
+t.insert({});
+
+var explain = db.runCommand({
+  explain: { find: collName },
+  verbosity: "executionStats"
+});
+assert.commandWorked(explain);
+
+explain = db.runCommand({
+  explain: { find: collName },
+  verosity: "executionStats"
+});
+assert.commandFailedWithCode(explain, ErrorCodes.InvalidOptions);
+assert.eq("explain does not support 'verosity' argument(s).", explain.errmsg);
+
+explain = db.runCommand({
+  explain: { find: collName },
+  verbosity: "executionStats",
+  foo: 1
+});
+assert.commandFailedWithCode(explain, ErrorCodes.InvalidOptions);
+assert.eq("explain does not support 'foo' argument(s).", explain.errmsg);
+
+explain = db.runCommand({
+  explain: { find: collName },
+  foo: 1,
+  verbosity: "executionStats",
+  bar: 1
+});
+assert.commandFailedWithCode(explain, ErrorCodes.InvalidOptions);
+assert.eq("explain does not support 'foo', 'bar' argument(s).", explain.errmsg);
+
+explain = db.runCommand({
+  explain: { find: collName },
+  explain: {},
+  bar: 1
+});
+assert.commandFailedWithCode(explain, ErrorCodes.InvalidOptions);
+assert.eq("explain does not support 'bar' argument(s).", explain.errmsg);

--- a/jstests/core/explain_invalid_arguments.js
+++ b/jstests/core/explain_invalid_arguments.js
@@ -1,52 +1,55 @@
-// Tests for validating arguments of the explain command.
+/**
+ * Tests for validating arguments of the explain command:
+ *  -- SERVER-27976 Do not accept unknown argument for the explain command.
+ */
+(function() {
+    "use strict";
 
-var collName = "jstests_explain_invalid_arguments";
-var t = db[collName];
-t.drop();
-t.insert({});
+    var collName = "jstests_explain_invalid_arguments";
 
-var explain = db.runCommand({
-  explain: { find: collName },
-  verbosity: "executionStats"
-});
-assert.commandWorked(explain);
+    var explain = db.runCommand({
+        explain: { find: collName },
+        verbosity: "executionStats"
+    });
+    assert.commandWorked(explain);
 
-explain = db.runCommand({
-  explain: { find: collName },
-  verosity: "executionStats"
-});
-assert.commandFailedWithCode(explain, ErrorCodes.InvalidOptions);
-assert.eq("explain does not support 'verosity' argument.", explain.errmsg);
+    explain = db.runCommand({
+        explain: { find: collName },
+        verosity: "executionStats"
+    });
+    assert.commandFailedWithCode(explain, ErrorCodes.InvalidOptions);
+    assert.eq("explain does not support 'verosity' argument.", explain.errmsg);
 
-explain = db.runCommand({
-  explain: { find: collName },
-  verbosity: "executionStats",
-  foo: 1
-});
-assert.commandFailedWithCode(explain, ErrorCodes.InvalidOptions);
-assert.eq("explain does not support 'foo' argument.", explain.errmsg);
+    explain = db.runCommand({
+        explain: { find: collName },
+        verbosity: "executionStats",
+        foo: 1
+    });
+    assert.commandFailedWithCode(explain, ErrorCodes.InvalidOptions);
+    assert.eq("explain does not support 'foo' argument.", explain.errmsg);
 
-explain = db.runCommand({
-  explain: { find: collName },
-  foo: 1,
-  bar: 1
-});
-assert.commandFailedWithCode(explain, ErrorCodes.InvalidOptions);
-assert.eq("explain does not support 'foo' argument.", explain.errmsg);
+    explain = db.runCommand({
+        explain: { find: collName },
+        foo: 1,
+        bar: 1
+    });
+    assert.commandFailedWithCode(explain, ErrorCodes.InvalidOptions);
+    assert.eq("explain does not support 'foo' argument.", explain.errmsg);
 
-explain = db.runCommand({
-  explain: { find: collName },
-  foo: 1,
-  verbosity: "executionStats",
-  bar: 1
-});
-assert.commandFailedWithCode(explain, ErrorCodes.InvalidOptions);
-assert.eq("explain does not support 'foo' argument.", explain.errmsg);
+    explain = db.runCommand({
+        explain: { find: collName },
+        foo: 1,
+        verbosity: "executionStats",
+        bar: 1
+    });
+    assert.commandFailedWithCode(explain, ErrorCodes.InvalidOptions);
+    assert.eq("explain does not support 'foo' argument.", explain.errmsg);
 
-explain = db.runCommand({
-  explain: { find: collName },
-  explain: {},
-  bar: 1
-});
-assert.commandFailedWithCode(explain, ErrorCodes.InvalidOptions);
-assert.eq("explain does not support 'bar' argument.", explain.errmsg);
+    explain = db.runCommand({
+        explain: { find: collName },
+        explain: {},
+        bar: 1
+    });
+    assert.commandFailedWithCode(explain, ErrorCodes.InvalidOptions);
+    assert.eq("explain does not support 'bar' argument.", explain.errmsg);
+})();

--- a/jstests/core/explain_invalid_arguments.js
+++ b/jstests/core/explain_invalid_arguments.js
@@ -3,53 +3,30 @@
  *  -- SERVER-27976 Do not accept unknown argument for the explain command.
  */
 (function() {
-    "use strict";
+"use strict";
 
-    var collName = "jstests_explain_invalid_arguments";
+var collName = "jstests_explain_invalid_arguments";
 
-    var explain = db.runCommand({
-        explain: { find: collName },
-        verbosity: "executionStats"
-    });
-    assert.commandWorked(explain);
+var explain = db.runCommand({explain: {find: collName}, verbosity: "executionStats"});
+assert.commandWorked(explain);
 
-    explain = db.runCommand({
-        explain: { find: collName },
-        verosity: "executionStats"
-    });
-    assert.commandFailedWithCode(explain, ErrorCodes.InvalidOptions);
-    assert.eq("explain does not support 'verosity' argument.", explain.errmsg);
+explain = db.runCommand({explain: {find: collName}, verosity: "executionStats"});
+assert.commandFailedWithCode(explain, ErrorCodes.InvalidOptions);
+assert.eq("explain does not support 'verosity' argument.", explain.errmsg);
 
-    explain = db.runCommand({
-        explain: { find: collName },
-        verbosity: "executionStats",
-        foo: 1
-    });
-    assert.commandFailedWithCode(explain, ErrorCodes.InvalidOptions);
-    assert.eq("explain does not support 'foo' argument.", explain.errmsg);
+explain = db.runCommand({explain: {find: collName}, verbosity: "executionStats", foo: 1});
+assert.commandFailedWithCode(explain, ErrorCodes.InvalidOptions);
+assert.eq("explain does not support 'foo' argument.", explain.errmsg);
 
-    explain = db.runCommand({
-        explain: { find: collName },
-        foo: 1,
-        bar: 1
-    });
-    assert.commandFailedWithCode(explain, ErrorCodes.InvalidOptions);
-    assert.eq("explain does not support 'foo' argument.", explain.errmsg);
+explain = db.runCommand({explain: {find: collName}, foo: 1, bar: 1});
+assert.commandFailedWithCode(explain, ErrorCodes.InvalidOptions);
+assert.eq("explain does not support 'foo' argument.", explain.errmsg);
 
-    explain = db.runCommand({
-        explain: { find: collName },
-        foo: 1,
-        verbosity: "executionStats",
-        bar: 1
-    });
-    assert.commandFailedWithCode(explain, ErrorCodes.InvalidOptions);
-    assert.eq("explain does not support 'foo' argument.", explain.errmsg);
+explain = db.runCommand({explain: {find: collName}, foo: 1, verbosity: "executionStats", bar: 1});
+assert.commandFailedWithCode(explain, ErrorCodes.InvalidOptions);
+assert.eq("explain does not support 'foo' argument.", explain.errmsg);
 
-    explain = db.runCommand({
-        explain: { find: collName },
-        explain: {},
-        bar: 1
-    });
-    assert.commandFailedWithCode(explain, ErrorCodes.InvalidOptions);
-    assert.eq("explain does not support 'bar' argument.", explain.errmsg);
+explain = db.runCommand({explain: {find: collName}, explain: {}, bar: 1});
+assert.commandFailedWithCode(explain, ErrorCodes.InvalidOptions);
+assert.eq("explain does not support 'bar' argument.", explain.errmsg);
 })();

--- a/src/mongo/db/query/explain_options.cpp
+++ b/src/mongo/db/query/explain_options.cpp
@@ -59,6 +59,7 @@ StatusWith<ExplainOptions::Verbosity> ExplainOptions::parseCmdBSON(const BSONObj
         return Status(ErrorCodes::FailedToParse, "explain command requires a nested object");
     }
 
+    bool verbositySpecified = false;
     auto verbosity = Verbosity::kExecAllPlans;
     if (auto verbosityElt = cmdObj[kVerbosityName]) {
         if (verbosityElt.type() != BSONType::String) {
@@ -77,7 +78,11 @@ StatusWith<ExplainOptions::Verbosity> ExplainOptions::parseCmdBSON(const BSONObj
                               << "', '" << kExecStatsVerbosityStr << "', '"
                               << kAllPlansExecutionVerbosityStr << "'}");
         }
+        verbositySpecified = true;
     }
+    uassert(ErrorCodes::InvalidOptions,
+            str::stream() << "explain command requires a single argument with an optional verbosity",
+            cmdObj.nFields() == (verbositySpecified ? 3 : 2));
 
     return verbosity;
 }

--- a/src/mongo/db/query/explain_options.cpp
+++ b/src/mongo/db/query/explain_options.cpp
@@ -80,11 +80,20 @@ StatusWith<ExplainOptions::Verbosity> ExplainOptions::parseCmdBSON(const BSONObj
         }
         verbositySpecified = true;
     }
-    if (cmdObj.nFields() != (verbositySpecified ? 2 : 1)) {
-        return Status(
-            ErrorCodes::InvalidOptions,
-            str::stream()
-                << "explain command requires a single argument with an optional verbosity.");
+
+    int numFields = 0;
+    BSONObjIterator i(cmdObj);
+    while (i.moreWithEOO()) {
+        BSONElement e = i.next();
+        if (e.eoo())
+            break;
+        if (e.fieldNameStringData() == "$db")
+            continue;
+        numFields++;
+    }
+    if (numFields != (verbositySpecified ? 2 : 1)) {
+        return Status(ErrorCodes::InvalidOptions,
+                      str::stream() << "explain command supports an optional verbosity argument.");
     }
     return verbosity;
 }

--- a/src/mongo/db/query/explain_options.cpp
+++ b/src/mongo/db/query/explain_options.cpp
@@ -80,9 +80,10 @@ StatusWith<ExplainOptions::Verbosity> ExplainOptions::parseCmdBSON(const BSONObj
         }
         verbositySpecified = true;
     }
-    uassert(ErrorCodes::InvalidOptions,
-            str::stream() << "explain command requires a single argument with an optional verbosity",
-            cmdObj.nFields() == (verbositySpecified ? 3 : 2));
+    uassert(
+        ErrorCodes::InvalidOptions,
+        str::stream() << "explain command requires a single argument with an optional verbosity",
+        cmdObj.nFields() == (verbositySpecified ? 3 : 2));
 
     return verbosity;
 }

--- a/src/mongo/db/query/explain_options.cpp
+++ b/src/mongo/db/query/explain_options.cpp
@@ -80,11 +80,12 @@ StatusWith<ExplainOptions::Verbosity> ExplainOptions::parseCmdBSON(const BSONObj
         }
         verbositySpecified = true;
     }
-    uassert(
-        ErrorCodes::InvalidOptions,
-        str::stream() << "explain command requires a single argument with an optional verbosity",
-        cmdObj.nFields() == (verbositySpecified ? 3 : 2));
-
+    if (cmdObj.nFields() != (verbositySpecified ? 2 : 1)) {
+        return Status(
+            ErrorCodes::InvalidOptions,
+            str::stream()
+                << "explain command requires a single argument with an optional verbosity.");
+    }
     return verbosity;
 }
 

--- a/src/mongo/db/query/explain_options.cpp
+++ b/src/mongo/db/query/explain_options.cpp
@@ -37,6 +37,8 @@
 namespace mongo {
 
 constexpr StringData ExplainOptions::kVerbosityName;
+constexpr StringData ExplainOptions::kDatabaseName;
+constexpr StringData ExplainOptions::kLogicalSessionIdName;
 constexpr StringData ExplainOptions::kQueryPlannerVerbosityStr;
 constexpr StringData ExplainOptions::kExecStatsVerbosityStr;
 constexpr StringData ExplainOptions::kAllPlansExecutionVerbosityStr;
@@ -90,7 +92,7 @@ StatusWith<ExplainOptions::Verbosity> ExplainOptions::parseCmdBSON(const BSONObj
         if (e.eoo())
             break;
         auto name = e.fieldNameStringData();
-        if (name == kVerbosityName || name == "$db" || name == "lsid")
+        if (name == kVerbosityName || name == kDatabaseName || name == kLogicalSessionIdName)
             continue;
 
         if (invalidFields.ss.len() > 0) {

--- a/src/mongo/db/query/explain_options.h
+++ b/src/mongo/db/query/explain_options.h
@@ -61,6 +61,8 @@ public:
     };
 
     static constexpr StringData kVerbosityName = "verbosity"_sd;
+    static constexpr StringData kDatabaseName = "$db"_sd;
+    static constexpr StringData kLogicalSessionIdName = "lsid"_sd;
 
     // String representations for verbosity levels.
     static constexpr StringData kQueryPlannerVerbosityStr = "queryPlanner"_sd;

--- a/src/mongo/db/query/explain_options_test.cpp
+++ b/src/mongo/db/query/explain_options_test.cpp
@@ -61,6 +61,8 @@ TEST(ExplainOptionsTest, ExplainOptionsSerializeToBSONCorrectly) {
 }
 
 TEST(ExplainOptionsTest, InvalidOptionsIfAgumentNotRecognized) {
+    ASSERT(
+        ExplainOptions::parseCmdBSON(fromjson("{explain: { find: \"bar\" }}")).getStatus().isOK());
     ASSERT_EQ(ExplainOptions::parseCmdBSON(fromjson("{explain: {}, foo: 1}")).getStatus(),
               ErrorCodes::InvalidOptions);
     ASSERT_EQ(

--- a/src/mongo/db/query/explain_options_test.cpp
+++ b/src/mongo/db/query/explain_options_test.cpp
@@ -60,6 +60,18 @@ TEST(ExplainOptionsTest, ExplainOptionsSerializeToBSONCorrectly) {
                       ExplainOptions::toBSON(ExplainOptions::Verbosity::kExecAllPlans));
 }
 
+TEST(ExplainOptionsTest, InvalidOptionsIfAgumentNotRecognized) {
+    ASSERT_EQ(ExplainOptions::parseCmdBSON(fromjson("{explain: {}, foo: 1}")).getStatus(),
+              ErrorCodes::InvalidOptions);
+    ASSERT_EQ(
+        ExplainOptions::parseCmdBSON(fromjson("{explain: {}, verbosity: 'queryPlanner', foo: 1}"))
+            .getStatus(),
+        ErrorCodes::InvalidOptions);
+    ASSERT_EQ(
+        ExplainOptions::parseCmdBSON(fromjson("{explain: {}, verosity: {foo: 'bar'}}")).getStatus(),
+        ErrorCodes::InvalidOptions);
+}
+
 TEST(ExplainOptionsTest, CanParseExplainVerbosity) {
     auto verbosity = unittest::assertGet(
         ExplainOptions::parseCmdBSON(fromjson("{explain: {}, verbosity: 'queryPlanner'}")));


### PR DESCRIPTION
Example error message added with this PR:
```js
> db.runCommand({explain: {find: "c"}, unknownArg: "unknown"})
{
	"ok" : 0,
	"errmsg" : "explain command requires a single argument with an optional verbosity",
	"code" : 72,
	"codeName" : "InvalidOptions"
}
```