### PR TITLE
SERVER-67793: Change log_progress_msg to show message in Ubuntu

### DIFF
--- a/debian/init.d
+++ b/debian/init.d
@@ -187,7 +187,7 @@ case "$1" in
         log_daemon_msg "Starting $DESC" "$NAME"
         # Check if it's running first
         if running ;  then
-            log_progress_msg "apparently already running"
+            log_success_msg "apparently already running"
             log_end_msg 0
             exit 0
         fi
@@ -217,7 +217,7 @@ case "$1" in
             log_end_msg $errcode
         else
             # If it's not running don't do anything
-            log_progress_msg "apparently not running"
+            log_success_msg "apparently not running"
             log_end_msg 0
             exit 0
         fi
@@ -248,10 +248,10 @@ case "$1" in
 
         log_daemon_msg "Checking status of $DESC" "$NAME"
         if running ;  then
-            log_progress_msg "running"
+            log_successs_msg "running"
             log_end_msg 0
         else
-            log_progress_msg "apparently not running"
+            log_failure_msg "apparently not running"
             log_end_msg 1
             exit 1
         fi


### PR DESCRIPTION
`log_progress_msg` does not print any message in Ubuntu-20.04.4 LTS in WSL. In file `/lib/lsb/init-functions.d/50-ubuntu-logging`, the function `log_progress_msg () { : }` does nothing. To show the message, `log_success_msg` and `log_failure_msg` could be good alternatives.