### PR TITLE
SERVER-70542 Create override that injects security tokens

### DIFF
--- a/buildscripts/resmokeconfig/suites/native_tenant_data_isolation_jscore_passthrough.yml
+++ b/buildscripts/resmokeconfig/suites/native_tenant_data_isolation_jscore_passthrough.yml
@@ -1,0 +1,30 @@
+test_kind: js_test
+
+selector:
+  roots:
+  # TODO SERVER-70545: Pass through more jscore tests "jstests/core/**/*.js" and add hooks for test.
+  # Currently, the test suite is only used for verify the override implemented by inject_security_token.js.
+  - jstests/core/basic8.js
+
+executor:
+  archive:
+    tests: true
+  config:
+    shell_options:
+      eval: |
+        load('jstests/libs/override_methods/inject_security_token.js');
+  fixture:
+    class: ReplicaSetFixture
+    num_nodes: 3
+    mongod_options:
+      set_parameters:
+        enableTestCommands: 1
+        multitenancySupport: true
+        featureFlagMongoStore: true
+        # TODO SERVER-70740: remove featureFlagRequireTenantID from the parameters and have the
+        # inject_security_token override to be able to test both tenant-perfixed request and non-tenant-prefixed request.
+        # Currently, we only test non-tenant-prefixed request and enable the featureFlagRequireTenantID
+        # to have mongod return non-tenant-prefixed response too.
+        featureFlagRequireTenantID: true
+        logComponentVerbosity:
+          command: 3

--- a/etc/evergreen_yml_components/definitions.yml
+++ b/etc/evergreen_yml_components/definitions.yml
@@ -5586,6 +5586,14 @@ tasks:
       use_large_distro: "true"
 
 - <<: *gen_task_template
+  name: native_tenant_data_isolation_jscore_passthrough_gen
+  tags: ["serverless"]
+  commands:
+  - func: "generate resmoke tasks"
+    vars:
+      use_large_distro: "true"
+
+- <<: *gen_task_template
   name: clustered_collection_passthrough_gen
   tags: ["large", "clustered_collections"]
   commands:

--- a/jstests/libs/override_methods/inject_security_token.js
+++ b/jstests/libs/override_methods/inject_security_token.js
@@ -1,0 +1,113 @@
+/**
+ * Overrides the runCommand method to set security token on connection, so that the requests send by
+ * client will pass the signed tenant information to server through the security token.
+ */
+(function() {
+'use strict';
+
+load("jstests/libs/override_methods/override_helpers.js");  // For 'OverrideHelpers'.
+
+const kUserName = "userTenant1";
+const kTenantId = ObjectId();
+
+function createTenantUser(userName, tenantId) {
+    let prepareRootUser = (adminDb) => {
+        // Create a user which has root role so that it can be authenticated as a user with
+        // ActionType::useTenant in order to use $tenant.
+        let res = adminDb.runCommand(
+            {createUser: 'injectST', pwd: 'pwd', roles: ['root'], comment: 'skipOverride'});
+        if (res.ok === 1) {
+            assert.commandWorked(res);
+        } else {
+            // If 'username' already exists, then attempts to create a user with the same name
+            // will fail with error code 51003.
+            assert.commandFailedWithCode(res, 51003);
+        }
+    };
+
+    const adminDb = db.getSiblingDB('admin')
+    prepareRootUser(adminDb);
+    assert(adminDb.auth('injectST', 'pwd'));
+
+    // Create a user for tenant and then set the security token on the connection.
+    assert.commandWorked(db.getSiblingDB('$external').runCommand({
+        createUser: userName,
+        '$tenant': tenantId,
+        roles:
+            [{role: 'dbAdminAnyDatabase', db: 'admin'}, {role: 'readWriteAnyDatabase', db: 'admin'}]
+    }));
+
+    adminDb.logout();
+}
+
+function prepareSecurityToken(conn) {
+    if (typeof conn._securityToken == 'undefined') {
+        print(`Inject security token to the connection ${tojsononeline(conn)}`);
+        const securityToken =
+            _createSecurityToken({user: kUserName, db: '$external', tenant: kTenantId});
+        conn._setSecurityToken(securityToken);
+    }
+}
+
+function getDbName(nss) {
+    if (nss.length === 0 || !nss.includes(".")) {
+        return ns;
+    }
+    return nss.split(".")[0];
+}
+
+function checkErrMsg(errMsg, requestDbName, logError) {
+    if (requestDbName.length === 0) {
+        return;
+    }
+    if (requestDbName.includes("_")) {
+        return;
+    }
+    assert.eq(false, errMsg.includes("_" + requestDbName), logError);
+}
+
+function checkReponse(res, requestDbName, logError) {
+    // We expect the response db name matches request.
+    for (let k of Object.keys(res)) {
+        let v = res[k];
+        if (typeof v === "string") {
+            if (k === "dbName" || k == "db" || k == "dropped") {
+                assert.eq(v, requestDbName, logError);
+            } else if (k === "namespace" || k === "ns") {
+                assert.eq(getDbName(v), requestDbName, logError);
+            } else if (k === "errmsg" || k == "name") {
+                checkErrMsg(v, requestDbName, logError);
+            }
+        } else if (Array.isArray(v)) {
+            v.forEach((item) => {
+                if (typeof item === "object" && item !== null)
+                    checkReponse(item, requestDbName, logError);
+            });
+        } else if (typeof v === "object" && v !== null && Object.keys(v).length > 0) {
+            checkReponse(v, requestDbName, logError);
+        }
+    }
+}
+
+// Override the runCommand to check for the response has the right nss and db name.
+function runCommandWithResponseCheck(
+    conn, dbName, cmdName, cmdObj, originalRunCommand, makeRunCommandArgs) {
+    prepareSecurityToken(conn);
+
+    // Actually run the provided command.
+    let res = originalRunCommand.apply(conn, makeRunCommandArgs(cmdObj));
+    const logUnmatchedDbName = (dbName, resObj) => {
+        return `Response db name does not match sent db name "${dbName}", response: ${
+            tojsononeline(resObj)}`;
+    };
+    
+    checkReponse(res, dbName, logUnmatchedDbName(dbName, res));
+    return res;
+}
+
+createTenantUser(kUserName, kTenantId);
+
+OverrideHelpers.prependOverrideInParallelShell(
+    "jstests/libs/override_methods/inject_security_token.js");
+OverrideHelpers.overrideRunCommand(runCommandWithResponseCheck);
+}());


### PR DESCRIPTION
[Evergreen Link](https://spruce.mongodb.com/version/63519f503627e0672f4665b0/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

In this PR, a new override inject_security_token.js is added. It overrides the runCommand function to inject security token on connections before sending request and checks the response to verify the response dbname matches the request dbname.
A passthrough test suite is added in this PR. The reason to have it in this PR is that it can be used to verify the override implemented by inject_security_token.js. So, currently, only one core js test is assigned to the passthrough test suite. We will improve the suite in ticket [SERVER-70545](https://jira.mongodb.org/browse/SERVER-70545) .