### PR TITLE
SERVER-44035 Remove duplicate item from allowedFieldNames

### DIFF
--- a/src/mongo/db/catalog/index_key_validate.cpp
+++ b/src/mongo/db/catalog/index_key_validate.cpp
@@ -71,7 +71,6 @@ namespace {
 MONGO_FAIL_POINT_DEFINE(skipIndexCreateFieldNameValidation);
 
 static std::set<StringData> allowedFieldNames = {
-    IndexDescriptor::k2dIndexMaxFieldName,
     IndexDescriptor::k2dIndexBitsFieldName,
     IndexDescriptor::k2dIndexMaxFieldName,
     IndexDescriptor::k2dIndexMinFieldName,


### PR DESCRIPTION
`IndexDescriptor::k2dIndexBitsFieldName` is listed in the set twice.