### PR TITLE
SERVER-58817 Ubuntu 20.04 "python3.7-dev" package is no more.

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -58,7 +58,7 @@ Note: In order to compile C-based Python modules, you'll also need the
 Python and OpenSSL C headers. Run:
 
 * Fedora/RHEL - `dnf install python3-devel openssl-devel`
-* Ubuntu/Debian - `apt-get install python3.7-dev libssl-dev`
+* Ubuntu/Debian - `apt install python-dev-is-python3 libssl-dev`
 
 
 SCons


### PR DESCRIPTION
In my ubuntu 20.04 WSL2.
As follow build manual, when install package.
apt talk to me.

```console
myubuntu@paranlee:~mongo$ sudo apt install python3.7-dev
[sudo] password for paranlee: 
Reading package lists... Done 
Building dependency tree       
Reading state information... Done
E: Unable to locate package python3.7-dev
E: Couldn't find any package by glob 'python3.7-dev'
```

I can find 

```console
myubuntu@paranlee:~mongo$ apt search python-dev-is-python3
Sorting... Done        
Full Text Search... Done
python-dev-is-python3/focal,now 3.8.2-4 all [installed]
  symlinks /usr/bin/python-config to python3-config  
```

[SERVER-58817](https://jira.mongodb.org/browse/SERVER-58817)

This pull request is solve this issue.