### PR TITLE
SERVER-68578

### DIFF
--- a/src/mongo/db/commands/generic_servers.cpp
+++ b/src/mongo/db/commands/generic_servers.cpp
@@ -171,7 +171,9 @@ HostInfoReply HostInfoCmd::Invocation::typedRun(OperationContext*) {
     reply.setOs(std::move(os));
 
     // OS-specific information.
-    reply.setExtra(p.getSystemDetails());
+    BSONObjBuilder extra;
+    p.appendSystemDetails(extra);
+    reply.setExtra(extra.obj());
 
     return reply;
 }

--- a/src/mongo/db/commands/generic_servers.cpp
+++ b/src/mongo/db/commands/generic_servers.cpp
@@ -171,9 +171,7 @@ HostInfoReply HostInfoCmd::Invocation::typedRun(OperationContext*) {
     reply.setOs(std::move(os));
 
     // OS-specific information.
-    BSONObjBuilder extra;
-    p.appendSystemDetails(extra);
-    reply.setExtra(extra.obj());
+    reply.setExtra(p.getSystemDetails());
 
     return reply;
 }

--- a/src/mongo/util/processinfo.h
+++ b/src/mongo/util/processinfo.h
@@ -151,10 +151,9 @@ public:
     /**
      * Get extra system stats
      */
-    void appendSystemDetails(BSONObjBuilder& details) const {
-        details.append(StringData("extra"), sysInfo()._extraStats.copy());
+    static const BSONObj getSystemDetails() {
+        return sysInfo()._extraStats.copy();
     }
-
     /**
      * Append platform-specific data to obj
      */

--- a/src/mongo/util/processinfo.h
+++ b/src/mongo/util/processinfo.h
@@ -151,9 +151,10 @@ public:
     /**
      * Get extra system stats
      */
-    static const BSONObj getSystemDetails() {
-        return sysInfo()._extraStats.copy();
+    void appendSystemDetails(BSONObjBuilder& details) const {
+        details.appendElements(sysInfo()._extraStats);
     }
+
     /**
      * Append platform-specific data to obj
      */


### PR DESCRIPTION
There's a single reference to `appendSystemDetails` in `generic_servers.cpp`. It makes sense to have the function return an un-nested BSON object in the same `getSystemFoo()` and `reply.setFoo()` style instead of modifying its referenced object argument.