### PR TITLE
SERVER-45063 fix: fix the bug in mongo::uriDecode

### DIFF
--- a/src/mongo/client/mongo_uri.cpp
+++ b/src/mongo/client/mongo_uri.cpp
@@ -86,7 +86,7 @@ mongo::StatusWith<std::string> mongo::uriDecode(StringData toDecode) {
     for (size_t i = 0; i < toDecode.size(); ++i) {
         const char c = toDecode[i];
         if (c == '%') {
-            if (i + 2 > toDecode.size()) {
+            if (i + 2 >= toDecode.size()) {
                 return Status(ErrorCodes::FailedToParse,
                               "Encountered partial escape sequence at end of string");
             }


### PR DESCRIPTION
In mongo, we use mongo::uriDecode to decode the encoded uri. But there is a bug in corner case. For example: 
If the toDecode string is ```%2```(the %2 must be a wrong uri, because it is partial escape sequence at end of string), the size of toDecode is 2. when i is 0, i + 2 = 2,  so i + 2 > toDecode.size() is not satisfied, so the process does not enter the branch of ```if (i + 2 > toDecode.size()) ```,  which would return a right status like this:
```return Status(ErrorCodes::FailedToParse, "Encountered partial escape sequence at end of string")```