### PR TITLE
Type cannot be `array`

### DIFF
--- a/src/mongo/shell/types.js
+++ b/src/mongo/shell/types.js
@@ -557,7 +557,6 @@ Map.hash = function(val) {
         case 'date':
             return val.toString();
         case 'object':
-        case 'array':
             var s = "";
             for (var k in val) {
                 s += k + val[k];


### PR DESCRIPTION
```node
> typeof [NaN, undefined, Object]
'object'
```