### PR TITLE
SERVER-74457 Added support building for Tremont CPU microarchitecture

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -362,6 +362,7 @@ experimental_optimizations = [
     'nofp',
     'nordyn',
     'sandybridge',
+    'tremont',
     'tbaa',
     'treevec',
     'vishidden',
@@ -3158,6 +3159,12 @@ if not env.TargetOSIs('windows', 'macOS') and (env.ToolchainIs('GCC', 'clang')):
             "-march=": "sandybridge",
             "-mtune=": "generic",
             "-mprefer-vector-width=": "128",
+        }
+        
+    if "tremont" in selected_experimental_optimizations:
+        default_targeting_flags_for_architecture["x86_64"] = {
+            "-march=": "tremont",
+            "-mtune=": "tremont",
         }
 
     default_targeting_flags = default_targeting_flags_for_architecture.get(env['TARGET_ARCH'])


### PR DESCRIPTION
Hello everyone, you may have forgotten, but there are no AVX instructions on modern architecture energy-efficient processors. But building for this architecture can improve performance well.

There are both embedded devices and servers on this architecture.

More info: https://www.phoronix.com/news/Tremont-Faster-GCC

Patch series on GCC: https://gcc.gnu.org/pipermail/gcc-patches/2021-September/579436.html

![image](https://user-images.githubusercontent.com/21138600/219215395-4e7f731c-5685-4db2-855a-fc010afd5b71.png)

![image](https://user-images.githubusercontent.com/21138600/219215012-0164bf7e-7a30-44c9-88ab-0e4105d79c24.png)

![image](https://user-images.githubusercontent.com/21138600/219215074-8aad5e9c-5ef4-4536-809f-e58f1792bee1.png)
