### PR TITLE
mongod crush， bug fix when connections > wiredtiger's session_max

### DIFF
--- a/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp
@@ -366,10 +366,14 @@ WiredTigerKVEngine::WiredTigerKVEngine(OperationContext* opCtx,
         }
     }
 
+#define DEFAULT_WIREDTIGER_MAX_SESSIONS 33000
     std::stringstream ss;
     ss << "create,";
     ss << "cache_size=" << cacheSizeMB << "M,";
-    ss << "session_max=33000,";
+    if (serverGlobalParams.maxConns <= DEFAULT_WIREDTIGER_MAX_SESSIONS)
+        ss << "session_max=DEFAULT_WIREDTIGER_MAX_SESSIONS,";
+    else
+        ss << "session_max=" << serverGlobalParams.maxConns << ",";
     ss << "eviction=(threads_min=4,threads_max=4),";
 
     if (gWiredTigerEvictionDirtyTargetGB)


### PR DESCRIPTION
if  user's max connections is greater than wiredtiger's session_max， it will crush.

wiredtiger's session_max must great than user's connection.