### PR TITLE
SERVER-44974 Typo in debian/mongod.service

### DIFF
--- a/debian/mongod.service
+++ b/debian/mongod.service
@@ -25,7 +25,7 @@ LimitMEMLOCK=infinity
 TasksMax=infinity
 TasksAccounting=false
 
-# Recommended limits for for mongod as specified in
+# Recommended limits for mongod as specified in
 # https://docs.mongodb.com/manual/reference/ulimit/#recommended-ulimit-settings
 
 [Install]


### PR DESCRIPTION
Removed extra 'for'