### PR TITLE
SERVER-33871 - Stricter systemd .service settings

### DIFF
--- a/debian/mongod.service
+++ b/debian/mongod.service
@@ -24,6 +24,12 @@ LimitMEMLOCK=infinity
 # total threads (user+kernel)
 TasksMax=infinity
 TasksAccounting=false
+# read-only /usr, /boot, /etc
+ProtectSystem=full
+# inaccessible /home, /root and /run/user
+ProtectHome=true
+# remove CAP_SYS_PTRACE kernel capability
+CapabilityBoundingSet=~CAP_SYS_PTRACE
 
 # Recommended limits for mongod as specified in
 # https://docs.mongodb.com/manual/reference/ulimit/#recommended-ulimit-settings

--- a/rpm/mongod.service
+++ b/rpm/mongod.service
@@ -30,6 +30,13 @@ LimitMEMLOCK=infinity
 # total threads (user+kernel)
 TasksMax=infinity
 TasksAccounting=false
+# read-only /usr, /boot, /etc
+ProtectSystem=full
+# inaccessible /home, /root and /run/user
+ProtectHome=true
+# remove CAP_SYS_PTRACE kernel capability
+CapabilityBoundingSet=~CAP_SYS_PTRACE
+
 # Recommended limits for mongod as specified in
 # https://docs.mongodb.com/manual/reference/ulimit/#recommended-ulimit-settings
 


### PR DESCRIPTION
Stricter systemd .service settings.
Using ProtectSystem, ProtectHome and removing the CAP_SYS_PTRACE capability.

Tested on Ubuntu and Centos.

Short version at https://github.com/konstruktoid/hardening/blob/master/systemd.adoc#unit-configuration and official documentation http://0pointer.de/public/systemd-man/systemd.exec.html.

New PR since unset upstream and rebased, closes #1224 