### PR TITLE
SERVER-53566 make OperationId to be uint64_t

### DIFF
--- a/src/mongo/db/service_context.h
+++ b/src/mongo/db/service_context.h
@@ -128,7 +128,7 @@ private:
  * ServiceContext. Generally speaking, OperationId is used for forming maps of OperationContexts and
  * directing metaoperations like killop.
  */
-using OperationId = uint32_t;
+using OperationId = uint64_t;
 
 /**
  * Users may provide an OperationKey when sending a command request as a stable token by which to


### PR DESCRIPTION
It seems like `_nextOpId` (which is `OperationId`) is overlapped if it is
`uint32_t`. Cause of it new short living operations rewrite references in
`_clientByOperationId` map.

Long living loops (`KeysCollectionManager::PeriodicRunner::_doPeriodicRefresh`,
`WaitForMajorityService::_periodicallyWaitForMajority`, `TopologyVersionObserver::_workerThreadBody`)
then couldn't find item in `_clientByOperationId` when `UniqueContextOperator`'s destructor calls
`ServiceContext::_delistOperation`. Therefore resetOperationContext is not
called.

Changing `OperationId` to be `uint64_t` should eliminate this possibility:
even if there is 1 billion of operations per second, it will take 584
years to overflow.