### PR TITLE
SERVER-52904 Status facelift

### DIFF
--- a/src/mongo/base/status.h
+++ b/src/mongo/base/status.h
@@ -31,76 +31,100 @@
 
 #include <iosfwd>
 #include <string>
+#include <type_traits>
+
+#include <boost/intrusive_ptr.hpp>
+#include <boost/smart_ptr/intrusive_ref_counter.hpp>
 
 #include "mongo/base/error_codes.h"
 #include "mongo/base/error_extra_info.h"
-#include "mongo/platform/atomic_word.h"
+#include "mongo/base/string_data.h"
+#include "mongo/bson/util/builder_fwd.h"
 #include "mongo/platform/compiler.h"
+#include "mongo/util/static_immortal.h"
+
+#define MONGO_INCLUDE_INVARIANT_H_WHITELISTED
+#include "mongo/util/invariant.h"
+#undef MONGO_INCLUDE_INVARIANT_H_WHITELISTED
 
 namespace mongo {
-
-namespace str {
-class stream;
-}  // namespace str
-
-// Including builder.h here would cause a cycle.
-template <typename Allocator>
-class StringBuilderImpl;
 
 /**
  * Status represents an error state or the absence thereof.
  *
- * A Status uses the standardized error codes -- from file 'error_codes.err' -- to
+ * A Status uses the standardized error codes from file "error_codes.yml" to
  * determine an error's cause. It further clarifies the error with a textual
  * description, and code-specific extra info (a subclass of ErrorExtraInfo).
  */
 class MONGO_WARN_UNUSED_RESULT_CLASS Status {
 public:
-    /**
-     * This is the best way to construct an OK status.
-     */
-    static inline Status OK();
+    /** This is the best way to construct an OK status. */
+    static Status OK() {
+        return {};
+    }
 
     /**
-     * Builds an error status given the error code and a textual description of what
-     * caused the error.
+     * Builds an error Status given the error code and a textual description of the error.
      *
-     * For OK Statuses prefer using Status::OK(). If code is OK, the remaining arguments are
-     * ignored.
+     * In all Status constructors, the `reason` is natively a `std::string`, but
+     * as a convenience it can be given as any type explicitly convertible to
+     * `std::string`, such as `const char*`, `StringData`, or `str::stream`, or
+     * `std::string_view`.
+     *
+     * If code is ErrorCodes::OK, the remaining arguments are ignored. Prefer
+     * using Status::OK(), to make an OK Status.
      *
      * For adding context to the reason string, use withContext/addContext rather than making a new
-     * Status manually.
+     * Status manually, as these functions apply a formatting convention.
      *
-     * If the status comes from a command reply, use getStatusFromCommandResult() instead of manual
+     * If the Status comes from a command reply, use getStatusFromCommandResult() instead of manual
      * parsing. If the status is round-tripping through non-command BSON, use the constructor that
      * takes a BSONObj so that it can extract the extra info if the code is supposed to have any.
      */
-    MONGO_COMPILER_COLD_FUNCTION Status(ErrorCodes::Error code, const std::string& reason);
-    MONGO_COMPILER_COLD_FUNCTION Status(ErrorCodes::Error code, const char* reason);
-    MONGO_COMPILER_COLD_FUNCTION Status(ErrorCodes::Error code, StringData reason);
-    MONGO_COMPILER_COLD_FUNCTION Status(ErrorCodes::Error code, const str::stream& reason);
-    MONGO_COMPILER_COLD_FUNCTION Status(ErrorCodes::Error code,
-                                        StringData message,
-                                        const BSONObj& extraInfoHolder);
+    MONGO_COMPILER_COLD_FUNCTION Status(ErrorCodes::Error code, std::string reason)
+        : Status{code, std::move(reason), nullptr} {}
+
+    template <typename Reason,
+              std::enable_if_t<std::is_constructible_v<std::string, Reason&&>, int> = 0>
+    MONGO_COMPILER_COLD_FUNCTION Status(ErrorCodes::Error code, Reason&& reason)
+        : Status{code, std::string{std::forward<Reason>(reason)}} {}
 
     /**
-     * Constructs a Status with a subclass of ErrorExtraInfo.
+     * Same as above, but with an attached BSON object carrying errorExtraInfo to be parsed.
+     * Parse is performed according to `code` and its associated ErrorExtraInfo subclass.
      */
-    template <typename T, typename = stdx::enable_if_t<std::is_base_of<ErrorExtraInfo, T>::value>>
-    MONGO_COMPILER_COLD_FUNCTION Status(T&& detail, StringData message)
-        : Status(T::code,
-                 message,
-                 std::make_shared<const std::remove_reference_t<T>>(std::forward<T>(detail))) {
-        MONGO_STATIC_ASSERT(std::is_same<error_details::ErrorExtraInfoFor<T::code>, T>());
+    MONGO_COMPILER_COLD_FUNCTION Status(ErrorCodes::Error code,
+                                        std::string reason,
+                                        const BSONObj& extraObj)
+        : _error{_parseErrorInfo(code, std::move(reason), extraObj)} {}
+
+    template <typename Reason,
+              std::enable_if_t<std::is_constructible_v<std::string, Reason&&>, int> = 0>
+    MONGO_COMPILER_COLD_FUNCTION Status(ErrorCodes::Error code,
+                                        Reason&& reason,
+                                        const BSONObj& extraObj)
+        : Status{code, std::string{std::forward<Reason>(reason)}, extraObj} {}
+
+    /**
+     * Builds a Status with a subclass of ErrorExtraInfo.
+     * The Status code is inferred from the static type of the `extra` parameter.
+     */
+    template <typename Extra, std::enable_if_t<std::is_base_of_v<ErrorExtraInfo, Extra>, int> = 0>
+    MONGO_COMPILER_COLD_FUNCTION Status(Extra&& extra, std::string reason)
+        : Status{
+              Extra::code,
+              std::move(reason),
+              std::make_shared<const std::remove_reference_t<Extra>>(std::forward<Extra>(extra))} {
+        MONGO_STATIC_ASSERT(std::is_same_v<error_details::ErrorExtraInfoFor<Extra::code>, Extra>);
     }
 
-    inline Status(const Status& other);
-    inline Status& operator=(const Status& other);
-
-    inline Status(Status&& other) noexcept;
-    inline Status& operator=(Status&& other) noexcept;
-
-    inline ~Status();
+    template <typename Extra,
+              typename Reason,
+              std::enable_if_t<std::is_base_of_v<ErrorExtraInfo, Extra> &&
+                                   std::is_constructible_v<std::string, Reason&&>,
+                               int> = 0>
+    MONGO_COMPILER_COLD_FUNCTION Status(Extra&& extra, Reason&& reason)
+        : Status{std::forward<Extra>(extra), std::string{std::forward<Reason>(reason)}} {}
 
     /**
      * Returns a new Status with the same data as this, but with the reason string replaced with
@@ -109,7 +133,15 @@ public:
      *
      * No-op when called on an OK status.
      */
-    Status withReason(StringData newReason) const;
+    Status withReason(std::string newReason) const {
+        return isOK() ? OK() : Status(code(), std::move(newReason), _error->extra);
+    }
+
+    template <typename Reason,
+              std::enable_if_t<std::is_constructible_v<std::string, Reason&&>, int> = 0>
+    Status withReason(Reason&& newReason) const {
+        return withReason(std::string{std::forward<Reason>(newReason)});
+    }
 
     /**
      * Returns a new Status with the same data as this, but with the reason string prefixed with
@@ -119,75 +151,50 @@ public:
      * No-op when called on an OK status.
      */
     Status withContext(StringData reasonPrefix) const;
+
     void addContext(StringData reasonPrefix) {
-        *this = this->withContext(reasonPrefix);
+        _error = withContext(reasonPrefix)._error;
     }
 
-    /**
-     * Only compares codes. Ignores reason strings.
-     */
-    bool operator==(const Status& other) const {
-        return code() == other.code();
-    }
-    bool operator!=(const Status& other) const {
-        return !(*this == other);
+    bool isOK() const {
+        return !_error;
     }
 
-    /**
-     * Compares this Status's code with an error code.
-     */
-    bool operator==(const ErrorCodes::Error other) const {
-        return code() == other;
-    }
-    bool operator!=(const ErrorCodes::Error other) const {
-        return !(*this == other);
+    ErrorCodes::Error code() const {
+        return _error ? _error->code : ErrorCodes::OK;
     }
 
-    //
-    // accessors
-    //
+    std::string codeString() const {
+        return ErrorCodes::errorString(code());
+    }
 
-    inline bool isOK() const;
-
-    inline ErrorCodes::Error code() const;
-
-    inline std::string codeString() const;
-
-
-    /**
-     * Returns the reason string or the empty string if isOK().
-     */
+    /** Returns the reason string or the empty string if isOK(). */
     const std::string& reason() const {
         if (_error)
             return _error->reason;
-
-        static const std::string empty;
-        return empty;
+        static StaticImmortal<const std::string> empty;
+        return *empty;
     }
 
-    /**
-     * Returns the generic ErrorExtraInfo if present.
-     */
-    const std::shared_ptr<const ErrorExtraInfo> extraInfo() const {
+    /** Returns the generic ErrorExtraInfo if present. */
+    std::shared_ptr<const ErrorExtraInfo> extraInfo() const {
         return isOK() ? nullptr : _error->extra;
     }
 
-    /**
-     * Returns a specific subclass of ErrorExtraInfo if the error code matches that type.
-     */
+    /** Returns a specific subclass of ErrorExtraInfo if the error code matches that type. */
     template <typename T>
     std::shared_ptr<const T> extraInfo() const {
-        MONGO_STATIC_ASSERT(std::is_base_of<ErrorExtraInfo, T>());
-        MONGO_STATIC_ASSERT(std::is_same<error_details::ErrorExtraInfoFor<T::code>, T>());
+        MONGO_STATIC_ASSERT(std::is_base_of_v<ErrorExtraInfo, T>);
+        MONGO_STATIC_ASSERT(std::is_same_v<error_details::ErrorExtraInfoFor<T::code>, T>);
 
         if (isOK())
-            return {};
+            return nullptr;
         if (code() != T::code)
-            return {};
+            return nullptr;
 
         if (!_error->extra) {
             invariant(!ErrorCodes::mustHaveExtraInfo(_error->code));
-            return {};
+            return nullptr;
         }
 
         // Can't use checked_cast due to include cycle.
@@ -197,20 +204,23 @@ public:
 
     std::string toString() const;
 
+    /**
+     * Serializes the "code", "codeName", "errmsg" (aka `Status::reason()`) in
+     * the canonical format used in the server command responses. If present,
+     * the `extraInfo()` object is also serialized to the builder.
+     */
     void serialize(BSONObjBuilder* builder) const;
 
-    /**
-     * May only be called if the status is *not OK*. Serializes the code, code name and reason in
-     * the canonical code/codeName/errmsg format used in the server command responses.
-     */
-    void serializeErrorToBSON(BSONObjBuilder* builder) const;
+    /** Same as `serialize`, but may only be called on non-OK Status. */
+    void serializeErrorToBSON(BSONObjBuilder* builder) const {
+        invariant(!isOK());
+        serialize(builder);
+    }
 
-    /**
-     * Returns true if this Status's code is a member of the given category.
-     */
+    /** Returns true if this Status's code is a member of the given category. */
     template <ErrorCategory category>
     bool isA() const {
-        return ErrorCodes::isA<category>(*this);
+        return ErrorCodes::isA<category>(code());
     }
 
     /**
@@ -231,117 +241,82 @@ public:
     void transitional_ignore() && noexcept {};
     void transitional_ignore() const& noexcept = delete;
 
-    //
-    // Below interface used for testing code only.
-    //
+    /** Only compares codes. Ignores reason strings. */
+    friend bool operator==(const Status& a, const Status& b) {
+        return a.code() == b.code();
+    }
+    friend bool operator!=(const Status& a, const Status& b) {
+        return !(a == b);
+    }
 
-    inline unsigned refCount() const;
-
-private:
-    // Private since it could result in a type mismatch between code and extraInfo.
-    MONGO_COMPILER_COLD_FUNCTION Status(ErrorCodes::Error code,
-                                        StringData reason,
-                                        std::shared_ptr<const ErrorExtraInfo>);
-    inline Status();
-
-    struct ErrorInfo {
-        AtomicWord<unsigned> refs;     // reference counter
-        const ErrorCodes::Error code;  // error code
-        const std::string reason;      // description of error cause
-        const std::shared_ptr<const ErrorExtraInfo> extra;
-
-        static ErrorInfo* create(ErrorCodes::Error code,
-                                 StringData reason,
-                                 std::shared_ptr<const ErrorExtraInfo> extra);
-
-        ErrorInfo(ErrorCodes::Error code, StringData reason, std::shared_ptr<const ErrorExtraInfo>);
-    };
-
-    ErrorInfo* _error;
+    /** Status and ErrorCodes::Error are symmetrically EqualityComparable. */
+    friend bool operator==(const Status& a, ErrorCodes::Error b) {
+        return a.code() == b;
+    }
+    friend bool operator!=(const Status& a, ErrorCodes::Error b) {
+        return !(a == b);
+    }
+    friend bool operator==(ErrorCodes::Error a, const Status& b) {
+        return b == a;
+    }
+    friend bool operator!=(ErrorCodes::Error a, const Status& b) {
+        return b != a;
+    }
 
     /**
-     * Increment/Decrement the reference counter inside an ErrorInfo
-     *
-     * @param error  ErrorInfo to be incremented
+     * A `std::ostream` receives a minimal Status representation:
+     *     os << codeString() << " " << reason();
+     * This leaves a trailing space if reason is empty (e.g. the OK Status).
      */
-    static inline void ref(ErrorInfo* error);
-    static inline void unref(ErrorInfo* error);
+    friend std::ostream& operator<<(std::ostream& os, const Status& status) {
+        return status._streamTo(os);
+    }
+
+    /**
+     * A `StringBuilder` receives the serialized errorInfo:
+     *
+     * For an isOK() Status:
+     *     os << codeString();
+     * Otherwise:
+     *     os << codeString()
+     *        << serializedErrorInfo // if present
+     *        << ": " << reason()
+     */
+    friend StringBuilder& operator<<(StringBuilder& os, const Status& status) {
+        return status._streamTo(os);
+    }
+
+private:
+    struct ErrorInfo : boost::intrusive_ref_counter<ErrorInfo> {
+        ErrorInfo(ErrorCodes::Error code,
+                  std::string reason,
+                  std::shared_ptr<const ErrorExtraInfo> extra)
+            : code{code}, reason{std::move(reason)}, extra{std::move(extra)} {}
+
+        ErrorCodes::Error code;
+        std::string reason;
+        std::shared_ptr<const ErrorExtraInfo> extra;
+    };
+
+    static boost::intrusive_ptr<const ErrorInfo> _createErrorInfo(
+        ErrorCodes::Error code, std::string reason, std::shared_ptr<const ErrorExtraInfo> extra);
+
+    static boost::intrusive_ptr<const ErrorInfo> _parseErrorInfo(ErrorCodes::Error code,
+                                                                 std::string reason,
+                                                                 const BSONObj& extraObj);
+
+    Status() = default;
+
+    // Private since it could result in a type mismatch between code and extraInfo.
+    MONGO_COMPILER_COLD_FUNCTION Status(ErrorCodes::Error code,
+                                        std::string reason,
+                                        std::shared_ptr<const ErrorExtraInfo> extra)
+        : _error{_createErrorInfo(code, std::move(reason), std::move(extra))} {}
+
+    std::ostream& _streamTo(std::ostream& os) const;
+    StringBuilder& _streamTo(StringBuilder& os) const;
+
+    boost::intrusive_ptr<const ErrorInfo> _error;
 };
-
-inline bool operator==(const ErrorCodes::Error lhs, const Status& rhs);
-
-inline bool operator!=(const ErrorCodes::Error lhs, const Status& rhs);
-
-std::ostream& operator<<(std::ostream& os, const Status& status);
-
-// This is only implemented for StringBuilder, not StackStringBuilder.
-template <typename Allocator>
-StringBuilderImpl<Allocator>& operator<<(StringBuilderImpl<Allocator>& os, const Status& status);
-
-inline Status Status::OK() {
-    return Status();
-}
-
-inline Status::Status(const Status& other) : _error(other._error) {
-    ref(_error);
-}
-
-inline Status& Status::operator=(const Status& other) {
-    ref(other._error);
-    unref(_error);
-    _error = other._error;
-    return *this;
-}
-
-inline Status::Status(Status&& other) noexcept : _error(other._error) {
-    other._error = nullptr;
-}
-
-inline Status& Status::operator=(Status&& other) noexcept {
-    unref(_error);
-    _error = other._error;
-    other._error = nullptr;
-    return *this;
-}
-
-inline Status::~Status() {
-    unref(_error);
-}
-
-inline bool Status::isOK() const {
-    return !_error;
-}
-
-inline ErrorCodes::Error Status::code() const {
-    return _error ? _error->code : ErrorCodes::OK;
-}
-
-inline std::string Status::codeString() const {
-    return ErrorCodes::errorString(code());
-}
-
-inline unsigned Status::refCount() const {
-    return _error ? _error->refs.load() : 0;
-}
-
-inline Status::Status() : _error(nullptr) {}
-
-inline void Status::ref(ErrorInfo* error) {
-    if (error)
-        error->refs.fetchAndAdd(1);
-}
-
-inline void Status::unref(ErrorInfo* error) {
-    if (error && (error->refs.subtractAndFetch(1) == 0))
-        delete error;
-}
-
-inline bool operator==(const ErrorCodes::Error lhs, const Status& rhs) {
-    return rhs == lhs;
-}
-
-inline bool operator!=(const ErrorCodes::Error lhs, const Status& rhs) {
-    return rhs != lhs;
-}
 
 }  // namespace mongo

--- a/src/mongo/base/status_test.cpp
+++ b/src/mongo/base/status_test.cpp
@@ -32,6 +32,7 @@
 #include <string>
 
 #include <boost/exception/exception.hpp>
+#include <fmt/format.h>
 
 #include "mongo/base/status.h"
 #include "mongo/config.h"
@@ -43,30 +44,102 @@
 namespace mongo {
 namespace {
 
-TEST(Basic, Accessors) {
+using namespace fmt::literals;
+
+static constexpr const char* kReason = "reason";
+static const std::string& kReasonString = *new std::string{kReason};
+
+// Check a reason argument specified in various types.
+template <typename R>
+void checkReason(R&& r, std::string expected = kReasonString) {
+    ASSERT_EQUALS(Status(ErrorCodes::MaxError, std::forward<R>(r)).reason(), expected)
+        << "type {}"_format(demangleName(typeid(decltype(r))));
+};
+
+struct CanString {
+    operator std::string() const {
+        return kReason;
+    }
+};
+
+struct CanStringExplicit {
+    explicit operator std::string() const {
+        return kReason;
+    }
+};
+
+struct CanStringOrStringData {
+    operator StringData() const {
+        return "bad choice"_sd;
+    }
+    operator std::string() const {
+        return "good choice";
+    }
+};
+
+struct CanStringRef {
+    operator const std::string&() const {
+        return kReasonString;
+    }
+};
+
+template <typename... Args>
+constexpr bool usableStatusArgs = std::is_constructible_v<Status, Args...>;
+
+TEST(Status, ReasonStrings) {
+    // Try several types of `reason` arguments.
+    checkReason(kReason);
+    checkReason(kReasonString);
+    checkReason(std::string_view{kReason});
+    checkReason(std::string{kReason});
+    checkReason(StringData{kReason});
+    checkReason(str::stream{} << kReason);
+    checkReason(CanStringOrStringData{}, "good choice");
+    checkReason(CanStringRef{});
+
+    ASSERT((usableStatusArgs<ErrorCodes::Error, std::string>));
+    ASSERT((usableStatusArgs<ErrorCodes::Error, std::string&>));
+    ASSERT((usableStatusArgs<ErrorCodes::Error, const std::string&>));
+    ASSERT((usableStatusArgs<ErrorCodes::Error, std::string&&>));
+    ASSERT((usableStatusArgs<ErrorCodes::Error, StringData>));
+    ASSERT((usableStatusArgs<ErrorCodes::Error, StringData&>));
+    ASSERT((usableStatusArgs<ErrorCodes::Error, const StringData&>));
+    ASSERT((usableStatusArgs<ErrorCodes::Error, StringData&&>));
+    ASSERT((!usableStatusArgs<ErrorCodes::Error, boost::optional<std::string>>));
+    ASSERT((usableStatusArgs<ErrorCodes::Error, CanString>));
+    ASSERT((usableStatusArgs<ErrorCodes::Error, CanStringExplicit>));
+    ASSERT((usableStatusArgs<ErrorCodes::Error, CanStringOrStringData>));
+    ASSERT((usableStatusArgs<ErrorCodes::Error, CanStringRef>));
+    ASSERT((usableStatusArgs<ErrorCodes::Error, std::reference_wrapper<std::string>>));
+    ASSERT((usableStatusArgs<ErrorCodes::Error, std::reference_wrapper<const std::string>>));
+    ASSERT((usableStatusArgs<ErrorCodes::Error, std::reference_wrapper<const char*>>));
+    ASSERT((usableStatusArgs<ErrorCodes::Error, std::reference_wrapper<const char*>>));
+}
+
+TEST(Status, Accessors) {
     Status status(ErrorCodes::MaxError, "error");
     ASSERT_EQUALS(status.code(), ErrorCodes::MaxError);
     ASSERT_EQUALS(status.reason(), "error");
 }
 
-TEST(Basic, IsA) {
+TEST(Status, IsA) {
     ASSERT(!Status(ErrorCodes::BadValue, "").isA<ErrorCategory::Interruption>());
     ASSERT(Status(ErrorCodes::Interrupted, "").isA<ErrorCategory::Interruption>());
     ASSERT(!Status(ErrorCodes::Interrupted, "").isA<ErrorCategory::ShutdownError>());
 }
 
-TEST(Basic, OKIsAValidStatus) {
+TEST(Status, OKIsAValidStatus) {
     Status status = Status::OK();
     ASSERT_EQUALS(status.code(), ErrorCodes::OK);
 }
 
-TEST(Basic, Compare) {
+TEST(Status, Compare) {
     Status errMax(ErrorCodes::MaxError, "error");
     ASSERT_EQ(errMax, errMax);
     ASSERT_NE(errMax, Status::OK());
 }
 
-TEST(Basic, WithReason) {
+TEST(Status, WithReason) {
     const Status orig(ErrorCodes::MaxError, "error");
 
     const auto copy = orig.withReason("reason");
@@ -77,162 +150,100 @@ TEST(Basic, WithReason) {
     ASSERT_EQ(orig.reason(), "error");
 }
 
-TEST(Basic, WithContext) {
+TEST(Status, WithContext) {
     const Status orig(ErrorCodes::MaxError, "error");
 
     const auto copy = orig.withContext("context");
     ASSERT_EQ(copy.code(), ErrorCodes::MaxError);
-    ASSERT(str::startsWith(copy.reason(), "context ")) << copy.reason();
-    ASSERT(str::endsWith(copy.reason(), " error")) << copy.reason();
+    ASSERT_STRING_SEARCH_REGEX(copy.reason(), "^context .* error$");
 
     ASSERT_EQ(orig.code(), ErrorCodes::MaxError);
     ASSERT_EQ(orig.reason(), "error");
 }
 
-TEST(Cloning, Copy) {
+TEST(Status, CloningCopy) {
     Status orig(ErrorCodes::MaxError, "error");
-    ASSERT_EQUALS(orig.refCount(), 1U);
-
     Status dest(orig);
     ASSERT_EQUALS(dest.code(), ErrorCodes::MaxError);
     ASSERT_EQUALS(dest.reason(), "error");
-
-    ASSERT_EQUALS(dest.refCount(), 2U);
-    ASSERT_EQUALS(orig.refCount(), 2U);
 }
 
-TEST(Cloning, MoveCopyOK) {
+TEST(Status, CloningMoveConstructOK) {
     Status orig = Status::OK();
     ASSERT_TRUE(orig.isOK());
-    ASSERT_EQUALS(orig.refCount(), 0U);
 
     Status dest(std::move(orig));
 
-    ASSERT_TRUE(orig.isOK());            // NOLINT(bugprone-use-after-move)
-    ASSERT_EQUALS(orig.refCount(), 0U);  // NOLINT(bugprone-use-after-move)
-
+    ASSERT_TRUE(orig.isOK());  // NOLINT(bugprone-use-after-move)
     ASSERT_TRUE(dest.isOK());
-    ASSERT_EQUALS(dest.refCount(), 0U);
 }
 
-TEST(Cloning, MoveCopyError) {
+TEST(Status, CloningMoveConstructError) {
     Status orig(ErrorCodes::MaxError, "error");
-    ASSERT_FALSE(orig.isOK());
-    ASSERT_EQUALS(orig.refCount(), 1U);
 
     Status dest(std::move(orig));
 
-    ASSERT_TRUE(orig.isOK());            // NOLINT(bugprone-use-after-move)
-    ASSERT_EQUALS(orig.refCount(), 0U);  // NOLINT(bugprone-use-after-move)
-
+    ASSERT_TRUE(orig.isOK());  // NOLINT(bugprone-use-after-move)
     ASSERT_FALSE(dest.isOK());
-    ASSERT_EQUALS(dest.refCount(), 1U);
     ASSERT_EQUALS(dest.code(), ErrorCodes::MaxError);
     ASSERT_EQUALS(dest.reason(), "error");
 }
 
-TEST(Cloning, MoveAssignOKToOK) {
+TEST(Status, CloningMoveAssignOKToOK) {
     Status orig = Status::OK();
-    ASSERT_TRUE(orig.isOK());
-    ASSERT_EQUALS(orig.refCount(), 0U);
-
     Status dest = Status::OK();
-    ASSERT_TRUE(dest.isOK());
-    ASSERT_EQUALS(dest.refCount(), 0U);
 
     dest = std::move(orig);
 
-    ASSERT_TRUE(orig.isOK());            // NOLINT(bugprone-use-after-move)
-    ASSERT_EQUALS(orig.refCount(), 0U);  // NOLINT(bugprone-use-after-move)
-
+    ASSERT_TRUE(orig.isOK());  // NOLINT(bugprone-use-after-move)
     ASSERT_TRUE(dest.isOK());
-    ASSERT_EQUALS(dest.refCount(), 0U);
 }
 
-TEST(Cloning, MoveAssignErrorToError) {
+TEST(Status, CloningMoveAssignErrorToError) {
     Status orig = Status(ErrorCodes::MaxError, "error");
-    ASSERT_FALSE(orig.isOK());
-    ASSERT_EQUALS(orig.refCount(), 1U);
-    ASSERT_EQUALS(orig.code(), ErrorCodes::MaxError);
-    ASSERT_EQUALS(orig.reason(), "error");
-
     Status dest = Status(ErrorCodes::InternalError, "error2");
-    ASSERT_FALSE(dest.isOK());
-    ASSERT_EQUALS(dest.refCount(), 1U);
-    ASSERT_EQUALS(dest.code(), ErrorCodes::InternalError);
-    ASSERT_EQUALS(dest.reason(), "error2");
 
     dest = std::move(orig);
 
-    ASSERT_TRUE(orig.isOK());            // NOLINT(bugprone-use-after-move)
-    ASSERT_EQUALS(orig.refCount(), 0U);  // NOLINT(bugprone-use-after-move)
-
+    ASSERT_TRUE(orig.isOK());  // NOLINT(bugprone-use-after-move)
     ASSERT_FALSE(dest.isOK());
-    ASSERT_EQUALS(dest.refCount(), 1U);
     ASSERT_EQUALS(dest.code(), ErrorCodes::MaxError);
     ASSERT_EQUALS(dest.reason(), "error");
 }
 
-TEST(Cloning, MoveAssignErrorToOK) {
+TEST(Status, CloningMoveAssignErrorToOK) {
     Status orig = Status(ErrorCodes::MaxError, "error");
-    ASSERT_FALSE(orig.isOK());
-    ASSERT_EQUALS(orig.refCount(), 1U);
-    ASSERT_EQUALS(orig.code(), ErrorCodes::MaxError);
-    ASSERT_EQUALS(orig.reason(), "error");
-
     Status dest = Status::OK();
-    ASSERT_TRUE(dest.isOK());
-    ASSERT_EQUALS(dest.refCount(), 0U);
 
     dest = std::move(orig);
 
-    ASSERT_TRUE(orig.isOK());            // NOLINT(bugprone-use-after-move)
-    ASSERT_EQUALS(orig.refCount(), 0U);  // NOLINT(bugprone-use-after-move)
-
+    ASSERT_TRUE(orig.isOK());  // NOLINT(bugprone-use-after-move)
     ASSERT_FALSE(dest.isOK());
-    ASSERT_EQUALS(dest.refCount(), 1U);
     ASSERT_EQUALS(dest.code(), ErrorCodes::MaxError);
     ASSERT_EQUALS(dest.reason(), "error");
 }
 
-TEST(Cloning, MoveAssignOKToError) {
+TEST(Status, CloningMoveAssignOKToError) {
     Status orig = Status::OK();
-    ASSERT_TRUE(orig.isOK());
-    ASSERT_EQUALS(orig.refCount(), 0U);
-
     Status dest = Status(ErrorCodes::MaxError, "error");
-    ASSERT_FALSE(dest.isOK());
-    ASSERT_EQUALS(dest.refCount(), 1U);
-    ASSERT_EQUALS(dest.code(), ErrorCodes::MaxError);
-    ASSERT_EQUALS(dest.reason(), "error");
 
     orig = std::move(dest);
 
     ASSERT_FALSE(orig.isOK());
-    ASSERT_EQUALS(orig.refCount(), 1U);
     ASSERT_EQUALS(orig.code(), ErrorCodes::MaxError);
     ASSERT_EQUALS(orig.reason(), "error");
 
-    ASSERT_TRUE(dest.isOK());            // NOLINT(bugprone-use-after-move)
-    ASSERT_EQUALS(dest.refCount(), 0U);  // NOLINT(bugprone-use-after-move)
+    ASSERT_TRUE(dest.isOK());  // NOLINT(bugprone-use-after-move)
 }
 
-TEST(Cloning, OKIsNotRefCounted) {
-    ASSERT_EQUALS(Status::OK().refCount(), 0U);
-
-    Status myOk = Status::OK();
-    ASSERT_EQUALS(myOk.refCount(), 0U);
-    ASSERT_EQUALS(Status::OK().refCount(), 0U);
-}
-
-TEST(Parsing, CodeToEnum) {
+TEST(Status, ParsingCodeToEnum) {
     ASSERT_EQUALS(ErrorCodes::TypeMismatch, ErrorCodes::Error(int(ErrorCodes::TypeMismatch)));
     ASSERT_EQUALS(ErrorCodes::UnknownError, ErrorCodes::Error(int(ErrorCodes::UnknownError)));
     ASSERT_EQUALS(ErrorCodes::MaxError, ErrorCodes::Error(int(ErrorCodes::MaxError)));
     ASSERT_EQUALS(ErrorCodes::OK, ErrorCodes::duplicateCodeForTest(0));
 }
 
-TEST(Transformers, ExceptionToStatus) {
+TEST(Status, ExceptionToStatus) {
     using mongo::DBException;
     using mongo::exceptionToStatus;
 
@@ -294,6 +305,29 @@ TEST(ErrorExtraInfo, ConvertCodeOnMissingExtraInfo) {
     ASSERT_EQ(status, ErrorCodes::duplicateCodeForTest(40671));
 }
 #endif
+
+TEST(ErrorExtraInfo, StatusCtorExtraAndReason) {
+    using Extra = OptionalErrorExtraInfoExample;
+    // Check another ctor
+    ASSERT((usableStatusArgs<Extra, std::string>));
+    ASSERT((usableStatusArgs<Extra, std::string&>));
+    ASSERT((usableStatusArgs<Extra, const std::string&>));
+    ASSERT((usableStatusArgs<Extra, std::string&&>));
+    ASSERT((usableStatusArgs<Extra, StringData>));
+    ASSERT((usableStatusArgs<Extra, StringData&>));
+    ASSERT((usableStatusArgs<Extra, const StringData&>));
+    ASSERT((usableStatusArgs<Extra, StringData&&>));
+    ASSERT((!usableStatusArgs<Extra, boost::optional<std::string>>));
+    ASSERT((usableStatusArgs<Extra, CanString>));
+    ASSERT((usableStatusArgs<Extra, CanStringExplicit>));
+    ASSERT((usableStatusArgs<Extra, CanStringOrStringData>));
+    ASSERT((usableStatusArgs<Extra, CanStringRef>));
+    ASSERT((usableStatusArgs<Extra, std::reference_wrapper<std::string>>));
+    ASSERT((usableStatusArgs<Extra, std::reference_wrapper<const std::string>>));
+    ASSERT((usableStatusArgs<Extra, std::reference_wrapper<const char*>>));
+    ASSERT((usableStatusArgs<Extra, std::reference_wrapper<const char*>>));
+}
+
 
 TEST(ErrorExtraInfo, OptionalExtraInfoDoesNotThrowAndReturnsOriginalError) {
     const auto status = Status(ErrorCodes::ForTestingOptionalErrorExtraInfo, "");

--- a/src/mongo/bson/util/builder.h
+++ b/src/mongo/bson/util/builder.h
@@ -40,6 +40,8 @@
 
 #include <boost/optional.hpp>
 
+#include "mongo/bson/util/builder_fwd.h"
+
 #include "mongo/base/data_type_endian.h"
 #include "mongo/base/data_view.h"
 #include "mongo/base/static_assert.h"
@@ -72,9 +74,6 @@ const int BSONObjMaxUserSize = 16 * 1024 * 1024;
 const int BSONObjMaxInternalSize = BSONObjMaxUserSize + (16 * 1024);
 
 const int BufferMaxSize = 64 * 1024 * 1024;
-
-template <typename Builder>
-class StringBuilderImpl;
 
 class SharedBufferAllocator {
     SharedBufferAllocator(const SharedBufferAllocator&) = delete;
@@ -176,7 +175,6 @@ private:
     SharedBufferFragmentBuilder& _fragmentBuilder;
 };
 
-enum { StackSizeDefault = 512 };
 template <size_t SZ>
 class StackAllocator {
     StackAllocator(const StackAllocator&) = delete;
@@ -472,7 +470,6 @@ public:
     StackBufBuilderBase(const StackBufBuilderBase&) = delete;
     StackBufBuilderBase(StackBufBuilderBase&&) = delete;
 };
-using StackBufBuilder = StackBufBuilderBase<StackSizeDefault>;
 MONGO_STATIC_ASSERT(!std::is_move_constructible<StackBufBuilder>::value);
 
 /** std::stringstream deals with locale so this is a lot faster than std::stringstream for UTF8 */
@@ -630,9 +627,6 @@ private:
 
     Builder _buf;
 };
-
-using StringBuilder = StringBuilderImpl<BufBuilder>;
-using StackStringBuilder = StringBuilderImpl<StackBufBuilderBase<StackSizeDefault>>;
 
 extern template class StringBuilderImpl<BufBuilder>;
 extern template class StringBuilderImpl<StackBufBuilderBase<StackSizeDefault>>;

--- a/src/mongo/bson/util/builder_fwd.h
+++ b/src/mongo/bson/util/builder_fwd.h
@@ -1,0 +1,51 @@
+/**
+ *    Copyright (C) 2018-present MongoDB, Inc.
+ *
+ *    This program is free software: you can redistribute it and/or modify
+ *    it under the terms of the Server Side Public License, version 1,
+ *    as published by MongoDB, Inc.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    Server Side Public License for more details.
+ *
+ *    You should have received a copy of the Server Side Public License
+ *    along with this program. If not, see
+ *    <http://www.mongodb.com/licensing/server-side-public-license>.
+ *
+ *    As a special exception, the copyright holders give permission to link the
+ *    code of portions of this program with the OpenSSL library under certain
+ *    conditions as described in each individual source file and distribute
+ *    linked combinations including the program with the OpenSSL library. You
+ *    must comply with the Server Side Public License in all respects for
+ *    all of the code used other than as permitted herein. If you modify file(s)
+ *    with this exception, you may extend this exception to your version of the
+ *    file(s), but you are not obligated to do so. If you do not wish to do so,
+ *    delete this exception statement from your version. If you delete this
+ *    exception statement from all source files in the program, then also delete
+ *    it in the license file.
+ */
+
+#pragma once
+
+#include <cstddef>
+
+namespace mongo {
+
+class BufBuilder;
+
+template <std::size_t SZ>
+class StackBufBuilderBase;
+
+inline constexpr std::size_t StackSizeDefault = 512;
+
+using StackBufBuilder = StackBufBuilderBase<StackSizeDefault>;
+
+template <typename Allocator>
+class StringBuilderImpl;
+
+using StringBuilder = StringBuilderImpl<BufBuilder>;
+using StackStringBuilder = StringBuilderImpl<StackBufBuilder>;
+
+}  // namespace mongo


### PR DESCRIPTION
Status has a lot of old code that needs a facelift.

Use {{boost::intrusive_ptr}} instead of handrolled refcounting for {{_error}} member.
This eliminates the need for copy and move ctors, assigns, and the destructor.

Don't declare operator<< for StringBuilderImpl that we don't define.

Inline the ubiquitous Status::OK() function.
Inline most constructors. Usually they forward to another constructor.

Define inlines inside the class consistently. This was previously mixed and inconsistent. It eliminates a lot of the boilerplate from out-of-class definitions.

Pass {{reason}} by {{std::string}} value when possible to save string copies!

Accept anything as a {{reason}} parameter if it can direct-initialize a {{std::string}}. This eliminates fwd decl of {{std::stream}}, and eliminates the combinatoric redundancy of providing overloads for {{const char*}}, {{StringData}}, {{std::string}}, and {{std::stream}}, which also leaves a lot of viable argument types missing anyway.

Remove useless {{const}} from return types and from parameters.

Use {{std::is_..._v}} traits bools.

Define inline-friend-defs for all overloaded operators {{==}}, {{!=}}, and {{<<}} so they are applied symmetrically, and are only visible to ADL search.

Allocate the empty {{reason()}} static local string so it is valid at shutdown.

Remove the {{refCount()}} member, replace with a {{testOnlyAccess()}} proxy object that can retrieve the same data, but more obviously and strictly test only.

Simplify ErrorInfo to a simple struct, inherit from {{boost::intrusive_ref_counter}}. No explicit atomics for refcounting, no const members, no member functions. Let Status enforce the constness and creation invariants. {{Status::ErrorInfo}} becomes just plain info.

Add static {{Status::_createErrorInfo}} and {{Status::_parseErrorInfo}} functions to produce intrusive_ptr to initialize the _error member from constructors. Get rid of the risky {{*this = someStatus...}} error handling in favor of these functions.



    fix and document stream operators
    status_with: forward stringlike reason to status(code,reason) ctor (decouple from str::stream)
    is_constructible,
    invariant.h
    unit test for Reason conversions
    test new ctors
    simplify unit tests: remove refCount accesses and redundant asserts