### PR TITLE
Make compilation_db decider compatible with scons 2.

### DIFF
--- a/site_scons/site_tools/compilation_db.py
+++ b/site_scons/site_tools/compilation_db.py
@@ -49,7 +49,7 @@ class __CompilationDbNode(SCons.Node.Python.Value):
         self.Decider(changed_since_last_build_node)
 
 
-def changed_since_last_build_node(child, target, prev_ni, node):
+def changed_since_last_build_node(child, target, prev_ni, node=None):
     """ Dummy decider to force always building"""
     return True
 


### PR DESCRIPTION
This allows the compilation_db tool to be used in projects that still use scons 2.