### PR TITLE
Use explicit typecast to size_t

### DIFF
--- a/src/mongo/db/pipeline/document_source_group.cpp
+++ b/src/mongo/db/pipeline/document_source_group.cpp
@@ -399,7 +399,7 @@ DocumentSourceGroup::DocumentSourceGroup(const intrusive_ptr<ExpressionContext>&
       _doingMerge(false),
       _memoryTracker{expCtx->allowDiskUse && !expCtx->inMongos,
                      maxMemoryUsageBytes ? *maxMemoryUsageBytes
-                                         : internalDocumentSourceGroupMaxMemoryBytes.load()},
+                                         : (size_t)internalDocumentSourceGroupMaxMemoryBytes.load()},
       _initialized(false),
       _groups(expCtx->getValueComparator().makeUnorderedValueMap<Accumulators>()),
       _spilled(false) {


### PR DESCRIPTION
maxMemoryUsageBytes is size_t type which may not match long long value
internalDocumentSourceGroupMaxMemoryBytes.load() returns, so typecast it
to avoid narrowing warning from clang

document_source_group.cpp:378:22: error: non-constant-expression cannot be narrowed from type 'long long' to 'size_t' (aka 'unsigned int') in initializer list [-Wc++11-narrowing]
                     maxMemoryUsageBytes ? *maxMemoryUsageBytes
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Upstream-Status: Pending
Signed-off-by: Khem Raj <raj.khem@gmail.com>