### PR TITLE
SERVER-80720 - [refine] mongod: check duplicated fields in create indexes

### DIFF
--- a/src/mongo/db/catalog/index_key_validate.cpp
+++ b/src/mongo/db/catalog/index_key_validate.cpp
@@ -370,9 +370,20 @@ StatusWith<BSONObj> validateIndexSpec(OperationContext* opCtx, const BSONObj& in
 
     boost::optional<IndexVersion> resolvedIndexVersion;
     std::string indexType;
+    std::set<StringData> fieldsNames;
 
     for (auto&& indexSpecElem : indexSpec) {
         auto indexSpecElemFieldName = indexSpecElem.fieldNameStringData();
+
+        if (fieldsNames.count(indexSpecElemFieldName)) {
+            return {ErrorCodes::BadValue,
+                    str::stream() << "The field '" << indexSpecElemFieldName
+                    << "' appears more than one times in the index specification "
+                    << indexSpec
+            };
+        }
+        fieldsNames.insert(indexSpecElemFieldName);
+
         if (IndexDescriptor::kKeyPatternFieldName == indexSpecElemFieldName) {
             if (indexSpecElem.type() != BSONType::Object) {
                 return {ErrorCodes::TypeMismatch,

--- a/src/mongo/db/catalog/index_key_validate_test.cpp
+++ b/src/mongo/db/catalog/index_key_validate_test.cpp
@@ -526,5 +526,10 @@ TEST(IndexKeyValidateTest, GeoIndexSpecs) {
         fromjson("{'key':{'loc':'2dsphere'},'name':'loc_2dsphere','finestIndexedLevel':true,'"
                  "coarsestIndexedLevel':5}")));
 }
+
+TEST(IndexKeyValidateTest, DuplicatedFieldNames) {
+    ASSERT_NOT_OK(index_key_validate::validateIndexSpec(
+        nullptr, fromjson("{key: {a: 1}, name: 'index', background: true, background: true}")));
+}
 }  // namespace
 }  // namespace mongo


### PR DESCRIPTION
pull request for this [jira issue](https://jira.mongodb.org/browse/SERVER-80720)