### PR TITLE
WIP Change the network chunk version format to the new format

### DIFF
--- a/jstests/sharding/chunk_operations_invalidate_single_shard.js
+++ b/jstests/sharding/chunk_operations_invalidate_single_shard.js
@@ -59,13 +59,17 @@ let testSplit = () => {
     assert.eq(mongosCollectionVersion, getMongosCollVersion(ns));
 
     testColl.findOne({x: -1000});
-    assert.lt(mongosCollectionVersion, getMongosCollVersion(ns));
+    let mongosVersion = getMongosCollVersion(ns);
+    let mongosVersionInitial = mongosCollectionVersion;
+    mongosVersionInitial = mongosVersionInitial.hasOwnProperty('v') ? mongosVersionInitial.v : mongosVersionInitial;
+    mongosVersion = mongosVersion.hasOwnProperty('v') ? mongosVersion.v : mongosVersion;
+    assert.lt(tojson(mongosVersionInitial), tojson(mongosVersion));
 };
 
 // Verify that a merge doesn't update the mongos' catalog cache unless an affected chunk is
 // targeted.
 let testMerge = () => {
-    const mongosCollectionVersion = getMongosCollVersion(ns);
+    let mongosCollectionVersion = getMongosCollVersion(ns);
 
     assert.commandWorked(st.s.adminCommand({mergeChunks: ns, bounds: [{x: MinKey}, {x: -10}]}));
     testColl.findOne({x: 0});
@@ -73,7 +77,10 @@ let testMerge = () => {
     assert.eq(mongosCollectionVersion, getMongosCollVersion(ns));
 
     testColl.findOne({x: -1000});
-    assert.lt(mongosCollectionVersion, getMongosCollVersion(ns));
+    mongosCollectionVersion = mongosCollectionVersion.hasOwnProperty('v') ? mongosCollectionVersion.v : mongosCollectionVersion;
+    let mongosVersion = getMongosCollVersion(ns);
+    mongosVersion = mongosVersion.hasOwnProperty('v') ? mongosVersion.v : mongosVersion;
+    assert.lt(tojson(mongosCollectionVersion), tojson(mongosVersion));
 };
 
 // Verify that a chunk move doesn't update the mongos' catalog cache unless an affected chunk is
@@ -88,7 +95,10 @@ let testMoveChunk = () => {
     assert.eq(mongosCollectionVersion, getMongosCollVersion(ns));
 
     testColl.findOne({x: -1000});
-    assert.lt(mongosCollectionVersion, getMongosCollVersion(ns));
+    let mongosVersion = getMongosCollVersion(ns);
+    mongosVersion = mongosVersion.hasOwnProperty('v') ? mongosVersion.v : mongosVersion;
+    mongosCollectionVersion = mongosCollectionVersion.hasOwnProperty('v') ? mongosCollectionVersion.v : mongosCollectionVersion;
+    assert.lt(tojson(mongosCollectionVersion), tojson(mongosVersion));
 
     // Contact the recipient shard to trigger update.
     mongosCollectionVersion = getMongosCollVersion(ns);
@@ -99,7 +109,10 @@ let testMoveChunk = () => {
     assert.eq(mongosCollectionVersion, getMongosCollVersion(ns));
 
     testColl.findOne({x: -1000});
-    assert.lt(mongosCollectionVersion, getMongosCollVersion(ns));
+    mongosVersion = getMongosCollVersion(ns);
+    mongosVersion = mongosVersion.hasOwnProperty('v') ? mongosVersion.v : mongosVersion;
+    mongosCollectionVersion = mongosCollectionVersion.hasOwnProperty('v') ? mongosCollectionVersion.v : mongosCollectionVersion;
+    assert.lt(tojson(mongosCollectionVersion), tojson(mongosVersion));
 };
 
 setUp();

--- a/jstests/sharding/libs/shard_versioning_util.js
+++ b/jstests/sharding/libs/shard_versioning_util.js
@@ -21,7 +21,9 @@ var ShardVersioningUtil = (function() {
      * is equal to the given collection version.
      */
     let assertCollectionVersionEquals = function(shard, ns, collectionVersion) {
-        assert.eq(getMetadataOnShard(shard, ns).collVersion, collectionVersion);
+        let collVersion = getMetadataOnShard(shard, ns).collVersion;
+        collVersion = collVersion.hasOwnProperty('v') ? collVersion.v : collVersion;
+        assert.eq(collVersion, collectionVersion);
     };
 
     /*
@@ -31,7 +33,7 @@ var ShardVersioningUtil = (function() {
     let assertCollectionVersionOlderThan = function(shard, ns, collectionVersion) {
         let shardCollectionVersion = getMetadataOnShard(shard, ns).collVersion;
         if (shardCollectionVersion != undefined) {
-            assert.lt(shardCollectionVersion.t, collectionVersion.t);
+            assert.lt(tojson(shardCollectionVersion.t), tojson(collectionVersion.t));
         }
     };
 
@@ -40,7 +42,9 @@ var ShardVersioningUtil = (function() {
      * given shard version.
      */
     let assertShardVersionEquals = function(shard, ns, shardVersion) {
-        assert.eq(getMetadataOnShard(shard, ns).shardVersion, shardVersion);
+        let collVersion = getMetadataOnShard(shard, ns).shardVersion;
+        collVersion = collVersion.hasOwnProperty('v') ? collVersion.v : collVersion;
+        assert.eq(collVersion, shardVersion);
     };
 
     /*

--- a/jstests/sharding/list_indexes_shard_targeting.js
+++ b/jstests/sharding/list_indexes_shard_targeting.js
@@ -61,7 +61,10 @@ const latestCollectionVersion = ShardVersioningUtil.getMetadataOnShard(st.shard1
 const mongosCollectionVersion = st.s.adminCommand({getShardVersion: ns}).version;
 
 // Assert that the mongos and all non-donor shards have a stale collection version.
-assert.lt(mongosCollectionVersion, latestCollectionVersion);
+let mongosVersion = mongosCollectionVersion.hasOwnProperty('v') ? mongosCollectionVersion.v : mongosCollectionVersion;
+let latestVersion = latestCollectionVersion.hasOwnProperty('v') ? latestCollectionVersion.v : latestCollectionVersion;
+
+assert.lt(mongosVersion, latestVersion);
 ShardVersioningUtil.assertCollectionVersionOlderThan(st.shard0, ns, latestCollectionVersion);
 ShardVersioningUtil.assertCollectionVersionEquals(st.shard1, ns, latestCollectionVersion);
 ShardVersioningUtil.assertCollectionVersionOlderThan(st.shard2, ns, latestCollectionVersion);

--- a/jstests/sharding/safe_secondary_reads_single_migration_waitForDelete.js
+++ b/jstests/sharding/safe_secondary_reads_single_migration_waitForDelete.js
@@ -488,8 +488,12 @@ for (let command of commands) {
             profileDB: recipientShardSecondary.getDB(db),
             filter: Object.extend({
                 "command.shardVersion": {"$exists": true},
-                "command.shardVersion.0": {$ne: ShardVersioningUtil.kIgnoredShardVersion[0]},
-                "command.shardVersion.1": {$ne: ShardVersioningUtil.kIgnoredShardVersion[1]},
+                "$or" : [
+                    {"command.shardVersion.0": {$ne: ShardVersioningUtil.kIgnoredShardVersion[0]}},
+                    {"command.shardVersion.1": {$ne: ShardVersioningUtil.kIgnoredShardVersion[1]}},
+                    {"command.shardVersion.v": {$ne: ShardVersioningUtil.kIgnoredShardVersion[0]}},
+                    {"command.shardVersion.e": {$ne: ShardVersioningUtil.kIgnoredShardVersion[1]}},
+                ],
                 "command.$readPreference": {"mode": "secondary"},
                 "command.readConcern": {"level": "local"},
                 "errCode": {"$ne": ErrorCodes.StaleConfig},

--- a/src/mongo/s/chunk_version.cpp
+++ b/src/mongo/s/chunk_version.cpp
@@ -211,29 +211,23 @@ void ChunkVersion::serializeToPositionalWronlyEcondedOr60AsBSON(StringData field
     }
 }
 
+void ChunkVersion::serializeTo60BSON(StringData field,  BSONObjBuilder* builder) const {
+    ChunkVersion60Format chunkVersion(
+        _timestamp, _epoch, Timestamp(majorVersion(), minorVersion()));
+    builder->append(field, chunkVersion.toBSON());
+}
+
 void ChunkVersion::serializeToBSON(StringData field, BSONObjBuilder* builder) const {
-    BSONArrayBuilder arr(builder->subarrayStart(field));
-    arr.appendTimestamp(_combined);
-    arr.append(_epoch);
-    arr.append(_timestamp);
+    serializeTo60BSON(field, builder);
 }
 
 void ChunkVersion::serializeToPositionalFormatWronglyEncodedAsBSON(StringData field,
                                                                    BSONObjBuilder* builder) const {
-    BSONObjBuilder subObjBuilder(builder->subobjStart(field));
-    subObjBuilder.appendElements([&] {
-        BSONArrayBuilder arr;
-        arr.appendTimestamp(_combined);
-        arr.append(_epoch);
-        arr.append(_timestamp);
-        return arr.obj();
-    }());
+    serializeTo60BSON(field, builder);
 }
 
 void ChunkVersion::appendLegacyWithField(BSONObjBuilder* out, StringData field) const {
-    out->appendTimestamp(field, _combined);
-    out->append(field + "Epoch", _epoch);
-    out->append(field + "Timestamp", _timestamp);
+    serializeTo60BSON(field, out);
 }
 
 std::string ChunkVersion::toString() const {

--- a/src/mongo/s/chunk_version.h
+++ b/src/mongo/s/chunk_version.h
@@ -208,6 +208,8 @@ public:
     void serializeToPositionalWronlyEcondedOr60AsBSON(StringData fieldName,
                                                       BSONObjBuilder* builder) const;
 
+    void serializeTo60BSON(StringData fieldName,  BSONObjBuilder* builder) const;
+
     /**
      * Serializes the version held by this object to 'out' in the form:
      *  { ..., <field>: [ <combined major/minor>, <OID epoch>, <Timestamp> ], ... }.

--- a/src/mongo/s/chunk_version.idl
+++ b/src/mongo/s/chunk_version.idl
@@ -63,7 +63,7 @@ types:
         bson_serialization_type: any
         description: An object representing a chunk version for a collection.
         cpp_type: ChunkVersion
-        serializer: ChunkVersion::serializeToBSON
+        serializer: ChunkVersion::serializeTo60BSON
         deserializer: ChunkVersion::fromBSONPositionalOrNewerFormat
 
     # DO NOT add any new usages of this format, use ChunkVersion above instead
@@ -75,5 +75,5 @@ types:
         bson_serialization_type: any
         description: An object representing a chunk version for a collection.
         cpp_type: ChunkVersion
-        serializer: ChunkVersion::serializeToPositionalFormatWronglyEncodedAsBSON
+        serializer: ChunkVersion::serializeTo60BSON
         deserializer: ChunkVersion::fromBSONPositionalOrNewerFormat

--- a/src/mongo/s/pm2583_feature_flags.idl
+++ b/src/mongo/s/pm2583_feature_flags.idl
@@ -38,4 +38,5 @@ feature_flags:
     featureFlagNewPersistedChunkVersionFormat:
         description: Feature flag for enabling the new persisted chunk version format.
         cpp_varname: gFeatureFlagNewPersistedChunkVersionFormat
-        default: false
+        default: true
+        version: 6.0


### PR DESCRIPTION
This is a WIP test that changes the chunk version format from an array format:

`[<major|minor>, <epoch>, <timestamp>]`

To an object like format:

`{v: <major|minor>, e: <epoch>, t: <timestamp>}`

There are several tests that need to be fixed, and some extra code necessary to fully complete the transition, one of the major problems seems to be split chunk, the full evergreen patch can be found [here](https://spruce.mongodb.com/version/6213afd9c9ec4477ac9e8f53/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC).