### PR TITLE
BF-15988: Disable tool_replset for ephemeralForTest storage engine

### DIFF
--- a/jstests/tool/tool_replset.js
+++ b/jstests/tool/tool_replset.js
@@ -10,6 +10,7 @@
  * 8. Import the collection.
  */
 
+// @tags: [requires_persistence]
 (function() {
 "use strict";
 


### PR DESCRIPTION
evergreen: https://evergreen.mongodb.com/version/5e2ddc0c32f4172d758171d0

We can see the test is still running on WT tests, and that ephemeralForTest is now green.