### PR TITLE
Update CONTRIBUTING.rst

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -4,6 +4,10 @@ Contributing to the MongoDB project
 Pull requests are always welcome, and the MongoDB dev team appreciates any help the community can
 give to help make MongoDB better.
 
+GitHub Issues are turned off in favor of `Jira issues`_. GitHub Discussions are turned off in favor of `MongoDB Developer Community`_.
+
 For more information about how to contribute, please read `the MongoDB Wiki on GitHub`_.
 
 .. _the MongoDB Wiki on GitHub: https://github.com/mongodb/mongo/wiki
+.. _Jira issues: https://github.com/mongodb/mongo/wiki/Submit-Bug-Reports
+.. _MongoDB Developer Community: https://www.mongodb.com/community/forums/


### PR DESCRIPTION
Lack of Issues and Discussions are documented now. Source for the lack of issues is inferred from a [Forum post](https://www.mongodb.com/community/forums/t/why-arent-github-issues-turned-on/231559).

Do let me know if I made a wrong conclusion about the Discussions being turned off in favor of the MongoDB Developer Community.