### PR TITLE
SERVER-64595 add ref to openssl_init for proper initialization

### DIFF
--- a/src/mongo/crypto/SConscript
+++ b/src/mongo/crypto/SConscript
@@ -3,6 +3,7 @@
 Import([
     'env',
     'get_option',
+    'ssl_provider',
 ])
 
 env = env.Clone()
@@ -134,7 +135,7 @@ env.CppUnitTest(
     LIBDEPS=[
         '$BUILD_DIR/mongo/base',
         '$BUILD_DIR/mongo/base/secure_allocator',
-        '$BUILD_DIR/mongo/util/net/openssl_init',
+        '$BUILD_DIR/mongo/util/net/openssl_init' if ssl_provider == 'openssl' else '',
         'aead_encryption',
         'encrypted_field_config',
         'fle_crypto',

--- a/src/mongo/crypto/SConscript
+++ b/src/mongo/crypto/SConscript
@@ -134,6 +134,7 @@ env.CppUnitTest(
     LIBDEPS=[
         '$BUILD_DIR/mongo/base',
         '$BUILD_DIR/mongo/base/secure_allocator',
+        '$BUILD_DIR/mongo/util/net/openssl_init',
         'aead_encryption',
         'encrypted_field_config',
         'fle_crypto',


### PR DESCRIPTION
Apparently, openssl was not getting initialized in AEAD tests. This caused `EVP_get_cipherbyname("aes-256-ctr")` to return null on amazon2-arm64-large. Adding reference triggers static initialization.

Will shortly be testing in evergreen to determine if this solution will or will not break windoze and mac