### PR TITLE
SERVER-62498: non-`const` `unique_function` should not convert to `std::function` e…

### DIFF
--- a/src/mongo/util/functional.h
+++ b/src/mongo/util/functional.h
@@ -123,6 +123,8 @@ public:
     // NOTE: This is not quite able to disable all `std::function` conversions on MSVC, at this
     // time.
     template <typename Signature>
+    operator std::function<Signature>() = delete;
+    template <typename Signature>
     operator std::function<Signature>() const = delete;
 
 private:


### PR DESCRIPTION
…ven after LWG-2774

[LWG-2774](https://wg21.link/lwg2774) changes `std::function`'s converting constructor to accept its argument by forwarding reference. With that change implemented, that constructor becomes a better match for non-`const` `unique_function` arguments than `unique_function`'s `const`-qualified deleted conversion operator template to `std::function`. As a result, `std::is_convertible_v<unique_function<T>, std::function<T>>` changes from `false` to `true` when Standard Libraries implement LWG-2774. (MSVC recently implemented this LWG issue in https://github.com/microsoft/STL/pull/2098 and noticed the `unique_function` test failing as a result.)

I believe the fix is to add another deleted conversion operator template that is not `const`-qualified to `unique_function`. This makes the test pass for me locally with the updated STL.