### PR TITLE
SERVER-68548: Backport - check quiet globalServerParam before logging

### DIFF
--- a/src/mongo/transport/transport_layer_asio.cpp
+++ b/src/mongo/transport/transport_layer_asio.cpp
@@ -319,9 +319,13 @@ void TransportLayerASIO::TimerService::start() {
     auto precondition = State::kInitialized;
     if (_state.compareAndSwap(&precondition, State::kStarted)) {
         _thread = _spawn([reactor = _reactor] {
-            LOGV2_INFO(5490002, "Started a new thread for the timer service");
+            if (!serverGlobalParams.quiet.load()) {
+                LOGV2_INFO(5490002, "Started a new thread for the timer service");
+            }
             reactor->run();
-            LOGV2_INFO(5490003, "Returning from the timer service thread");
+            if (!serverGlobalParams.quiet.load()) {
+                LOGV2_INFO(5490003, "Returning from the timer service thread");
+            }
         });
     }
 }


### PR DESCRIPTION
Backports the ASIO-Logging fix from [SERVER-68548](https://jira.mongodb.org/browse/SERVER-68548) to v5.0 Branch