### PR TITLE
SERVER-57206 Reslove Compiler warnings in JSStringWrapper::JSStringWr…

### DIFF
--- a/src/mongo/scripting/mozjs/jsstringwrapper.cpp
+++ b/src/mongo/scripting/mozjs/jsstringwrapper.cpp
@@ -45,7 +45,8 @@ namespace mozjs {
 JSStringWrapper::JSStringWrapper(std::int32_t value) : _isSet(true) {
     auto formatted = fmt::format_int(value);
     _length = formatted.size();
-    strncpy(_buf, formatted.c_str(), sizeof(_buf));
+    strncpy(_buf, formatted.c_str(), sizeof(_buf) - 1);
+    _buf[sizeof(_buf) - 1] = '\0';
 }
 
 JSStringWrapper::JSStringWrapper(JSContext* cx, JSString* str) : _isSet(true) {


### PR DESCRIPTION
Resolve compiler warnings 
```
In file included from /usr/include/string.h:494,
                 from /usr/include/c++/9/cstring:42,
                 from src/third_party/mozjs-60/include/mozilla/Span.h:33,
                 from src/third_party/mozjs-60/include/mozilla/Range.h:12,
                 from src/third_party/mozjs-60/include/jsapi.h:15,
                 from src/mongo/scripting/mozjs/jsstringwrapper.h:33,
                 from src/mongo/scripting/mozjs/jsstringwrapper.cpp:32:
In function 'char* strncpy(char*, const char*, size_t)',
    inlined from 'mongo::mozjs::JSStringWrapper::JSStringWrapper(int32_t)' at src/mongo/scripting/mozjs/jsstringwrapper.cpp:48:12:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:34: error: 'char* __builtin_strncpy(char*, const char*, long unsigned int)' specified bound 64 equals destination size [-Werror=stringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```