### PR TITLE
SERVER-78113: not cache meaningless plan, it will increased memory overhead and increase computing overhead.

### DIFF
--- a/src/mongo/db/exec/plan_cache_util.cpp
+++ b/src/mongo/db/exec/plan_cache_util.cpp
@@ -68,5 +68,15 @@ void logNotCachingNoData(std::string&& solution) {
                 "Not caching query because this solution has no cache data",
                 "solutions"_attr = redact(solution));
 }
+
+void logNotCachingOneWorkesAndZeroResults(std::string&& query, double score, std::string winnerPlanSummary) {
+    LOGV2_DEBUG(20570,
+                1,
+                "Winning plan had zero results, and only one work, skip caching",
+                "query"_attr = redact(query),
+                "winnerScore"_attr = score,
+                "winnerPlanSummary"_attr = winnerPlanSummary);
+
+}
 }  // namespace log_detail
 }  // namespace mongo::plan_cache_util


### PR DESCRIPTION
    // when the mode is PlanCachingMode::AlwaysCache or PlanCachingMode::SometimesCache, there is a special case.
    // take Classic plan cache for example:
    //   If the winning index's advanced = 0 && works == 1 && isEOF == true, which means we didn't get any data to rank score, all candidates 
    //   score is same. the score of the calculation is meaningless.
    //
    //In this case, if we cache the plan, it will increased memory overhead. when the cached plan stage pick best plan, 
    //it will trigger replan. this will increase computing overhead.