### PR TITLE
SERVER-76111: the common users(with readWrite role on system db) can modify the system collection's data,it is very dangerous,this can cause serious problems.normal collection perfect

### DIFF
--- a/src/mongo/db/namespace_string.h
+++ b/src/mongo/db/namespace_string.h
@@ -319,14 +319,15 @@ public:
 
         if (isMongos() || serverGlobalParams.clusterRole == ClusterRole::ConfigServer) {
             if (isConfigDB() 
-                && (coll() == "actionlog" || coll() == "changelog"
-                    || coll() == "chunks" || coll() == "collections"
-                    || coll() == "databases" || coll() == "lockpings"
-                    || coll() == "locks" || coll() == "migrations"
-                    || coll() == "mongos" || coll() == "settings"
-                    || coll() == "shards" || coll() == "tags"
-                    || coll() == "transactions" || coll() == "version"
-                    || coll() == "migrations")) {
+                && (coll() == "chunks" || coll() == "databases"
+                    || coll() == "collections" || coll() == "shards"
+                    || coll() == "transactions" || coll() == "migrations"
+                    || coll() == "tags" || coll() == "settings"
+                    || coll() == "migrations" || coll() == "locks"
+                    || coll() == "lockpings" || coll() == "version"
+                    || coll() == "mongos" || coll() == "actionlog"
+                    || coll() == "changelog")
+
                 return false;
             }
         }

--- a/src/mongo/db/namespace_string.h
+++ b/src/mongo/db/namespace_string.h
@@ -317,7 +317,7 @@ public:
             return false;
         }
 
-        if (isMongos() || serverGlobalParams.clusterRole == ClusterRole::ConfigServer) {
+        if (serverGlobalParams.clusterRole == ClusterRole::ConfigServer) {
             if (isConfigDB() 
                 && (coll() == "actionlog" || coll() == "changelog"
                     || coll() == "chunks" || coll() == "collections"

--- a/src/mongo/db/namespace_string.h
+++ b/src/mongo/db/namespace_string.h
@@ -317,7 +317,7 @@ public:
             return false;
         }
 
-        if (serverGlobalParams.clusterRole == ClusterRole::ConfigServer) {
+        if (isMongos() || serverGlobalParams.clusterRole == ClusterRole::ConfigServer) {
             if (isConfigDB() 
                 && (coll() == "actionlog" || coll() == "changelog"
                     || coll() == "chunks" || coll() == "collections"

--- a/src/mongo/db/namespace_string.h
+++ b/src/mongo/db/namespace_string.h
@@ -42,6 +42,7 @@
 #include "mongo/logv2/log_attr.h"
 #include "mongo/util/assert_util.h"
 #include "mongo/util/uuid.h"
+#include "mongo/s/is_mongos.h"
 
 namespace mongo {
 
@@ -298,7 +299,39 @@ public:
         return coll().startsWith("system.");
     }
     bool isNormalCollection() const {
-        return !isSystem() && !(isLocal() && coll().startsWith("replset."));
+        if (isSystem())
+            return false;
+            
+        if (isLocal() && (coll().startsWith("replset.") || coll() == "startup_log"))
+            return false;
+      
+        if (isConfigDB() 
+            && (coll().startsWith("cache.") || coll().startsWith("localReshardingOperations.")
+                || coll() == "transactions" || coll() == "transaction_coordinators"
+                || coll() == "migrationCoordinators" || coll() == "tenantMigrationDonors"
+                || coll() == "rangeDeletions" || coll() == "rangeDeletionsForRename"
+                || coll() == "tenantMigrationRecipients" || coll() == "external_validation_keys"
+                || coll() == "reshardingOperations" || coll() == "localRenameParticipants"
+                || coll() == "vectorClock" || coll() == "collection_critical_sections"
+                || coll() == "image_collection")) {
+            return false;
+        }
+
+        if (isMongos() || serverGlobalParams.clusterRole == ClusterRole::ConfigServer) {
+            if (isConfigDB() 
+                && (coll() == "actionlog" || coll() == "changelog"
+                    || coll() == "chunks" || coll() == "collections"
+                    || coll() == "databases" || coll() == "lockpings"
+                    || coll() == "locks" || coll() == "migrations"
+                    || coll() == "mongos" || coll() == "settings"
+                    || coll() == "shards" || coll() == "tags"
+                    || coll() == "transactions" || coll() == "version"
+                    || coll() == "migrations")) {
+                return false;
+            }
+        }
+
+        return true;
     }
     bool isAdminDB() const {
         return db() == kAdminDb;


### PR DESCRIPTION
When we create an account that can read and write the system db(admin,config,local), the account can modify the system namespace(config.transactions,config.chunks.xxx,config.cache.xx, etc).The reason is that we missed some system namespace when we judge the nornal collection.
