### PR TITLE
Remove extra single quote in error 5491300

### DIFF
--- a/src/mongo/db/query/allowed_contexts.cpp
+++ b/src/mongo/db/query/allowed_contexts.cpp
@@ -107,7 +107,7 @@ void assertAllowedInternalIfRequired(const OperationContext* opCtx,
     const auto isInternal = isInternalClient(opCtx->getClient());
 
     uassert(5491300,
-            str::stream() << operatorName << "' is not allowed in user requests",
+            str::stream() << operatorName << " is not allowed in user requests",
             !(allowedWithClientType == AllowedWithClientType::kInternal && !isInternal));
 }
 }  // namespace mongo


### PR DESCRIPTION
While attempting to run an aggregation with the `$documents` stage, I've got an error and noticed that it had an extra single quote mark in it. As I started to look into the source code in order to better understand the nature of it, I've decided to create a PR quickly in order to fix it.

```
    MongoServerError: $documents' is not allowed in user requests

      at Connection.onMessage (node_modules/mongodb/src/cmap/connection.ts:413:18)
      at MessageStream.<anonymous> (node_modules/mongodb/src/cmap/connection.ts:243:56)
      at processIncomingData (node_modules/mongodb/src/cmap/message_stream.ts:187:12)
      at MessageStream._write (node_modules/mongodb/src/cmap/message_stream.ts:68:5)
```