### PR TITLE
SConstruct: Remove invalid 'f' char

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -359,8 +359,8 @@ for pack in [
     pretty = name
     if len(pack) == 2:
         pretty = pack[1]
-    add_option(f'use-system-{name}',
-               help=f'use system version of {pretty} library',
+    add_option('use-system-{name}',
+               help='use system version of {pretty} library',
                nargs=0)
 
 add_option('system-boost-lib-search-suffixes',


### PR DESCRIPTION
Fixes: 3abf0cce9db6("SERVER-33259 add libunwind to third_party")
Signed-off-by: Xiao Yang <xiaox.yang@intel.com>