### PR TITLE
[DRAFT] make WriteConcernOptions immutable

### DIFF
--- a/src/mongo/db/catalog/drop_database.cpp
+++ b/src/mongo/db/catalog/drop_database.cpp
@@ -320,7 +320,7 @@ Status _dropDatabase(OperationContext* opCtx, const std::string& dbName, bool ab
     // The user-supplied wTimeout should be used when waiting for majority write concern.
     const auto& userWriteConcern = opCtx->getWriteConcern();
     const auto wTimeout = !userWriteConcern.isImplicitDefaultWriteConcern()
-        ? Milliseconds{userWriteConcern.wTimeout}
+        ? Milliseconds{userWriteConcern.wTimeout()}
         : duration_cast<Milliseconds>(Minutes(10));
 
     // This is used to wait for the collection drops to replicate to a majority of the replica
@@ -344,7 +344,7 @@ Status _dropDatabase(OperationContext* opCtx, const std::string& dbName, bool ab
     auto result = replCoord->awaitReplication(opCtx, awaitOpTime, dropDatabaseWriteConcern);
 
     // If the user-provided write concern is weaker than majority, this is effectively a no-op.
-    if (result.status.isOK() && !userWriteConcern.usedDefaultConstructedWC) {
+    if (result.status.isOK() && !userWriteConcern.isDefaultConstructed()) {
         LOGV2(20341,
               "dropDatabase {dbName} waiting for {awaitOpTime} to be replicated at "
               "{userWriteConcern}",

--- a/src/mongo/db/commands/feature_compatibility_version.cpp
+++ b/src/mongo/db/commands/feature_compatibility_version.cpp
@@ -230,7 +230,7 @@ void runUpdateCommand(OperationContext* opCtx, const FeatureCompatibilityVersion
     }
     auto timeout = opCtx->getWriteConcern().isImplicitDefaultWriteConcern()
         ? WriteConcernOptions::kNoTimeout
-        : opCtx->getWriteConcern().wTimeout;
+        : opCtx->getWriteConcern().wTimeout();
     auto newWC = WriteConcernOptions(
         WriteConcernOptions::kMajority, WriteConcernOptions::SyncMode::UNSET, timeout);
     updateCmd.append(WriteConcernOptions::kWriteConcernField, newWC.toBSON());

--- a/src/mongo/db/commands/set_feature_compatibility_version_command.cpp
+++ b/src/mongo/db/commands/set_feature_compatibility_version_command.cpp
@@ -241,7 +241,7 @@ public:
             // Propagate the user's wTimeout if one was given.
             auto timeout = opCtx->getWriteConcern().isImplicitDefaultWriteConcern()
                 ? INT_MAX
-                : opCtx->getWriteConcern().wTimeout;
+                : opCtx->getWriteConcern().wTimeout();
             WriteConcernResult res;
             auto waitForWCStatus = waitForWriteConcern(
                 opCtx,

--- a/src/mongo/db/commands/write_commands.cpp
+++ b/src/mongo/db/commands/write_commands.cpp
@@ -105,9 +105,9 @@ void redactTooLongLog(mutablebson::Document* cmdObj, StringData fieldName) {
 
 bool shouldSkipOutput(OperationContext* opCtx) {
     const WriteConcernOptions& writeConcern = opCtx->getWriteConcern();
-    return writeConcern.wMode.empty() && writeConcern.wNumNodes == 0 &&
-        (writeConcern.syncMode == WriteConcernOptions::SyncMode::NONE ||
-         writeConcern.syncMode == WriteConcernOptions::SyncMode::UNSET);
+    return writeConcern.wMode().empty() && writeConcern.wNumNodes() == 0 &&
+        (writeConcern.syncMode() == WriteConcernOptions::SyncMode::NONE ||
+         writeConcern.syncMode() == WriteConcernOptions::SyncMode::UNSET);
 }
 
 /**

--- a/src/mongo/db/curop.cpp
+++ b/src/mongo/db/curop.cpp
@@ -908,7 +908,7 @@ void OpDebug::report(OperationContext* opCtx,
         }
     }
 
-    if (writeConcern && !writeConcern->usedDefaultConstructedWC) {
+    if (writeConcern && !writeConcern->isDefaultConstructed()) {
         pAttrs->add("writeConcern", writeConcern->toBSON());
     }
 
@@ -1052,7 +1052,7 @@ void OpDebug::append(OperationContext* opCtx,
         }
     }
 
-    if (writeConcern && !writeConcern->usedDefaultConstructedWC) {
+    if (writeConcern && !writeConcern->isDefaultConstructed()) {
         b.append("writeConcern", writeConcern->toBSON());
     }
 
@@ -1321,7 +1321,7 @@ std::function<BSONObj(ProfileFilter::Args)> OpDebug::appendStaged(StringSet requ
     });
 
     addIfNeeded("writeConcern", [](auto field, auto args, auto& b) {
-        if (args.op.writeConcern && !args.op.writeConcern->usedDefaultConstructedWC) {
+        if (args.op.writeConcern && !args.op.writeConcern->isDefaultConstructed()) {
             b.append(field, args.op.writeConcern->toBSON());
         }
     });

--- a/src/mongo/db/pipeline/sharded_agg_helpers.cpp
+++ b/src/mongo/db/pipeline/sharded_agg_helpers.cpp
@@ -1253,7 +1253,7 @@ StatusWith<ChunkManager> getExecutionNsRoutingInfo(OperationContext* opCtx,
 Shard::RetryPolicy getDesiredRetryPolicy(OperationContext* opCtx) {
     // The idempotent retry policy will retry even for writeConcern failures, so only set it if the
     // pipeline does not support writeConcern.
-    if (!opCtx->getWriteConcern().usedDefaultConstructedWC) {
+    if (!opCtx->getWriteConcern().isDefaultConstructed()) {
         return Shard::RetryPolicy::kNotIdempotent;
     }
     return Shard::RetryPolicy::kIdempotent;

--- a/src/mongo/db/read_write_concern_defaults_test.cpp
+++ b/src/mongo/db/read_write_concern_defaults_test.cpp
@@ -100,7 +100,7 @@ TEST_F(ReadWriteConcernDefaultsTest, TestGetDefaultWithAbsentCWRWCWithImplicitWC
     ASSERT(defaults.getDefaultReadConcernSource() == DefaultReadConcernSourceEnum::kImplicit);
 
     ASSERT(defaults.getDefaultWriteConcern());
-    ASSERT_EQ(WriteConcernOptions::kMajority, defaults.getDefaultWriteConcern().get().wMode);
+    ASSERT_EQ(WriteConcernOptions::kMajority, defaults.getDefaultWriteConcern().get().wMode());
     ASSERT(!defaults.getUpdateOpTime());
     ASSERT(!defaults.getUpdateWallClockTime());
     ASSERT_EQ(Date_t(), defaults.localUpdateWallClockTime());
@@ -144,7 +144,7 @@ TEST_F(ReadWriteConcernDefaultsTest, TestGetDefaultWithCWRWCNeverSetWithImplicit
     ASSERT(defaults.getDefaultReadConcernSource() == DefaultReadConcernSourceEnum::kImplicit);
 
     ASSERT(defaults.getDefaultWriteConcern());
-    ASSERT_EQ(WriteConcernOptions::kMajority, defaults.getDefaultWriteConcern().get().wMode);
+    ASSERT_EQ(WriteConcernOptions::kMajority, defaults.getDefaultWriteConcern().get().wMode());
     ASSERT(!defaults.getUpdateOpTime());
     ASSERT(!defaults.getUpdateWallClockTime());
     ASSERT_GT(defaults.localUpdateWallClockTime(), Date_t());
@@ -193,7 +193,7 @@ TEST_F(ReadWriteConcernDefaultsTest, TestGetDefaultWithUnsetCWRWCWithImplicitWCM
     ASSERT(defaults.getDefaultReadConcernSource() == DefaultReadConcernSourceEnum::kImplicit);
 
     ASSERT(defaults.getDefaultWriteConcern());
-    ASSERT_EQ(WriteConcernOptions::kMajority, defaults.getDefaultWriteConcern().get().wMode);
+    ASSERT_EQ(WriteConcernOptions::kMajority, defaults.getDefaultWriteConcern().get().wMode());
     ASSERT_EQ(Timestamp(1, 2), *defaults.getUpdateOpTime());
     ASSERT_EQ(1234, defaults.getUpdateWallClockTime()->toMillisSinceEpoch());
     ASSERT_GT(defaults.localUpdateWallClockTime(), Date_t());
@@ -222,10 +222,8 @@ TEST_F(ReadWriteConcernDefaultsTest, TestGetDefaultWithCWRWCNotSetThenSetWithImp
     RWConcernDefault newDefaults;
     newDefaults.setDefaultReadConcern(
         repl::ReadConcernArgs(repl::ReadConcernLevel::kLocalReadConcern));
-    WriteConcernOptions wc;
-    wc.wNumNodes = 4;
-    wc.usedDefaultConstructedWC = false;
-    wc.notExplicitWValue = false;
+    WriteConcernOptions wc(
+        4, WriteConcernOptions::SyncMode::UNSET, WriteConcernOptions::kNoTimeout);
     newDefaults.setDefaultWriteConcern(wc);
     newDefaults.setUpdateOpTime(Timestamp(1, 2));
     newDefaults.setUpdateWallClockTime(Date_t::fromMillisSinceEpoch(1234));
@@ -239,7 +237,7 @@ TEST_F(ReadWriteConcernDefaultsTest, TestGetDefaultWithCWRWCNotSetThenSetWithImp
     ASSERT(defaults.getDefaultReadConcernSource());
     ASSERT(defaults.getDefaultReadConcernSource() == DefaultReadConcernSourceEnum::kGlobal);
 
-    ASSERT_EQ(4, defaults.getDefaultWriteConcern()->wNumNodes);
+    ASSERT_EQ(4, defaults.getDefaultWriteConcern()->wNumNodes());
     ASSERT_EQ(Timestamp(1, 2), *defaults.getUpdateOpTime());
     ASSERT_EQ(1234, defaults.getUpdateWallClockTime()->toMillisSinceEpoch());
     ASSERT_GT(defaults.localUpdateWallClockTime(), Date_t());
@@ -260,7 +258,7 @@ TEST_F(ReadWriteConcernDefaultsTest, TestGetDefaultWithCWRWCNotSetThenSetWithImp
     ASSERT(oldDefaults.getDefaultReadConcernSource() == DefaultReadConcernSourceEnum::kImplicit);
 
     ASSERT(oldDefaults.getDefaultWriteConcern());
-    ASSERT_EQ(WriteConcernOptions::kMajority, oldDefaults.getDefaultWriteConcern().get().wMode);
+    ASSERT_EQ(WriteConcernOptions::kMajority, oldDefaults.getDefaultWriteConcern().get().wMode());
     ASSERT(!oldDefaults.getUpdateOpTime());
     ASSERT(!oldDefaults.getUpdateWallClockTime());
     ASSERT_GT(oldDefaults.localUpdateWallClockTime(), Date_t());
@@ -269,10 +267,9 @@ TEST_F(ReadWriteConcernDefaultsTest, TestGetDefaultWithCWRWCNotSetThenSetWithImp
     RWConcernDefault newDefaults;
     newDefaults.setDefaultReadConcern(
         repl::ReadConcernArgs(repl::ReadConcernLevel::kLocalReadConcern));
-    WriteConcernOptions wc;
-    wc.wNumNodes = 4;
-    wc.usedDefaultConstructedWC = false;
-    wc.notExplicitWValue = false;
+
+    WriteConcernOptions wc(
+        4, WriteConcernOptions::SyncMode::UNSET, WriteConcernOptions::kNoTimeout);
     newDefaults.setDefaultWriteConcern(wc);
     newDefaults.setUpdateOpTime(Timestamp(1, 2));
     newDefaults.setUpdateWallClockTime(Date_t::fromMillisSinceEpoch(1234));
@@ -286,7 +283,7 @@ TEST_F(ReadWriteConcernDefaultsTest, TestGetDefaultWithCWRWCNotSetThenSetWithImp
     ASSERT(defaults.getDefaultReadConcernSource());
     ASSERT(defaults.getDefaultReadConcernSource() == DefaultReadConcernSourceEnum::kGlobal);
 
-    ASSERT_EQ(4, defaults.getDefaultWriteConcern()->wNumNodes);
+    ASSERT_EQ(4, defaults.getDefaultWriteConcern()->wNumNodes());
     ASSERT_EQ(Timestamp(1, 2), *defaults.getUpdateOpTime());
     ASSERT_EQ(1234, defaults.getUpdateWallClockTime()->toMillisSinceEpoch());
     ASSERT_GT(defaults.localUpdateWallClockTime(), Date_t());
@@ -300,10 +297,9 @@ TEST_F(ReadWriteConcernDefaultsTest, TestGetDefaultWithSetCWRWCWithImplicitWCW1)
     RWConcernDefault newDefaults;
     newDefaults.setDefaultReadConcern(
         repl::ReadConcernArgs(repl::ReadConcernLevel::kLocalReadConcern));
-    WriteConcernOptions wc;
-    wc.wNumNodes = 4;
-    wc.usedDefaultConstructedWC = false;
-    wc.notExplicitWValue = false;
+
+    WriteConcernOptions wc(
+        4, WriteConcernOptions::SyncMode::UNSET, WriteConcernOptions::kNoTimeout);
     newDefaults.setDefaultWriteConcern(wc);
     newDefaults.setUpdateOpTime(Timestamp(1, 2));
     newDefaults.setUpdateWallClockTime(Date_t::fromMillisSinceEpoch(1234));
@@ -315,7 +311,7 @@ TEST_F(ReadWriteConcernDefaultsTest, TestGetDefaultWithSetCWRWCWithImplicitWCW1)
     ASSERT(defaults.getDefaultReadConcernSource());
     ASSERT(defaults.getDefaultReadConcernSource() == DefaultReadConcernSourceEnum::kGlobal);
 
-    ASSERT_EQ(4, defaults.getDefaultWriteConcern()->wNumNodes);
+    ASSERT_EQ(4, defaults.getDefaultWriteConcern()->wNumNodes());
     ASSERT_EQ(Timestamp(1, 2), *defaults.getUpdateOpTime());
     ASSERT_EQ(1234, defaults.getUpdateWallClockTime()->toMillisSinceEpoch());
     ASSERT_GT(defaults.localUpdateWallClockTime(), Date_t());
@@ -328,10 +324,9 @@ TEST_F(ReadWriteConcernDefaultsTest, TestGetDefaultWithSetCWRWCWithImplicitWCMaj
     RWConcernDefault newDefaults;
     newDefaults.setDefaultReadConcern(
         repl::ReadConcernArgs(repl::ReadConcernLevel::kLocalReadConcern));
-    WriteConcernOptions wc;
-    wc.wNumNodes = 4;
-    wc.usedDefaultConstructedWC = false;
-    wc.notExplicitWValue = false;
+
+    WriteConcernOptions wc(
+        4, WriteConcernOptions::SyncMode::UNSET, WriteConcernOptions::kNoTimeout);
     newDefaults.setDefaultWriteConcern(wc);
     newDefaults.setUpdateOpTime(Timestamp(1, 2));
     newDefaults.setUpdateWallClockTime(Date_t::fromMillisSinceEpoch(1234));
@@ -344,7 +339,7 @@ TEST_F(ReadWriteConcernDefaultsTest, TestGetDefaultWithSetCWRWCWithImplicitWCMaj
     ASSERT(defaults.getDefaultReadConcernSource());
     ASSERT(defaults.getDefaultReadConcernSource() == DefaultReadConcernSourceEnum::kGlobal);
 
-    ASSERT_EQ(4, defaults.getDefaultWriteConcern()->wNumNodes);
+    ASSERT_EQ(4, defaults.getDefaultWriteConcern()->wNumNodes());
     ASSERT_EQ(Timestamp(1, 2), *defaults.getUpdateOpTime());
     ASSERT_EQ(1234, defaults.getUpdateWallClockTime()->toMillisSinceEpoch());
     ASSERT_GT(defaults.localUpdateWallClockTime(), Date_t());
@@ -370,10 +365,9 @@ TEST_F(ReadWriteConcernDefaultsTest, TestGetDefaultWriteConcernSourceImplicitWit
     ASSERT(defaults.getDefaultReadConcernSource());
     ASSERT(defaults.getDefaultReadConcernSource() == DefaultReadConcernSourceEnum::kImplicit);
 
-    // The default write concern source should be set to implicit if wc.usedDefaultConstructedWC is
-    // true
-    ASSERT_EQ(0, defaults.getDefaultWriteConcern()->wNumNodes);
-    ASSERT_EQ(WriteConcernOptions::kMajority, defaults.getDefaultWriteConcern().get().wMode);
+    // The default write concern source should be set to implicit if wc.isDefaultConstructed()
+    ASSERT_EQ(0, defaults.getDefaultWriteConcern()->wNumNodes());
+    ASSERT_EQ(WriteConcernOptions::kMajority, defaults.getDefaultWriteConcern().get().wMode());
     ASSERT_EQ(Timestamp(1, 2), *defaults.getUpdateOpTime());
     ASSERT_EQ(1234, defaults.getUpdateWallClockTime()->toMillisSinceEpoch());
     ASSERT_GT(defaults.localUpdateWallClockTime(), Date_t());
@@ -447,7 +441,7 @@ TEST_F(ReadWriteConcernDefaultsTest, TestGetDefaultWithSetAndUnSetCWRCWithImplic
     ASSERT(defaults.getDefaultReadConcernSource() == DefaultReadConcernSourceEnum::kGlobal);
 
     ASSERT(defaults.getDefaultWriteConcern());
-    ASSERT_EQ(WriteConcernOptions::kMajority, defaults.getDefaultWriteConcern().get().wMode);
+    ASSERT_EQ(WriteConcernOptions::kMajority, defaults.getDefaultWriteConcern().get().wMode());
     ASSERT_EQ(Timestamp(1, 2), *defaults.getUpdateOpTime());
     ASSERT_EQ(1234, defaults.getUpdateWallClockTime()->toMillisSinceEpoch());
     ASSERT_GT(defaults.localUpdateWallClockTime(), Date_t());
@@ -470,7 +464,7 @@ TEST_F(ReadWriteConcernDefaultsTest, TestGetDefaultWithSetAndUnSetCWRCWithImplic
     ASSERT(defaults.getDefaultReadConcernSource());
     ASSERT(defaults.getDefaultReadConcernSource() == DefaultReadConcernSourceEnum::kImplicit);
 
-    ASSERT_EQ(WriteConcernOptions::kMajority, defaults.getDefaultWriteConcern().get().wMode);
+    ASSERT_EQ(WriteConcernOptions::kMajority, defaults.getDefaultWriteConcern().get().wMode());
     ASSERT_EQ(Timestamp(1, 3), *defaults.getUpdateOpTime());
     ASSERT_EQ(1234, defaults.getUpdateWallClockTime()->toMillisSinceEpoch());
     ASSERT_GT(defaults.localUpdateWallClockTime(), Date_t());
@@ -511,10 +505,9 @@ TEST_F(ReadWriteConcernDefaultsTest, TestGetDefaultWithoutInvalidateDoesNotCallL
     RWConcernDefault newDefaults2;
     newDefaults2.setDefaultReadConcern(
         repl::ReadConcernArgs(repl::ReadConcernLevel::kAvailableReadConcern));
-    WriteConcernOptions wc;
-    wc.wNumNodes = 4;
-    wc.usedDefaultConstructedWC = false;
-    wc.notExplicitWValue = false;
+
+    WriteConcernOptions wc(
+        4, WriteConcernOptions::SyncMode::UNSET, WriteConcernOptions::kNoTimeout);
     newDefaults2.setDefaultWriteConcern(wc);
     newDefaults2.setUpdateOpTime(Timestamp(3, 4));
     newDefaults2.setUpdateWallClockTime(Date_t::fromMillisSinceEpoch(5678));
@@ -563,10 +556,9 @@ TEST_F(ReadWriteConcernDefaultsTest, TestInvalidate) {
     RWConcernDefault newDefaults2;
     newDefaults2.setDefaultReadConcern(
         repl::ReadConcernArgs(repl::ReadConcernLevel::kAvailableReadConcern));
-    WriteConcernOptions wc;
-    wc.wNumNodes = 4;
-    wc.usedDefaultConstructedWC = false;
-    wc.notExplicitWValue = false;
+
+    WriteConcernOptions wc(
+        4, WriteConcernOptions::SyncMode::UNSET, WriteConcernOptions::kNoTimeout);
     newDefaults2.setDefaultWriteConcern(wc);
     newDefaults2.setUpdateOpTime(Timestamp(3, 4));
     newDefaults2.setUpdateWallClockTime(Date_t::fromMillisSinceEpoch(5678));
@@ -580,7 +572,7 @@ TEST_F(ReadWriteConcernDefaultsTest, TestInvalidate) {
     ASSERT(defaults2.getDefaultReadConcernSource());
     ASSERT(defaults2.getDefaultReadConcernSource() == DefaultReadConcernSourceEnum::kGlobal);
 
-    ASSERT_EQ(4, defaults2.getDefaultWriteConcern()->wNumNodes);
+    ASSERT_EQ(4, defaults2.getDefaultWriteConcern()->wNumNodes());
     ASSERT_EQ(Timestamp(3, 4), *defaults2.getUpdateOpTime());
     ASSERT_EQ(5678, defaults2.getUpdateWallClockTime()->toMillisSinceEpoch());
     ASSERT_GT(defaults2.localUpdateWallClockTime(), Date_t());
@@ -702,7 +694,7 @@ protected:
         // default read concern source is not saved on disk.
         ASSERT(!defaults.getDefaultReadConcernSource());
 
-        ASSERT_EQ(4, defaults.getDefaultWriteConcern()->wNumNodes);
+        ASSERT_EQ(4, defaults.getDefaultWriteConcern()->wNumNodes());
         ASSERT(defaults.getUpdateOpTime());
         ASSERT(defaults.getUpdateWallClockTime());
         // Default write concern source is not saved on disk.
@@ -801,7 +793,7 @@ TEST_F(ReadWriteConcernDefaultsTestWithClusterTime,
            repl::ReadConcernLevel::kMajorityReadConcern);
     ASSERT(!defaults.getDefaultReadConcernSource());
 
-    ASSERT_EQ(5, defaults.getDefaultWriteConcern()->wNumNodes);
+    ASSERT_EQ(5, defaults.getDefaultWriteConcern()->wNumNodes());
     ASSERT_LT(*oldDefaults.getUpdateOpTime(), *defaults.getUpdateOpTime());
     ASSERT_LT(*oldDefaults.getUpdateWallClockTime(), *defaults.getUpdateWallClockTime());
     // Default write concern source is not saved on disk.
@@ -826,8 +818,8 @@ TEST_F(ReadWriteConcernDefaultsTestWithClusterTime,
            repl::ReadConcernLevel::kMajorityReadConcern);
     ASSERT(!defaults.getDefaultReadConcernSource());
 
-    ASSERT_EQ(oldDefaults.getDefaultWriteConcern()->wNumNodes,
-              defaults.getDefaultWriteConcern()->wNumNodes);
+    ASSERT_EQ(oldDefaults.getDefaultWriteConcern()->wNumNodes(),
+              defaults.getDefaultWriteConcern()->wNumNodes());
     ASSERT_LT(*oldDefaults.getUpdateOpTime(), *defaults.getUpdateOpTime());
     ASSERT_LT(*oldDefaults.getUpdateWallClockTime(), *defaults.getUpdateWallClockTime());
     // Default write concern source is not saved on disk.
@@ -871,7 +863,7 @@ TEST_F(ReadWriteConcernDefaultsTestWithClusterTime,
            defaults.getDefaultReadConcern()->getLevel());
     ASSERT(!defaults.getDefaultReadConcernSource());
 
-    ASSERT_EQ(5, defaults.getDefaultWriteConcern()->wNumNodes);
+    ASSERT_EQ(5, defaults.getDefaultWriteConcern()->wNumNodes());
     ASSERT_LT(*oldDefaults.getUpdateOpTime(), *defaults.getUpdateOpTime());
     ASSERT_LT(*oldDefaults.getUpdateWallClockTime(), *defaults.getUpdateWallClockTime());
     // Default write concern source is not saved on disk.
@@ -912,7 +904,7 @@ TEST_F(ReadWriteConcernDefaultsTestWithClusterTime,
         uassertStatusOK(WriteConcernOptions::parse(BSON("w" << 5))));
     ASSERT(newDefaults.getDefaultReadConcern()->getLevel() ==
            defaults.getDefaultReadConcern()->getLevel());
-    ASSERT_EQ(5, defaults.getDefaultWriteConcern()->wNumNodes);
+    ASSERT_EQ(5, defaults.getDefaultWriteConcern()->wNumNodes());
     // Default write concern source is not saved on disk.
     ASSERT(!defaults.getDefaultWriteConcernSource());
 
@@ -920,7 +912,7 @@ TEST_F(ReadWriteConcernDefaultsTestWithClusterTime,
     _rwcd.refreshIfNecessary(operationContext());
     newDefaults = _rwcd.getDefault(operationContext());
     ASSERT(newDefaults.getDefaultWriteConcern());
-    ASSERT_EQ(5, newDefaults.getDefaultWriteConcern()->wNumNodes);
+    ASSERT_EQ(5, newDefaults.getDefaultWriteConcern()->wNumNodes());
     // Default write concern source is calculated through 'getDefault'.
     ASSERT(newDefaults.getDefaultWriteConcernSource() == DefaultWriteConcernSourceEnum::kGlobal);
 }
@@ -935,8 +927,8 @@ TEST_F(ReadWriteConcernDefaultsTestWithClusterTime,
     ASSERT(!defaults.getDefaultReadConcernSource());
 
     ASSERT(defaults.getDefaultWriteConcern());
-    ASSERT_EQ(oldDefaults.getDefaultWriteConcern()->wNumNodes,
-              defaults.getDefaultWriteConcern()->wNumNodes);
+    ASSERT_EQ(oldDefaults.getDefaultWriteConcern()->wNumNodes(),
+              defaults.getDefaultWriteConcern()->wNumNodes());
     ASSERT_LT(*oldDefaults.getUpdateOpTime(), *defaults.getUpdateOpTime());
     ASSERT_LT(*oldDefaults.getUpdateWallClockTime(), *defaults.getUpdateWallClockTime());
     // Default write concern source is not saved on disk.
@@ -1001,9 +993,9 @@ TEST_F(ReadWriteConcernDefaultsTestWithClusterTime,
     ASSERT(oldDefaults.getDefaultReadConcern()->getLevel() ==
            defaults.getDefaultReadConcern()->getLevel());
     ASSERT(!defaults.getDefaultReadConcernSource());
-    ASSERT_EQ(1, defaults.getDefaultWriteConcern()->wNumNodes);
-    ASSERT_EQ(0, defaults.getDefaultWriteConcern()->wTimeout);
-    ASSERT(WriteConcernOptions::SyncMode::JOURNAL == defaults.getDefaultWriteConcern()->syncMode);
+    ASSERT_EQ(1, defaults.getDefaultWriteConcern()->wNumNodes());
+    ASSERT_EQ(0, defaults.getDefaultWriteConcern()->wTimeout());
+    ASSERT(WriteConcernOptions::SyncMode::JOURNAL == defaults.getDefaultWriteConcern()->syncMode());
     ASSERT_LT(*oldDefaults.getUpdateOpTime(), *defaults.getUpdateOpTime());
     ASSERT_LT(*oldDefaults.getUpdateWallClockTime(), *defaults.getUpdateWallClockTime());
     // Default write concern source is not saved on disk.
@@ -1027,9 +1019,9 @@ TEST_F(ReadWriteConcernDefaultsTestWithClusterTime,
     ASSERT(oldDefaults.getDefaultReadConcern()->getLevel() ==
            defaults.getDefaultReadConcern()->getLevel());
     ASSERT(!defaults.getDefaultReadConcernSource());
-    ASSERT_EQ(1, defaults.getDefaultWriteConcern()->wNumNodes);
-    ASSERT_EQ(12345, defaults.getDefaultWriteConcern()->wTimeout);
-    ASSERT(WriteConcernOptions::SyncMode::UNSET == defaults.getDefaultWriteConcern()->syncMode);
+    ASSERT_EQ(1, defaults.getDefaultWriteConcern()->wNumNodes());
+    ASSERT_EQ(12345, defaults.getDefaultWriteConcern()->wTimeout());
+    ASSERT(WriteConcernOptions::SyncMode::UNSET == defaults.getDefaultWriteConcern()->syncMode());
     ASSERT_LT(*oldDefaults.getUpdateOpTime(), *defaults.getUpdateOpTime());
     ASSERT_LT(*oldDefaults.getUpdateWallClockTime(), *defaults.getUpdateWallClockTime());
     // Default write concern source is not saved on disk.

--- a/src/mongo/db/repl/repl_set_config.cpp
+++ b/src/mongo/db/repl/repl_set_config.cpp
@@ -410,8 +410,8 @@ Status ReplSetConfig::_validate(bool allowSplitHorizonIP) const {
 
 Status ReplSetConfig::checkIfWriteConcernCanBeSatisfied(
     const WriteConcernOptions& writeConcern) const {
-    if (!writeConcern.wMode.empty() && writeConcern.wMode != WriteConcernOptions::kMajority) {
-        StatusWith<ReplSetTagPattern> tagPatternStatus = findCustomWriteMode(writeConcern.wMode);
+    if (!writeConcern.wMode().empty() && writeConcern.wMode() != WriteConcernOptions::kMajority) {
+        StatusWith<ReplSetTagPattern> tagPatternStatus = findCustomWriteMode(writeConcern.wMode());
         if (!tagPatternStatus.isOK()) {
             return tagPatternStatus.getStatus();
         }
@@ -431,9 +431,9 @@ Status ReplSetConfig::checkIfWriteConcernCanBeSatisfied(
         // write concern mode.
         return Status(ErrorCodes::UnsatisfiableWriteConcern,
                       str::stream() << "Not enough nodes match write concern mode \""
-                                    << writeConcern.wMode << "\"");
+                                    << writeConcern.wMode() << "\"");
     } else {
-        int nodesRemaining = writeConcern.wNumNodes;
+        int nodesRemaining = writeConcern.wNumNodes();
         for (size_t j = 0; j < getMembers().size(); ++j) {
             if (!getMembers()[j].isArbiter()) {  // Only count data-bearing nodes
                 --nodesRemaining;
@@ -694,8 +694,8 @@ bool ReplSetConfig::containsCustomizedGetLastErrorDefaults() const {
     // Since the ReplSetConfig always has a WriteConcernOptions, the only way to know if it has been
     // customized through getLastErrorDefaults is if it's different from { w: 1, wtimeout: 0 }.
     const auto& getLastErrorDefaults = getDefaultWriteConcern();
-    return !(getLastErrorDefaults.wNumNodes == 1 && getLastErrorDefaults.wTimeout == 0 &&
-             getLastErrorDefaults.syncMode == WriteConcernOptions::SyncMode::UNSET);
+    return !(getLastErrorDefaults.wNumNodes() == 1 && getLastErrorDefaults.wTimeout() == 0 &&
+             getLastErrorDefaults.syncMode() == WriteConcernOptions::SyncMode::UNSET);
 }
 
 MemberConfig* MutableReplSetConfig::_findMemberByID(MemberId id) {

--- a/src/mongo/db/repl/repl_set_config_test.cpp
+++ b/src/mongo/db/repl/repl_set_config_test.cpp
@@ -665,7 +665,6 @@ TEST(ReplSetConfig, ParseFailsWithNonObjectSettingsField) {
 }
 
 TEST(ReplSetConfig, ParseFailsWithGetLastErrorDefaultsFieldUnparseable) {
-    ReplSetConfig config;
     ASSERT_THROWS(ReplSetConfig::parse(BSON("_id"
                                             << "rs0"
                                             << "version" << 1 << "protocolVersion" << 1 << "members"
@@ -674,7 +673,7 @@ TEST(ReplSetConfig, ParseFailsWithGetLastErrorDefaultsFieldUnparseable) {
                                             << "settings"
                                             << BSON("getLastErrorDefaults" << BSON("fsync"
                                                                                    << "seven")))),
-                  ExceptionFor<ErrorCodes::FailedToParse>);
+                  ExceptionFor<ErrorCodes::TypeMismatch>);
 }
 
 TEST(ReplSetConfig, ParseFailsWithNonObjectGetLastErrorDefaultsField) {

--- a/src/mongo/db/repl/repl_set_config_test.cpp
+++ b/src/mongo/db/repl/repl_set_config_test.cpp
@@ -92,8 +92,8 @@ TEST(ReplSetConfig, ParseMinimalConfigAndCheckDefaults) {
     ASSERT_EQUALS(1, config.getConfigTerm());
     ASSERT_EQUALS(1, config.getNumMembers());
     ASSERT_EQUALS(MemberId(0), config.membersBegin()->getId());
-    ASSERT_EQUALS(1, config.getDefaultWriteConcern().wNumNodes);
-    ASSERT_EQUALS("", config.getDefaultWriteConcern().wMode);
+    ASSERT_EQUALS(1, config.getDefaultWriteConcern().wNumNodes());
+    ASSERT_EQUALS("", config.getDefaultWriteConcern().wMode());
     ASSERT_EQUALS(ReplSetConfig::kDefaultHeartbeatInterval, config.getHeartbeatInterval());
     ASSERT_EQUALS(ReplSetConfig::kDefaultHeartbeatTimeoutPeriod,
                   config.getHeartbeatTimeoutPeriod());
@@ -1271,8 +1271,8 @@ bool operator==(const ReplSetConfig& a, const ReplSetConfig& b) {
         a.getElectionTimeoutPeriod() == b.getElectionTimeoutPeriod() &&
         a.isChainingAllowed() == b.isChainingAllowed() &&
         a.getConfigServer() == b.getConfigServer() &&
-        a.getDefaultWriteConcern().wNumNodes == b.getDefaultWriteConcern().wNumNodes &&
-        a.getDefaultWriteConcern().wMode == b.getDefaultWriteConcern().wMode &&
+        a.getDefaultWriteConcern().wNumNodes() == b.getDefaultWriteConcern().wNumNodes() &&
+        a.getDefaultWriteConcern().wMode() == b.getDefaultWriteConcern().wMode() &&
         a.getProtocolVersion() == b.getProtocolVersion() &&
         a.getReplicaSetId() == b.getReplicaSetId();
 }
@@ -1427,35 +1427,37 @@ TEST(ReplSetConfig, CheckIfWriteConcernCanBeSatisfied) {
                     "valid" << BSON("dc" << 2 << "rack" << 3) << "invalidNotEnoughValues"
                             << BSON("dc" << 3) << "invalidNotEnoughNodes" << BSON("rack" << 6)))));
 
-    WriteConcernOptions validNumberWC;
-    validNumberWC.wNumNodes = 5;
+    WriteConcernOptions validNumberWC(
+        5, WriteConcernOptions::SyncMode::UNSET, WriteConcernOptions::kNoTimeout);
     ASSERT_OK(configA.checkIfWriteConcernCanBeSatisfied(validNumberWC));
 
-    WriteConcernOptions invalidNumberWC;
-    invalidNumberWC.wNumNodes = 6;
+    WriteConcernOptions invalidNumberWC(
+        6, WriteConcernOptions::SyncMode::UNSET, WriteConcernOptions::kNoTimeout);
     ASSERT_EQUALS(ErrorCodes::UnsatisfiableWriteConcern,
                   configA.checkIfWriteConcernCanBeSatisfied(invalidNumberWC));
 
-    WriteConcernOptions majorityWC;
-    majorityWC.wMode = "majority";
+    WriteConcernOptions majorityWC(
+        "majority", WriteConcernOptions::SyncMode::UNSET, WriteConcernOptions::kNoTimeout);
     ASSERT_OK(configA.checkIfWriteConcernCanBeSatisfied(majorityWC));
 
-    WriteConcernOptions validModeWC;
-    validModeWC.wMode = "valid";
+    WriteConcernOptions validModeWC(
+        "valid", WriteConcernOptions::SyncMode::UNSET, WriteConcernOptions::kNoTimeout);
     ASSERT_OK(configA.checkIfWriteConcernCanBeSatisfied(validModeWC));
 
-    WriteConcernOptions fakeModeWC;
-    fakeModeWC.wMode = "fake";
+    WriteConcernOptions fakeModeWC(
+        "fake", WriteConcernOptions::SyncMode::UNSET, WriteConcernOptions::kNoTimeout);
     ASSERT_EQUALS(ErrorCodes::UnknownReplWriteConcern,
                   configA.checkIfWriteConcernCanBeSatisfied(fakeModeWC));
 
-    WriteConcernOptions invalidModeNotEnoughValuesWC;
-    invalidModeNotEnoughValuesWC.wMode = "invalidNotEnoughValues";
+    WriteConcernOptions invalidModeNotEnoughValuesWC("invalidNotEnoughValues",
+                                                     WriteConcernOptions::SyncMode::UNSET,
+                                                     WriteConcernOptions::kNoTimeout);
     ASSERT_EQUALS(ErrorCodes::UnsatisfiableWriteConcern,
                   configA.checkIfWriteConcernCanBeSatisfied(invalidModeNotEnoughValuesWC));
 
-    WriteConcernOptions invalidModeNotEnoughNodesWC;
-    invalidModeNotEnoughNodesWC.wMode = "invalidNotEnoughNodes";
+    WriteConcernOptions invalidModeNotEnoughNodesWC("invalidNotEnoughNodes",
+                                                    WriteConcernOptions::SyncMode::UNSET,
+                                                    WriteConcernOptions::kNoTimeout);
     ASSERT_EQUALS(ErrorCodes::UnsatisfiableWriteConcern,
                   configA.checkIfWriteConcernCanBeSatisfied(invalidModeNotEnoughNodesWC));
 }

--- a/src/mongo/db/repl/repl_set_config_validators.h
+++ b/src/mongo/db/repl/repl_set_config_validators.h
@@ -49,7 +49,7 @@ inline Status validateTrue(bool boolVal) {
 }
 
 inline Status validateDefaultWriteConcernHasMember(const WriteConcernOptions& defaultWriteConcern) {
-    if (defaultWriteConcern.wMode.empty() && defaultWriteConcern.wNumNodes == 0) {
+    if (defaultWriteConcern.wMode().empty() && defaultWriteConcern.wNumNodes() == 0) {
         return Status(ErrorCodes::BadValue,
                       "Default write concern mode must wait for at least 1 member");
     }

--- a/src/mongo/db/repl/replication_coordinator.h
+++ b/src/mongo/db/repl/replication_coordinator.h
@@ -234,7 +234,7 @@ public:
      * ErrorCodes::ExceededTimeLimit if the opCtx->getMaxTimeMicrosRemaining is reached before
      *     the data has been sufficiently replicated
      * ErrorCodes::NotWritablePrimary if the node is not a writable primary
-     * ErrorCodes::UnknownReplWriteConcern if the writeConcern.wMode contains a write concern
+     * ErrorCodes::UnknownReplWriteConcern if the writeConcern.wMode() contains a write concern
      *     mode that is not known
      * ErrorCodes::ShutdownInProgress if we are mid-shutdown
      * ErrorCodes::Interrupted if the operation was killed with killop()

--- a/src/mongo/db/repl/replication_coordinator_impl_reconfig_test.cpp
+++ b/src/mongo/db/repl/replication_coordinator_impl_reconfig_test.cpp
@@ -881,11 +881,8 @@ TEST_F(ReplCoordTest, ReconfigThatChangesIDWCFromW1toWMajWithoutCWWCSetFails) {
 
 TEST_F(ReplCoordTest, ReconfigThatChangesIDWCWMajToW1WithCWWCSetPasses) {
     RWConcernDefault newDefaults;
-    WriteConcernOptions wc;
-    wc.wMode = "majority";
-    wc.usedDefaultConstructedWC = false;
-    wc.notExplicitWValue = false;
-    newDefaults.setDefaultWriteConcern(wc);
+    auto writeConcern = WriteConcernOptions::parse(WriteConcernOptions::Majority).getValue();
+    newDefaults.setDefaultWriteConcern(writeConcern);
     lookupMock.setLookupCallReturnValue(std::move(newDefaults));
 
     assertStartSuccess(BSON("_id"
@@ -944,11 +941,8 @@ TEST_F(ReplCoordTest, ReconfigThatChangesIDWCWMajToW1WithCWWCSetPasses) {
 
 TEST_F(ReplCoordTest, ReconfigThatChangesIDWCW1ToWMajWithCWWCSetPasses) {
     RWConcernDefault newDefaults;
-    WriteConcernOptions wc;
-    wc.wMode = "majority";
-    wc.usedDefaultConstructedWC = false;
-    wc.notExplicitWValue = false;
-    newDefaults.setDefaultWriteConcern(wc);
+    auto writeConcern = WriteConcernOptions::parse(WriteConcernOptions::Majority).getValue();
+    newDefaults.setDefaultWriteConcern(writeConcern);
     lookupMock.setLookupCallReturnValue(std::move(newDefaults));
 
     assertStartSuccess(BSON("_id"
@@ -2270,11 +2264,8 @@ TEST_F(ReplCoordReconfigTest, NodesWithNewlyAddedFieldSetHavePriorityZero) {
 
 TEST_F(ReplCoordReconfigTest, ArbiterNodesShouldNeverHaveNewlyAddedField) {
     RWConcernDefault newDefaults;
-    WriteConcernOptions wc;
-    wc.wMode = "majority";
-    wc.usedDefaultConstructedWC = false;
-    wc.notExplicitWValue = false;
-    newDefaults.setDefaultWriteConcern(wc);
+    auto writeConcern = WriteConcernOptions::parse(WriteConcernOptions::Majority).getValue();
+    newDefaults.setDefaultWriteConcern(writeConcern);
     lookupMock.setLookupCallReturnValue(std::move(newDefaults));
 
     setUpNewlyAddedFieldTest();

--- a/src/mongo/db/repl/replication_coordinator_mock.cpp
+++ b/src/mongo/db/repl/replication_coordinator_mock.cpp
@@ -638,11 +638,11 @@ void ReplicationCoordinatorMock::createWMajorityWriteAvailabilityDateWaiter(OpTi
 
 WriteConcernOptions ReplicationCoordinatorMock::populateUnsetWriteConcernOptionsSyncMode(
     WriteConcernOptions wc) {
-    if (wc.syncMode == WriteConcernOptions::SyncMode::UNSET) {
-        if (wc.wMode == WriteConcernOptions::kMajority) {
-            wc.syncMode = WriteConcernOptions::SyncMode::JOURNAL;
+    if (wc.syncMode() == WriteConcernOptions::SyncMode::UNSET) {
+        if (wc.wMode() == WriteConcernOptions::kMajority) {
+            wc._syncMode = WriteConcernOptions::SyncMode::JOURNAL;
         } else {
-            wc.syncMode = WriteConcernOptions::SyncMode::NONE;
+            wc._syncMode = WriteConcernOptions::SyncMode::NONE;
         }
     }
     return wc;

--- a/src/mongo/db/repl/tenant_migration_recipient_service.cpp
+++ b/src/mongo/db/repl/tenant_migration_recipient_service.cpp
@@ -583,7 +583,7 @@ TenantMigrationRecipientService::Instance::waitUntilMigrationReachesReturnAfterR
 
     WriteConcernOptions writeConcern(repl::ReplSetConfig::kConfigAllWriteConcernName,
                                      WriteConcernOptions::SyncMode::NONE,
-                                     opCtx->getWriteConcern().wTimeout);
+                                     opCtx->getWriteConcern().wTimeout());
     uassertStatusOK(replCoord->awaitReplication(opCtx, lastOpAfterUpdate, writeConcern).status);
 
     _stopOrHangOnFailPoint(&fpAfterWaitForRejectReadsBeforeTimestamp, opCtx);

--- a/src/mongo/db/s/clone_catalog_data_command.cpp
+++ b/src/mongo/db/s/clone_catalog_data_command.cpp
@@ -99,7 +99,7 @@ public:
                 str::stream()
                     << "_shardsvrCloneCatalogData must be called with majority writeConcern, got "
                     << cmdObj,
-                opCtx->getWriteConcern().wMode == WriteConcernOptions::kMajority);
+                opCtx->getWriteConcern().wMode() == WriteConcernOptions::kMajority);
 
         const auto cloneCatalogDataRequest =
             CloneCatalogData::parse(IDLParserErrorContext("_shardsvrCloneCatalogData"), cmdObj);

--- a/src/mongo/db/s/config/configsvr_abort_reshard_collection_command.cpp
+++ b/src/mongo/db/s/config/configsvr_abort_reshard_collection_command.cpp
@@ -109,7 +109,7 @@ public:
                     serverGlobalParams.clusterRole == ClusterRole::ConfigServer);
             uassert(ErrorCodes::InvalidOptions,
                     "_configsvrAbortReshardCollection must be called with majority writeConcern",
-                    opCtx->getWriteConcern().wMode == WriteConcernOptions::kMajority);
+                    opCtx->getWriteConcern().wMode() == WriteConcernOptions::kMajority);
 
             const auto reshardingUUID = retrieveReshardingUUID(opCtx, ns());
 

--- a/src/mongo/db/s/config/configsvr_add_shard_command.cpp
+++ b/src/mongo/db/s/config/configsvr_add_shard_command.cpp
@@ -102,7 +102,7 @@ public:
             ErrorCodes::InvalidOptions,
             str::stream() << "_configsvrAddShard must be called with majority writeConcern, got "
                           << cmdObj,
-            opCtx->getWriteConcern().wMode == WriteConcernOptions::kMajority);
+            opCtx->getWriteConcern().wMode() == WriteConcernOptions::kMajority);
 
         // Set the operation context read concern level to local for reads into the config database.
         repl::ReadConcernArgs::get(opCtx) =

--- a/src/mongo/db/s/config/configsvr_clear_jumbo_flag_command.cpp
+++ b/src/mongo/db/s/config/configsvr_clear_jumbo_flag_command.cpp
@@ -59,7 +59,7 @@ public:
                     serverGlobalParams.clusterRole == ClusterRole::ConfigServer);
             uassert(ErrorCodes::InvalidOptions,
                     "_configsvrClearJumboFlag must be called with majority writeConcern",
-                    opCtx->getWriteConcern().wMode == WriteConcernOptions::kMajority);
+                    opCtx->getWriteConcern().wMode() == WriteConcernOptions::kMajority);
 
             // Set the operation context read concern level to local for reads into the config
             // database.

--- a/src/mongo/db/s/config/configsvr_commit_reshard_collection_command.cpp
+++ b/src/mongo/db/s/config/configsvr_commit_reshard_collection_command.cpp
@@ -82,7 +82,7 @@ public:
             uassert(ErrorCodes::InvalidOptions,
                     format(FMT_STRING("{} must be called with majority writeConcern"),
                            definition()->getName()),
-                    opCtx->getWriteConcern().wMode == WriteConcernOptions::kMajority);
+                    opCtx->getWriteConcern().wMode() == WriteConcernOptions::kMajority);
 
             UUID reshardingUUID = retrieveReshardingUUID(opCtx, ns());
 

--- a/src/mongo/db/s/config/configsvr_create_database_command.cpp
+++ b/src/mongo/db/s/config/configsvr_create_database_command.cpp
@@ -74,7 +74,7 @@ public:
             uassert(ErrorCodes::InvalidOptions,
                     str::stream()
                         << "_configsvrCreateDatabase must be called with majority writeConcern",
-                    opCtx->getWriteConcern().wMode == WriteConcernOptions::kMajority);
+                    opCtx->getWriteConcern().wMode() == WriteConcernOptions::kMajority);
 
             // Set the operation context read concern level to local for reads into the config
             // database.

--- a/src/mongo/db/s/config/configsvr_ensure_chunk_version_is_greater_than_command.cpp
+++ b/src/mongo/db/s/config/configsvr_ensure_chunk_version_is_greater_than_command.cpp
@@ -55,7 +55,7 @@ public:
             uassert(ErrorCodes::InvalidOptions,
                     "_configsvrEnsureChunkVersionIsGreaterThan must be called with majority "
                     "writeConcern",
-                    opCtx->getWriteConcern().wMode == WriteConcernOptions::kMajority);
+                    opCtx->getWriteConcern().wMode() == WriteConcernOptions::kMajority);
             ShardingCatalogManager::get(opCtx)->ensureChunkVersionIsGreaterThan(
                 opCtx,
                 request().getCollectionUUID(),

--- a/src/mongo/db/s/config/configsvr_refine_collection_shard_key_command.cpp
+++ b/src/mongo/db/s/config/configsvr_refine_collection_shard_key_command.cpp
@@ -58,7 +58,7 @@ public:
                     serverGlobalParams.clusterRole == ClusterRole::ConfigServer);
             uassert(ErrorCodes::InvalidOptions,
                     "_configsvrRefineCollectionShardKey must be called with majority writeConcern",
-                    opCtx->getWriteConcern().wMode == WriteConcernOptions::kMajority);
+                    opCtx->getWriteConcern().wMode() == WriteConcernOptions::kMajority);
             _internalRun(opCtx);
         }
 

--- a/src/mongo/db/s/config/configsvr_remove_chunks_command.cpp
+++ b/src/mongo/db/s/config/configsvr_remove_chunks_command.cpp
@@ -64,7 +64,7 @@ public:
                     serverGlobalParams.clusterRole == ClusterRole::ConfigServer);
             uassert(ErrorCodes::InvalidOptions,
                     "_configsvrRemoveChunks must be called with majority writeConcern",
-                    opCtx->getWriteConcern().wMode == WriteConcernOptions::kMajority);
+                    opCtx->getWriteConcern().wMode() == WriteConcernOptions::kMajority);
 
             // Set the operation context read concern level to local for reads into the config
             // database.

--- a/src/mongo/db/s/config/configsvr_remove_shard_command.cpp
+++ b/src/mongo/db/s/config/configsvr_remove_shard_command.cpp
@@ -102,7 +102,7 @@ public:
             ErrorCodes::InvalidOptions,
             str::stream() << "_configsvrRemoveShard must be called with majority writeConcern, got "
                           << cmdObj,
-            opCtx->getWriteConcern().wMode == WriteConcernOptions::kMajority);
+            opCtx->getWriteConcern().wMode() == WriteConcernOptions::kMajority);
 
         // Set the operation context read concern level to local for reads into the config database.
         repl::ReadConcernArgs::get(opCtx) =

--- a/src/mongo/db/s/config/configsvr_remove_tags_command.cpp
+++ b/src/mongo/db/s/config/configsvr_remove_tags_command.cpp
@@ -64,7 +64,7 @@ public:
                     serverGlobalParams.clusterRole == ClusterRole::ConfigServer);
             uassert(ErrorCodes::InvalidOptions,
                     "_configsvrRemoveTags must be called with majority writeConcern",
-                    opCtx->getWriteConcern().wMode == WriteConcernOptions::kMajority);
+                    opCtx->getWriteConcern().wMode() == WriteConcernOptions::kMajority);
 
             // Set the operation context read concern level to local for reads into the config
             // database.

--- a/src/mongo/db/s/config/configsvr_rename_collection_metadata_command.cpp
+++ b/src/mongo/db/s/config/configsvr_rename_collection_metadata_command.cpp
@@ -77,7 +77,7 @@ public:
                     serverGlobalParams.clusterRole == ClusterRole::ConfigServer);
             uassert(ErrorCodes::InvalidOptions,
                     "_configsvrRenameCollectionMetadata must be called with majority writeConcern",
-                    opCtx->getWriteConcern().wMode == WriteConcernOptions::kMajority);
+                    opCtx->getWriteConcern().wMode() == WriteConcernOptions::kMajority);
 
             opCtx->setAlwaysInterruptAtStepDownOrUp();
 

--- a/src/mongo/db/s/config/configsvr_reshard_collection_cmd.cpp
+++ b/src/mongo/db/s/config/configsvr_reshard_collection_cmd.cpp
@@ -92,7 +92,7 @@ public:
                     serverGlobalParams.clusterRole == ClusterRole::ConfigServer);
             uassert(ErrorCodes::InvalidOptions,
                     "_configsvrReshardCollection must be called with majority writeConcern",
-                    opCtx->getWriteConcern().wMode == WriteConcernOptions::kMajority);
+                    opCtx->getWriteConcern().wMode() == WriteConcernOptions::kMajority);
             repl::ReadConcernArgs::get(opCtx) =
                 repl::ReadConcernArgs(repl::ReadConcernLevel::kLocalReadConcern);
 

--- a/src/mongo/db/s/config/configsvr_set_allow_migrations_command.cpp
+++ b/src/mongo/db/s/config/configsvr_set_allow_migrations_command.cpp
@@ -58,7 +58,7 @@ public:
                     serverGlobalParams.clusterRole == ClusterRole::ConfigServer);
             uassert(ErrorCodes::InvalidOptions,
                     "_configsvrSetAllowMigrations must be called with majority writeConcern",
-                    opCtx->getWriteConcern().wMode == WriteConcernOptions::kMajority);
+                    opCtx->getWriteConcern().wMode() == WriteConcernOptions::kMajority);
 
             // Set the operation context read concern level to local for reads into the config
             // database.

--- a/src/mongo/db/s/migration_destination_manager.cpp
+++ b/src/mongo/db/s/migration_destination_manager.cpp
@@ -229,8 +229,13 @@ bool opReplicatedEnough(OperationContext* opCtx,
 
     // Enforce the user specified write concern after "majority" so it covers the union of the 2
     // write concerns in case the user's write concern is stronger than majority
-    WriteConcernOptions userWriteConcern(writeConcern);
-    userWriteConcern.wTimeout = -1;
+    WriteConcernOptions userWriteConcern = writeConcern.wMode().empty()
+        ? WriteConcernOptions(
+              writeConcern.wNumNodes(), writeConcern.syncMode(), WriteConcernOptions::kNoWaiting)
+        : WriteConcernOptions(writeConcern.wMode().toString(),
+                              writeConcern.syncMode(),
+                              WriteConcernOptions::kNoWaiting);
+    userWriteConcern.getProvenance().setSource(writeConcern.getProvenance().getSource());
     writeConcernResult.wTimedOut = false;
 
     Status userStatus =

--- a/src/mongo/db/s/migration_destination_manager_legacy_commands.cpp
+++ b/src/mongo/db/s/migration_destination_manager_legacy_commands.cpp
@@ -343,8 +343,8 @@ public:
 
         uassert(ErrorCodes::InvalidOptions,
                 str::stream() << getName() << " must be called with majority writeConcern, got "
-                              << opCtx->getWriteConcern().wMode,
-                opCtx->getWriteConcern().wMode == WriteConcernOptions::kMajority);
+                              << opCtx->getWriteConcern().wMode(),
+                opCtx->getWriteConcern().wMode() == WriteConcernOptions::kMajority);
 
         const auto sessionId = uassertStatusOK(MigrationSessionId::extractFromBSON(cmdObj));
 

--- a/src/mongo/db/s/sharding_logging.cpp
+++ b/src/mongo/db/s/sharding_logging.cpp
@@ -102,7 +102,7 @@ Status ShardingLogging::logChangeChecked(OperationContext* opCtx,
                                          const BSONObj& detail,
                                          const WriteConcernOptions& writeConcern) {
     invariant(serverGlobalParams.clusterRole == ClusterRole::ConfigServer ||
-              writeConcern.wMode == WriteConcernOptions::kMajority);
+              writeConcern.wMode() == WriteConcernOptions::kMajority);
     if (_changeLogCollectionCreated.load() == 0) {
         Status result = _createCappedConfigCollection(
             opCtx, kChangeLogCollectionName, kChangeLogCollectionSizeMB, writeConcern);

--- a/src/mongo/db/s/shardsvr_abort_reshard_collection_command.cpp
+++ b/src/mongo/db/s/shardsvr_abort_reshard_collection_command.cpp
@@ -63,7 +63,7 @@ public:
                     serverGlobalParams.clusterRole == ClusterRole::ShardServer);
             uassert(ErrorCodes::InvalidOptions,
                     "_shardsvrAbortReshardCollection must be called with majority writeConcern",
-                    opCtx->getWriteConcern().wMode == WriteConcernOptions::kMajority);
+                    opCtx->getWriteConcern().wMode() == WriteConcernOptions::kMajority);
 
             std::vector<SharedSemiFuture<void>> futuresToWait;
 

--- a/src/mongo/db/s/shardsvr_collmod_command.cpp
+++ b/src/mongo/db/s/shardsvr_collmod_command.cpp
@@ -91,8 +91,8 @@ public:
         uassert(ErrorCodes::InvalidOptions,
                 str::stream() << Request::kCommandName
                               << " must be called with majority writeConcern, got "
-                              << opCtx->getWriteConcern().wMode,
-                opCtx->getWriteConcern().wMode == WriteConcernOptions::kMajority);
+                              << opCtx->getWriteConcern().wMode(),
+                opCtx->getWriteConcern().wMode() == WriteConcernOptions::kMajority);
 
         opCtx->setAlwaysInterruptAtStepDownOrUp();
 

--- a/src/mongo/db/s/shardsvr_collmod_participant_command.cpp
+++ b/src/mongo/db/s/shardsvr_collmod_participant_command.cpp
@@ -73,8 +73,8 @@ public:
             uassert(ErrorCodes::InvalidOptions,
                     str::stream() << Request::kCommandName
                                   << " must be called with majority writeConcern, got "
-                                  << opCtx->getWriteConcern().wMode,
-                    opCtx->getWriteConcern().wMode == WriteConcernOptions::kMajority);
+                                  << opCtx->getWriteConcern().wMode(),
+                    opCtx->getWriteConcern().wMode() == WriteConcernOptions::kMajority);
 
             opCtx->setAlwaysInterruptAtStepDownOrUp();
 

--- a/src/mongo/db/s/shardsvr_commit_reshard_collection_command.cpp
+++ b/src/mongo/db/s/shardsvr_commit_reshard_collection_command.cpp
@@ -63,7 +63,7 @@ public:
                     serverGlobalParams.clusterRole == ClusterRole::ShardServer);
             uassert(ErrorCodes::InvalidOptions,
                     "_shardsvrCommitReshardCollection must be called with majority writeConcern",
-                    opCtx->getWriteConcern().wMode == WriteConcernOptions::kMajority);
+                    opCtx->getWriteConcern().wMode() == WriteConcernOptions::kMajority);
 
             std::vector<SharedSemiFuture<void>> futuresToWait;
 

--- a/src/mongo/db/s/shardsvr_create_collection_command.cpp
+++ b/src/mongo/db/s/shardsvr_create_collection_command.cpp
@@ -78,7 +78,7 @@ public:
                 str::stream()
                     << "_shardsvrCreateCollection must be called with majority writeConcern, got "
                     << request().toBSON(BSONObj()),
-                opCtx->getWriteConcern().wMode == WriteConcernOptions::kMajority);
+                opCtx->getWriteConcern().wMode() == WriteConcernOptions::kMajority);
 
             uassert(ErrorCodes::NotImplemented,
                     "Create Collection path has not been implemented",

--- a/src/mongo/db/s/shardsvr_create_collection_participant_command.cpp
+++ b/src/mongo/db/s/shardsvr_create_collection_participant_command.cpp
@@ -75,7 +75,7 @@ public:
                     str::stream() << "_shardsvrCreateCollectionParticipant must be called with "
                                      "majority writeConcern, got "
                                   << request().toBSON(BSONObj()),
-                    opCtx->getWriteConcern().wMode == WriteConcernOptions::kMajority);
+                    opCtx->getWriteConcern().wMode() == WriteConcernOptions::kMajority);
 
             opCtx->setAlwaysInterruptAtStepDownOrUp();
 

--- a/src/mongo/db/s/shardsvr_drop_collection_command.cpp
+++ b/src/mongo/db/s/shardsvr_drop_collection_command.cpp
@@ -71,8 +71,8 @@ public:
             uassert(ErrorCodes::InvalidOptions,
                     str::stream() << Request::kCommandName
                                   << " must be called with majority writeConcern, got "
-                                  << opCtx->getWriteConcern().wMode,
-                    opCtx->getWriteConcern().wMode == WriteConcernOptions::kMajority);
+                                  << opCtx->getWriteConcern().wMode(),
+                    opCtx->getWriteConcern().wMode() == WriteConcernOptions::kMajority);
 
             opCtx->setAlwaysInterruptAtStepDownOrUp();
 

--- a/src/mongo/db/s/shardsvr_drop_collection_participant_command.cpp
+++ b/src/mongo/db/s/shardsvr_drop_collection_participant_command.cpp
@@ -73,8 +73,8 @@ public:
             uassert(ErrorCodes::InvalidOptions,
                     str::stream() << Request::kCommandName
                                   << " must be called with majority writeConcern, got "
-                                  << opCtx->getWriteConcern().wMode,
-                    opCtx->getWriteConcern().wMode == WriteConcernOptions::kMajority);
+                                  << opCtx->getWriteConcern().wMode(),
+                    opCtx->getWriteConcern().wMode() == WriteConcernOptions::kMajority);
 
             opCtx->setAlwaysInterruptAtStepDownOrUp();
 

--- a/src/mongo/db/s/shardsvr_drop_database_command.cpp
+++ b/src/mongo/db/s/shardsvr_drop_database_command.cpp
@@ -72,8 +72,8 @@ public:
             uassert(ErrorCodes::InvalidOptions,
                     str::stream() << Request::kCommandName
                                   << " must be called with majority writeConcern, got "
-                                  << opCtx->getWriteConcern().wMode,
-                    opCtx->getWriteConcern().wMode == WriteConcernOptions::kMajority);
+                                  << opCtx->getWriteConcern().wMode(),
+                    opCtx->getWriteConcern().wMode() == WriteConcernOptions::kMajority);
 
             opCtx->setAlwaysInterruptAtStepDownOrUp();
 

--- a/src/mongo/db/s/shardsvr_drop_database_participant_command.cpp
+++ b/src/mongo/db/s/shardsvr_drop_database_participant_command.cpp
@@ -71,8 +71,8 @@ public:
             uassert(ErrorCodes::InvalidOptions,
                     str::stream() << Request::kCommandName
                                   << " must be called with majority writeConcern, got "
-                                  << opCtx->getWriteConcern().wMode,
-                    opCtx->getWriteConcern().wMode == WriteConcernOptions::kMajority);
+                                  << opCtx->getWriteConcern().wMode(),
+                    opCtx->getWriteConcern().wMode() == WriteConcernOptions::kMajority);
 
             const auto& dbName = request().getDbName();
 

--- a/src/mongo/db/s/shardsvr_move_primary_command.cpp
+++ b/src/mongo/db/s/shardsvr_move_primary_command.cpp
@@ -114,7 +114,7 @@ public:
             ErrorCodes::InvalidOptions,
             str::stream() << "_shardsvrMovePrimary must be called with majority writeConcern, got "
                           << cmdObj,
-            opCtx->getWriteConcern().wMode == WriteConcernOptions::kMajority);
+            opCtx->getWriteConcern().wMode() == WriteConcernOptions::kMajority);
 
         ON_BLOCK_EXIT(
             [opCtx, dbNss] { Grid::get(opCtx)->catalogCache()->purgeDatabase(dbNss.db()); });

--- a/src/mongo/db/s/shardsvr_rename_collection_command.cpp
+++ b/src/mongo/db/s/shardsvr_rename_collection_command.cpp
@@ -86,8 +86,8 @@ public:
             uassert(ErrorCodes::InvalidOptions,
                     str::stream() << Request::kCommandName
                                   << " must be called with majority writeConcern, got "
-                                  << opCtx->getWriteConcern().wMode,
-                    opCtx->getWriteConcern().wMode == WriteConcernOptions::kMajority);
+                                  << opCtx->getWriteConcern().wMode(),
+                    opCtx->getWriteConcern().wMode() == WriteConcernOptions::kMajority);
 
             if (fromNss.db() != toNss.db()) {
                 sharding_ddl_util::checkDbPrimariesOnTheSameShard(opCtx, fromNss, toNss);

--- a/src/mongo/db/s/shardsvr_rename_collection_participant_command.cpp
+++ b/src/mongo/db/s/shardsvr_rename_collection_participant_command.cpp
@@ -74,8 +74,8 @@ public:
             uassert(ErrorCodes::InvalidOptions,
                     str::stream() << Request::kCommandName
                                   << " must be called with majority writeConcern, got "
-                                  << opCtx->getWriteConcern().wMode,
-                    opCtx->getWriteConcern().wMode == WriteConcernOptions::kMajority);
+                                  << opCtx->getWriteConcern().wMode(),
+                    opCtx->getWriteConcern().wMode() == WriteConcernOptions::kMajority);
 
             auto const shardingState = ShardingState::get(opCtx);
             uassertStatusOK(shardingState->canAcceptShardedCommands());
@@ -170,8 +170,8 @@ public:
             uassert(ErrorCodes::InvalidOptions,
                     str::stream() << Request::kCommandName
                                   << " must be called with majority writeConcern, got "
-                                  << opCtx->getWriteConcern().wMode,
-                    opCtx->getWriteConcern().wMode == WriteConcernOptions::kMajority);
+                                  << opCtx->getWriteConcern().wMode(),
+                    opCtx->getWriteConcern().wMode() == WriteConcernOptions::kMajority);
 
             auto const shardingState = ShardingState::get(opCtx);
             uassertStatusOK(shardingState->canAcceptShardedCommands());

--- a/src/mongo/db/s/shardsvr_reshard_collection_command.cpp
+++ b/src/mongo/db/s/shardsvr_reshard_collection_command.cpp
@@ -73,8 +73,8 @@ public:
             uassert(ErrorCodes::InvalidOptions,
                     str::stream() << Request::kCommandName
                                   << " must be called with majority writeConcern, got "
-                                  << opCtx->getWriteConcern().wMode,
-                    opCtx->getWriteConcern().wMode == WriteConcernOptions::kMajority);
+                                  << opCtx->getWriteConcern().wMode(),
+                    opCtx->getWriteConcern().wMode() == WriteConcernOptions::kMajority);
             // (Generic FCV reference): To run this command and ensure the consistency of the
             // metadata we need to make sure we are on a stable state.
             uassert(

--- a/src/mongo/db/s/shardsvr_set_allow_migrations_command.cpp
+++ b/src/mongo/db/s/shardsvr_set_allow_migrations_command.cpp
@@ -76,7 +76,7 @@ public:
                     str::stream() << Request::kCommandName
                                   << " must be called with majority writeConcern, got "
                                   << request().toBSON(BSONObj()),
-                    opCtx->getWriteConcern().wMode == WriteConcernOptions::kMajority);
+                    opCtx->getWriteConcern().wMode() == WriteConcernOptions::kMajority);
 
             SetAllowMigrationsRequest setAllowMigationsCmdRequest =
                 request().getSetAllowMigrationsRequest();

--- a/src/mongo/db/service_entry_point_common.cpp
+++ b/src/mongo/db/service_entry_point_common.cpp
@@ -1228,7 +1228,7 @@ Future<void> RunCommandAndWaitForWriteConcern::_handleError(Status status) {
     auto opCtx = _execContext->getOpCtx();
     // Do no-op write before returning NoSuchTransaction if command has writeConcern.
     if (status.code() == ErrorCodes::NoSuchTransaction &&
-        !opCtx->getWriteConcern().usedDefaultConstructedWC) {
+        !opCtx->getWriteConcern().isDefaultConstructed()) {
         TransactionParticipant::performNoopWrite(opCtx, "NoSuchTransaction error");
     }
     _waitForWriteConcern(*_ecd->getExtraFieldsBuilder());

--- a/src/mongo/db/transaction_metrics_observer.cpp
+++ b/src/mongo/db/transaction_metrics_observer.cpp
@@ -121,11 +121,11 @@ void TransactionMetricsObserver::onCommit(OperationContext* opCtx,
         serverTransactionsMetrics->decrementCurrentPrepared();
     }
 
-    serverTransactionsMetrics->updateLastTransaction(
-        operationCount,
-        oplogOperationBytes,
-        opCtx->getWriteConcern().usedDefaultConstructedWC ? BSONObj()
-                                                          : opCtx->getWriteConcern().toBSON());
+    serverTransactionsMetrics->updateLastTransaction(operationCount,
+                                                     oplogOperationBytes,
+                                                     opCtx->getWriteConcern().isDefaultConstructed()
+                                                         ? BSONObj()
+                                                         : opCtx->getWriteConcern().toBSON());
 
     auto duration =
         durationCount<Microseconds>(_singleTransactionStats.getDuration(tickSource, curTick));

--- a/src/mongo/db/transaction_participant.cpp
+++ b/src/mongo/db/transaction_participant.cpp
@@ -1491,7 +1491,7 @@ void TransactionParticipant::Participant::commitUnpreparedTransaction(OperationC
     //
     // TODO (SERVER-41165): Snapshot read concern should wait on the read timestamp instead.
     auto wc = opCtx->getWriteConcern();
-    auto needsNoopWrite = txnOps.empty() && !opCtx->getWriteConcern().usedDefaultConstructedWC;
+    auto needsNoopWrite = txnOps.empty() && !opCtx->getWriteConcern().isDefaultConstructed();
 
     const size_t operationCount = p().transactionOperations.size();
     const size_t oplogOperationBytes = p().transactionOperationBytes;

--- a/src/mongo/db/transaction_validation.cpp
+++ b/src/mongo/db/transaction_validation.cpp
@@ -82,7 +82,7 @@ bool isTransactionCommand(StringData cmdName) {
 void validateWriteConcernForTransaction(const WriteConcernOptions& wcResult, StringData cmdName) {
     uassert(ErrorCodes::InvalidOptions,
             "writeConcern is not allowed within a multi-statement transaction",
-            wcResult.usedDefaultConstructedWC || isTransactionCommand(cmdName));
+            wcResult.isDefaultConstructed() || isTransactionCommand(cmdName));
 }
 
 bool isReadConcernLevelAllowedInTransaction(repl::ReadConcernLevel readConcernLevel) {

--- a/src/mongo/db/write_concern_options.h
+++ b/src/mongo/db/write_concern_options.h
@@ -172,7 +172,6 @@ public:
 
 private:
     ReadWriteConcernProvenance _provenance;
-    static StatusWith<WriteConcernOptions> convertFromIdl(const WriteConcernIdl& writeConcernIdl);
 };
 
 }  // namespace mongo

--- a/src/mongo/db/write_concern_options_test.cpp
+++ b/src/mongo/db/write_concern_options_test.cpp
@@ -66,40 +66,40 @@ TEST(WriteConcernOptionsTest, ParseSetsSyncModeToJournelIfJIsTrue) {
     auto sw = WriteConcernOptions::parse(BSON("j" << true));
     ASSERT_OK(sw.getStatus());
     WriteConcernOptions options = sw.getValue();
-    ASSERT_TRUE(WriteConcernOptions::SyncMode::JOURNAL == options.syncMode);
-    ASSERT_EQUALS(1, options.wNumNodes);
-    ASSERT_EQUALS("", options.wMode);
-    ASSERT_EQUALS(0, options.wTimeout);
+    ASSERT_TRUE(WriteConcernOptions::SyncMode::JOURNAL == options.syncMode());
+    ASSERT_EQUALS(1, options.wNumNodes());
+    ASSERT_EQUALS("", options.wMode());
+    ASSERT_EQUALS(0, options.wTimeout());
 }
 
 TEST(WriteConcernOptionsTest, ParseSetsSyncModeToFSyncIfFSyncIsTrue) {
     auto sw = WriteConcernOptions::parse(BSON("fsync" << true));
     ASSERT_OK(sw.getStatus());
     WriteConcernOptions options = sw.getValue();
-    ASSERT_TRUE(WriteConcernOptions::SyncMode::FSYNC == options.syncMode);
-    ASSERT_EQUALS(1, options.wNumNodes);
-    ASSERT_EQUALS("", options.wMode);
-    ASSERT_EQUALS(0, options.wTimeout);
+    ASSERT_TRUE(WriteConcernOptions::SyncMode::FSYNC == options.syncMode());
+    ASSERT_EQUALS(1, options.wNumNodes());
+    ASSERT_EQUALS("", options.wMode());
+    ASSERT_EQUALS(0, options.wTimeout());
 }
 
 TEST(WriteConcernOptionsTest, ParseSetsSyncModeToNoneIfJIsFalse) {
     auto sw = WriteConcernOptions::parse(BSON("j" << false));
     ASSERT_OK(sw.getStatus());
     WriteConcernOptions options = sw.getValue();
-    ASSERT_TRUE(WriteConcernOptions::SyncMode::NONE == options.syncMode);
-    ASSERT_EQUALS(1, options.wNumNodes);
-    ASSERT_EQUALS("", options.wMode);
-    ASSERT_EQUALS(0, options.wTimeout);
+    ASSERT_TRUE(WriteConcernOptions::SyncMode::NONE == options.syncMode());
+    ASSERT_EQUALS(1, options.wNumNodes());
+    ASSERT_EQUALS("", options.wMode());
+    ASSERT_EQUALS(0, options.wTimeout());
 }
 
 TEST(WriteConcernOptionsTest, ParseLeavesSyncModeAsUnsetIfFSyncIsFalse) {
     auto sw = WriteConcernOptions::parse(BSON("fsync" << false));
     ASSERT_OK(sw.getStatus());
     WriteConcernOptions options = sw.getValue();
-    ASSERT_TRUE(WriteConcernOptions::SyncMode::UNSET == options.syncMode);
-    ASSERT_EQUALS(1, options.wNumNodes);
-    ASSERT_EQUALS("", options.wMode);
-    ASSERT_EQUALS(0, options.wTimeout);
+    ASSERT_TRUE(WriteConcernOptions::SyncMode::UNSET == options.syncMode());
+    ASSERT_EQUALS(1, options.wNumNodes());
+    ASSERT_EQUALS("", options.wMode());
+    ASSERT_EQUALS(0, options.wTimeout());
 }
 
 TEST(WriteConcernOptionsTest, ParseReturnsFailedToParseIfWIsNotNumberOrString) {
@@ -120,20 +120,20 @@ TEST(WriteConcernOptionsTest, ParseSetsWNumNodesIfWIsANumber) {
     auto sw = WriteConcernOptions::parse(BSON("w" << 3));
     ASSERT_OK(sw.getStatus());
     WriteConcernOptions options = sw.getValue();
-    ASSERT_TRUE(WriteConcernOptions::SyncMode::UNSET == options.syncMode);
-    ASSERT_EQUALS(3, options.wNumNodes);
-    ASSERT_EQUALS("", options.wMode);
-    ASSERT_EQUALS(0, options.wTimeout);
+    ASSERT_TRUE(WriteConcernOptions::SyncMode::UNSET == options.syncMode());
+    ASSERT_EQUALS(3, options.wNumNodes());
+    ASSERT_EQUALS("", options.wMode());
+    ASSERT_EQUALS(0, options.wTimeout());
 }
 
 TEST(WriteConcernOptionsTest, ParseWTimeoutAsNumber) {
     auto sw = WriteConcernOptions::parse(BSON("wtimeout" << 123));
     ASSERT_OK(sw.getStatus());
     WriteConcernOptions options = sw.getValue();
-    ASSERT_TRUE(WriteConcernOptions::SyncMode::UNSET == options.syncMode);
-    ASSERT_EQUALS("", options.wMode);
-    ASSERT_EQUALS(1, options.wNumNodes);
-    ASSERT_EQUALS(123, options.wTimeout);
+    ASSERT_TRUE(WriteConcernOptions::SyncMode::UNSET == options.syncMode());
+    ASSERT_EQUALS("", options.wMode());
+    ASSERT_EQUALS(1, options.wNumNodes());
+    ASSERT_EQUALS(123, options.wTimeout());
 }
 
 TEST(WriteConcernOptionsTest, ParseWTimeoutAsNaNDouble) {
@@ -141,10 +141,10 @@ TEST(WriteConcernOptionsTest, ParseWTimeoutAsNaNDouble) {
     auto sw = WriteConcernOptions::parse(BSON("wtimeout" << nan));
     ASSERT_OK(sw.getStatus());
     WriteConcernOptions options = sw.getValue();
-    ASSERT_TRUE(WriteConcernOptions::SyncMode::UNSET == options.syncMode);
-    ASSERT_EQUALS("", options.wMode);
-    ASSERT_EQUALS(1, options.wNumNodes);
-    ASSERT_EQUALS(0, options.wTimeout);
+    ASSERT_TRUE(WriteConcernOptions::SyncMode::UNSET == options.syncMode());
+    ASSERT_EQUALS("", options.wMode());
+    ASSERT_EQUALS(1, options.wNumNodes());
+    ASSERT_EQUALS(0, options.wTimeout());
 }
 
 TEST(WriteConcernOptionsTest, ParseWTimeoutAsDoubleLargerThanInt) {
@@ -152,10 +152,10 @@ TEST(WriteConcernOptionsTest, ParseWTimeoutAsDoubleLargerThanInt) {
     auto sw = WriteConcernOptions::parse(BSON("wtimeout" << 2999999999.0));
     ASSERT_OK(sw.getStatus());
     WriteConcernOptions options = sw.getValue();
-    ASSERT_TRUE(WriteConcernOptions::SyncMode::UNSET == options.syncMode);
-    ASSERT_EQUALS("", options.wMode);
-    ASSERT_EQUALS(1, options.wNumNodes);
-    ASSERT_LESS_THAN(options.wTimeout, 0);
+    ASSERT_TRUE(WriteConcernOptions::SyncMode::UNSET == options.syncMode());
+    ASSERT_EQUALS("", options.wMode());
+    ASSERT_EQUALS(1, options.wNumNodes());
+    ASSERT_LESS_THAN(options.wTimeout(), 0);
 }
 
 TEST(WriteConcernOptionsTest, ParseReturnsFailedToParseOnUnknownField) {
@@ -167,10 +167,10 @@ void _testIgnoreWriteConcernField(const char* fieldName) {
     auto sw = WriteConcernOptions::parse(BSON(fieldName << 1));
     ASSERT_OK(sw.getStatus());
     WriteConcernOptions options = sw.getValue();
-    ASSERT_TRUE(WriteConcernOptions::SyncMode::UNSET == options.syncMode);
-    ASSERT_EQUALS("", options.wMode);
-    ASSERT_EQUALS(1, options.wNumNodes);
-    ASSERT_EQUALS(0, options.wTimeout);
+    ASSERT_TRUE(WriteConcernOptions::SyncMode::UNSET == options.syncMode());
+    ASSERT_EQUALS("", options.wMode());
+    ASSERT_EQUALS(1, options.wNumNodes());
+    ASSERT_EQUALS(0, options.wTimeout());
 }
 TEST(WriteConcernOptionsTest, ParseIgnoresSpecialFields) {
     _testIgnoreWriteConcernField("wElectionId");

--- a/src/mongo/embedded/replication_coordinator_embedded.cpp
+++ b/src/mongo/embedded/replication_coordinator_embedded.cpp
@@ -137,7 +137,7 @@ bool ReplicationCoordinatorEmbedded::isReplEnabled() const {
 WriteConcernOptions ReplicationCoordinatorEmbedded::populateUnsetWriteConcernOptionsSyncMode(
     WriteConcernOptions wc) {
     WriteConcernOptions writeConcern(wc);
-    writeConcern.syncMode = WriteConcernOptions::SyncMode::NONE;
+    writeConcern._syncMode = WriteConcernOptions::SyncMode::NONE;
     return writeConcern;
 }
 

--- a/src/mongo/idl/basic_types.idl
+++ b/src/mongo/idl/basic_types.idl
@@ -232,7 +232,7 @@ types:
         cpp_type: "mongo::IDLAnyType"
         serializer: mongo::IDLAnyType::serializeToBSON
         deserializer: mongo::IDLAnyType::parseFromBSON
-    
+
     IDLAnyTypeOwned:
         bson_serialization_type: any
         description: "Holds a BSONElement of any type. Does not require the backing BSON to stay
@@ -309,16 +309,16 @@ structs:
         strict: false
         fields:
             ok:
-                type: safeDouble 
+                type: safeDouble
                 validator: { gte: 0.0, lte: 0.0 }
                 unstable: false
-            code: 
+            code:
                 type: int
                 unstable: false
-            codeName: 
+            codeName:
                 type: string
                 unstable: false
-            errmsg: 
+            errmsg:
                 type: string
                 unstable: false
             errorLabels:

--- a/src/mongo/s/commands/cluster_write_cmd.cpp
+++ b/src/mongo/s/commands/cluster_write_cmd.cpp
@@ -412,7 +412,7 @@ private:
         // The batched request will only have WC if it was supplied by the client. Otherwise, the
         // batched request should use the WC from the opCtx.
         if (!batchedRequest.hasWriteConcern()) {
-            if (opCtx->getWriteConcern().usedDefaultConstructedWC) {
+            if (opCtx->getWriteConcern().isDefaultConstructed()) {
                 // Pass writeConcern: {}, rather than {w: 1, wtimeout: 0}, so as to not override the
                 // configsvr w:majority upconvert.
                 batchedRequest.setWriteConcern(BSONObj());

--- a/src/mongo/s/commands/strategy.cpp
+++ b/src/mongo/s/commands/strategy.cpp
@@ -660,9 +660,9 @@ Status ParseAndRunCommand::RunInvocation::_setup() {
     }
 
     // This is the WC extracted from the command object, so the CWWC or implicit default hasn't been
-    // applied yet, which is why "usedDefaultConstructedWC" flag can be used an indicator of whether
+    // applied yet, which is why "isDefaultConstructed" flag can be used an indicator of whether
     // the client supplied a WC or not.
-    bool clientSuppliedWriteConcern = !_parc->_wc->usedDefaultConstructedWC;
+    bool clientSuppliedWriteConcern = !_parc->_wc->isDefaultConstructed();
     bool customDefaultWriteConcernWasApplied = false;
     bool isInternalClient =
         (opCtx->getClient()->session() &&

--- a/src/mongo/s/request_types/balance_chunk_request_test.cpp
+++ b/src/mongo/s/request_types/balance_chunk_request_test.cpp
@@ -114,7 +114,7 @@ TEST(BalanceChunkRequest, ParseFromConfigCommandWithSecondaryThrottle) {
 
     const auto& secondaryThrottle = request.getSecondaryThrottle();
     ASSERT_EQ(MigrationSecondaryThrottleOptions::kOn, secondaryThrottle.getSecondaryThrottle());
-    ASSERT_EQ(2, secondaryThrottle.getWriteConcern().wNumNodes);
+    ASSERT_EQ(2, secondaryThrottle.getWriteConcern().wNumNodes());
 }
 
 }  // namespace

--- a/src/mongo/s/request_types/migration_secondary_throttle_options.cpp
+++ b/src/mongo/s/request_types/migration_secondary_throttle_options.cpp
@@ -56,7 +56,7 @@ MigrationSecondaryThrottleOptions MigrationSecondaryThrottleOptions::create(
 MigrationSecondaryThrottleOptions MigrationSecondaryThrottleOptions::createWithWriteConcern(
     const WriteConcernOptions& writeConcern) {
     // Optimize on write concern, which makes no difference
-    if (writeConcern.wNumNodes <= 1 && writeConcern.wMode.empty()) {
+    if (writeConcern.wNumNodes() <= 1 && writeConcern.wMode().empty()) {
         return MigrationSecondaryThrottleOptions(kOff, boost::none);
     }
 

--- a/src/mongo/s/request_types/migration_secondary_throttle_options_test.cpp
+++ b/src/mongo/s/request_types/migration_secondary_throttle_options_test.cpp
@@ -89,10 +89,10 @@ TEST(MigrationSecondaryThrottleOptions, EnabledInCommandBSONWithSimpleWriteConce
     ASSERT(options.isWriteConcernSpecified());
 
     WriteConcernOptions writeConcern = options.getWriteConcern();
-    ASSERT_EQ(2, writeConcern.wNumNodes);
+    ASSERT_EQ(2, writeConcern.wNumNodes());
     ASSERT_EQ(static_cast<int>(WriteConcernOptions::SyncMode::UNSET),
-              static_cast<int>(writeConcern.syncMode));
-    ASSERT_EQ(WriteConcernOptions::kNoTimeout, writeConcern.wTimeout);
+              static_cast<int>(writeConcern.syncMode()));
+    ASSERT_EQ(WriteConcernOptions::kNoTimeout, writeConcern.wTimeout());
 }
 
 TEST(MigrationSecondaryThrottleOptions, EnabledInCommandBSONWithCompleteWriteConcern) {
@@ -104,10 +104,10 @@ TEST(MigrationSecondaryThrottleOptions, EnabledInCommandBSONWithCompleteWriteCon
     ASSERT(options.isWriteConcernSpecified());
 
     WriteConcernOptions writeConcern = options.getWriteConcern();
-    ASSERT_EQ(3, writeConcern.wNumNodes);
+    ASSERT_EQ(3, writeConcern.wNumNodes());
     ASSERT_EQ(static_cast<int>(WriteConcernOptions::SyncMode::JOURNAL),
-              static_cast<int>(writeConcern.syncMode));
-    ASSERT_EQ(WriteConcernOptions::kNoTimeout, writeConcern.wTimeout);
+              static_cast<int>(writeConcern.syncMode()));
+    ASSERT_EQ(WriteConcernOptions::kNoTimeout, writeConcern.wTimeout());
 }
 
 TEST(MigrationSecondaryThrottleOptions, DisabledInCommandBSON) {
@@ -141,10 +141,10 @@ TEST(MigrationSecondaryThrottleOptions, EnabledInBalancerConfigWithSimpleWriteCo
     ASSERT(options.isWriteConcernSpecified());
 
     WriteConcernOptions writeConcern = options.getWriteConcern();
-    ASSERT_EQ(2, writeConcern.wNumNodes);
+    ASSERT_EQ(2, writeConcern.wNumNodes());
     ASSERT_EQ(static_cast<int>(WriteConcernOptions::SyncMode::UNSET),
-              static_cast<int>(writeConcern.syncMode));
-    ASSERT_EQ(WriteConcernOptions::kNoTimeout, writeConcern.wTimeout);
+              static_cast<int>(writeConcern.syncMode()));
+    ASSERT_EQ(WriteConcernOptions::kNoTimeout, writeConcern.wTimeout());
 }
 
 TEST(MigrationSecondaryThrottleOptions, EnabledInBalancerConfigWithCompleteWriteConcern) {
@@ -155,10 +155,10 @@ TEST(MigrationSecondaryThrottleOptions, EnabledInBalancerConfigWithCompleteWrite
     ASSERT(options.isWriteConcernSpecified());
 
     WriteConcernOptions writeConcern = options.getWriteConcern();
-    ASSERT_EQ(3, writeConcern.wNumNodes);
+    ASSERT_EQ(3, writeConcern.wNumNodes());
     ASSERT_EQ(static_cast<int>(WriteConcernOptions::SyncMode::JOURNAL),
-              static_cast<int>(writeConcern.syncMode));
-    ASSERT_EQ(WriteConcernOptions::kNoTimeout, writeConcern.wTimeout);
+              static_cast<int>(writeConcern.syncMode()));
+    ASSERT_EQ(WriteConcernOptions::kNoTimeout, writeConcern.wTimeout());
 }
 
 TEST(MigrationSecondaryThrottleOptions, DisabledInBalancerConfig) {


### PR DESCRIPTION
This is a large change set over many files, so I'm putting it up as a draft first to see if we agree on the approach. Broadly, the PR is split up into two commits: one to deduplicate the parsing logic in `WriteConcernOptions`, and a second which makes `WriteConcernOptions` an immutable class (as much as possible). I've left comments on the PR on all of the interesting changes, but most of the noise here are simple text changes converting direct member access into calls to an accessor.

patch build: https://spruce.mongodb.com/version/61d33b4d2fbabe54a46ae96c