### PR TITLE
SERVER-61495 Fix "--replset" error message typo

### DIFF
--- a/src/mongo/db/mongod_options.cpp
+++ b/src/mongo/db/mongod_options.cpp
@@ -621,7 +621,7 @@ Status storeMongodOptions(const moe::Environment& params) {
             return Status(ErrorCodes::BadValue,
                           str::stream() << "Cannot start a " << clusterRoleParam
                                         << " as a standalone server. Please use the option "
-                                           "--replset to start the node as a replica set.");
+                                           "--replSet to start the node as a replica set.");
         }
         if (clusterRoleParam == "configsvr") {
             serverGlobalParams.clusterRole = ClusterRole::ConfigServer;


### PR DESCRIPTION
    Error parsing command line: unrecognised option '--replset'
    try 'mongod --help' for more information