### PR TITLE
SERVER-61202 remove timing dependency in cluster_ip_allowlist_replset

### DIFF
--- a/jstests/auth/cluster_ip_allowlist_replset.js
+++ b/jstests/auth/cluster_ip_allowlist_replset.js
@@ -25,25 +25,22 @@ admin.auth('admin', 'admin');
 assert.commandWorked(primary.adminCommand(
     {setDefaultRWConcern: 1, defaultWriteConcern: {w: "majority"}, writeConcern: {w: "majority"}}));
 
-jsTest.log("ReplSet started, will block __system connections and expect error");
-
-assert.commandWorked(
-    primary.adminCommand({setParameter: 1, "clusterIpSourceAllowlist": ["192.0.2.1"]}));
-
 function resetClusterIpSourceAllowlist(host) {
     jsTest.log("resetClusterIpSourceAllowlist: started");
-    sleep(15000);
     const mongo = new Mongo(host);
     const admin = mongo.getDB("admin");
     admin.auth('admin', 'admin');
+
+    jsTest.log("Check log for denied connections");
+    checkLog.containsJson(admin, 20240, {});
+    jsTest.log("Found denied connection(s)");
+
     assert.commandWorked(admin.adminCommand({setParameter: 1, "clusterIpSourceAllowlist": null}));
     jsTest.log("Successfully reset clusterIpSourceAllowlist");
 }
 
 let thread = new Thread(resetClusterIpSourceAllowlist, primary.host);
 thread.start();
-
-jsTest.log("Attempt to add host. This should be failing, then succeed");
 
 const arbiterConn = replTest.add();
 const conf = replTest.getReplSetConfigFromNode();
@@ -52,11 +49,14 @@ conf.version++;
 
 // Following function will succeed after resetClusterIpSourceAllowlist()
 // successfully resets IP for connection
+jsTest.log("ReplSet started, will block __system connections and expect error");
+assert.commandWorked(
+    primary.adminCommand({setParameter: 1, "clusterIpSourceAllowlist": ["192.0.2.1"]}));
 assert.commandWorked(admin.runCommand({replSetReconfig: conf}));
 thread.join();
 
 jsTest.log("Verify that connections were denied");
-checkLog.containsJson(admin, 20240, {}, 15000);
+checkLog.containsJson(admin, 20240, {}, 0);
 
 replTest.awaitReplication();
 

--- a/jstests/auth/cluster_ip_allowlist_replset.js
+++ b/jstests/auth/cluster_ip_allowlist_replset.js
@@ -56,7 +56,7 @@ assert.commandWorked(admin.runCommand({replSetReconfig: conf}));
 thread.join();
 
 jsTest.log("Verify that connections were denied");
-checkLog.containsJson(admin, 20240, {}, 0);
+checkLog.containsJson(admin, 20240, {}, 1);
 
 replTest.awaitReplication();
 


### PR DESCRIPTION
Getting a failure on MacOS DEBUG. Unclear why, but it seems to be a timing issue. In original test a replication is initiated, while another thread waits 15 sec, during which access denied log entries are supposed to appear, and it does not happen on https://jira.mongodb.org/browse/BF-23201.

This patch refactors test to wait as long as necessary, but make sure that access denied happens.

EVG: https://spruce.mongodb.com/version/6181ad703e8e866d1df9feb1/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC