### PR TITLE
SERVER-61494 Fix "mongod --shutdown" to check size of "mongod.lock" instead of existence

### DIFF
--- a/src/mongo/db/mongod_main.cpp
+++ b/src/mongo/db/mongod_main.cpp
@@ -927,7 +927,8 @@ Status shutdownProcessByDBPathPidFile(const std::string& dbpath) {
                 str::stream() << "Failed to kill process: " << errnoWithDescription(e)};
     }
 
-    while (boost::filesystem::exists(pidfile)) {
+    uintmax_t size;
+    while ((size = boost::filesystem::file_size(pidfile)) != 0 && size != static_cast<uintmax_t>(-1)) {
         sleepsecs(1);
     }
 


### PR DESCRIPTION
In a07dc78e49c53de539dff92748334cd7fbe2e2a9, the code for `mongod --shutdown` was refactored, and appears to have inadvertently changed from `while (boost::filesystem::exists(procPath))` to `while (boost::filesystem::exists(pidfile))`, which never becomes false as the `mongod.lock` file this new version is waiting for is only ever emptied, not deleted.

This fixes that to wait for the file to be either deleted *or* emptied.  I debated switching back to `procPath` like the previous code, but I figured maybe it was changed on purpose?  I'm not sure how that previous change was tested, though.

The difference between the behavior currently in 5.0 and this new implementation is that the old `--shutdown` would exit even if the server exited uncleanly (because it was waiting for the PID to no longer exist) while the new implementation would instead hang forever (which is what happens on the 5.1 RCs when you run `mongod --shutdown` whether the server shuts down or not, and how I discovered this issue).

I'll add my standard disclaimer that I'm happy to adjust, rebase, amend, etc this change in any way. :smile:

(I've already signed the CLA, so hopefully that carries forward here and I don't get slapped by a bot :crossed_fingers:)