### PR TITLE
add query count in getPlanCache list, this can help us to get the hot query sql.

### DIFF
--- a/src/mongo/db/query/explain.cpp
+++ b/src/mongo/db/query/explain.cpp
@@ -376,6 +376,8 @@ void Explain::planCacheEntryToBSON(const PlanCacheEntry& entry, BSONObjBuilder* 
     // Append whether or not the entry is active.
     out->append("isActive", entry.isActive);
     out->append("works", static_cast<long long>(entry.works));
+    // we can use this counter to get the hot query sql
+    out->append("counters", static_cast<long long>(entry.queryCounters));
     out->append("timeOfCreation", entry.timeOfCreation);
 
     if (entry.debugInfo) {

--- a/src/mongo/db/query/get_executor.cpp
+++ b/src/mongo/db/query/get_executor.cpp
@@ -647,6 +647,9 @@ public:
                                     "query"_attr = redact(_cq->toStringShort()));
                     }
 
+                    PlanCache* cache = CollectionQueryInfo::get(_collection).getPlanCache();
+                    cache->increaseCacheQueryCounters(*_cq);
+
                     return buildCachedPlan(
                         std::move(querySolution), plannerParams, cs->decisionWorks);
                 }

--- a/src/mongo/db/query/plan_cache.h
+++ b/src/mongo/db/query/plan_cache.h
@@ -401,6 +401,9 @@ public:
     // cause this value to be increased.
     size_t works = 0;
 
+    //the query count that use this plan to run the sql
+    uint64_t queryCounters = 0;
+
     // Optional debug info containing detailed statistics. Includes a description of the query which
     // resulted in this plan cache's creation as well as runtime stats from the multi-planner trial
     // period that resulted in this cache entry.
@@ -518,6 +521,12 @@ public:
      * perform even worse than the one already in the cache may not easily take its place.
      */
     void deactivate(const CanonicalQuery& query);
+
+    /**
+     * increase the query counters that hit this cached plan.
+     * through this counters, we can get the hot query
+     */
+    void increaseCacheQueryCounters(const CanonicalQuery& query);
 
     /**
      * Look up the cached data access for the provided 'query'.  Used by the query planner


### PR DESCRIPTION
now,we can not get the hot query sql.
after add query count, wo can get the hot qeury, this can help us to analysis the hot sql priority .

