### PR TITLE
permission issue running as a service on WSL2

### DIFF
--- a/debian/init.d
+++ b/debian/init.d
@@ -145,8 +145,11 @@ start_server() {
             fi
 
             # Start the process using the wrapper
+            sudo touch $PIDFILE
+            sudo chown mongodb:mongodb $PIDFILE
+
             start-stop-daemon --background --start --quiet --pidfile $PIDFILE \
-                        --make-pidfile --chuid $DAEMONUSER:$DAEMONGROUP \
+                        --chuid $DAEMONUSER:$DAEMONGROUP \
                         --exec $NUMACTL $DAEMON $DAEMON_OPTS
             errcode=$?
         return $errcode


### PR DESCRIPTION
mongoDB install as a service on WSL2 does not work due to permissions issue with PIDFILE.

in "init.d" file, Line 149 creates the PIDFILE with sudo priviledges.
When mongodb is started up as a service, it's started as mongodb:mongodb. This prevents access to the PIDFILE, which prevents mongodb from running.

Fix: create the PIDFILE and transfer ownership to mongodb:mongodb