### PR TITLE
Fixed typo in `docs` folder of mongo

### DIFF
--- a/docs/build_system.md
+++ b/docs/build_system.md
@@ -174,7 +174,7 @@ using.
 #### Adding tests to a suite
 #### Running individual tests
 
-## Modifying the buid system
+## Modifying the build system
 ### What is SCons?
 #### `SConstruct` and `SConscripts`
 #### `Environments `and their `Clone`s

--- a/docs/evergreen-testing/configuration.md
+++ b/docs/evergreen-testing/configuration.md
@@ -13,11 +13,11 @@ section of the Evergreen wiki.
 ### `mongodb-mongo-master`
 The main project for testing MongoDB's dev environments with a number build variants,
 each one corresponding to a particular compile or testing environment to support development.
-Each build variant runs a set of tasks; each task ususally runs one or more tests.
+Each build variant runs a set of tasks; each task usually runs one or more tests.
 
 ### `mongodb-mongo-master-nightly
 Tracks the same branch as `mongodb-mongo-master`, each build variant corresponds to a
-(version, OS, architecure) triplet for a supported MongoDB nightly release.
+(version, OS, architecture) triplet for a supported MongoDB nightly release.
 
 ### `sys_perf`
 The system performance project.

--- a/docs/fail_points.md
+++ b/docs/fail_points.md
@@ -25,7 +25,7 @@ tests][fail_point_test].
 
 ## Configuring and Waiting on Fail Points
 
-Fail point configuration involves chosing a "mode" for activation (e.g., "alwaysOn") and optionally
+Fail point configuration involves choosing a "mode" for activation (e.g., "alwaysOn") and optionally
 providing additional data in the form of a BSON object. For the vast majority of cases, this is done
 by issuing a `configureFailPoint` command request. This is made easier in JavaScript using the
 `configureFailPoint` helper from [fail_point_util.js][fail_point_util]. Fail points can also be

--- a/docs/golden_data_test_framework.md
+++ b/docs/golden_data_test_framework.md
@@ -293,7 +293,7 @@ outputRootPattern:
     type: String
     optional: true
     description:
-         Root path patten that will be used to write expected and actual test outputs for all tests 
+         Root path pattern that will be used to write expected and actual test outputs for all tests 
          in the test run.
          If not specified a temporary folder location will be used.
          Path pattern string may use '%' characters in the last part of the path. '%' characters in

--- a/docs/load_balancer_support.md
+++ b/docs/load_balancer_support.md
@@ -14,7 +14,7 @@ protocol standard.
 e.g., when connecting to a local `mongos` instance, if the `loadBalancerPort` server parameter was set to 20100, the
 connection string must be of the form `"mongodb://localhost:20100/?loadBalanced=true"`.
 
-`mongos` will emit appropiate error messages on connection attempts if these requirements are not
+`mongos` will emit appropriate error messages on connection attempts if these requirements are not
 met.
 
 There are some subtle behavioral differences that these configuration options enable, chief of

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -222,7 +222,7 @@ Fatal level log statements using `LOGV2_FATAL` perform `fassert` after logging,
 using the provided ID as assert id. `LOGV2_FATAL_NOTRACE` perform
 `fassertNoTrace` and `LOGV2_FATAL_CONTINUE` does not `fassert` allowing for
 continued execution. `LOGV2_FATAL_CONTINUE` is meant to be used when a fatal
-error has occured but a different way of halting execution is desired such as
+error has occurred but a different way of halting execution is desired such as
 `std::terminate` or `fassertFailedWithStatus`.
 
 `LOGV2_FATAL_OPTIONS` performs `fassert` by default like `LOGV2_FATAL` but this
@@ -520,7 +520,7 @@ implemented as a friend function in a class with the following signature:
 
 In some cases a loggable type might be composed as a hierarchy in the C++ type
 system which would lead to a very verbose structured log output as every level
-in the hierarcy needs a name when outputted as JSON. The attribute naming
+in the hierarchy needs a name when outputted as JSON. The attribute naming
 abstraction system can also be used to collapse such hierarchies. Instead of
 making a type loggable it can instead return one or more attributes from its
 members by using `multipleAttrs` in `logAttrs` functions.


### PR DESCRIPTION
This PR fix the typo present in the `docs` folder

```pseudo
buid > build
ususally > usually
architecure > architecture
chosing > choosing
patten > pattern
occured > occurred
```