### PR TITLE
Alternative and more correct, but less discoverable comment.

### DIFF
--- a/src/mongo/util/tracing_support.cpp
+++ b/src/mongo/util/tracing_support.cpp
@@ -137,7 +137,7 @@ private:
  * Trace Event Format
  * Defined: https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/edit
  *
- * Consumed by Google Chome Tracing, Catapult, and https://perfetto.dev
+ * Consumed by Google Chromium Tracing, Catapult, and https://perfetto.dev
  */
 class TraceEventTracerFactory final : public Tracer::Factory {
 public:


### PR DESCRIPTION
CLA signed. But this comment fix did not warrant a jira ticket. 

`Chome` => `Chromium`

It is an alternative to [1547](https://github.com/mongodb/mongo/pull/1547) which was closed immediately. 