### PR TITLE
SERVER-73846 Thread affinity benefit

### DIFF
--- a/src/mongo/transport/service_executor_utils.cpp
+++ b/src/mongo/transport/service_executor_utils.cpp
@@ -36,6 +36,7 @@
 #include <fmt/format.h>
 #include <functional>
 #include <memory>
+#include <sched.h>
 
 #include "mongo/logv2/log.h"
 #include "mongo/stdx/thread.h"
@@ -59,6 +60,13 @@ namespace mongo {
 
 namespace {
 void* runFunc(void* ctx) {
+    pthread_t tid = pthread_self();
+    int cpuid = sched_getcpu();
+    cpu_set_t cpuset; 
+    CPU_ZERO(&cpuset);       //clears the cpuset
+    CPU_SET(cpuid, &cpuset); //set CPU cpuid on cpuset
+    sched_setaffinity(0, sizeof(cpuset), &cpuset);
+
     auto taskPtr =
         std::unique_ptr<unique_function<void()>>(static_cast<unique_function<void()>*>(ctx));
     (*taskPtr)();


### PR DESCRIPTION
Hello,
I've been working to understand the mongodb server performance on system with large number of cores.  
During the testing of Mongodb with YCSB client (at the time of experiment the YCSB java code only works with v5.0 of the server), I notices large number of migrations statistics as reported by "perf stat" command. See detail below,

| Event | Baseline | Baseline |
| ----- | ----- | ----- |
| Threads | 40 | 80 |
| Throughput | 337,008 | 304,580 |
| sched:sched_process_free | 13 |  18 |
| sched:sched_process_exit | 13 | 16 |
| sched:sched_process_wait | 34 | 34 |
| sched:sched_process_fork | 11 | 15 |
| sched:sched_process_exec | 10 | 11  |
| sched:sched_process_hang | 0 | 0 |
| task:task_newtask | 11 | 15 |
| task:task_rename | 10 | 14 |
| L1-dcache-loads | 1,406,341,217,349 | 1,321,016,036,512 |
| L1-dcache_load_misses | 140,998,950,663 | 148,306,686,642 |
| cycles | 8,938,835,361,677 | 9,556,957,123,623 |
| cs | 199,014,407 | 179,466,722 |
|  **migrations** | **411,085** | **37,726,014** |
| Elapsed time (sec) | 60 | 60 |

As you can see from the table above, the migrations stats is quite high. With addition of few lines of "thread affinity" code in the "runFunc" function which is a thread function per connection, I was able to see almost **70% reduction** in this number with a small improvement (2% to 5%) in overall throughput.

New data snapshot,
| Event | Thread-affinity | Thread-affinity |
| ----- | ----- | ----- |
| Threads | 40 | 80 |
| Throughput | 342,339 | 325,860 |
|  **migrations** | **38,418** | **9,116,093** |
| Elapsed time (sec) | 60 | 60 |

I started with upstream docker version of mongodb server which was based on v5.0.13 at the time hence this PR is based on v5.0 branch.

Environment Details:
Server: Icelake server
OS: Ubuntu 20.04.2 LTS
Kernel: 5.4.0-65-generic
Compiler: gcc version 10.3.0 (Ubuntu 10.3.0-1ubuntu1~20.04)
No. records: 40M
Type of Request: Read-Only queries.

YCSB Commands:
Loading of the database: 
```
$ python2.7 ./bin/ycsb load mongodb -jvm-args="-Dlogback.configurationFile=../logback.xml" -s -P workloads/workloadc -threads 20  -p mongodb.url=mongodb://localhost/ycsb
```
Execution of queries (40 threads)
```
$ python2.7 ./bin/ycsb run mongodb -jvm-args="-Dlogback.configurationFile=../logback.xml" -s -P workloads/workloadc -threads 40  -p mongodb.url=mongodb://localhost/ycsb
```
Execution of queries (80 threads)
```
$ python2.7 ./bin/ycsb run mongodb -jvm-args="-Dlogback.configurationFile=../logback.xml" -s -P workloads/workloadc -threads 80  -p mongodb.url=mongodb://localhost/ycsb
```

Perf command
```
$ sudo perf stat -e "sched:sched_process*,task:*,L1-dcache-loads,L1-dcache-load-misses,cycles,cs,faults,migrations" -d -d -d -a -- sleep  60
```

This is my first PR and hoping to contribute more to the project.
