### PR TITLE
SERVER-42964 Wrong ulimit recommended settings link in init / systemd files

### DIFF
--- a/debian/init.d
+++ b/debian/init.d
@@ -126,7 +126,7 @@ running() {
 
 start_server() {
             # Recommended ulimit values for mongod or mongos
-            # See http://docs.mongodb.org/manual/reference/ulimit/#recommended-settings
+            # See https://docs.mongodb.com/manual/reference/ulimit/#recommended-ulimit-settings
             #
             ulimit -f unlimited
             ulimit -t unlimited

--- a/debian/mongod.service
+++ b/debian/mongod.service
@@ -26,7 +26,7 @@ TasksMax=infinity
 TasksAccounting=false
 
 # Recommended limits for for mongod as specified in
-# http://docs.mongodb.org/manual/reference/ulimit/#recommended-settings
+# https://docs.mongodb.com/manual/reference/ulimit/#recommended-ulimit-settings
 
 [Install]
 WantedBy=multi-user.target

--- a/debian/mongod.upstart
+++ b/debian/mongod.upstart
@@ -1,7 +1,7 @@
 # Ubuntu upstart file at /etc/init/mongod.conf
 
 # Recommended ulimit values for mongod or mongos
-# See http://docs.mongodb.org/manual/reference/ulimit/#recommended-settings
+# See https://docs.mongodb.com/manual/reference/ulimit/#recommended-ulimit-settings
 #
 limit fsize unlimited unlimited
 limit cpu unlimited unlimited

--- a/rpm/init.d-mongod
+++ b/rpm/init.d-mongod
@@ -56,7 +56,7 @@ start()
   fi
 
   # Recommended ulimit values for mongod or mongos
-  # See http://docs.mongodb.org/manual/reference/ulimit/#recommended-settings
+  # See https://docs.mongodb.com/manual/reference/ulimit/#recommended-ulimit-settings
   #
   ulimit -f unlimited
   ulimit -t unlimited

--- a/rpm/init.d-mongod.suse
+++ b/rpm/init.d-mongod.suse
@@ -57,7 +57,7 @@ start()
   fi
 
   # Recommended ulimit values for mongod or mongos
-  # See http://docs.mongodb.org/manual/reference/ulimit/#recommended-settings
+  # See https://docs.mongodb.com/manual/reference/ulimit/#recommended-ulimit-settings
   #
   ulimit -f unlimited
   ulimit -t unlimited

--- a/rpm/mongod.service
+++ b/rpm/mongod.service
@@ -31,7 +31,7 @@ LimitMEMLOCK=infinity
 TasksMax=infinity
 TasksAccounting=false
 # Recommended limits for for mongod as specified in
-# http://docs.mongodb.org/manual/reference/ulimit/#recommended-settings
+# https://docs.mongodb.com/manual/reference/ulimit/#recommended-ulimit-settings
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This PR updates the referenced ulimit recommended settings documentation link in all init and systemd service files.