### PR TITLE
Expose IAA compressor in MongoDB.

### DIFF
--- a/src/mongo/db/storage/wiredtiger/wiredtiger_global_options.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_global_options.cpp
@@ -74,11 +74,13 @@ Status WiredTigerGlobalOptions::validateWiredTigerCompressor(const std::string& 
     constexpr auto kSnappy = "snappy"_sd;
     constexpr auto kZlib = "zlib"_sd;
     constexpr auto kZstd = "zstd"_sd;
+    constexpr auto kIaa = "iaa"_sd;
 
     if (!kNone.equalCaseInsensitive(value) && !kSnappy.equalCaseInsensitive(value) &&
-        !kZlib.equalCaseInsensitive(value) && !kZstd.equalCaseInsensitive(value)) {
+        !kZlib.equalCaseInsensitive(value) && !kZstd.equalCaseInsensitive(value) &&
+        !kIaa.equalCaseInsensitive(value)) {
         return {ErrorCodes::BadValue,
-                "Compression option must be one of: 'none', 'snappy', 'zlib', or 'zstd'"};
+                "Compression option must be one of: 'none', 'snappy', 'zlib', 'zstd', or 'iaa'"};
     }
 
     return Status::OK();


### PR DESCRIPTION
With some effort, we already merged IAA compressor to WiredTiger (https://jira.mongodb.org/browse/WT-10407) now if we need to use this new compressor in MongoDB, we have a small change in MongoDB to expose the option of IAA compressor, it will be a small PR (several line of code change) to MongoDB since most of the code are in WiredTiger which is already done.