### PR TITLE
SERVER-62333 use std::ptrdiff_t to avoid UB in MurmurHash3

### DIFF
--- a/src/third_party/murmurhash3/MurmurHash3.cpp
+++ b/src/third_party/murmurhash3/MurmurHash3.cpp
@@ -82,6 +82,8 @@ FORCE_INLINE T nativeToLittle( T t )
     return t;
 }
 
+template <typename T> constexpr std::ptrdiff_t ssizeof = sizeof(T);
+
 //-----------------------------------------------------------------------------
 // Block read - if your platform needs to do endian-swapping or can only
 // handle aligned reads, do the conversion here
@@ -89,7 +91,7 @@ template <typename T>
 FORCE_INLINE T getblock( const void* p, int i )
 {
     T t;
-    std::memcpy(&t, static_cast<const char*>(p) + i * sizeof(T), sizeof(T));
+    std::memcpy(&t, static_cast<const char*>(p) + i * ssizeof<T>, sizeof(T));
     return nativeToLittle(t);
 }
 
@@ -108,7 +110,7 @@ template <typename T>
 FORCE_INLINE void putblock( void* p, int i, T t )
 {
     t = nativeToLittle(t);
-    std::memcpy(static_cast<char*>(p) + i * sizeof(T), &t, sizeof(T));
+    std::memcpy(static_cast<char*>(p) + i * ssizeof<T>, &t, sizeof(T));
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Ensure we are using `std::ptrdiff_t` to prevent undefined behavior in the `getblock`/`putblock` implementations,. 