### PR TITLE
SERVER-78077: the log of getProductivityFormula function print inconsistency

### DIFF
--- a/src/mongo/db/query/sbe_plan_ranker.cpp
+++ b/src/mongo/db/query/sbe_plan_ranker.cpp
@@ -65,7 +65,7 @@ protected:
         StringBuilder sb;
 
         //in calculateProductivity func, add 1 to both the numerator and denominator, So we need to keep the results consistent 
-        sb << "(" << (root->common.advances + 1) << " advances + 1)/(" << numReads << " numReads + 1)";
+        sb << "(" << (root->common.advances) << " advances + 1)/(" << numReads << " numReads + 1)";
 
         return sb.str();
     }

--- a/src/mongo/db/query/sbe_plan_ranker.cpp
+++ b/src/mongo/db/query/sbe_plan_ranker.cpp
@@ -64,7 +64,7 @@ protected:
         auto numReads{calculateNumberOfReads(root)};
         StringBuilder sb;
 
-        sb << "(" << (root->common.advances + 1) << " advances)/(" << numReads << " numReads)";
+        sb << "(" << (root->common.advances + 1) << " advances + 1)/(" << numReads << " numReads + 1)";
 
         return sb.str();
     }

--- a/src/mongo/db/query/sbe_plan_ranker.cpp
+++ b/src/mongo/db/query/sbe_plan_ranker.cpp
@@ -64,6 +64,7 @@ protected:
         auto numReads{calculateNumberOfReads(root)};
         StringBuilder sb;
 
+        //in calculateProductivity func, add 1 to both the numerator and denominator, So we need to keep the results consistent 
         sb << "(" << (root->common.advances + 1) << " advances + 1)/(" << numReads << " numReads + 1)";
 
         return sb.str();


### PR DESCRIPTION
{"t":{"$date":"2023-06-14T20:44:38.165+08:00"},"s":"D2", "c":"QUERY",    "id":20961,   "ctx":"conn149","msg":"Score formula","attr":{"formula":"score(1.5002) = baseScore(1) + productivity_((1 advances)/(1 numReads) = 0.5)_ + tieBreakers(0 noFetchBonus + 0.0001 noSortBonus + 0.0001 noIxisectBonus = 0.00020000000000000001)"}}

1/1=0.5，it is wrong。In fact， it is (0 + 1) / (1 + 1) = 0.5

in calculateProductivity func, add 1 to both the numerator and denominator, So we need to keep the results consistent

in calculateProductivity func, add 1 to both the numerator and denominator, So we need to keep the results consistent 