### PR TITLE
SERVER-59010 Fix SSL off build, OCSPManager shouldn't be used when ssl = off

### DIFF
--- a/src/mongo/db/db.cpp
+++ b/src/mongo/db/db.cpp
@@ -338,7 +338,9 @@ ExitCode _initAndListen(ServiceContext* serviceContext, int listenPort) {
     auto runner = makePeriodicRunner(serviceContext);
     serviceContext->setPeriodicRunner(std::move(runner));
 
+#ifdef MONGO_CONFIG_SSL
     OCSPManager::get()->startThreadPool();
+#endif
 
     if (!storageGlobalParams.repair) {
         auto tl =

--- a/src/mongo/s/server.cpp
+++ b/src/mongo/s/server.cpp
@@ -640,7 +640,9 @@ ExitCode runMongosServer(ServiceContext* serviceContext) {
         serviceContext->setPeriodicRunner(std::move(runner));
     }
 
+#ifdef MONGO_CONFIG_SSL
     OCSPManager::get()->startThreadPool();
+#endif
 
     serviceContext->setServiceEntryPoint(std::make_unique<ServiceEntryPointMongos>(serviceContext));
 

--- a/src/mongo/shell/dbshell.cpp
+++ b/src/mongo/shell/dbshell.cpp
@@ -728,7 +728,9 @@ int _main(int argc, char* argv[], char** envp) {
     // TODO This should use a TransportLayerManager or TransportLayerFactory
     auto serviceContext = getGlobalServiceContext();
 
+#ifdef MONGO_CONFIG_SSL
     OCSPManager::get()->startThreadPool();
+#endif
 
     transport::TransportLayerASIO::Options opts;
     opts.enableIPv6 = shellGlobalParams.enableIPv6;


### PR DESCRIPTION
When building with SSL=off, latest 4.4.4 release doesn't compile with the following error:

```
src/mongo/db/db.cpp:340: error: undefined reference to 'mongo::OCSPManager::startThreadPool()'
src/mongo/util/net/ocsp/ocsp_manager.h:49: error: undefined reference to 'mongo::OCSPManager::OCSPManager()'
collect2: error: ld returned 1 exit status
scons: *** [build/opt/mongo/mongod] Error 1
scons: building terminated because of errors.
build/opt/mongo/mongod failed: Error 1
```

OCSPManager thread pool probably shouldn't be started when SSL is off, as this class is not compiled in the presence of such an option.

Also some info here: https://developer.mongodb.com/community/forums/t/failure-to-build-mongodb-4-4-4/100231

This is blocking Meteor build of MongoDB, as we do use a small binary without SSL for development easiness.

The last version it was working is : MONGODB_VERSION='4.2.8'