### PR TITLE
SERVER-84220:wiredTigerEngineRuntimeConfig perfect

### DIFF
--- a/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.cpp
@@ -2155,6 +2155,10 @@ int WiredTigerKVEngine::reconfigure(const char* str) {
     return _conn->reconfigure(_conn, str);
 }
 
+const char * WiredTigerKVEngine::get_configuration() {
+    return _conn->get_configuration(_conn);
+}
+
 void WiredTigerKVEngine::_ensureIdentPath(StringData ident) {
     size_t start = 0;
     size_t idx;

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_kv_engine.h
@@ -347,6 +347,11 @@ public:
     // Calls WT_CONNECTION::reconfigure on the underlying WT_CONNECTION
     // held by this class
     int reconfigure(const char* str);
+    
+    // wiredtiger specific
+    // Calls WT_CONNECTION::get_configuration on the underlying WT_CONNECTION
+    // held by this class
+    const char* get_configuration();
 
     WT_CONNECTION* getConnection() {
         return _conn;

--- a/src/mongo/db/storage/wiredtiger/wiredtiger_parameters.cpp
+++ b/src/mongo/db/storage/wiredtiger/wiredtiger_parameters.cpp
@@ -65,7 +65,7 @@ void WiredTigerEngineRuntimeConfigParameter::append(OperationContext* opCtx,
                                                     BSONObjBuilder* b,
                                                     StringData name,
                                                     const boost::optional<TenantId>&) {
-    *b << name << _data.first;
+    *b << name << _data.second->get_configuration();
 }
 
 Status validateExtraDiagnostics(const std::vector<std::string>& value,


### PR DESCRIPTION
When we modify the configuration information of WT multiple times, Mongo server can only retain the last result and cannot obtain all modification records.

![image](https://github.com/mongodb/mongo/assets/14356223/5bffd686-f312-4377-8cab-35b2ea89c2e9)
db.adminCommand( { setParameter : 1, "wiredTigerEngineRuntimeConfig" : "io_capacity=(total=110M)"})
{ "was" : "", "ok" : 1 }

db.adminCommand( { setParameter : 1, "wiredTigerEngineRuntimeConfig" : "eviction=(threads_min=8, threads_max=12)"})
{ "was" : "io_capacity=(total=110M)", "ok" : 1 }

db.adminCommand( { setParameter : 1, "wiredTigerEngineRuntimeConfig" : "verbose=[api:5]"})
{ "was" : "eviction=(threads_min=8, threads_max=12)", "ok" : 1 }

db.adminCommand( { getParameter : "1", wiredTigerEngineRuntimeConfig : 1 } )
{ "wiredTigerEngineRuntimeConfig" : "verbose=[api:5]", "ok" : 1 }