### PR TITLE
SERVER-71449: log_successs_msg: not found

### DIFF
--- a/debian/init.d
+++ b/debian/init.d
@@ -248,7 +248,7 @@ case "$1" in
 
         log_daemon_msg "Checking status of $DESC" "$NAME"
         if running ;  then
-            log_successs_msg "running"
+            log_success_msg "running"
             log_end_msg 0
         else
             log_failure_msg "apparently not running"


### PR DESCRIPTION
when using service status command
fixing "/etc/init.d/mongodb: 251: log_successs_msg: not found" 
error spelling mistake, changed "log_successs_msg" to "log_success_msg"