### PR TITLE
SERVER-75754 Move planCache counters into planCache sub-document

### DIFF
--- a/jstests/noPassthrough/plan_cache_invalidation.js
+++ b/jstests/noPassthrough/plan_cache_invalidation.js
@@ -12,11 +12,11 @@ assert.neq(conn, null, "mongod failed to start");
 const db = conn.getDB("sbe_plan_cache_invalidation");
 
 function getPlanCacheSize() {
-    return db.runCommand({serverStatus: 1}).metrics.query.planCacheTotalSizeEstimateBytes;
+    return db.runCommand({serverStatus: 1}).metrics.query.planCache.totalSizeEstimateBytes;
 }
 
 function getGlobalPlanCacheNumEntries() {
-    return db.runCommand({serverStatus: 1}).metrics.query.planCacheTotalQueryShapes;
+    return db.runCommand({serverStatus: 1}).metrics.query.planCache.totalQueryShapes;
 }
 
 /**

--- a/jstests/noPassthrough/plan_cache_memory_debug_info.js
+++ b/jstests/noPassthrough/plan_cache_memory_debug_info.js
@@ -19,7 +19,7 @@ function createIndexesForColl(coll) {
 
 function totalPlanCacheSize() {
     const serverStatus = assert.commandWorked(db.serverStatus());
-    return serverStatus.metrics.query.planCacheTotalSizeEstimateBytes;
+    return serverStatus.metrics.query.planCache.totalSizeEstimateBytes;
 }
 
 function planCacheContents(coll) {

--- a/jstests/noPassthrough/plan_cache_metrics.js
+++ b/jstests/noPassthrough/plan_cache_metrics.js
@@ -27,7 +27,7 @@ const sortObj = {
 
 function getPlanCacheSize() {
     const serverStatus = assert.commandWorked(db.serverStatus());
-    return serverStatus.metrics.query.planCacheTotalSizeEstimateBytes;
+    return serverStatus.metrics.query.planCache.totalSizeEstimateBytes;
 }
 
 function assertCacheLength(coll, length) {

--- a/jstests/noPassthrough/sbe_plan_cache_memory_debug_info.js
+++ b/jstests/noPassthrough/sbe_plan_cache_memory_debug_info.js
@@ -56,7 +56,7 @@ function assertCacheEntryIsMissingDebugInfo(coll, queryShape) {
 }
 
 function getPlanCacheSize() {
-    return db.runCommand({serverStatus: 1}).metrics.query.planCacheTotalSizeEstimateBytes;
+    return db.runCommand({serverStatus: 1}).metrics.query.planCache.totalSizeEstimateBytes;
 }
 
 // Set a large value to internalQueryCacheMaxSizeBytesBeforeStripDebugInfo to make sure that Debug

--- a/jstests/noPassthrough/sbe_plan_cache_size_metric.js
+++ b/jstests/noPassthrough/sbe_plan_cache_size_metric.js
@@ -1,5 +1,5 @@
 /**
- * Tests that planCacheTotalSizeEstimateBytes metric is updated when entries are added or evicted
+ * Tests that planCache.totalSizeEstimateBytes metric is updated when entries are added or evicted
  * from SBE and Classic Plan Cache entries.
  *
  * @tags: [
@@ -31,11 +31,11 @@ function getCacheEntriesByQueryHashKey(coll, queryHash) {
 }
 
 function getPlanCacheSize() {
-    return db.serverStatus().metrics.query.planCacheTotalSizeEstimateBytes;
+    return db.serverStatus().metrics.query.planCache.totalSizeEstimateBytes;
 }
 
 function getPlanCacheNumEntries() {
-    return db.serverStatus().metrics.query.planCacheTotalQueryShapes;
+    return db.serverStatus().metrics.query.planCache.totalQueryShapes;
 }
 function assertQueryInPlanCache(coll, query) {
     const explainResult = assert.commandWorked(coll.explain().find(query).finish());

--- a/src/mongo/db/query/classic_plan_cache.cpp
+++ b/src/mongo/db/query/classic_plan_cache.cpp
@@ -46,8 +46,8 @@
 #include "mongo/util/str.h"
 
 namespace mongo {
-CounterMetric planCacheTotalSizeEstimateBytes("query.planCacheTotalSizeEstimateBytes");
-CounterMetric planCacheEntries("query.planCacheTotalQueryShapes");
+CounterMetric planCacheTotalSizeEstimateBytes("query.planCache.totalSizeEstimateBytes");
+CounterMetric planCacheEntries("query.planCache.totalQueryShapes");
 
 std::ostream& operator<<(std::ostream& stream, const PlanCacheKey& key) {
     stream << key.toString();


### PR DESCRIPTION
The counters:
 query.planCacheTotalSizeEstimateBytes
 query.planCacheTotalQueryShapes

are both planCache specific; for consistency with other planCache counters (e.g., hits, misses), move these to:

 query.planCache.totalSizeEstimateBytes
 query.planCache.totalQueryShapes

This leaves the planCache subdocument appearing as follows:

 "planCache" : {
         "totalQueryShapes" : NumberLong(0),
         "totalSizeEstimateBytes" : NumberLong(0),
         "classic" : {
                 "hits" : NumberLong(0),
                 "misses" : NumberLong(2)
         },
         "sbe" : {
                 "hits" : NumberLong(0),
                 "misses" : NumberLong(0)
         }
 },

These counters are not specific to classic/sbe.