### PR TITLE
SERVER-60097 Add method to wait for topology state

### DIFF
--- a/src/mongo/db/repl/replication_coordinator.h
+++ b/src/mongo/db/repl/replication_coordinator.h
@@ -31,6 +31,7 @@
 
 #include "mongo/db/repl/replication_coordinator_fwd.h"
 
+#include "mongo/util/cancellation.h"
 #include <vector>
 
 #include "mongo/base/status.h"
@@ -247,6 +248,18 @@ public:
      */
     virtual SharedSemiFuture<void> awaitReplicationAsyncNoWTimeout(
         const OpTime& opTime, const WriteConcernOptions& writeConcern) = 0;
+
+    struct NodeInfo {
+        MemberState state;
+        MemberConfig config;
+    };
+
+    /**
+     * Returns a future that will be set when a desired topology state predicate has been satisfied
+     */
+    using TopologyStatePredicate = std::function<bool(std::vector<NodeInfo>)>;
+    virtual SharedSemiFuture<void> awaitTopologyState(const CancellationToken& token,
+                                                      TopologyStatePredicate predicate) = 0;
 
     /**
      * Causes this node to relinquish being primary for at least 'stepdownTime'.  If 'force' is

--- a/src/mongo/db/repl/replication_coordinator_mock.cpp
+++ b/src/mongo/db/repl/replication_coordinator_mock.cpp
@@ -176,6 +176,11 @@ SharedSemiFuture<void> ReplicationCoordinatorMock::awaitReplicationAsyncNoWTimeo
     MONGO_UNREACHABLE;
 }
 
+SharedSemiFuture<void> ReplicationCoordinatorMock::awaitTopologyState(
+    const CancellationToken& token, TopologyStatePredicate predicate) {
+    MONGO_UNREACHABLE;
+}
+
 void ReplicationCoordinatorMock::stepDown(OperationContext* opCtx,
                                           bool force,
                                           const Milliseconds& waitTime,

--- a/src/mongo/db/repl/replication_coordinator_mock.h
+++ b/src/mongo/db/repl/replication_coordinator_mock.h
@@ -107,6 +107,9 @@ public:
     virtual SharedSemiFuture<void> awaitReplicationAsyncNoWTimeout(
         const OpTime& opTime, const WriteConcernOptions& writeConcern);
 
+    virtual SharedSemiFuture<void> awaitTopologyState(const CancellationToken& token,
+                                                      TopologyStatePredicate predicate);
+
     void stepDown(OperationContext* opCtx,
                   bool force,
                   const Milliseconds& waitTime,

--- a/src/mongo/db/repl/replication_coordinator_noop.cpp
+++ b/src/mongo/db/repl/replication_coordinator_noop.cpp
@@ -262,6 +262,11 @@ SharedSemiFuture<void> ReplicationCoordinatorNoOp::awaitReplicationAsyncNoWTimeo
     MONGO_UNREACHABLE;
 }
 
+SharedSemiFuture<void> ReplicationCoordinatorNoOp::awaitTopologyState(
+    const CancellationToken& token, TopologyStatePredicate predicate) {
+    MONGO_UNREACHABLE;
+}
+
 void ReplicationCoordinatorNoOp::stepDown(OperationContext*,
                                           const bool,
                                           const Milliseconds&,

--- a/src/mongo/db/repl/replication_coordinator_noop.h
+++ b/src/mongo/db/repl/replication_coordinator_noop.h
@@ -114,6 +114,9 @@ public:
     SharedSemiFuture<void> awaitReplicationAsyncNoWTimeout(
         const OpTime& opTime, const WriteConcernOptions& writeConcern) final;
 
+    SharedSemiFuture<void> awaitTopologyState(const CancellationToken& token,
+                                              TopologyStatePredicate predicate) final;
+
     void stepDown(OperationContext*, bool, const Milliseconds&, const Milliseconds&) final;
 
     Status checkIfWriteConcernCanBeSatisfied(const WriteConcernOptions&) const final;

--- a/src/mongo/embedded/replication_coordinator_embedded.cpp
+++ b/src/mongo/embedded/replication_coordinator_embedded.cpp
@@ -286,6 +286,11 @@ SharedSemiFuture<void> ReplicationCoordinatorEmbedded::awaitReplicationAsyncNoWT
     UASSERT_NOT_IMPLEMENTED;
 }
 
+SharedSemiFuture<void> ReplicationCoordinatorEmbedded::awaitTopologyState(
+    const CancellationToken& token, TopologyStatePredicate predicate) {
+    UASSERT_NOT_IMPLEMENTED;
+}
+
 void ReplicationCoordinatorEmbedded::stepDown(OperationContext*,
                                               const bool,
                                               const Milliseconds&,

--- a/src/mongo/embedded/replication_coordinator_embedded.h
+++ b/src/mongo/embedded/replication_coordinator_embedded.h
@@ -117,6 +117,9 @@ public:
     SharedSemiFuture<void> awaitReplicationAsyncNoWTimeout(const repl::OpTime&,
                                                            const WriteConcernOptions&) override;
 
+    SharedSemiFuture<void> awaitTopologyState(const CancellationToken& token,
+                                              TopologyStatePredicate predicate) override;
+
     void stepDown(OperationContext*, bool, const Milliseconds&, const Milliseconds&) override;
 
     Status checkIfWriteConcernCanBeSatisfied(const WriteConcernOptions&) const override;


### PR DESCRIPTION
The TenantSplitDonorService needs to wait for three non-voting
replica set nodes to complete an initial sync before the reconfig
which will establish them as the recipient slice. This patch
introduces a new method `awaitTopologyState` which allows us to
wait for the local replica set to meet some provided condition.
Additionally, a new "waiter list" was introduced since the
existing `WaiterList` is primarily focused on waiting for opTimes
which is unrelated to topology state changes.