### PR TITLE
cacheRefresh optimize(Performance increase 1000 times when chunks More than 2 million)

### DIFF
--- a/src/mongo/s/mongod_and_mongos_server_parameters.idl
+++ b/src/mongo/s/mongod_and_mongos_server_parameters.idl
@@ -69,3 +69,12 @@ server_parameters:
     cpp_vartype: bool
     cpp_varname: "gEnableFinerGrainedCatalogCacheRefresh"
     default: false
+  CatalogCacheRefreshVectorVerticalDepth:
+    description: >-
+        .Set vector vertical depth of catalog cache refresh.
+    set_at: [ startup ]
+    cpp_vartype: int
+    cpp_varname: "CatalogCacheRefreshVectorVerticalDepth"
+    default: 500 # 500 Chunks
+    validator:
+      gte: 100


### PR DESCRIPTION
In recent releases of MongoDB, there’s a couple optimization been made around Refreshing Routing Info, however the performance issue caused by it wasn’t rooted out for good that big sharded clusters would still suffer slow queries due to it.

Tencent MongoDB team have (or hope so) come up with an optimization solution to solve the problem by utilizing Two-Dimensional Sorting & Search. With the optimization, there’d be no latency caused by refreshing routing info, that the refreshing time cost would remain at around 2ms regardless of the data size of the shreded cluster.

In the official release, refreshing routing info requires iterating full ChunkInfo in the ChunkMap twice, plus iterating ChunkVector once to free shared pointers – This could be very time- & resource-consuming if the chunk size exceeds certain threshold.

The updated _chunkMap and algorithm in the proposed method requires only one iteration on a very small portion of ChunkInfo based on the changed Chunks to update routing info: _chunkMap, _collectionVersion & _shardVersions.