### PR TITLE
SERVER-78888 unschedule mixed_workloads

### DIFF
--- a/etc/system_perf.yml
+++ b/etc/system_perf.yml
@@ -813,13 +813,14 @@ tasks:
       - func: f_run_dsi_workload
         vars:
           test_control: "cursor_manager"
-
-  - name: mixed_workloads
-    priority: 5
-    commands:
-      - func: f_run_dsi_workload
-        vars:
-          test_control: "mixed_workloads"
+  
+  # unscheduling according to SERVER-78888
+  # - name: mixed_workloads
+  #   priority: 5
+  #   commands:
+  #     - func: f_run_dsi_workload
+  #       vars:
+  #         test_control: "mixed_workloads"
 
   - name: mixed_workloads_genny_stepdowns
     priority: 5
@@ -2010,7 +2011,6 @@ buildvariants:
       - name: crud_workloads_w1
       - name: genny_canaries
       - name: cursor_manager
-      - name: mixed_workloads
       - name: misc_workloads
       - name: map_reduce_workloads
       - name: non_sharded_workloads
@@ -2425,7 +2425,6 @@ buildvariants:
       - name: ycsb_60GB
       - name: ycsb_60GB.long
       - name: crud_workloads_majority
-      - name: mixed_workloads
       - name: misc_workloads
       - name: map_reduce_workloads
       - name: smoke_test
@@ -2541,7 +2540,6 @@ buildvariants:
       - name: ycsb_60GB
       - name: ycsb_60GB.long
       - name: crud_workloads_majority
-      - name: mixed_workloads
       - name: tpcc
       - name: linkbench
       - name: linkbench2
@@ -2745,7 +2743,6 @@ buildvariants:
       - name: industry_benchmarks_w1
       - name: crud_workloads_majority
       - name: crud_workloads_w1
-      - name: mixed_workloads
       - name: misc_workloads
       - name: map_reduce_workloads
       - name: smoke_test
@@ -2783,7 +2780,6 @@ buildvariants:
       - name: industry_benchmarks
       - name: crud_workloads_majority
       - name: crud_workloads_w1
-      - name: mixed_workloads
 
   - name: linux-3-shard-heuristic-bonsai.2022-11
     display_name: Linux 3-Shard Cluster 2022-11 (Bonsai with Heuristic CE)
@@ -2860,7 +2856,6 @@ buildvariants:
       - name: change_streams_listen_throughput
       - name: industry_benchmarks
       - name: linkbench
-      - name: mixed_workloads
       - name: mongos_workloads
       - name: mongos_large_catalog_workloads
       - name: move_chunk_large_chunk_map_workloads
@@ -2893,7 +2888,6 @@ buildvariants:
       - name: schedule_patch_auto_tasks
       - name: schedule_variant_auto_tasks
       - name: industry_benchmarks
-      - name: mixed_workloads
       - name: mongos_workloads
       - name: move_chunk_workloads
       - name: move_chunk_waiting_workloads
@@ -3001,7 +2995,6 @@ buildvariants:
       - name: industry_benchmarks_secondary_reads
       - name: crud_workloads_majority
       - name: crud_workloads_w1
-      - name: mixed_workloads
       - name: misc_workloads
       - name: map_reduce_workloads
       - name: refine_shard_key_transaction_stress
@@ -3057,7 +3050,6 @@ buildvariants:
       - name: industry_benchmarks
       - name: ycsb_60GB
       - name: crud_workloads_majority
-      - name: mixed_workloads
       - name: smoke_test
       - name: linkbench
       - name: linkbench2
@@ -3090,7 +3082,6 @@ buildvariants:
       - name: industry_benchmarks_w1
       - name: crud_workloads_majority
       - name: crud_workloads_w1
-      - name: mixed_workloads
       - name: misc_workloads
       - name: map_reduce_workloads
       - name: refine_shard_key_transaction_stress
@@ -3148,7 +3139,6 @@ buildvariants:
       - name: industry_benchmarks_w1
       - name: crud_workloads_majority
       - name: crud_workloads_w1
-      - name: mixed_workloads
       - name: misc_workloads
       - name: map_reduce_workloads
       - name: refine_shard_key_transaction_stress
@@ -3206,7 +3196,6 @@ buildvariants:
       - name: industry_benchmarks_w1
       - name: crud_workloads_majority
       - name: crud_workloads_w1
-      - name: mixed_workloads
       - name: misc_workloads
       - name: map_reduce_workloads
       - name: refine_shard_key_transaction_stress
@@ -3261,7 +3250,6 @@ buildvariants:
       - name: schedule_variant_auto_tasks
       - name: crud_workloads_majority
       - name: industry_benchmarks
-      - name: mixed_workloads
 
   - name: linux-3-node-replSet-maintenance-events.2022-11
     display_name: Linux 3-Node ReplSet (Maintenance Events) 2022-11
@@ -3464,7 +3452,6 @@ buildvariants:
       - name: ycsb_60GB.long
       - name: crud_workloads_majority
       - name: crud_workloads_w1
-      - name: mixed_workloads
       - name: tpcc
       - name: linkbench
       - name: linkbench2
@@ -3494,7 +3481,6 @@ buildvariants:
       - name: industry_benchmarks
       - name: linkbench2
       - name: misc_workloads
-      - name: mixed_workloads
       - name: snapshot_reads
       - name: tpcc
       - name: ycsb_60GB


### PR DESCRIPTION
Evergreen patch: https://spruce.mongodb.com/version/64afdba8e3c331ff784d85be/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Mixed_workloads used to run on both mix js and Genny, but they would catch the same BFs with mix js being noisier. We are unscheduling mixed_workloads, while Genny version will run as normal.