### PR TITLE
Fix typo in FLEUtil::checkEFCForECC error message

### DIFF
--- a/src/mongo/crypto/fle_crypto.cpp
+++ b/src/mongo/crypto/fle_crypto.cpp
@@ -4995,7 +4995,7 @@ PrfBlock FLEUtil::prf(ConstDataRange key, uint64_t value) {
 void FLEUtil::checkEFCForECC(const EncryptedFieldConfig& efc) {
     uassert(7568300,
             str::stream()
-                << "Queryable Encryption version 2 collections nust not contain the eccCollection"
+                << "Queryable Encryption version 2 collections must not contain the eccCollection"
                 << " in EncryptedFieldConfig",
             !efc.getEccCollection());
 }


### PR DESCRIPTION
This originated in 5e31330b37acd7ae599ada97a5161b1e3681c30e for SERVER-75683

Original PR: 10gen/mongo/pull/12814