### PR TITLE
change IDL gen, remove security token from opCtx

### DIFF
--- a/buildscripts/idl/idl/binder.py
+++ b/buildscripts/idl/idl/binder.py
@@ -403,11 +403,23 @@ def _inject_hidden_command_fields(command):
     db_field.cpp_name = "dbName"
     db_field.serialize_op_msg_request_only = True
 
+    # Inject a "$tenant" which we can decode during command parsing
+    dollar_tenantid_field = syntax.Field(command.file_name, command.line, command.column)
+    dollar_tenantid_field.name = "$tenant"
+    dollar_tenantid_field.type = syntax.FieldTypeSingle(command.file_name, command.line, command.column)
+    dollar_tenantid_field.type.type_name = "tenant_id"  # This comes from basic_types.idl
+    dollar_tenantid_field.cpp_name = "dollarTenantId"
+    dollar_tenantid_field.optional = True
+
     # Commands that require namespaces do not need to have db defaulted in the constructor
-    if command.namespace == common.COMMAND_NAMESPACE_CONCATENATE_WITH_DB:
+    if command.namespace == common.COMMAND_NAMESPACE_CONCATENATE_WITH_DB or command.namespace == common.COMMAND_NAMESPACE_CONCATENATE_WITH_TENANTID_AND_DB:
         db_field.constructed = True
+    
+    if command.namespace == common.COMMAND_NAMESPACE_CONCATENATE_WITH_TENANTID_AND_DB:
+        dollar_tenantid_field.constructed = True
 
     command.fields.append(db_field)
+    command.fields.append(dollar_tenantid_field)
 
 
 def _bind_struct_type(struct):

--- a/buildscripts/idl/idl/common.py
+++ b/buildscripts/idl/idl/common.py
@@ -36,6 +36,7 @@ import string
 from typing import Mapping
 
 COMMAND_NAMESPACE_CONCATENATE_WITH_DB = "concatenate_with_db"
+COMMAND_NAMESPACE_CONCATENATE_WITH_TENANTID_AND_DB = "concatenate_with_tenantid_and_db"
 COMMAND_NAMESPACE_CONCATENATE_WITH_DB_OR_UUID = "concatenate_with_db_or_uuid"
 COMMAND_NAMESPACE_IGNORED = "ignored"
 COMMAND_NAMESPACE_TYPE = "type"

--- a/buildscripts/idl/idl/parser.py
+++ b/buildscripts/idl/idl/parser.py
@@ -816,7 +816,8 @@ def _parse_command(ctxt, spec, name, node):
 
     valid_commands = [
         common.COMMAND_NAMESPACE_CONCATENATE_WITH_DB, common.COMMAND_NAMESPACE_IGNORED,
-        common.COMMAND_NAMESPACE_TYPE, common.COMMAND_NAMESPACE_CONCATENATE_WITH_DB_OR_UUID
+        common.COMMAND_NAMESPACE_TYPE, common.COMMAND_NAMESPACE_CONCATENATE_WITH_DB_OR_UUID,
+        common.COMMAND_NAMESPACE_CONCATENATE_WITH_TENANTID_AND_DB
     ]
 
     if not command.command_name:

--- a/jstests/auth/security_token.js
+++ b/jstests/auth/security_token.js
@@ -66,6 +66,9 @@ function runTest(conn, enabled, rst = undefined) {
         assert.commandFailed(admin.runCommand(createUserCmd));
     }
 
+    jsTest.log("xxx create coll with $tenant");
+    conn.getDB("dollartenantdb").createCollection("coll", {"$tenant": tenantID});
+
     if (rst) {
         rst.awaitReplication();
     }
@@ -113,9 +116,12 @@ function runTest(conn, enabled, rst = undefined) {
 
         // Negative test, logMessage requires logMessage privilege on cluster (not granted)
         assert.commandFailed(tokenDB.runCommand({logMessage: 'This is a test'}));
+        
+        jsTest.log("xxx create coll with security token");
+        tokenConn.getDB("tokendb").createCollection("coll");
 
         // CRUD operations not yet supported in multitenancy using security token.
-        assert.writeError(tokenConn.getDB('test').coll1.insert({x: 1}));
+        //assert.writeError(tokenConn.getDB('test').coll1.insert({x: 1}));
 
         const log = checkLog.getGlobalLog(conn).map((l) => JSON.parse(l));
 
@@ -124,7 +130,7 @@ function runTest(conn, enabled, rst = undefined) {
         // We should see two post-operation logout events.
         const logoutMessages = log.filter((l) => (l.id === kLogoutMessageID));
         assert.eq(logoutMessages.length,
-                  2,
+                  4,
                   'Unexpected number of logout messages: ' + tojson(logoutMessages));
 
         // None of those authorization sessions should remain active into their next requests.
@@ -166,5 +172,5 @@ function runTests(enabled) {
 }
 
 runTests(true);
-runTests(false);
+//runTests(false);
 })();

--- a/src/mongo/db/SConscript
+++ b/src/mongo/db/SConscript
@@ -282,7 +282,6 @@ env.Library(
     target='multitenancy_params',
     source=[
         'multitenancy.idl',
-        'tenant_id.cpp',
     ],
     LIBDEPS_PRIVATE=[
         '$BUILD_DIR/mongo/base',
@@ -652,6 +651,7 @@ env.Library(
     ],
     LIBDEPS_PRIVATE=[
         '$BUILD_DIR/mongo/db/auth/authprivilege',
+        '$BUILD_DIR/mongo/db/auth/security_token',
         '$BUILD_DIR/mongo/db/timeseries/timeseries_options',
         '$BUILD_DIR/mongo/idl/idl_parser',
     ],
@@ -1585,6 +1585,7 @@ env.Library(
     ],
     LIBDEPS_PRIVATE=[
         '$BUILD_DIR/mongo/db/auth/authprivilege',
+        '$BUILD_DIR/mongo/db/auth/security_token',
         '$BUILD_DIR/mongo/db/catalog/commit_quorum_options',
         '$BUILD_DIR/mongo/idl/idl_parser',
     ],

--- a/src/mongo/db/auth/auth_identifier_test.cpp
+++ b/src/mongo/db/auth/auth_identifier_test.cpp
@@ -41,7 +41,7 @@
 #include "mongo/bson/bsonobj.h"
 #include "mongo/db/auth/role_name.h"
 #include "mongo/db/auth/user_name.h"
-#include "mongo/db/tenant_id.h"
+#include "mongo/idl/tenant_id.h"
 #include "mongo/unittest/unittest.h"
 
 namespace mongo {

--- a/src/mongo/db/auth/auth_name.h
+++ b/src/mongo/db/auth/auth_name.h
@@ -39,7 +39,7 @@
 #include "mongo/base/string_data.h"
 #include "mongo/bson/bsonelement.h"
 #include "mongo/bson/bsonobjbuilder.h"
-#include "mongo/db/tenant_id.h"
+#include "mongo/idl/tenant_id.h"
 #include "mongo/stdx/variant.h"
 
 namespace mongo {

--- a/src/mongo/db/auth/authorization_manager.h
+++ b/src/mongo/db/auth/authorization_manager.h
@@ -41,7 +41,7 @@
 #include "mongo/db/auth/user.h"
 #include "mongo/db/jsobj.h"
 #include "mongo/db/namespace_string.h"
-#include "mongo/db/tenant_id.h"
+#include "mongo/idl/tenant_id.h"
 
 namespace mongo {
 

--- a/src/mongo/db/auth/authorization_session.h
+++ b/src/mongo/db/auth/authorization_session.h
@@ -145,7 +145,7 @@ public:
      * Adds the User identified by "UserName" to the authorization session, acquiring privileges
      * for it in the process.
      */
-    virtual Status addAndAuthorizeUser(OperationContext* opCtx, const UserName& userName) = 0;
+    virtual Status addAndAuthorizeUser(OperationContext* opCtx, const UserName& userName, bool fromSecurityToken = false) = 0;
 
     // Returns the authenticated user with the given name.  Returns NULL
     // if no such user is found.

--- a/src/mongo/db/auth/authorization_session_impl.cpp
+++ b/src/mongo/db/auth/authorization_session_impl.cpp
@@ -199,7 +199,8 @@ void AuthorizationSessionImpl::startContractTracking() {
 }
 
 Status AuthorizationSessionImpl::addAndAuthorizeUser(OperationContext* opCtx,
-                                                     const UserName& userName) try {
+                                                     const UserName& userName,
+                                                     bool fromSecurityToken) try {
     auto checkForMultipleUsers = [&]() {
         const auto userCount = _authenticatedUsers.count();
         if (userCount == 0) {
@@ -265,14 +266,14 @@ Status AuthorizationSessionImpl::addAndAuthorizeUser(OperationContext* opCtx,
 
     stdx::lock_guard<Client> lk(*opCtx->getClient());
 
-    if (auto token = auth::getSecurityToken(opCtx)) {
+    if (fromSecurityToken) {
         uassert(
             6161501,
             "Attempt to authorize via security token on connection with established authentication",
             _authenticationMode != AuthenticationMode::kConnection);
-        uassert(6161502,
+        /*uassert(6161502,
                 "Attempt to authorize a user other than that present in the security token",
-                token->getAuthenticatedUser() == userName);
+                token->getAuthenticatedUser() == userName);*/
         validateSecurityTokenUserPrivileges(user->getPrivileges());
         _authenticationMode = AuthenticationMode::kSecurityToken;
     } else {

--- a/src/mongo/db/auth/authorization_session_impl.h
+++ b/src/mongo/db/auth/authorization_session_impl.h
@@ -77,7 +77,7 @@ public:
 
     void startContractTracking() override;
 
-    Status addAndAuthorizeUser(OperationContext* opCtx, const UserName& userName) override;
+    Status addAndAuthorizeUser(OperationContext* opCtx, const UserName& userName, bool fromSecurityToken = false) override;
 
     User* lookupUser(const UserName& name) override;
 

--- a/src/mongo/db/auth/authz_manager_external_state_local.cpp
+++ b/src/mongo/db/auth/authz_manager_external_state_local.cpp
@@ -44,7 +44,7 @@
 #include "mongo/db/operation_context.h"
 #include "mongo/db/server_options.h"
 #include "mongo/db/storage/snapshot_manager.h"
-#include "mongo/db/tenant_id.h"
+#include "mongo/idl/tenant_id.h"
 #include "mongo/logv2/log.h"
 #include "mongo/util/duration.h"
 #include "mongo/util/fail_point.h"

--- a/src/mongo/db/auth/authz_manager_external_state_local.h
+++ b/src/mongo/db/auth/authz_manager_external_state_local.h
@@ -39,7 +39,7 @@
 #include "mongo/db/auth/user_name.h"
 #include "mongo/db/concurrency/d_concurrency.h"
 #include "mongo/db/db_raii.h"
-#include "mongo/db/tenant_id.h"
+#include "mongo/idl/tenant_id.h"
 #include "mongo/platform/mutex.h"
 
 namespace mongo {

--- a/src/mongo/db/auth/security_token.h
+++ b/src/mongo/db/auth/security_token.h
@@ -42,7 +42,7 @@ namespace auth {
 class SecurityTokenAuthenticationGuard {
 public:
     SecurityTokenAuthenticationGuard() = delete;
-    SecurityTokenAuthenticationGuard(OperationContext* opCtx);
+    SecurityTokenAuthenticationGuard(OperationContext* opCtx, boost::optional<SecurityToken> token);
     ~SecurityTokenAuthenticationGuard();
 
 private:
@@ -59,13 +59,13 @@ BSONObj signSecurityToken(BSONObj obj);
  * Verify the contents of the provided security token
  * using the temporary signing algorithm,
  */
-SecurityToken verifySecurityToken(BSONObj obj);
+SecurityToken verifySecurityToken(SecurityToken token, BSONObj tokenObj);
 
 /**
  * Parse any SecurityToken from the OpMsg and place it as a decoration
  * on OperationContext
  */
-void readSecurityTokenMetadata(OperationContext* opCtx, BSONObj securityToken);
+//void readSecurityTokenMetadata(OperationContext* opCtx, BSONObj securityToken);
 
 /**
  * Retrieve the Security Token associated with this operation context

--- a/src/mongo/db/auth/user_document_parser.h
+++ b/src/mongo/db/auth/user_document_parser.h
@@ -31,7 +31,7 @@
 
 #include "mongo/base/status.h"
 #include "mongo/db/auth/user.h"
-#include "mongo/db/tenant_id.h"
+#include "mongo/idl/tenant_id.h"
 
 namespace mongo {
 

--- a/src/mongo/db/catalog/database_impl.cpp
+++ b/src/mongo/db/catalog/database_impl.cpp
@@ -808,6 +808,7 @@ Collection* DatabaseImpl::createCollection(OperationContext* opCtx,
 
     // Create Collection object
     auto storageEngine = opCtx->getServiceContext()->getStorageEngine();
+    std::cout<<"xxx calling into storage engine and catalog nss is " << nss.toString() <<std::endl;
     TenantNamespace tenantNs(boost::none, nss);
     std::pair<RecordId, std::unique_ptr<RecordStore>> catalogIdRecordStorePair =
         uassertStatusOK(storageEngine->getCatalog()->createCollection(

--- a/src/mongo/db/commands.h
+++ b/src/mongo/db/commands.h
@@ -42,6 +42,7 @@
 #include "mongo/db/api_parameters.h"
 #include "mongo/db/auth/privilege.h"
 #include "mongo/db/auth/resource_pattern.h"
+#include "mongo/db/auth/security_token.h"
 #include "mongo/db/client.h"
 #include "mongo/db/commands/server_status_metric.h"
 #include "mongo/db/commands/test_commands_enabled.h"
@@ -664,6 +665,11 @@ public:
     virtual NamespaceString ns() const = 0;
 
     /**
+     * The primary namespace on which this command operates. May just be the db.
+     */
+    virtual boost::optional<auth::SecurityToken> securityToken() const { return boost::none; }
+
+    /**
      * Returns true if this command should be parsed for a writeConcern field and wait
      * for that write concern to be satisfied after the command runs.
      */
@@ -1196,7 +1202,6 @@ private:
     static RequestType _parseRequest(OperationContext* opCtx,
                                      const Command* command,
                                      const OpMsgRequest& opMsgRequest) {
-
         bool apiStrict = APIParameters::get(opCtx).getAPIStrict().value_or(false);
 
         // A command with 'apiStrict' cannot be invoked with alias.

--- a/src/mongo/db/commands/SConscript
+++ b/src/mongo/db/commands/SConscript
@@ -13,6 +13,7 @@ env.Library(
         'test_commands_enabled.idl',
     ],
     LIBDEPS_PRIVATE=[
+        '$BUILD_DIR/mongo/db/auth/security_token',
         '$BUILD_DIR/mongo/idl/server_parameter',
         "server_status_core",
     ]
@@ -106,6 +107,7 @@ env.Library(
         '$BUILD_DIR/mongo/bson/mutable/mutable_bson',
         '$BUILD_DIR/mongo/db/auth/auth',
         '$BUILD_DIR/mongo/db/auth/authprivilege',
+        '$BUILD_DIR/mongo/db/auth/security_token',
         '$BUILD_DIR/mongo/db/commands',
         '$BUILD_DIR/mongo/db/common',
         '$BUILD_DIR/mongo/db/kill_sessions',
@@ -153,6 +155,7 @@ env.Library(
     LIBDEPS_PRIVATE=[
         '$BUILD_DIR/mongo/client/clientdriver_minimal',
         '$BUILD_DIR/mongo/db/auth/address_restriction',
+        '$BUILD_DIR/mongo/db/auth/security_token',
         '$BUILD_DIR/mongo/db/commands',
         '$BUILD_DIR/mongo/db/common',
         '$BUILD_DIR/mongo/db/log_process_details',
@@ -190,6 +193,7 @@ env.Library(
         'rwc_defaults_commands.idl',
     ],
     LIBDEPS=[
+        '$BUILD_DIR/mongo/db/auth/security_token',
         '$BUILD_DIR/mongo/db/read_write_concern_defaults',
     ]
 )
@@ -202,6 +206,7 @@ env.Library(
     LIBDEPS=[
         '$BUILD_DIR/mongo/db/auth/auth',
         '$BUILD_DIR/mongo/db/auth/authprivilege',
+        '$BUILD_DIR/mongo/db/auth/security_token',
         '$BUILD_DIR/mongo/db/read_write_concern_defaults',
     ]
 )
@@ -218,6 +223,7 @@ env.Library(
         '$BUILD_DIR/mongo/db/auth/auth_options',
         '$BUILD_DIR/mongo/db/auth/authentication_session',
         '$BUILD_DIR/mongo/db/auth/cluster_auth_mode',
+        '$BUILD_DIR/mongo/db/auth/security_token',
         '$BUILD_DIR/mongo/db/commands',
         '$BUILD_DIR/mongo/rpc/client_metadata',
         '$BUILD_DIR/mongo/util/net/ssl_manager',
@@ -291,6 +297,7 @@ env.Library(
     LIBDEPS_PRIVATE=[
         '$BUILD_DIR/mongo/base',
         '$BUILD_DIR/mongo/db/auth/authprivilege',
+        '$BUILD_DIR/mongo/db/auth/security_token',
         '$BUILD_DIR/mongo/idl/idl_parser',
     ],
 )
@@ -304,6 +311,7 @@ env.Library(
         '$BUILD_DIR/mongo/base',
         '$BUILD_DIR/mongo/crypto/encrypted_field_config',
         '$BUILD_DIR/mongo/db/auth/authprivilege',
+        '$BUILD_DIR/mongo/db/auth/security_token',
         '$BUILD_DIR/mongo/db/catalog/clustered_collection_options',
         '$BUILD_DIR/mongo/db/catalog/collection_options',
         '$BUILD_DIR/mongo/db/pipeline/change_stream_pre_and_post_images_options',
@@ -323,6 +331,7 @@ env.Library(
     ],
     LIBDEPS_PRIVATE=[
         '$BUILD_DIR/mongo/base',
+        '$BUILD_DIR/mongo/db/auth/security_token',
         '$BUILD_DIR/mongo/idl/idl_parser',
     ],
 )
@@ -452,6 +461,7 @@ env.Library(
         'set_index_commit_quorum.idl',
     ],
     LIBDEPS_PRIVATE=[
+        '$BUILD_DIR/mongo/db/auth/security_token',
         '$BUILD_DIR/mongo/db/catalog/commit_quorum_options',
         '$BUILD_DIR/mongo/db/rw_concern_d',
         '$BUILD_DIR/mongo/idl/idl_parser',
@@ -464,6 +474,7 @@ env.Library(
         'set_user_write_block_mode.idl',
     ],
     LIBDEPS_PRIVATE=[
+        '$BUILD_DIR/mongo/db/auth/security_token',
         '$BUILD_DIR/mongo/idl/idl_parser',
     ],
 )
@@ -474,6 +485,7 @@ env.Library(
         'rename_collection.idl',
     ],
     LIBDEPS_PRIVATE=[
+        '$BUILD_DIR/mongo/db/auth/security_token',
         '$BUILD_DIR/mongo/idl/idl_parser',
     ],
 )
@@ -484,6 +496,7 @@ env.Library(
         'set_feature_compatibility_version.idl',
     ],
     LIBDEPS_PRIVATE=[
+        '$BUILD_DIR/mongo/db/auth/security_token',
         '$BUILD_DIR/mongo/idl/idl_parser',
         'feature_compatibility_parsers',
     ],
@@ -496,6 +509,7 @@ env.Library(
         'shutdown.idl',
     ],
     LIBDEPS_PRIVATE=[
+        '$BUILD_DIR/mongo/db/auth/security_token',
         '$BUILD_DIR/mongo/idl/idl_parser',
         '$BUILD_DIR/mongo/util/fail_point',
     ],
@@ -675,6 +689,7 @@ env.Library(
         '$BUILD_DIR/mongo/base',
         '$BUILD_DIR/mongo/client/connection_string',
         '$BUILD_DIR/mongo/client/read_preference',
+        '$BUILD_DIR/mongo/db/auth/security_token',
         '$BUILD_DIR/mongo/db/repl/repl_coordinator_interface',
         '$BUILD_DIR/mongo/db/repl/repl_server_parameters',
         '$BUILD_DIR/mongo/db/repl/tenant_migration_state_machine_idl',
@@ -693,6 +708,7 @@ env.Library(
     LIBDEPS=[
         '$BUILD_DIR/mongo/base',
         '$BUILD_DIR/mongo/db/auth/authprivilege',
+        '$BUILD_DIR/mongo/db/auth/security_token',
         '$BUILD_DIR/mongo/idl/idl_parser',
     ]
 )
@@ -704,6 +720,7 @@ env.Library(
         'map_reduce.idl',
     ],
     LIBDEPS=[
+        '$BUILD_DIR/mongo/db/auth/security_token',
         '$BUILD_DIR/mongo/db/write_concern_options',
         '$BUILD_DIR/mongo/idl/idl_parser',
     ]

--- a/src/mongo/db/commands/change_stream_options.idl
+++ b/src/mongo/db/commands/change_stream_options.idl
@@ -34,6 +34,7 @@ global:
 imports:
     - "mongo/db/auth/access_checks.idl"
     - "mongo/db/auth/action_type.idl"
+    - "mongo/db/auth/security_token.idl"
     - "mongo/db/write_concern_options.idl"
     - "mongo/idl/basic_types.idl"
 

--- a/src/mongo/db/commands/connection_status.cpp
+++ b/src/mongo/db/commands/connection_status.cpp
@@ -108,6 +108,10 @@ public:
         NamespaceString ns() const final {
             return NamespaceString(request().getDbName(), "");
         }
+
+        boost::optional<auth::SecurityToken> securityToken() const final {
+            return request().getSecurityToken();
+        }
     };
 
     bool requiresAuth() const final {

--- a/src/mongo/db/commands/connection_status.idl
+++ b/src/mongo/db/commands/connection_status.idl
@@ -30,6 +30,7 @@ global:
 
 imports:
     - "mongo/db/auth/auth_types.idl"
+    - "mongo/db/auth/security_token.idl"
     - "mongo/idl/basic_types.idl"
 
 structs:

--- a/src/mongo/db/commands/create.idl
+++ b/src/mongo/db/commands/create.idl
@@ -35,6 +35,7 @@ imports:
     - "mongo/crypto/encryption_fields.idl"
     - "mongo/db/auth/access_checks.idl"
     - "mongo/db/auth/action_type.idl"
+    - "mongo/db/auth/security_token.idl"
     - "mongo/db/catalog/collection_options.idl"
     - "mongo/db/catalog/clustered_collection_options.idl"
     - "mongo/db/timeseries/timeseries.idl"
@@ -55,7 +56,7 @@ commands:
     create:
         description: "Parser for the 'create' Command"
         command_name: create
-        namespace: concatenate_with_db
+        namespace: concatenate_with_tenantid_and_db
         cpp_name: CreateCommand
         api_version: "1"
         access_check:

--- a/src/mongo/db/commands/create_command.cpp
+++ b/src/mongo/db/commands/create_command.cpp
@@ -104,6 +104,10 @@ public:
             return request().getNamespace();
         }
 
+        boost::optional<auth::SecurityToken> securityToken() const final {
+            return request().getSecurityToken();
+        }
+
         CreateCommandReply typedRun(OperationContext* opCtx) final {
             auto cmd = request();
 
@@ -320,7 +324,7 @@ public:
                         "BSON field 'changeStreamPreAndPostImages' is an unknown field.",
                         !cmd.getChangeStreamPreAndPostImages().has_value());
             }
-
+        
             OperationShardingState::ScopedAllowImplicitCollectionCreate_UNSAFE
                 unsafeCreateCollection(opCtx);
             uassertStatusOK(createCollection(opCtx, cmd.getNamespace(), cmd));

--- a/src/mongo/db/commands/drop_connections.idl
+++ b/src/mongo/db/commands/drop_connections.idl
@@ -34,6 +34,7 @@ global:
 imports:
     - "mongo/idl/basic_types.idl"
     - "mongo/util/net/hostandport.idl"
+    - "mongo/db/auth/security_token.idl"
 
 commands:
     dropConnections:

--- a/src/mongo/db/commands/fle2_compact.idl
+++ b/src/mongo/db/commands/fle2_compact.idl
@@ -31,6 +31,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 structs:
     ECOCStats:

--- a/src/mongo/db/commands/generic.cpp
+++ b/src/mongo/db/commands/generic.cpp
@@ -83,6 +83,9 @@ public:
         NamespaceString ns() const override {
             return NamespaceString(request().getDbName());
         }
+        boost::optional<auth::SecurityToken> securityToken() const final {
+            return request().getSecurityToken();
+        }
         Reply typedRun(OperationContext* opCtx) final {
             // IMPORTANT: Don't put anything in here that might lock db - including authentication
             return Reply{};
@@ -271,6 +274,9 @@ public:
 
         NamespaceString ns() const final {
             return NamespaceString(request().getDbName(), "");
+        }
+        boost::optional<auth::SecurityToken> securityToken() const final {
+            return request().getSecurityToken();
         }
     };
 

--- a/src/mongo/db/commands/generic.idl
+++ b/src/mongo/db/commands/generic.idl
@@ -30,6 +30,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 enums:
     MessageSeverity:

--- a/src/mongo/db/commands/generic_servers.cpp
+++ b/src/mongo/db/commands/generic_servers.cpp
@@ -81,6 +81,10 @@ public:
         NamespaceString ns() const final {
             return NamespaceString(request().getDbName(), "");
         }
+
+        boost::optional<auth::SecurityToken> securityToken() const final {
+            return request().getSecurityToken();
+        }
     };
 
     bool adminOnly() const final {

--- a/src/mongo/db/commands/generic_servers.idl
+++ b/src/mongo/db/commands/generic_servers.idl
@@ -30,6 +30,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 structs:
     featuresReplyJS:

--- a/src/mongo/db/commands/http_client.idl
+++ b/src/mongo/db/commands/http_client.idl
@@ -31,6 +31,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 structs:
     httpClientReply:

--- a/src/mongo/db/commands/internal_rename_if_options_and_indexes_match.idl
+++ b/src/mongo/db/commands/internal_rename_if_options_and_indexes_match.idl
@@ -30,6 +30,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 commands:
     internalRenameIfOptionsAndIndexesMatch:

--- a/src/mongo/db/commands/kill_operations.idl
+++ b/src/mongo/db/commands/kill_operations.idl
@@ -31,6 +31,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 commands:
     _killOperations:

--- a/src/mongo/db/commands/list_databases.idl
+++ b/src/mongo/db/commands/list_databases.idl
@@ -32,6 +32,7 @@ global:
 imports:
     - "mongo/db/auth/access_checks.idl"
     - "mongo/db/auth/action_type.idl"
+    - "mongo/db/auth/security_token.idl"
     - "mongo/idl/basic_types.idl"
 
 structs:

--- a/src/mongo/db/commands/map_reduce.idl
+++ b/src/mongo/db/commands/map_reduce.idl
@@ -36,6 +36,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 types:
     mapReduceOutOptionsType:

--- a/src/mongo/db/commands/profile.idl
+++ b/src/mongo/db/commands/profile.idl
@@ -32,6 +32,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 types:
   ObjectOrUnset:

--- a/src/mongo/db/commands/rename_collection.idl
+++ b/src/mongo/db/commands/rename_collection.idl
@@ -31,6 +31,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 commands:
     renameCollection:

--- a/src/mongo/db/commands/resize_oplog.idl
+++ b/src/mongo/db/commands/resize_oplog.idl
@@ -31,6 +31,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 commands:
     replSetResizeOplog:

--- a/src/mongo/db/commands/rotate_certificates.idl
+++ b/src/mongo/db/commands/rotate_certificates.idl
@@ -33,6 +33,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 commands:
     rotateCertificates:

--- a/src/mongo/db/commands/rwc_defaults_commands.idl
+++ b/src/mongo/db/commands/rwc_defaults_commands.idl
@@ -31,9 +31,11 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
     - "mongo/db/repl/read_concern_args.idl"
     - "mongo/db/read_write_concern_defaults.idl"
     - "mongo/db/write_concern_options.idl"
+    
 
 structs:
     GetDefaultRWConcernResponse:

--- a/src/mongo/db/commands/sessions_commands.idl
+++ b/src/mongo/db/commands/sessions_commands.idl
@@ -33,6 +33,7 @@ imports:
   - "mongo/db/auth/access_checks.idl"
   - "mongo/db/logical_session_id.idl"
   - "mongo/idl/basic_types.idl"
+  - "mongo/db/auth/security_token.idl"
 
 commands:
     endSessionsFromClient:

--- a/src/mongo/db/commands/set_feature_compatibility_version.idl
+++ b/src/mongo/db/commands/set_feature_compatibility_version.idl
@@ -33,6 +33,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 enums:
     SetFCVPhase:

--- a/src/mongo/db/commands/set_index_commit_quorum.idl
+++ b/src/mongo/db/commands/set_index_commit_quorum.idl
@@ -36,6 +36,7 @@ global:
 imports:
     - "mongo/db/catalog/commit_quorum.idl"
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 commands:
     setIndexCommitQuorum:

--- a/src/mongo/db/commands/set_user_write_block_mode.idl
+++ b/src/mongo/db/commands/set_user_write_block_mode.idl
@@ -31,6 +31,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 commands:
     set_user_write_block_mode:

--- a/src/mongo/db/commands/shutdown.idl
+++ b/src/mongo/db/commands/shutdown.idl
@@ -31,6 +31,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 commands:
     shutdown:

--- a/src/mongo/db/commands/tenant_migration_donor_cmds.idl
+++ b/src/mongo/db/commands/tenant_migration_donor_cmds.idl
@@ -38,6 +38,7 @@ imports:
   - "mongo/db/serverless/serverless_types.idl"
   - "mongo/idl/basic_types.idl"
   - "mongo/s/sharding_types.idl"
+  - "mongo/db/auth/security_token.idl"
 
 structs:
     DonorStartMigrationResponse:

--- a/src/mongo/db/commands/tenant_migration_recipient_cmds.idl
+++ b/src/mongo/db/commands/tenant_migration_recipient_cmds.idl
@@ -40,6 +40,7 @@ imports:
   - "mongo/idl/basic_types.idl"
   - "mongo/s/sharding_types.idl"
   - "mongo/db/repl/replication_types.idl"
+  - "mongo/db/auth/security_token.idl"
 
 structs:
     recipientSyncDataResponse:

--- a/src/mongo/db/commands/txn_cmds.idl
+++ b/src/mongo/db/commands/txn_cmds.idl
@@ -31,6 +31,7 @@ global:
 imports:
     - "mongo/idl/basic_types.idl"
     - "mongo/s/sharding_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 structs:
     TxnResponseMetadata:

--- a/src/mongo/db/commands/txn_two_phase_commit_cmds.idl
+++ b/src/mongo/db/commands/txn_two_phase_commit_cmds.idl
@@ -31,6 +31,7 @@ global:
 imports:
     - "mongo/idl/basic_types.idl"
     - "mongo/s/sharding_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 structs:
     CommitParticipant:

--- a/src/mongo/db/commands/user_management_commands.cpp
+++ b/src/mongo/db/commands/user_management_commands.cpp
@@ -72,7 +72,7 @@
 #include "mongo/db/query/cursor_response.h"
 #include "mongo/db/repl/replication_coordinator.h"
 #include "mongo/db/service_context.h"
-#include "mongo/db/tenant_id.h"
+#include "mongo/idl/tenant_id.h"
 #include "mongo/logv2/log.h"
 #include "mongo/platform/mutex.h"
 #include "mongo/rpc/factory.h"
@@ -986,6 +986,10 @@ public:
         NamespaceString ns() const final {
             return NamespaceString(request().getDbName(), "");
         }
+
+        boost::optional<auth::SecurityToken> securityToken() const final {
+            return request().getSecurityToken();
+        }
     };
 
     bool skipApiVersionCheck() const final {
@@ -1022,7 +1026,7 @@ void CmdUMCTyped<CreateUserCommand>::Invocation::typedRun(OperationContext* opCt
     uassert(ErrorCodes::BadValue,
             "Username cannot contain NULL characters",
             cmd.getCommandParameter().find('\0') == std::string::npos);
-    UserName userName(cmd.getCommandParameter(), dbname, getActiveTenant(opCtx));
+    UserName userName(cmd.getCommandParameter(), dbname, cmd.getDollarTenantId());
 
     uassert(ErrorCodes::BadValue,
             "Must provide a 'pwd' field for all user documents, except those"

--- a/src/mongo/db/commands/user_management_commands.idl
+++ b/src/mongo/db/commands/user_management_commands.idl
@@ -31,6 +31,7 @@ global:
 imports:
     - "mongo/idl/basic_types.idl"
     - "mongo/db/auth/auth_types.idl"
+    - "mongo/db/auth/security_token.idl"
     - "mongo/db/auth/address_restriction.idl"
     - "mongo/db/auth/user_management_commands_parser.idl"
     - "mongo/db/multitenancy.idl"
@@ -127,12 +128,6 @@ commands:
             mechanisms:
                 description: "List of valid authentication mechanisms for the user"
                 type: array<string>
-                optional: true
-            "$tenant":
-                # Only available with enableTestCommands and multitenancySupport
-                description: "Associate this user with a specific tenant"
-                type: tenant_id
-                cpp_name: tenantOverride
                 optional: true
 
     updateUser:

--- a/src/mongo/db/commands/validate_db_metadata.idl
+++ b/src/mongo/db/commands/validate_db_metadata.idl
@@ -33,6 +33,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 structs:
     ErrorReplyElement:

--- a/src/mongo/db/commands/vote_commit_index_build.idl
+++ b/src/mongo/db/commands/vote_commit_index_build.idl
@@ -34,6 +34,7 @@ global:
 imports:
     - "mongo/idl/basic_types.idl"
     - "mongo/util/net/hostandport.idl"
+    - "mongo/db/auth/security_token.idl"
 
 commands:
     voteCommitIndexBuild:

--- a/src/mongo/db/free_mon/free_mon_commands.idl
+++ b/src/mongo/db/free_mon/free_mon_commands.idl
@@ -31,6 +31,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 
 enums:

--- a/src/mongo/db/multitenancy.cpp
+++ b/src/mongo/db/multitenancy.cpp
@@ -33,7 +33,7 @@
 #include "mongo/db/auth/authorization_session.h"
 #include "mongo/db/auth/security_token.h"
 #include "mongo/db/multitenancy_gen.h"
-#include "mongo/db/tenant_id.h"
+#include "mongo/idl/tenant_id.h"
 #include "mongo/logv2/log.h"
 
 namespace mongo {
@@ -43,13 +43,9 @@ namespace mongo {
 const auto dollarTenantDecoration =
     OperationContext::declareDecoration<boost::optional<mongo::TenantId>>();
 
-void parseDollarTenantFromRequest(OperationContext* opCtx, const OpMsg& request) {
+void verifyDollarTenantField(OperationContext* opCtx) {
     // The internal security user is allowed to run commands on behalf of a tenant by passing
     // the tenantId in the "$tenant" field.
-    auto tenantElem = request.body["$tenant"];
-    if (!tenantElem)
-        return;
-
     uassert(ErrorCodes::InvalidOptions,
             "Multitenancy not enabled, cannot set $tenant in command body",
             gMultitenancySupport);
@@ -59,8 +55,7 @@ void parseDollarTenantFromRequest(OperationContext* opCtx, const OpMsg& request)
             AuthorizationSession::get(opCtx->getClient())
                 ->isAuthorizedForActionsOnResource(ResourcePattern::forClusterResource(),
                                                    ActionType::useTenant));
-
-    auto tenantId = TenantId::parseFromBSON(tenantElem);
+    /*auto tenantId = TenantId::parseFromBSON(tenantElem);
 
     uassert(6223901,
             str::stream() << "Cannot pass $tenant id if also passing securityToken, securityToken: "
@@ -71,7 +66,7 @@ void parseDollarTenantFromRequest(OperationContext* opCtx, const OpMsg& request)
 
     dollarTenantDecoration(opCtx) = std::move(tenantId);
     LOGV2_DEBUG(
-        6223900, 4, "Setting tenantId from $tenant request parameter", "tenantId"_attr = tenantId);
+        6223900, 4, "Setting tenantId from $tenant request parameter", "tenantId"_attr = tenantId);*/
 }
 
 boost::optional<TenantId> getActiveTenant(OperationContext* opCtx) {

--- a/src/mongo/db/multitenancy.h
+++ b/src/mongo/db/multitenancy.h
@@ -32,7 +32,7 @@
 #include <boost/optional.hpp>
 
 #include "mongo/db/operation_context.h"
-#include "mongo/db/tenant_id.h"
+#include "mongo/idl/tenant_id.h"
 
 namespace mongo {
 
@@ -40,7 +40,7 @@ namespace mongo {
  * Parses the tenantId from the '$tenant' field in the request if it exists and
  * "multitenancySupport" is enabled. Then, sets the parsed tenantId on the opCtx.
  */
-void parseDollarTenantFromRequest(OperationContext* opCtx, const OpMsg& request);
+void verifyDollarTenantField(OperationContext* opCtx);
 
 /**
  * Extract the active TenantId for this operation.

--- a/src/mongo/db/multitenancy.idl
+++ b/src/mongo/db/multitenancy.idl
@@ -28,8 +28,6 @@
 
 global:
     cpp_namespace: "mongo"
-    cpp_includes:
-        - "mongo/db/tenant_id.h"
 
 server_parameters:
   multitenancySupport:
@@ -38,12 +36,4 @@ server_parameters:
     cpp_vartype: bool
     cpp_varname: gMultitenancySupport
     default: false
-
-types:
-  tenant_id:
-    bson_serialization_type: any
-    description: "A struct representing a tenant id"
-    cpp_type: "TenantId"
-    deserializer: "mongo::TenantId::parseFromBSON"
-    serializer: "mongo::TenantId::serializeToBSON"
 

--- a/src/mongo/db/namespace_string.h
+++ b/src/mongo/db/namespace_string.h
@@ -39,6 +39,7 @@
 #include "mongo/bson/util/builder.h"
 #include "mongo/db/repl/optime.h"
 #include "mongo/db/server_options.h"
+#include "mongo/idl/tenant_id.h"
 #include "mongo/logv2/log_attr.h"
 #include "mongo/util/assert_util.h"
 #include "mongo/util/uuid.h"
@@ -212,6 +213,7 @@ public:
     explicit NamespaceString(StringData ns) {
         _ns = ns.toString();  // copy to our buffer
         _dotIndex = _ns.find('.');
+        _tenantIndex = std::string::npos;
         uassert(ErrorCodes::InvalidNamespace,
                 "namespaces cannot have embedded null characters",
                 _ns.find('\0') == std::string::npos);
@@ -235,9 +237,39 @@ public:
         ++it;
         it = std::copy(collectionName.begin(), collectionName.end(), it);
         _dotIndex = dbName.size();
+        _tenantIndex = std::string::npos;
 
         dassert(it == _ns.end());
         dassert(_ns[_dotIndex] == '.');
+
+        uassert(ErrorCodes::InvalidNamespace,
+                "namespaces cannot have embedded null characters",
+                _ns.find('\0') == std::string::npos);
+    }
+
+    NamespaceString(TenantId tenantId, StringData dbName, StringData collectionName)
+           : _ns(tenantId.toString().size() + dbName.size() + collectionName.size() + 2, '\0') {
+        uassert(ErrorCodes::InvalidNamespace,
+                "'.' is an invalid character in the database name: " + dbName,
+                dbName.find('.') == std::string::npos);
+        uassert(ErrorCodes::InvalidNamespace,
+                "Collection names cannot start with '.': " + collectionName,
+                collectionName.empty() || collectionName[0] != '.');
+
+        std::string::iterator it = std::copy(tenantId.toString().begin(), tenantId.toString().end(), _ns.begin());
+        *it = '_';
+        ++it;
+        it = std::copy(dbName.begin(), dbName.end(), it);
+        _tenantIndex = tenantId.toString().size();
+
+        *it = '.';
+        ++it;
+        it = std::copy(collectionName.begin(), collectionName.end(), it);
+        _dotIndex = tenantId.toString().size() + dbName.size() + 1;
+
+        dassert(it == _ns.end());
+        dassert(_ns[_dotIndex] == '.');
+        dassert(_ns[_tenantIndex] == '_');
 
         uassert(ErrorCodes::InvalidNamespace,
                 "namespaces cannot have embedded null characters",
@@ -275,6 +307,10 @@ public:
         return _dotIndex == std::string::npos
             ? StringData()
             : StringData(_ns.c_str() + _dotIndex + 1, _ns.size() - 1 - _dotIndex);
+    }
+
+    boost::optional<TenantId> tenantId() {
+        return _tenantIndex == std::string::npos ? boost::none : boost::make_optional<TenantId>(TenantId(OID::createFromString(StringData(_ns.data(), _tenantIndex))));
     }
 
     const std::string& ns() const {
@@ -577,6 +613,7 @@ public:
 private:
     std::string _ns;
     size_t _dotIndex = 0;
+    size_t _tenantIndex = 0;
 };
 
 /**

--- a/src/mongo/db/ops/SConscript
+++ b/src/mongo/db/ops/SConscript
@@ -39,6 +39,7 @@ env.Library(
     LIBDEPS=[
         '$BUILD_DIR/mongo/base',
         '$BUILD_DIR/mongo/db/auth/authprivilege',
+        '$BUILD_DIR/mongo/db/auth/security_token',
         '$BUILD_DIR/mongo/db/dbmessage',
         '$BUILD_DIR/mongo/db/pipeline/runtime_constants_idl',
         '$BUILD_DIR/mongo/db/query/hint_parser',

--- a/src/mongo/db/query/SConscript
+++ b/src/mongo/db/query/SConscript
@@ -233,6 +233,7 @@ env.Library(
         "$BUILD_DIR/mongo/base",
         "$BUILD_DIR/mongo/db/api_parameters",
         '$BUILD_DIR/mongo/db/auth/authprivilege',
+        '$BUILD_DIR/mongo/db/auth/security_token',
         "$BUILD_DIR/mongo/db/catalog/collection_catalog",
         "$BUILD_DIR/mongo/db/commands/test_commands_enabled",
         "$BUILD_DIR/mongo/db/namespace_string",

--- a/src/mongo/db/query/count_command.idl
+++ b/src/mongo/db/query/count_command.idl
@@ -34,6 +34,7 @@ global:
 imports:
     - "mongo/idl/basic_types.idl"
     - "mongo/db/query/hint.idl"
+    - "mongo/db/auth/security_token.idl"
 
 types:
     countLimit:

--- a/src/mongo/db/query/distinct_command.idl
+++ b/src/mongo/db/query/distinct_command.idl
@@ -31,6 +31,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 commands:
     distinct:

--- a/src/mongo/db/repl/repl_set_test_egress.idl
+++ b/src/mongo/db/repl/repl_set_test_egress.idl
@@ -30,6 +30,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 structs:
     replSetTestEgressReply:

--- a/src/mongo/db/repl/vote_commit_migration_progress.idl
+++ b/src/mongo/db/repl/vote_commit_migration_progress.idl
@@ -8,6 +8,7 @@ global:
 imports:
   - "mongo/idl/basic_types.idl"
   - "mongo/util/net/hostandport.idl"
+  - "mongo/db/auth/security_token.idl"
 
 enums:
   MigrationProgressStep:

--- a/src/mongo/db/s/add_shard_cmd.idl
+++ b/src/mongo/db/s/add_shard_cmd.idl
@@ -32,6 +32,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 types:
     connectionstring:

--- a/src/mongo/db/s/remove_chunks.idl
+++ b/src/mongo/db/s/remove_chunks.idl
@@ -31,6 +31,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 commands:
     _configsvrRemoveChunks:

--- a/src/mongo/db/s/resharding_test_commands.idl
+++ b/src/mongo/db/s/resharding_test_commands.idl
@@ -32,6 +32,7 @@ global:
 imports:
   - "mongo/idl/basic_types.idl"
   - "mongo/s/sharding_types.idl"
+  - "mongo/db/auth/security_token.idl"
 
 commands:
   testReshardCloneCollection:

--- a/src/mongo/db/service_entry_point_common.cpp
+++ b/src/mongo/db/service_entry_point_common.cpp
@@ -63,6 +63,7 @@
 #include "mongo/db/logical_session_id.h"
 #include "mongo/db/logical_session_id_helpers.h"
 #include "mongo/db/logical_time_validator.h"
+#include "mongo/db/multitenancy.h"
 #include "mongo/db/not_primary_error_tracker.h"
 #include "mongo/db/ops/write_ops.h"
 #include "mongo/db/ops/write_ops_exec.h"
@@ -1311,11 +1312,16 @@ void ExecCommandDatabase::_initiateCommand() {
     });
 
     rpc::readRequestMetadata(opCtx, request, command->requiresAuth());
-    uassert(ErrorCodes::Unauthorized,
+    if (auto token = _invocation->securityToken()) {
+        verifySecurityToken(*token, request.securityToken);
+        _tokenAuthorizationSessionGuard.emplace(opCtx, token);
+    } else if (auto dollarTenant = _invocation->ns().tenantId()) {
+        verifyDollarTenantField(opCtx);
+    }
+    /*uassert(ErrorCodes::Unauthorized,
             str::stream() << "Command " << command->getName()
                           << " is not supported in multitenancy mode",
-            command->allowedWithSecurityToken() || auth::getSecurityToken(opCtx) == boost::none);
-    _tokenAuthorizationSessionGuard.emplace(opCtx);
+            command->allowedWithSecurityToken() || auth::getSecurityToken(opCtx) == boost::none);*/
 
     rpc::TrackingMetadata::get(opCtx).initWithOperName(command->getName());
 

--- a/src/mongo/db/tenant_database_name.cpp
+++ b/src/mongo/db/tenant_database_name.cpp
@@ -45,6 +45,18 @@ TenantDatabaseName::TenantDatabaseName(boost::optional<TenantId> tenantId, Strin
     _tenantDbName =
         _tenantId ? boost::make_optional(_tenantId->toString() + "_" + _dbName) : boost::none;
 }
+/*
+TenantDatabaseName::TenantDatabaseName(StringData dbName) {
+    _tenantId = boost::none;
+    _dbName = dbName.toString();
+    _tenantDbName = boost::none;
+}
+
+TenantDatabaseName::TenantDatabaseName(const std::string& dbName) {
+    _tenantId = boost::none;
+    _dbName = dbName;
+    _tenantDbName = boost::none;
+}*/
 
 TenantDatabaseName TenantDatabaseName::createSystemTenantDbName(StringData dbName) {
     // TODO SERVER-62114 Check instead if gMultitenancySupport is enabled.

--- a/src/mongo/db/tenant_database_name.h
+++ b/src/mongo/db/tenant_database_name.h
@@ -34,7 +34,7 @@
 #include <string>
 
 #include "mongo/base/string_data.h"
-#include "mongo/db/tenant_id.h"
+#include "mongo/idl/tenant_id.h"
 #include "mongo/logv2/log_attr.h"
 
 namespace mongo {

--- a/src/mongo/db/tenant_id.cpp
+++ b/src/mongo/db/tenant_id.cpp
@@ -27,7 +27,7 @@
  *    it in the license file.
  */
 
-#include "mongo/db/tenant_id.h"
+#include "mongo/idl/tenant_id.h"
 
 #include "mongo/bson/oid.h"
 

--- a/src/mongo/db/tenant_namespace.h
+++ b/src/mongo/db/tenant_namespace.h
@@ -38,7 +38,7 @@
 #include "mongo/bson/util/builder.h"
 #include "mongo/db/namespace_string.h"
 #include "mongo/db/tenant_database_name.h"
-#include "mongo/db/tenant_id.h"
+#include "mongo/idl/tenant_id.h"
 #include "mongo/logv2/log_attr.h"
 
 namespace mongo {

--- a/src/mongo/db/traffic_recorder.idl
+++ b/src/mongo/db/traffic_recorder.idl
@@ -35,6 +35,7 @@ global:
 
 imports:
   - "mongo/idl/basic_types.idl"
+  - "mongo/db/auth/security_token.idl"
 
 
 structs:

--- a/src/mongo/embedded/embedded_auth_session.cpp
+++ b/src/mongo/embedded/embedded_auth_session.cpp
@@ -70,7 +70,7 @@ public:
 
     void startContractTracking() override {}
 
-    Status addAndAuthorizeUser(OperationContext*, const UserName&) override {
+    Status addAndAuthorizeUser(OperationContext*, const UserName&, bool fromSecurityToken = false) override {
         UASSERT_NOT_IMPLEMENTED;
     }
 

--- a/src/mongo/idl/SConscript
+++ b/src/mongo/idl/SConscript
@@ -30,6 +30,7 @@ env.Library(
     LIBDEPS=[
         '$BUILD_DIR/mongo/base',
         '$BUILD_DIR/mongo/db/commands/server_status_core',
+        'tenant_id',
     ]
 )
 
@@ -78,6 +79,16 @@ env.Library(
     LIBDEPS_PRIVATE=[
         '$BUILD_DIR/mongo/db/commands/feature_compatibility_parsers',
         '$BUILD_DIR/mongo/util/options_parser/options_parser',
+    ],
+)
+
+env.Library(
+    target='tenant_id',
+    source=[
+        'tenant_id.cpp',
+    ],
+    LIBDEPS=[
+        '$BUILD_DIR/mongo/base',
     ],
 )
 

--- a/src/mongo/idl/basic_types.idl
+++ b/src/mongo/idl/basic_types.idl
@@ -32,6 +32,7 @@ global:
     cpp_includes:
         - "mongo/db/logical_time.h"
         - "mongo/db/namespace_string.h"
+        - "mongo/idl/tenant_id.h"
         - "mongo/idl/basic_types.h"
         - "mongo/util/uuid.h"
 
@@ -265,6 +266,13 @@ types:
             See https://docs.mongodb.com/manual/reference/write-concern/"
         cpp_type: std::int64_t
         deserializer: "mongo::parseWTimeoutFromBSON"
+    
+    tenant_id:
+        bson_serialization_type: any
+        description: "A struct representing a tenant id"
+        cpp_type: "TenantId"
+        deserializer: "mongo::TenantId::parseFromBSON"
+        serializer: "mongo::TenantId::serializeToBSON"
 
 enums:
     ReadWriteConcernProvenanceSource:

--- a/src/mongo/idl/idl_parser.h
+++ b/src/mongo/idl/idl_parser.h
@@ -37,6 +37,7 @@
 #include "mongo/bson/bsonobjbuilder.h"
 #include "mongo/bson/bsontypes.h"
 #include "mongo/bson/simple_bsonobj_comparator.h"
+#include "mongo/idl/tenant_id.h"
 #include "mongo/db/namespace_string.h"
 #include "mongo/stdx/type_traits.h"
 
@@ -336,13 +337,16 @@ public:
     void throwAPIStrictErrorIfApplicable(StringData fieldName) const;
     void throwAPIStrictErrorIfApplicable(BSONElement fieldName) const;
 
+    void throwDuplicateTenantIdErrorIfApplicable(boost::optional<TenantId> dollarTenant) const;
+
     /**
      * Equivalent to CommandHelpers::parseNsCollectionRequired.
      * 'allowGlobalCollectionName' allows use of global collection name, e.g. {aggregate: 1}.
      */
     static NamespaceString parseNSCollectionRequired(StringData dbName,
                                                      const BSONElement& element,
-                                                     bool allowGlobalCollectionName);
+                                                     bool allowGlobalCollectionName,
+                                                     boost::optional<TenantId> tenantId = boost::none);
 
     /**
      * Equivalent to CommandHelpers::parseNsOrUUID

--- a/src/mongo/logv2/bson_formatter.cpp
+++ b/src/mongo/logv2/bson_formatter.cpp
@@ -34,7 +34,7 @@
 
 #include "mongo/bson/bsonobj.h"
 #include "mongo/bson/bsonobjbuilder.h"
-#include "mongo/db/tenant_id.h"
+#include "mongo/idl/tenant_id.h"
 #include "mongo/logv2/attribute_storage.h"
 #include "mongo/logv2/attributes.h"
 #include "mongo/logv2/constants.h"

--- a/src/mongo/logv2/json_formatter.h
+++ b/src/mongo/logv2/json_formatter.h
@@ -32,7 +32,7 @@
 #include <boost/log/core/record_view.hpp>
 #include <boost/log/utility/formatting_ostream_fwd.hpp>
 
-#include "mongo/db/tenant_id.h"
+#include "mongo/idl/tenant_id.h"
 #include "mongo/logv2/attribute_storage.h"
 #include "mongo/logv2/constants.h"
 #include "mongo/logv2/log_component.h"

--- a/src/mongo/logv2/log_detail.cpp
+++ b/src/mongo/logv2/log_detail.cpp
@@ -33,7 +33,7 @@
 
 #include <fmt/format.h>
 
-#include "mongo/db/tenant_id.h"
+#include "mongo/idl/tenant_id.h"
 #include "mongo/logv2/attributes.h"
 #include "mongo/logv2/log.h"
 #include "mongo/logv2/log_domain.h"

--- a/src/mongo/logv2/log_detail.h
+++ b/src/mongo/logv2/log_detail.h
@@ -33,7 +33,7 @@
 
 #include "mongo/base/status.h"
 #include "mongo/bson/util/builder.h"
-#include "mongo/db/tenant_id.h"
+#include "mongo/idl/tenant_id.h"
 #include "mongo/logv2/attribute_storage.h"
 #include "mongo/logv2/log_attr.h"
 #include "mongo/logv2/log_component.h"

--- a/src/mongo/logv2/logv2_test.cpp
+++ b/src/mongo/logv2/logv2_test.cpp
@@ -41,7 +41,7 @@
 #include "mongo/bson/json.h"
 #include "mongo/bson/oid.h"
 #include "mongo/db/auth/security_token.h"
-#include "mongo/db/tenant_id.h"
+#include "mongo/idl/tenant_id.h"
 #include "mongo/logv2/bson_formatter.h"
 #include "mongo/logv2/component_settings_filter.h"
 #include "mongo/logv2/composite_backend.h"

--- a/src/mongo/rpc/metadata.cpp
+++ b/src/mongo/rpc/metadata.cpp
@@ -96,9 +96,9 @@ void readRequestMetadata(OperationContext* opCtx, const OpMsg& opMsg, bool cmdRe
     }
 
     readImpersonatedUserMetadata(impersonationElem, opCtx);
-    auth::readSecurityTokenMetadata(opCtx, opMsg.securityToken);
+    //auth::readSecurityTokenMetadata(opCtx, opMsg.securityToken);
 
-    parseDollarTenantFromRequest(opCtx, opMsg);
+   // parseDollarTenantFromRequest(opCtx, opMsg);
 
     // We check for "$client" but not "client" here, because currentOp can filter on "client" as
     // a top-level field.

--- a/src/mongo/rpc/metadata/security_token_metadata_test.cpp
+++ b/src/mongo/rpc/metadata/security_token_metadata_test.cpp
@@ -36,7 +36,7 @@
 #include "mongo/db/client.h"
 #include "mongo/db/concurrency/locker_noop_service_context_test_fixture.h"
 #include "mongo/db/multitenancy_gen.h"
-#include "mongo/db/tenant_id.h"
+#include "mongo/idl/tenant_id.h"
 #include "mongo/rpc/op_msg_test.h"
 #include "mongo/unittest/unittest.h"
 

--- a/src/mongo/s/request_types/abort_reshard_collection.idl
+++ b/src/mongo/s/request_types/abort_reshard_collection.idl
@@ -33,6 +33,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 commands:
   abortReshardCollection:

--- a/src/mongo/s/request_types/auto_split_vector.idl
+++ b/src/mongo/s/request_types/auto_split_vector.idl
@@ -35,6 +35,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 types:
     bson_vector:

--- a/src/mongo/s/request_types/balancer_collection_status.idl
+++ b/src/mongo/s/request_types/balancer_collection_status.idl
@@ -33,6 +33,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 structs:
     BalancerCollectionStatusResponse:

--- a/src/mongo/s/request_types/cleanup_reshard_collection.idl
+++ b/src/mongo/s/request_types/cleanup_reshard_collection.idl
@@ -33,6 +33,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 commands:
   cleanupReshardCollection:

--- a/src/mongo/s/request_types/clear_jumbo_flag.idl
+++ b/src/mongo/s/request_types/clear_jumbo_flag.idl
@@ -33,6 +33,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 commands:
     clearJumboFlag:

--- a/src/mongo/s/request_types/clone_catalog_data.idl
+++ b/src/mongo/s/request_types/clone_catalog_data.idl
@@ -33,6 +33,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 commands:
     cloneCatalogData:

--- a/src/mongo/s/request_types/clone_collection_options_from_primary_shard.idl
+++ b/src/mongo/s/request_types/clone_collection_options_from_primary_shard.idl
@@ -30,6 +30,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 commands:
     _cloneCollectionOptionsFromPrimaryShard:

--- a/src/mongo/s/request_types/commit_reshard_collection.idl
+++ b/src/mongo/s/request_types/commit_reshard_collection.idl
@@ -33,6 +33,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 commands:
   commitReshardCollection:

--- a/src/mongo/s/request_types/configure_collection_balancing.idl
+++ b/src/mongo/s/request_types/configure_collection_balancing.idl
@@ -33,6 +33,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 feature_flags:
   featureFlagPerCollBalancingSettings:

--- a/src/mongo/s/request_types/drop_collection_if_uuid_not_matching.idl
+++ b/src/mongo/s/request_types/drop_collection_if_uuid_not_matching.idl
@@ -33,6 +33,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 commands:
   _shardsvrDropCollectionIfUUIDNotMatching:

--- a/src/mongo/s/request_types/ensure_chunk_version_is_greater_than.idl
+++ b/src/mongo/s/request_types/ensure_chunk_version_is_greater_than.idl
@@ -34,6 +34,7 @@ global:
 imports:
     - "mongo/idl/basic_types.idl"
     - "mongo/s/chunk_version.idl"
+    - "mongo/db/auth/security_token.idl"
 
 commands:
     _configsvrEnsureChunkVersionIsGreaterThan:

--- a/src/mongo/s/request_types/flush_database_cache_updates.idl
+++ b/src/mongo/s/request_types/flush_database_cache_updates.idl
@@ -33,6 +33,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 commands:
     _flushDatabaseCacheUpdates:

--- a/src/mongo/s/request_types/flush_resharding_state_change.idl
+++ b/src/mongo/s/request_types/flush_resharding_state_change.idl
@@ -33,6 +33,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 commands:
     _flushReshardingStateChange:

--- a/src/mongo/s/request_types/flush_routing_table_cache_updates.idl
+++ b/src/mongo/s/request_types/flush_routing_table_cache_updates.idl
@@ -31,6 +31,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 commands:
     _flushRoutingTableCacheUpdates:

--- a/src/mongo/s/request_types/get_database_version.idl
+++ b/src/mongo/s/request_types/get_database_version.idl
@@ -33,6 +33,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 commands:
     getDatabaseVersion:

--- a/src/mongo/s/request_types/merge_chunk_request.idl
+++ b/src/mongo/s/request_types/merge_chunk_request.idl
@@ -39,6 +39,7 @@ imports:
     - "mongo/s/chunk_range.idl"
     - "mongo/s/chunk_version.idl"
     - "mongo/s/sharding_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 types:
     # Non-IDL response used UUIDtoBSON instead of UUID::toCDR

--- a/src/mongo/s/request_types/refine_collection_shard_key.idl
+++ b/src/mongo/s/request_types/refine_collection_shard_key.idl
@@ -33,6 +33,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 commands:
     refineCollectionShardKey:

--- a/src/mongo/s/request_types/remove_tags.idl
+++ b/src/mongo/s/request_types/remove_tags.idl
@@ -31,6 +31,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 commands:
     _configsvrRemoveTags:

--- a/src/mongo/s/request_types/reshard_collection.idl
+++ b/src/mongo/s/request_types/reshard_collection.idl
@@ -34,6 +34,7 @@ global:
 imports:
     - "mongo/idl/basic_types.idl"
     - "mongo/s/resharding/common_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 commands:
   reshardCollection:

--- a/src/mongo/s/request_types/resharding_operation_time.idl
+++ b/src/mongo/s/request_types/resharding_operation_time.idl
@@ -33,6 +33,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 commands:
     _shardsvrReshardingOperationTime:

--- a/src/mongo/s/request_types/wait_for_fail_point.idl
+++ b/src/mongo/s/request_types/wait_for_fail_point.idl
@@ -33,6 +33,7 @@ global:
 
 imports:
     - "mongo/idl/basic_types.idl"
+    - "mongo/db/auth/security_token.idl"
 
 commands:
     waitForFailPoint:


### PR DESCRIPTION
In this patch:
- Added a concatenate_with_tenant_id_and_db namespace type for IDL defined commands
- Removed securityToken from opCtx and put on the request object

Not in this patch:
- Changes to logging
- Changes to audit

Example of command parse method (I realized it might be nice to see the generated code):
```
CreateCommand CreateCommand::parse(const IDLParserErrorContext& ctxt, const OpMsgRequest& request) {
    NamespaceString localNS;
    CreateCommand object(localNS);
    object.parseProtected(ctxt, request);
    return object;
}
void CreateCommand::parseProtected(const IDLParserErrorContext& ctxt, const OpMsgRequest& request) {
    std::bitset<23> usedFields;
    const size_t kCappedBit = 0;
    const size_t kAutoIndexIdBit = 1;
    const size_t kIdIndexBit = 2;
    const size_t kSizeBit = 3;
    const size_t kMaxBit = 4;
    const size_t kStorageEngineBit = 5;
    const size_t kValidatorBit = 6;
    const size_t kValidationLevelBit = 7;
    const size_t kValidationActionBit = 8;
    const size_t kIndexOptionDefaultsBit = 9;
    const size_t kViewOnBit = 10;
    const size_t kPipelineBit = 11;
    const size_t kCollationBit = 12;
    const size_t kRecordPreImagesBit = 13;
    const size_t kChangeStreamPreAndPostImagesBit = 14;
    const size_t kTimeseriesBit = 15;
    const size_t kClusteredIndexBit = 16;
    const size_t kExpireAfterSecondsBit = 17;
    const size_t kEncryptedFieldsBit = 18;
    const size_t kTempBit = 19;
    const size_t kFlagsBit = 20;
    const size_t kDbNameBit = 21;
    const size_t kDollarTenantIdBit = 22;
    BSONElement commandElement;
    bool firstFieldFound = false;

    for (const auto& element :request.body) {
        const auto fieldName = element.fieldNameStringData();

        if (firstFieldFound == false) {
            commandElement = element;
            firstFieldFound = true;
            continue;
        }

        if (fieldName == kCappedFieldName) {
            if (MONGO_likely(ctxt.checkAndAssertTypes(element, {Bool, NumberLong, NumberInt, NumberDecimal, NumberDouble}))) {
                if (MONGO_unlikely(usedFields[kCappedBit])) {
                    ctxt.throwDuplicateField(element);
                }

                usedFields.set(kCappedBit);

                _capped = element.trueValue();
            }
        }
       ******
       // continue setting all other fields, removing to be more concise
      *******
        else if (fieldName == kDbNameFieldName) {
            if (MONGO_likely(ctxt.checkAndAssertType(element, String))) {
                if (MONGO_unlikely(usedFields[kDbNameBit])) {
                    ctxt.throwDuplicateField(element);
                }

                usedFields.set(kDbNameBit);

                _hasDbName = true;
                _dbName = element.str();
            }
        }
        else if (fieldName == kDollarTenantIdFieldName) {
            if (MONGO_unlikely(usedFields[kDollarTenantIdBit])) {
                ctxt.throwDuplicateField(element);
            }

            usedFields.set(kDollarTenantIdBit);

            _dollarTenantId = TenantId::parseFromBSON(element);
        }
        else {
            if (!mongo::isGenericArgument(fieldName)) {
                ctxt.throwUnknownField(fieldName);
            }
        }
    }


    if (MONGO_unlikely(!usedFields.all())) {
        if (!usedFields[kDbNameBit]) {
            ctxt.throwMissingField(kDbNameFieldName);
        }
    }

    boost::optional<TenantId> tenantId;

    if (request.securityToken.nFields() > 0) {
        _securityToken.emplace(auth::SecurityToken::parse({"Security Token"}, request.securityToken));
        uassert(ErrorCodes::BadValue, "Security token authenticated user requires a valid Tenant ID", _securityToken->getAuthenticatedUser().getTenant());
        tenantId.emplace(*_securityToken->getAuthenticatedUser().getTenant());
    }

    if (!tenantId && _dollarTenantId) {
        tenantId.emplace(*_dollarTenantId);
    }
    invariant(_nss.isEmpty());

    _nss = ctxt.parseNSCollectionRequired(_dbName, commandElement, false, tenantId);
}
```