### PR TITLE
SERVER-68579: Fix the compilation warning

### DIFF
--- a/src/mongo/crypto/fle_crypto.cpp
+++ b/src/mongo/crypto/fle_crypto.cpp
@@ -1043,7 +1043,7 @@ BSONObj toBSON(BSONType type, ConstDataRange cdr) {
 
     uassert(ErrorCodes::BadValue,
             "invalid decryption value",
-            docLength < std::numeric_limits<int32_t>::max());
+            docLength < static_cast<size_t>(std::numeric_limits<int32_t>::max()));
 
     builder.appendNum(static_cast<uint32_t>(docLength));
     builder.appendChar(static_cast<uint8_t>(type));


### PR DESCRIPTION
 It is not a big deal but should be better fixed:

```
 src/mongo/crypto/fle_crypto.cpp: In function 'mongo::BSONObj mongo::{anonymous}::toBSON(mongo::BSONType, mongo::ConstDataRange)':
src/mongo/crypto/fle_crypto.cpp:1046:23: warning: comparison of integer expressions of different signedness: 'size_t' {aka 'long unsigned int'} and 'int' [-Wsign-compare]
 1046 |             docLength < std::numeric_limits<int32_t>::max());
      |             ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/mongo/platform/compiler_gcc.h:91:80: note: in definition of macro 'MONGO_unlikely'
   91 | #define MONGO_unlikely(x) static_cast<bool>(__builtin_expect(static_cast<bool>(x), 0))
      |                                                                                ^
src/mongo/util/assert_util.h:417:5: note: in expansion of macro 'MONGO_BASE_ASSERT'
  417 |     MONGO_BASE_ASSERT(::mongo::uassertedWithLocation, msgid, msg, expr)
      |     ^~~~~~~~~~~~~~~~~
src/mongo/crypto/fle_crypto.cpp:1044:5: note: in expansion of macro 'uassert'
 1044 |     uassert(ErrorCodes::BadValue,
      |     ^~~~~~~ 
```