### PR TITLE
SERVER-77899 remove repeat contain index from the relevant candidate indexes, this can avoid some useless calculations.

### DIFF
--- a/src/mongo/db/query/planner_ixselect.cpp
+++ b/src/mongo/db/query/planner_ixselect.cpp
@@ -49,6 +49,7 @@
 #include "mongo/db/query/planner_wildcard_helpers.h"
 #include "mongo/db/query/query_planner_common.h"
 #include "mongo/logv2/log.h"
+#include "mongo/bson/simple_bsonelement_comparator.h"
 
 namespace mongo {
 
@@ -307,6 +308,103 @@ std::vector<IndexEntry> QueryPlannerIXSelect::findIndexesByHint(
     }
 
     return out;
+}
+
+// remove repeat contain index from the relevant candidate indexes, this can avoid some useless calculations.
+// for example:
+//   {a:1, b:1} contain {a:1}, so we can remove index {a:1} from the candidates
+//   {a:"hashed", b:1} contain {a:"hashed"}, so we can remove index {a:"hahsed"} from the candidates
+//
+// {a:1, b:1} is better than {a:1},because both cases are satisfied for db.collection.find({a:xx}) 
+//    and db.collection.find({a:xx,b:xx})
+//
+void QueryPlannerIXSelect::removeRepeatContainIndexes(std::vector<IndexEntry>& allIndices) {
+    if (allIndices.size() <= 1)
+       return;
+
+    auto isSpecialIndex = [](auto& it) {
+        if (it->type != INDEX_BTREE && it->type != INDEX_HASHED) {
+            return true;
+        }
+        
+        if (it->sparse || it->unique) {
+            return true;
+        }
+
+        if (it->collator) {
+            return true;
+        }
+        
+        if (it->filterExpr) {
+            return true;
+        }
+
+        BSONElement e = it->infoObj[IndexDescriptor::kExpireAfterSecondsFieldName];
+        if (e.isNumber() == false) {
+            return false;
+        }
+        
+        auto expireTime = e.number();
+        if (expireTime >= 0) {
+            return true;
+        } else {
+            return false;
+        }
+    };
+
+    auto dealKeyPattern = [](BSONObj& indexKeyPattern) {
+        BSONObjBuilder build;
+        BSONObjIterator kpIt(indexKeyPattern);
+        while (kpIt.more()) {
+            BSONElement elt = kpIt.next();
+            if (elt.type() == mongo::String) {
+                build.append(elt.fieldName(), elt.String());
+                continue;
+            }
+            
+            // The canonical check as to whether a key pattern element is "ascending" or "descending" is
+            // (elt.number() >= 0). This is defined by the Ordering class.  
+            invariant(elt.isNumber());
+            int sortOrder = (elt.number() >= 0) ? 1 : -1;
+            build.append(elt.fieldName(), sortOrder);
+        }
+        
+        return build.obj();
+    };
+
+    for (auto iterator1 = allIndices.begin(); iterator1 != allIndices.end();) {
+        if (isSpecialIndex(iterator1) == true) {
+            ++iterator1;
+            continue;
+        }
+
+        BSONObj keyPattern1 = dealKeyPattern((*iterator1).keyPattern);
+
+        bool eraseIterator1 = false;
+        auto iterator2 = iterator1;
+        ++iterator2;
+        while (iterator2 != allIndices.end()) {
+            if (isSpecialIndex(iterator2) == true) {
+                ++iterator2;
+                continue;
+            }
+            
+            BSONObj keyPattern2 = dealKeyPattern((*iterator2).keyPattern);
+            
+            if (keyPattern2.isPrefixOf(keyPattern1, SimpleBSONElementComparator::kInstance)) {
+                iterator2 = allIndices.erase(iterator2);
+            } else if (keyPattern1.isPrefixOf(keyPattern2, SimpleBSONElementComparator::kInstance)) {
+                iterator1 = allIndices.erase(iterator1);
+                eraseIterator1 = true;
+                break;
+            } else {
+                ++iterator2;
+            }
+        }
+
+        if (eraseIterator1 == false)
+            iterator1++;
+    }
 }
 
 // static

--- a/src/mongo/db/query/planner_ixselect.cpp
+++ b/src/mongo/db/query/planner_ixselect.cpp
@@ -380,7 +380,7 @@ void QueryPlannerIXSelect::removeRepeatContainIndexes(std::vector<IndexEntry>& a
 
         BSONObj keyPattern1 = dealKeyPattern((*iterator1).keyPattern);
 
-        bool eraseIterator1 = false;
+        bool eraseIterator = false;
         auto iterator2 = iterator1;
         ++iterator2;
         while (iterator2 != allIndices.end()) {
@@ -395,14 +395,14 @@ void QueryPlannerIXSelect::removeRepeatContainIndexes(std::vector<IndexEntry>& a
                 iterator2 = allIndices.erase(iterator2);
             } else if (keyPattern1.isPrefixOf(keyPattern2, SimpleBSONElementComparator::kInstance)) {
                 iterator1 = allIndices.erase(iterator1);
-                eraseIterator1 = true;
+                eraseIterator = true;
                 break;
             } else {
                 ++iterator2;
             }
         }
 
-        if (eraseIterator1 == false)
+        if (eraseIterator == false)
             iterator1++;
     }
 }

--- a/src/mongo/db/query/planner_ixselect.h
+++ b/src/mongo/db/query/planner_ixselect.h
@@ -76,6 +76,18 @@ public:
                                                      const std::vector<IndexEntry>& allIndices);
 
     /**
+     * remove repeat contain index from the relevant candidate indexes, this can avoid some useless calculations.
+     * for example:
+     *   {a:1, b:1} contain {a:1}, so we can remove index {a:1} from the candidates
+     *   {a:"hashed", b:1} contain {a:"hashed"}, so we can remove index {a:"hahsed"} from the candidates
+     *
+     * {a:1, b:1} is better than {a:1},because both cases are satisfied for db.collection.find({a:xx}) 
+     *    and db.collection.find({a:xx,b:xx})
+     */
+    static void removeRepeatContainIndexes(std::vector<IndexEntry>& indexes);
+    
+
+    /**
      * Finds all indices prefixed by fields we have predicates over.  Only these indices are
      * useful in answering the query.
      */

--- a/src/mongo/db/query/query_planner.cpp
+++ b/src/mongo/db/query/query_planner.cpp
@@ -776,13 +776,15 @@ StatusWith<std::vector<std::unique_ptr<QuerySolution>>> QueryPlanner::plan(
                     "index"_attr = relevantIndices[i].toString());
     }
 
-    QueryPlannerIXSelect::removeRepeatContainIndexes(relevantIndices);
-    for (size_t i = 0; i < relevantIndices.size(); ++i) {
-        LOGV2_DEBUG(20971,
-                    2,
-                    "After Remove Repeat Contain Btree And Hashed Index, Relevant index",
-                    "indexNumber"_attr = i,
-                    "index"_attr = relevantIndices[i].toString());
+    if (!hintedIndexEntry) {
+        QueryPlannerIXSelect::removeRepeatContainIndexes(relevantIndices);
+        for (size_t i = 0; i < relevantIndices.size(); ++i) {
+            LOGV2_DEBUG(20971,
+                        2,
+                        "After Remove Repeat Contain Btree And Hashed Index, Relevant index",
+                        "indexNumber"_attr = i,
+                        "index"_attr = relevantIndices[i].toString());
+        }
     }
 
     // Figure out how useful each index is to each predicate.

--- a/src/mongo/db/query/query_planner.cpp
+++ b/src/mongo/db/query/query_planner.cpp
@@ -776,6 +776,15 @@ StatusWith<std::vector<std::unique_ptr<QuerySolution>>> QueryPlanner::plan(
                     "index"_attr = relevantIndices[i].toString());
     }
 
+    QueryPlannerIXSelect::removeRepeatContainIndexes(relevantIndices);
+    for (size_t i = 0; i < relevantIndices.size(); ++i) {
+        LOGV2_DEBUG(20971,
+                    2,
+                    "After Remove Repeat Contain Btree And Hashed Index, Relevant index",
+                    "indexNumber"_attr = i,
+                    "index"_attr = relevantIndices[i].toString());
+    }
+
     // Figure out how useful each index is to each predicate.
     QueryPlannerIXSelect::rateIndices(query.root(), "", relevantIndices, query.getCollator());
     QueryPlannerIXSelect::stripInvalidAssignments(query.root(), relevantIndices);


### PR DESCRIPTION
// remove repeat contain index from the relevant candidate indexes, this can avoid some useless calculations.
// for example:
//   {a:1, b:1} contain {a:1}, so we can remove index {a:1} from the candidates
//   {a:"hashed", b:1} contain {a:"hashed"}, so we can remove index {a:"hahsed"} from the candidates
//
// {a:1, b:1} is better than {a:1},because both cases are satisfied for db.collection.find({a:xx}) 
//    and db.collection.find({a:xx,b:xx})
//