### PR TITLE
SERVER-60727: Remove mixed mode updates on local.system.replset

### DIFF
--- a/src/mongo/db/repl/replication_coordinator_external_state_impl.cpp
+++ b/src/mongo/db/repl/replication_coordinator_external_state_impl.cpp
@@ -623,6 +623,11 @@ Status ReplicationCoordinatorExternalStateImpl::storeLocalConfigDocument(Operati
             }
 
             if (writeOplog) {
+                // The no-op write doesn't affect the correctness of the safe reconfig protocol and
+                // so it doesn't have to be written in the same WUOW as the config write. In fact,
+                // the no-op write is only needed for some corner cases where the committed snapshot
+                // is dropped after a force reconfig that changes the config content or a safe
+                // reconfig that changes writeConcernMajorityJournalDefault.
                 WriteUnitOfWork wuow(opCtx);
                 auto msgObj = BSON("msg"
                                    << "Reconfig set"

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_record_store.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_record_store.cpp
@@ -774,8 +774,6 @@ StatusWith<std::string> WiredTigerRecordStore::generateCreateString(
         !ident.startsWith("internal-") &&
         // TODO (SERVER-60754): Remove special handling for setting multikey.
         !ident.startsWith("_mdb_catalog") &&
-        // TODO (SERVER-60727): Remove special handling for 'local.system.replset'.
-        ns != "local.system.replset" &&
         // TODO (SERVER-58410): Remove special handling for minValid.
         ns != "local.replset.minvalid" &&
         // TODO (SERVER-60753): Remove special handling for index build during recovery.


### PR DESCRIPTION
This patch makes all local.system.replset writes untimestamped. For `storeLocalConfigDocument`, I think the no-op doesn't have to be in the same WUOW of the config write.

For posterity, also see [this](https://docs.google.com/document/d/15Wms06BKmV2Bg0WFgqlJtbotCqHqUPGhU2XidXASQHo/edit?usp=sharing) for the full discussion about the no-op write and dropping the committed snapshot during reconfig.