### PR TITLE
SERVER-66955 Remove JSON.send usage in sys-perf and performance

### DIFF
--- a/etc/perf.yml
+++ b/etc/perf.yml
@@ -15,7 +15,7 @@ variables:
     - variant: linux-wt-standalone
       name: compile
   _real_expansions: &_expansion_updates
-    []
+      []
   ###
 
   ###
@@ -166,10 +166,6 @@ functions:
       params:
         script: ./src/dsi/run-dsi determine_failure -m TEST
   f_dsi_post_run:
-    - command: json.send
-      params:
-        name: perf
-        file: ./build/LegacyPerfJson/perf.json
     - command: shell.exec
       params:
         script: ./src/dsi/run-dsi post_run

--- a/etc/system_perf.yml
+++ b/etc/system_perf.yml
@@ -22,9 +22,7 @@ variables:
       - name: schedule_global_auto_tasks
         variant: task_generation
   _real_expansions: &_expansion_updates
-    # TODO: Disable in SERVER-57226.
-    - key: enable_detect_changes
-      value: "true"
+      []
   ###
 
 ###
@@ -190,12 +188,6 @@ functions:
       params:
         script: ./src/dsi/run-dsi determine_failure -m TEST
   f_dsi_post_run:
-    # TODO: SERVER-57226 will let us move this json.send to after dsi's post_run.
-    # This is preferred to keep DSI execution contiguous.
-    - command: json.send
-      params:
-        name: perf
-        file: ./build/LegacyPerfJson/perf.json
     - command: shell.exec
       params:
         script: ./src/dsi/run-dsi post_run


### PR DESCRIPTION
Accompanying https://github.com/10gen/dsi/pull/1055

[sys-perf patch](https://spruce.mongodb.com/version/6298bcae3627e00cacf28436)

[performance patch](https://spruce.mongodb.com/version/6298bd05e3c3312752d7d8a2)