### PR TITLE
Update scons.py

### DIFF
--- a/buildscripts/scons.py
+++ b/buildscripts/scons.py
@@ -6,7 +6,7 @@ import sys
 
 SCONS_VERSION = os.environ.get('SCONS_VERSION', "3.1.2")
 
-MONGODB_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+MONGODB_ROOT = os.path.abspath(os.path.dirname(__file__))
 SCONS_DIR = os.path.join(MONGODB_ROOT, 'src', 'third_party', 'scons-' + SCONS_VERSION,
                          'scons-local-' + SCONS_VERSION)
 


### PR DESCRIPTION
Remove redundant function call.

The following three perform the same logic, why not just call the os.path.dirnam() function once???

```python
MONGODB_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
MONGODB_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
MONGODB_ROOT = os.path.abspath(os.path.dirname(__file__))
```