### PR TITLE
SERVER-64129 Update sys-perf initialsync to 6.0 after 5.3 branch

### DIFF
--- a/etc/system_perf.yml
+++ b/etc/system_perf.yml
@@ -882,8 +882,8 @@ tasks:
         vars:
           test_control: "initialsync-logkeeper"
           mongodb_setup: "initialsync-logkeeper-short"
-          # Logkeeper dataset with FCV set to 5.3
-          mongodb_dataset: "https://s3-us-west-2.amazonaws.com/dsi-donot-remove/InitialSyncLogKeeper/logkeeper-slice-data-mongodb-5.3.tgz"
+          # Logkeeper dataset with FCV set to 6.0
+          mongodb_dataset: "https://s3-us-west-2.amazonaws.com/dsi-donot-remove/InitialSyncLogKeeper/logkeeper-slice-data-mongodb-6.0.tgz"
 
   - name: initialsync-logkeeper-short-fcbis
     priority: 5
@@ -892,8 +892,8 @@ tasks:
         vars:
           test_control: "initialsync-logkeeper"
           mongodb_setup: "initialsync-logkeeper-short-fcbis"
-          # Logkeeper dataset with FCV set to 5.3
-          mongodb_dataset: "https://s3-us-west-2.amazonaws.com/dsi-donot-remove/InitialSyncLogKeeper/logkeeper-slice-data-mongodb-5.3.tgz"
+          # Logkeeper dataset with FCV set to 6.0
+          mongodb_dataset: "https://s3-us-west-2.amazonaws.com/dsi-donot-remove/InitialSyncLogKeeper/logkeeper-slice-data-mongodb-6.0.tgz"
 
   - name: initialsync-logkeeper
     priority: 5
@@ -925,7 +925,7 @@ tasks:
           test_control: "initialsync-logkeeper-short-s3-update"
           mongodb_setup: "initialsync-logkeeper-short-s3-update"
           # Update this to Logkeeper dataset with FCV set to latest after each LTS release.
-          mongodb_dataset: "https://s3-us-west-2.amazonaws.com/dsi-donot-remove/InitialSyncLogKeeper/logkeeper-slice-data-mongodb-5.3.tgz"
+          mongodb_dataset: "https://s3-us-west-2.amazonaws.com/dsi-donot-remove/InitialSyncLogKeeper/logkeeper-slice-data-mongodb-6.0.tgz"
 
   - name: initialsync-logkeeper-snapshot-update
     priority: 5
@@ -1800,7 +1800,7 @@ buildvariants:
     expansions:
       mongodb_setup: initialsync-logkeeper
       infrastructure_provisioning: initialsync-logkeeper
-      # EBS logkeeper snapshot with FCV set to 5.3
+      # EBS logkeeper snapshot with FCV set to 6.0
       snapshotId: snap-012f25eea6e57b9b7
       platform: linux
       authentication: disabled


### PR DESCRIPTION
Corrected name for the mongodb_dataset (6.0, not 5.3).   
update step: https://spruce.mongodb.com/version/621fdc58850e615aaa37a373/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Note: the snapshotId is the same as the previous run on the 6.0.0-alpha tagged mainline
[2022/03/02 22:45:50.740] snapshotId: snap-012f25eea6e57b9b7

Test patch build: https://spruce.mongodb.com/version/621ffb1c7742ae3658038410/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC