### PR TITLE
SERVER-48076: fixing the clang 10 compile error in bsonelement.h

### DIFF
--- a/src/mongo/bson/bsonelement.h
+++ b/src/mongo/bson/bsonelement.h
@@ -1018,9 +1018,22 @@ Status BSONElement::tryCoerce(T* out) const {
             if (!std::isfinite(d)) {
                 return {ErrorCodes::BadValue, "Unable to coerce NaN/Inf to integral type"};
             }
+
+            #if defined(__clang__)
+            // This branch is executed only when the type is double, but it gives the Clang compile warning
+            // when T is long long.
+            #pragma clang diagnostic push
+            #pragma clang diagnostic ignored "-Wimplicit-int-float-conversion"
+            #endif
+
             if ((d > std::numeric_limits<T>::max()) || (d < std::numeric_limits<T>::lowest())) {
                 return {ErrorCodes::BadValue, "Out of bounds coercing to integral value"};
             }
+
+            #if defined(__clang__)
+            #pragma clang diagnostic pop
+            #endif
+
         } else if (type() == NumberDecimal) {
             Decimal128 d = numberDecimal();
             if (!d.isFinite()) {


### PR DESCRIPTION
This fixes the compile error: https://jira.mongodb.org/browse/SERVER-48076

The idea is to make the most non-intrusive change - the code works properly when the branch

`if (type() == NumberDouble) {`

is actually visited. The compile errors happen only when template T is specialized on something else than 'double', e.g. 'long long', but the code is not executed when T is 'long log'. So my choice here is to suppress the warning and leave the code untouched, with comments.

This is reproduced with clang 10 and ninja build.