### PR TITLE
Fix bug in wiredTiger parameter for cache

### DIFF
--- a/src/mongo/db/storage/wiredtiger/wiredtiger_global_options.idl
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_global_options.idl
@@ -44,6 +44,7 @@ configs:
         cpp_varname: 'wiredTigerGlobalOptions.cacheSizeGB'
         short_name: wiredTigerCacheSizeGB
         validator:
+            gte: 0.25
             lte: 10000
     "storage.wiredTiger.engineConfig.statisticsLogDelaySecs":
         # FTDC supercedes WiredTiger's statistics logging.


### PR DESCRIPTION
## Summary

According to mongo docs, the [wiredTiger parameter](https://docs.mongodb.com/manual/reference/program/mongod/#cmdoption-mongod-wiredtigercachesizegb) to limit the cache size should be between 0.25 and 10000:

> --wiredTigerCacheSizeGB <float>
Defines the maximum size of the internal cache that WiredTiger will use for all data. The memory consumed by an index build (see maxIndexBuildMemoryUsageMegabytes) is separate from the WiredTiger cache memory.

> Values can range from 0.25 GB to 10000 GB.



However, the option `--wiredTigerCacheSizeGB` does not enforce the limits stated in documentation. It even validly takes 0!

```
C:\Users\jweinstein\splunk\primary\main>"C:\Program Files\MongoDB\Server\3.6\bin\mongod.exe" --wiredTigerCacheSizeGB 0
2020-04-23T21:29:52.120-0700 I CONTROL  [initandlisten] MongoDB starting : pid=28000 port=27017 dbpath=C:\data\db\ 64-bit host=jweinstein-X1C1
2020-04-23T21:29:52.121-0700 I CONTROL  [initandlisten] targetMinOS: Windows 7/Windows Server 2008 R2
2020-04-23T21:29:52.122-0700 I CONTROL  [initandlisten] db version v3.6.17
2020-04-23T21:29:52.122-0700 I CONTROL  [initandlisten] git version: 3d6953c361213c5bfab23e51ab274ce592edafe6
2020-04-23T21:29:52.122-0700 I CONTROL  [initandlisten] OpenSSL version: OpenSSL 1.0.2s-fips  28 May 2019
2020-04-23T21:29:52.122-0700 I CONTROL  [initandlisten] allocator: tcmalloc
2020-04-23T21:29:52.122-0700 I CONTROL  [initandlisten] modules: none
2020-04-23T21:29:52.122-0700 I CONTROL  [initandlisten] build environment:
2020-04-23T21:29:52.122-0700 I CONTROL  [initandlisten]     distmod: 2008plus-ssl
2020-04-23T21:29:52.122-0700 I CONTROL  [initandlisten]     distarch: x86_64
2020-04-23T21:29:52.123-0700 I CONTROL  [initandlisten]     target_arch: x86_64
2020-04-23T21:29:52.123-0700 I CONTROL  [initandlisten] options: { storage: { wiredTiger: { engineConfig: { cacheSizeGB: 0.0 } } } }
2020-04-23T21:29:52.125-0700 I -        [initandlisten] Detected data files in C:\data\db\ created by the 'wiredTiger' storage engine, so setting the active storage engine to 'wiredTiger'.
2020-04-23T21:29:52.126-0700 I STORAGE  [initandlisten] wiredtiger_open config: create,cache_size=7597M,cache_overflow=(file_max=0M),session_max=20000,eviction=(threads_min=4,threads_max=4),config_base=false,statistics=(fast),compatibility=(release="3.0",require_max="3.0"),log=(enabled=true,archive=true,path=journal,compressor=snappy),file_manager=(close_idle_time=100000),statistics_log=(wait=0),verbose=(recovery_progress),
2020-04-23T21:29:52.264-0700 I STORAGE  [initandlisten] WiredTiger message [1587702592:263575][28000:140721335194208], txn-recover: Main recovery loop: starting at 2/4608
2020-04-23T21:29:52.391-0700 I STORAGE  [initandlisten] WiredTiger message [1587702592:391234][28000:140721335194208], txn-recover: Recovering log 2 through 3
2020-04-23T21:29:52.477-0700 I STORAGE  [initandlisten] WiredTiger message [1587702592:476882][28000:140721335194208], txn-recover: Recovering log 3 through 3
2020-04-23T21:29:52.525-0700 I STORAGE  [initandlisten] WiredTiger message [1587702592:524760][28000:140721335194208], txn-recover: Set global recovery timestamp: 0
2020-04-23T21:29:52.544-0700 I CONTROL  [initandlisten]
2020-04-23T21:29:52.544-0700 I CONTROL  [initandlisten] ** WARNING: Access control is not enabled for the database.
2020-04-23T21:29:52.545-0700 I CONTROL  [initandlisten] **          Read and write access to data and configuration is unrestricted.
2020-04-23T21:29:52.545-0700 I CONTROL  [initandlisten]
2020-04-23T21:29:52.545-0700 I CONTROL  [initandlisten] ** WARNING: This server is bound to localhost.
2020-04-23T21:29:52.545-0700 I CONTROL  [initandlisten] **          Remote systems will be unable to connect to this server.
2020-04-23T21:29:52.545-0700 I CONTROL  [initandlisten] **          Start the server with --bind_ip <address> to specify which IP
2020-04-23T21:29:52.545-0700 I CONTROL  [initandlisten] **          addresses it should serve responses from, or with --bind_ip_all to
2020-04-23T21:29:52.545-0700 I CONTROL  [initandlisten] **          bind to all interfaces. If this behavior is desired, start the
2020-04-23T21:29:52.545-0700 I CONTROL  [initandlisten] **          server with --bind_ip 127.0.0.1 to disable this warning.
2020-04-23T21:29:52.545-0700 I CONTROL  [initandlisten]
2020-04-23T21:29:52.713-0700 I FTDC     [initandlisten] Initializing full-time diagnostic data capture with directory 'C:/data/db/diagnostic.data'
2020-04-23T21:29:52.716-0700 I NETWORK  [initandlisten] listening via socket bound to 127.0.0.1
2020-04-23T21:29:52.716-0700 I NETWORK  [initandlisten] waiting for connections on port 27017
```

This fix just enforces the allowed ranges as stated in documentation