### PR TITLE
Add support for out-of-cache indexes.

### DIFF
--- a/src/mongo/client/index_spec.cpp
+++ b/src/mongo/client/index_spec.cpp
@@ -106,6 +106,13 @@ IndexSpec& IndexSpec::unique(bool value) {
     return *this;
 }
 
+IndexSpec& IndexSpec::outOfCache(bool value) {
+    uassert(
+        ErrorCodes::InvalidOptions, kDuplicateOption, !_options.asTempObj().hasField("outOfCache"));
+    _options.append("outOfCache", value);
+    return *this;
+}
+
 IndexSpec& IndexSpec::name(const StringData& value) {
     _name = value.toString();
     _dynamicName = false;

--- a/src/mongo/client/index_spec.h
+++ b/src/mongo/client/index_spec.h
@@ -109,6 +109,11 @@ public:
     /** Set the name for this index. If not set, a name will be automatically generated. */
     IndexSpec& name(const StringData& name);
 
+    /** Sets whether this index is expected to be larger than cache. By default, indexes are
+     *  in cache.
+     */
+    IndexSpec& outOfCache(bool value = true);
+
     /** Sets whether duplicates detected while indexing should be dropped. By default,
      *  duplicates are not dropped.
      */

--- a/src/mongo/db/catalog/index_catalog_impl.cpp
+++ b/src/mongo/db/catalog/index_catalog_impl.cpp
@@ -1903,6 +1903,10 @@ StatusWith<BSONObj> IndexCatalogImpl::_fixIndexSpec(OperationContext* opCtx,
         b.appendBool("prepareUnique",
                      true);  // normalize to bool true in case was int 1 or something...
 
+    if (o["outOfCache"].trueValue())
+        b.appendBool("outOfCache",
+                      true);  // normalize to bool true in case was int 1 or something...
+
     BSONObj key = fixIndexKey(o["key"].Obj());
     b.append("key", key);
 
@@ -1932,7 +1936,7 @@ StatusWith<BSONObj> IndexCatalogImpl::_fixIndexSpec(OperationContext* opCtx,
                 // dropDups is silently ignored and removed from the spec as of SERVER-14710.
                 // ns is removed from the spec as of 4.4.
             } else if (s == "v" || s == "unique" || s == "key" || s == "name" || s == "hidden" ||
-                       s == "prepareUnique") {
+                       s == "outOfCache" || s == "prepareUnique") {
                 // covered above
             } else {
                 b.append(e);

--- a/src/mongo/db/catalog/index_key_validate.cpp
+++ b/src/mongo/db/catalog/index_key_validate.cpp
@@ -268,6 +268,7 @@ BSONObj repairIndexSpec(const NamespaceString& ns,
              IndexDescriptor::kUniqueFieldName == fieldName ||
              IndexDescriptor::kSparseFieldName == fieldName ||
              IndexDescriptor::kDropDuplicatesFieldName == fieldName ||
+             IndexDescriptor::kOutOfCacheFieldName == fieldName ||
              IndexDescriptor::kPrepareUniqueFieldName == fieldName ||
              IndexDescriptor::kClusteredFieldName == fieldName) &&
             !indexSpecElem.isNumber() && !indexSpecElem.isBoolean() && indexSpecElem.trueValue()) {
@@ -502,6 +503,7 @@ StatusWith<BSONObj> validateIndexSpec(OperationContext* opCtx, const BSONObj& in
                     IndexDescriptor::kUniqueFieldName == indexSpecElemFieldName ||
                     IndexDescriptor::kSparseFieldName == indexSpecElemFieldName ||
                     IndexDescriptor::kDropDuplicatesFieldName == indexSpecElemFieldName ||
+                    IndexDescriptor::kOutOfCacheFieldName == indexSpecElemFieldName ||
                     IndexDescriptor::kPrepareUniqueFieldName == indexSpecElemFieldName ||
                     IndexDescriptor::kClusteredFieldName == indexSpecElemFieldName)) {
             if (!indexSpecElem.isNumber() && !indexSpecElem.isBoolean()) {

--- a/src/mongo/db/catalog/index_key_validate.h
+++ b/src/mongo/db/catalog/index_key_validate.h
@@ -61,6 +61,7 @@ static std::set<StringData> allowedFieldNames = {
     IndexDescriptor::kKeyPatternFieldName,
     IndexDescriptor::kLanguageOverrideFieldName,
     IndexDescriptor::kNamespaceFieldName,
+    IndexDescriptor::kOutOfCacheFieldName,
     IndexDescriptor::kPartialFilterExprFieldName,
     IndexDescriptor::kPathProjectionFieldName,
     IndexDescriptor::kSparseFieldName,

--- a/src/mongo/db/create_indexes.idl
+++ b/src/mongo/db/create_indexes.idl
@@ -176,6 +176,10 @@ structs:
                 type: safeBool
                 optional: true
                 unstable: true
+            outOfCache:
+                type: safeBool
+                optional: true
+                unstable: true
             clustered:
                 type: safeBool
                 optional: true

--- a/src/mongo/db/index/index_descriptor.cpp
+++ b/src/mongo/db/index/index_descriptor.cpp
@@ -63,6 +63,7 @@ std::map<StringData, BSONElement> populateOptionsMapForEqualityCheck(const BSONO
         IndexDescriptor::k2dsphereVersionFieldName,    // same as index version
         IndexDescriptor::kBackgroundFieldName,         // this is a creation time option only
         IndexDescriptor::kDropDuplicatesFieldName,     // this is now ignored
+        IndexDescriptor::kOutOfCacheFieldName,         // not considered for equivalence
         IndexDescriptor::kHiddenFieldName,             // not considered for equivalence
         IndexDescriptor::kCollationFieldName,          // checked specially
         IndexDescriptor::kPartialFilterExprFieldName,  // checked specially
@@ -101,6 +102,7 @@ constexpr StringData IndexDescriptor::kIndexVersionFieldName;
 constexpr StringData IndexDescriptor::kKeyPatternFieldName;
 constexpr StringData IndexDescriptor::kLanguageOverrideFieldName;
 constexpr StringData IndexDescriptor::kNamespaceFieldName;
+constexpr StringData IndexDescriptor::kOutOfCacheFieldName;
 constexpr StringData IndexDescriptor::kPartialFilterExprFieldName;
 constexpr StringData IndexDescriptor::kPathProjectionFieldName;
 constexpr StringData IndexDescriptor::kSparseFieldName;
@@ -123,6 +125,7 @@ IndexDescriptor::IndexDescriptor(const std::string& accessMethodName, BSONObj in
       _sparse(infoObj[IndexDescriptor::kSparseFieldName].trueValue()),
       _unique(_isIdIndex || infoObj[kUniqueFieldName].trueValue()),
       _hidden(infoObj[kHiddenFieldName].trueValue()),
+      _outOfCache(infoObj[kOutOfCacheFieldName].trueValue()),
       _partial(!infoObj[kPartialFilterExprFieldName].eoo()) {
     BSONElement e = _infoObj[IndexDescriptor::kIndexVersionFieldName];
     fassert(50942, e.isNumber());

--- a/src/mongo/db/index/index_descriptor.h
+++ b/src/mongo/db/index/index_descriptor.h
@@ -80,6 +80,7 @@ public:
     static constexpr StringData kKeyPatternFieldName = "key"_sd;
     static constexpr StringData kLanguageOverrideFieldName = "language_override"_sd;
     static constexpr StringData kNamespaceFieldName = "ns"_sd;  // Removed in 4.4
+    static constexpr StringData kOutOfCacheFieldName = "outOfCache"_sd;
     static constexpr StringData kPartialFilterExprFieldName = "partialFilterExpression"_sd;
     static constexpr StringData kPathProjectionFieldName = "wildcardProjection"_sd;
     static constexpr StringData kSparseFieldName = "sparse"_sd;
@@ -177,6 +178,11 @@ public:
     // May each key only occur once?
     bool unique() const {
         return _unique;
+    }
+
+    // May each key only occur once?
+    bool isOutOfCache() const {
+        return _outOfCache;
     }
 
     bool hidden() const {
@@ -277,6 +283,7 @@ private:
     bool _sparse;
     bool _unique;
     bool _hidden;
+    bool _outOfCache;
     bool _partial;
     IndexVersion _version;
     BSONObj _collation;

--- a/src/mongo/db/list_indexes.idl
+++ b/src/mongo/db/list_indexes.idl
@@ -150,6 +150,10 @@ structs:
                 type: safeBool
                 optional: true
                 unstable: false
+            outOfCache:
+                type: safeBool
+                optional: true
+                unstable: false
             originalSpec:
                 type: object_owned
                 optional: true

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_index.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_index.cpp
@@ -156,10 +156,13 @@ StatusWith<std::string> WiredTigerIndex::generateCreateString(
     // Separate out a prefix and suffix in the default string. User configuration will override
     // values in the prefix, but not values in the suffix.  Page sizes are chosen so that index
     // keys (up to 1024 bytes) will not overflow.
-    if (desc.isOutOfCache())
+    if (desc.isOutOfCache()) {
+        LOGV2(800001, "index create out of cache");
         ss << "type=lsm,";
-    else
+    } else {
+        LOGV2(800002, "index create NOT out of cache");
         ss << "type=file,";
+    }
     ss << "internal_page_max=16k,leaf_page_max=16k,";
     ss << "checksum=on,";
     if (wiredTigerGlobalOptions.useIndexPrefixCompression) {

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_index.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_index.cpp
@@ -156,7 +156,11 @@ StatusWith<std::string> WiredTigerIndex::generateCreateString(
     // Separate out a prefix and suffix in the default string. User configuration will override
     // values in the prefix, but not values in the suffix.  Page sizes are chosen so that index
     // keys (up to 1024 bytes) will not overflow.
-    ss << "type=file,internal_page_max=16k,leaf_page_max=16k,";
+    if (desc.isOutOfCache())
+        ss << "type=lsm,";
+    else
+        ss << "type=file,";
+    ss << "internal_page_max=16k,leaf_page_max=16k,";
     ss << "checksum=on,";
     if (wiredTigerGlobalOptions.useIndexPrefixCompression) {
         ss << "prefix_compression=true,";

--- a/src/mongo/shell/collection.js
+++ b/src/mongo/shell/collection.js
@@ -570,9 +570,9 @@ DBCollection.prototype._indexSpec = function(keys, options) {
         ret.unique = true;
     else if (typeof (options) == "object") {
         if (Array.isArray(options)) {
-            if (options.length > 3) {
+            if (options.length > 4) {
                 throw new Error("Index options that are supplied in array form may only specify" +
-                                " three values: name, unique, dropDups");
+                                " four values: name, unique, dropDups, outOfCache");
             }
             var nb = 0;
             for (var i = 0; i < options.length; i++) {


### PR DESCRIPTION
Knowing that a cache will be larger than cache allows to make different
decisions about how to ingest new content and store the index information.

This currently compiles, but I very much doubt it would work...