### PR TITLE
SERVER-61959 Add MSVS 2022 support to vendored SCons

### DIFF
--- a/src/third_party/scons-3.1.2/scons-local-3.1.2/SCons/Tool/MSCommon/vc.py
+++ b/src/third_party/scons-3.1.2/scons-local-3.1.2/SCons/Tool/MSCommon/vc.py
@@ -194,15 +194,18 @@ def get_host_target(env):
 
 # If you update this, update SupportedVSList in Tool/MSCommon/vs.py, and the
 # MSVC_VERSION documentation in Tool/msvc.xml.
-_VCVER = ["14.2", "14.1", "14.0", "14.0Exp", "12.0", "12.0Exp", "11.0", "11.0Exp", "10.0", "10.0Exp", "9.0", "9.0Exp","8.0", "8.0Exp","7.1", "7.0", "6.0"]
+_VCVER = ["14.3", "14.2", "14.1", "14.0", "14.0Exp", "12.0", "12.0Exp", "11.0", "11.0Exp", "10.0", "10.0Exp", "9.0", "9.0Exp","8.0", "8.0Exp","7.1", "7.0", "6.0"]
 
 # if using vswhere, a further mapping is needed
 _VCVER_TO_VSWHERE_VER = {
+    '14.3':  '[17.0, 18.0)',
     '14.2' : '[16.0, 17.0)',
     '14.1' : '[15.0, 16.0)',
 }
 
 _VCVER_TO_PRODUCT_DIR = {
+    '14.3': [
+        (SCons.Util.HKEY_LOCAL_MACHINE, r'')],  # not set by this version
     '14.2' : [
         (SCons.Util.HKEY_LOCAL_MACHINE, r'')], # VS 2019 doesn't set this key
     '14.1' : [


### PR DESCRIPTION
Backported MSVS2022 support from SCons 4.3.0