### PR TITLE
MSI installer produces incorrect config file

### DIFF
--- a/src/mongo/installer/msi/ca/CustomAction.cpp
+++ b/src/mongo/installer/msi/ca/CustomAction.cpp
@@ -331,6 +331,9 @@ extern "C" UINT __stdcall UpdateMongoYAML(MSIHANDLE hInstall) {
         DWORD written;
         if (!WriteFile(hFile, str.c_str(), str.length(), &written, NULL)) {
             CHECKGLE_AND_LOG("Failed to write yaml file");
+        }        
+        if (!SetEndOfFile(hFile) {
+            CHECKGLE_AND_LOG("Failed to truncate yaml file");
         }
     } catch (const std::exception& e) {
         CHECKHR_AND_LOG(E_FAIL, "Caught C++ exception %s", e.what());


### PR DESCRIPTION
If the user selects a shorter path of the log file or data directory, the written buffer is shorter than the original content, and the remaining part of the file is not truncate automatically. This leads to an incorrect config file, and thus the mongod service cannot start. 

(I hope that I haven't done some silly mistake - C++ is really not my language)