### PR TITLE
SERVER-74980: fix 5.0 regression where "Refreshed cached collection" …

### DIFF
--- a/src/mongo/s/catalog_cache.cpp
+++ b/src/mongo/s/catalog_cache.cpp
@@ -908,7 +908,7 @@ CatalogCache::CollectionCache::LookupResult CatalogCache::CollectionCache::_look
         newComparableVersion.setChunkVersion(newVersion);
 
         LOGV2_FOR_CATALOG_REFRESH(4619901,
-                                  isIncremental || newComparableVersion != previousVersion ? 0 : 1,
+                                  !isIncremental || newComparableVersion != previousVersion ? 0 : 1,
                                   "Refreshed cached collection",
                                   "namespace"_attr = nss,
                                   "lookupSinceVersion"_attr = lookupVersion,


### PR DESCRIPTION
…is logged at level 0 100x more often than intended