### PR TITLE
SERVER-77901 query plancache replan improvement

### DIFF
--- a/src/mongo/db/exec/cached_plan.cpp
+++ b/src/mongo/db/exec/cached_plan.cpp
@@ -92,10 +92,10 @@ Status CachedPlanStage::pickBestPlan(PlanYieldPolicy* yieldPolicy) {
     size_t maxWorksBeforeReplan =
         static_cast<size_t>(internalQueryCacheEvictionRatio * _decisionWorks);
 
-    // the replan works can not exceed the number of works that is set to be this fraction of the 
+    // the replan works can not exceed the number of works that is set to be the fraction of the 
     // collection size.
     // in extreme cases, if there are no restrictions, Probably more than the total collection size,
-    // this replan may lose effectiveness. this may lead that the query use wrong index.
+    // this replan may lose effectiveness. it may lead that the query use wrong index.
     size_t numUpperLimitWorks = trial_period::getTrialPeriodMaxWorks(opCtx(), collection());
     if (maxWorksBeforeReplan > numUpperLimitWorks) {
         maxWorksBeforeReplan = numUpperLimitWorks;

--- a/src/mongo/db/exec/cached_plan.cpp
+++ b/src/mongo/db/exec/cached_plan.cpp
@@ -92,6 +92,15 @@ Status CachedPlanStage::pickBestPlan(PlanYieldPolicy* yieldPolicy) {
     size_t maxWorksBeforeReplan =
         static_cast<size_t>(internalQueryCacheEvictionRatio * _decisionWorks);
 
+    // the replan works can not exceed the number of works that is set to be this fraction of the 
+    // collection size.
+    // in extreme cases, if there are no restrictions, Probably more than the total collection size,
+    // this replan may lose effectiveness. this may lead that the query use wrong index.
+    size_t numUpperLimitWorks = trial_period::getTrialPeriodMaxWorks(opCtx(), collection());
+    if (maxWorksBeforeReplan > numUpperLimitWorks) {
+        maxWorksBeforeReplan = numUpperLimitWorks;
+    }
+
     // The trial period ends without replanning if the cached plan produces this many results.
     size_t numResults = trial_period::getTrialPeriodNumToReturn(*_canonicalQuery);
 

--- a/src/mongo/db/exec/cached_plan.h
+++ b/src/mongo/db/exec/cached_plan.h
@@ -39,6 +39,7 @@
 #include "mongo/db/query/query_planner_params.h"
 #include "mongo/db/query/query_solution.h"
 #include "mongo/db/record_id.h"
+#include "mongo/platform/atomic_word.h"
 
 namespace mongo {
 
@@ -70,6 +71,10 @@ public:
 
     StageType stageType() const final {
         return STAGE_CACHED_PLAN;
+    }
+
+    size_t getDecisionWorks() const {
+        return _decisionWorks.load();
     }
 
     std::unique_ptr<PlanStageStats> getStats() final;
@@ -123,7 +128,7 @@ private:
 
     // The number of work cycles taken to decide on a winning plan when the plan was first
     // cached.
-    size_t _decisionWorks;
+    AtomicWord<size_t> _decisionWorks{0};
 
     // If we fall back to re-planning the query, and there is just one resulting query solution,
     // that solution is owned here.


### PR DESCRIPTION
the replan works can not exceed the number of works that is set to be the fraction of the  collection size.

in extreme cases, if there are no restrictions, Probably more than the total collection size,  this replan may lose effectiveness. it may lead that the query use wrong index.