### PR TITLE
Fix mongod.cfg file size when replacing tokens in the custom action. …

### DIFF
--- a/src/mongo/installer/msi/ca/CustomAction.cpp
+++ b/src/mongo/installer/msi/ca/CustomAction.cpp
@@ -332,6 +332,9 @@ extern "C" UINT __stdcall UpdateMongoYAML(MSIHANDLE hInstall) {
         if (!WriteFile(hFile, str.c_str(), str.length(), &written, NULL)) {
             CHECKGLE_AND_LOG("Failed to write yaml file");
         }
+        if (!SetEndOfFile(hFile)) {
+            CHECKGLE_AND_LOG("Failed to truncate yaml file");
+        }
     } catch (const std::exception& e) {
         CHECKHR_AND_LOG(E_FAIL, "Caught C++ exception %s", e.what());
     } catch (...) {


### PR DESCRIPTION
…Fix https://jira.mongodb.org/browse/SERVER-47138

When the length of the new replacement texts is lesser than the length of the tokens, then the string object is larger than the text it holds
The fix writes the length of the text rather than of the string object