### PR TITLE
SERVER-53566: Fix "opCtx != nullptr && _opCtx == nullptr" invariant

### DIFF
--- a/src/mongo/db/service_context.h
+++ b/src/mongo/db/service_context.h
@@ -690,7 +690,7 @@ private:
     std::vector<KillOpListenerInterface*> _killOpListeners;
 
     // Counter for assigning operation ids.
-    AtomicWord<OperationId> _nextOpId{1};
+    OperationId _nextOpId{1};
 
     // When the catalog is restarted, the generation goes up by one each time.
     AtomicWord<uint64_t> _catalogGeneration{0};


### PR DESCRIPTION
Check and skip already used `opId` to avoid `_nextOpId` wraparound issue.