### PR TITLE
SERVER-78199: btree index check, avoid create duplicate btree indexes, Avoid affecting performance

### DIFF
--- a/src/mongo/db/index/index_descriptor.cpp
+++ b/src/mongo/db/index/index_descriptor.cpp
@@ -171,16 +171,16 @@ IndexDescriptor::Comparison IndexDescriptor::compareIndexOptions(
     const IndexCatalogEntry* existingIndex) const {
     auto existingIndexDesc = existingIndex->descriptor();
 
-    //btree index check, avoid creating duplicate btree indexes.
-    //for example:
+    //Index check, avoid creating duplicate indexes.
+    //For example:
     // Add two indexes: db.collection.createIndex({a:1}) and db.collection.createIndex({a:11})
     // The two indexes are actually the same, One of them is a useless index
-    auto dealBtreeKeyPattern = [&](const BSONObj& indexKeyPattern) {
+    auto dealIndexKeyPattern = [&](const BSONObj& indexKeyPattern) {
         if (getIndexType() != INDEX_BTREE) {
              return indexKeyPattern;
         }
         
-        //hidden index is not restricted
+        //Hidden index is not restricted
         if (hidden() == true) {
             return indexKeyPattern;
         }
@@ -200,11 +200,12 @@ IndexDescriptor::Comparison IndexDescriptor::compareIndexOptions(
         return build.obj();
     };
     
-    BSONObj newKeyPattern = dealBtreeKeyPattern(keyPattern());
+    BSONObj newIndexKeyPattern = dealIndexKeyPattern(keyPattern());
+    BSONObj existingIndexKeyPattern = dealIndexKeyPattern(existingIndexDesc->keyPattern());
 
     // We first check whether the key pattern is identical for both indexes.
-    if (SimpleBSONObjComparator::kInstance.evaluate(newKeyPattern ==
-                                                    existingIndexDesc->keyPattern())) {
+    if (SimpleBSONObjComparator::kInstance.evaluate(newIndexKeyPattern !=
+                                                    existingIndexKeyPattern)) {
         return Comparison::kDifferent;
     }
 

--- a/src/mongo/db/index/index_descriptor.cpp
+++ b/src/mongo/db/index/index_descriptor.cpp
@@ -171,12 +171,10 @@ IndexDescriptor::Comparison IndexDescriptor::compareIndexOptions(
     const IndexCatalogEntry* existingIndex) const {
     auto existingIndexDesc = existingIndex->descriptor();
 
-    //btree index check, avoid create duplicate btree indexes, Avoid affecting performance by the deplicate index.
+    //btree index check, avoid creating duplicate btree indexes.
     //for example:
-    // add two index: db.collection.createIndex({a:1}) and db.collection.createIndex({a:11})
-    // the tow index are actually the same, One of them is a useless index, but it can affect the insert performance.
-    //
-    // In addition, They also affecting query performance because both are candidate indexes.
+    // Add two indexes: db.collection.createIndex({a:1}) and db.collection.createIndex({a:11})
+    // The two indexes are actually the same, One of them is a useless index
     auto dealBtreeKeyPattern = [&](const BSONObj& indexKeyPattern) {
         if (getIndexType() != INDEX_BTREE) {
              return indexKeyPattern;
@@ -205,7 +203,7 @@ IndexDescriptor::Comparison IndexDescriptor::compareIndexOptions(
     BSONObj newKeyPattern = dealBtreeKeyPattern(keyPattern());
 
     // We first check whether the key pattern is identical for both indexes.
-    if (SimpleBSONObjComparator::kInstance.evaluate(newKeyPattern =
+    if (SimpleBSONObjComparator::kInstance.evaluate(newKeyPattern ==
                                                     existingIndexDesc->keyPattern())) {
         return Comparison::kDifferent;
     }

--- a/src/mongo/db/index/index_descriptor.cpp
+++ b/src/mongo/db/index/index_descriptor.cpp
@@ -191,10 +191,10 @@ IndexDescriptor::Comparison IndexDescriptor::compareIndexOptions(
         return build.obj();
     };
     
-    BSONObj keyPattern = dealBtreeKeyPattern(keyPattern());
+    BSONObj newKeyPattern = dealBtreeKeyPattern(keyPattern());
 
     // We first check whether the key pattern is identical for both indexes.
-    if (SimpleBSONObjComparator::kInstance.evaluate(keyPattern =
+    if (SimpleBSONObjComparator::kInstance.evaluate(newKeyPattern =
                                                     existingIndexDesc->keyPattern())) {
         return Comparison::kDifferent;
     }

--- a/src/mongo/db/index/index_descriptor.cpp
+++ b/src/mongo/db/index/index_descriptor.cpp
@@ -171,6 +171,12 @@ IndexDescriptor::Comparison IndexDescriptor::compareIndexOptions(
     const IndexCatalogEntry* existingIndex) const {
     auto existingIndexDesc = existingIndex->descriptor();
 
+    //btree index check, avoid create duplicate btree indexes, Avoid affecting performance by the deplicate index.
+    //for example:
+    // add two index: db.collection.createIndex({a:1}) and db.collection.createIndex({a:11})
+    // the tow index are actually the same, One of them is a useless index, but it can affect the insert performance.
+    //
+    // In addition, They also affecting query performance because both are candidate indexes.
     auto dealBtreeKeyPattern = [&](const BSONObj& indexKeyPattern) {
         if (getIndexType() != INDEX_BTREE) {
              return indexKeyPattern;

--- a/src/mongo/db/index/index_descriptor.cpp
+++ b/src/mongo/db/index/index_descriptor.cpp
@@ -182,6 +182,11 @@ IndexDescriptor::Comparison IndexDescriptor::compareIndexOptions(
              return indexKeyPattern;
         }
         
+        //hidden index is not restricted
+        if (hidden() == true) {
+            return indexKeyPattern;
+        }
+ 
         BSONObjBuilder build;
         BSONObjIterator kpIt(indexKeyPattern);
         while (kpIt.more()) {


### PR DESCRIPTION
btree index check, avoid create duplicate btree indexes, Avoid affecting performance

btree index check, avoid create duplicate btree indexes, Avoid affecting performance by the deplicate index.
for example:
 add two index: db.collection.createIndex({a:1}) and db.collection.createIndex({a:11})
 the tow index are actually the same, One of them is a useless index, but it can affect the insert performance.

 In addition, They also affecting query performance because both are candidate indexes. This increases storage consts.