### PR TITLE
POC - Record retired instructions during find execution

### DIFF
--- a/src/mongo/db/commands/find_cmd.cpp
+++ b/src/mongo/db/commands/find_cmd.cpp
@@ -555,6 +555,7 @@ public:
             return val;
         }
 
+        // Todo : replace manual call by RAII to avoid leak issues
         void closePerf(std::pair<int, struct perf_event_attr*> perfPair) {
             free(perfPair.second);
 


### PR DESCRIPTION
I ran `jstest/core/query/find/find4.js` on my personal laptop (Ubuntu 22.04 variant on Intel(R) Core(TM) i7-10750H). Running it on my workstation didn't work (most likely due to HW performance counter not supported on my instance type and/or permissionning issues) although I think it seems possible on specific AWS instances types.

Here is relevant logs from a local run :
```
[j0] {"t":{"$date":"2023-10-21T13:04:31.386-04:00"},"s":"I",  "c":"QUERY",    "id":11111,   "ctx":"conn9","msg":"Collecting performance counter for query","attr":{"query":{"find":"find4","filter":{},"limit":1,"singleBatch":true,"lsid":{"id":{"$uuid":"614ffd58-d7dc-4128-8d01-1e1da85739a5"}},"$db":"test"}}}
[j0] {"t":{"$date":"2023-10-21T13:04:31.401-04:00"},"s":"I",  "c":"QUERY",    "id":11111,   "ctx":"conn9","msg":"Opened HW performance counter","attr":{"fd":66}}
[j0] {"t":{"$date":"2023-10-21T13:04:31.404-04:00"},"s":"I",  "c":"QUERY",    "id":111111,  "ctx":"conn9","msg":"Number of HW instructions executed","attr":{"instructions":4491280}}
[j0] {"t":{"$date":"2023-10-21T13:04:31.405-04:00"},"s":"I",  "c":"QUERY",    "id":11111,   "ctx":"conn9","msg":"Collecting performance counter for query","attr":{"query":{"find":"find4","filter":{},"limit":1,"singleBatch":true,"projection":{"a":1},"lsid":{"id":{"$uuid":"614ffd58-d7dc-4128-8d01-1e1da85739a5"}},"$db":"test"}}}
[j0] {"t":{"$date":"2023-10-21T13:04:31.405-04:00"},"s":"I",  "c":"QUERY",    "id":11111,   "ctx":"conn9","msg":"Opened HW performance counter","attr":{"fd":66}}
[j0] {"t":{"$date":"2023-10-21T13:04:31.406-04:00"},"s":"I",  "c":"QUERY",    "id":111111,  "ctx":"conn9","msg":"Number of HW instructions executed","attr":{"instructions":996241}}
[j0] {"t":{"$date":"2023-10-21T13:04:31.406-04:00"},"s":"I",  "c":"QUERY",    "id":11111,   "ctx":"conn9","msg":"Collecting performance counter for query","attr":{"query":{"find":"find4","filter":{},"limit":1,"singleBatch":true,"projection":{"b":1},"lsid":{"id":{"$uuid":"614ffd58-d7dc-4128-8d01-1e1da85739a5"}},"$db":"test"}}}
[j0] {"t":{"$date":"2023-10-21T13:04:31.407-04:00"},"s":"I",  "c":"QUERY",    "id":11111,   "ctx":"conn9","msg":"Opened HW performance counter","attr":{"fd":66}}
[j0] {"t":{"$date":"2023-10-21T13:04:31.407-04:00"},"s":"I",  "c":"QUERY",    "id":111111,  "ctx":"conn9","msg":"Number of HW instructions executed","attr":{"instructions":127689}}
```