### PR TITLE
Remove `array` type

### DIFF
--- a/src/mongo/shell/types.js
+++ b/src/mongo/shell/types.js
@@ -564,7 +564,6 @@ Map.hash = function(val) {
         case 'date':
             return val.toString();
         case 'object':
-        case 'array':
             var s = "";
             for (var k in val) {
                 s += k + val[k];


### PR DESCRIPTION
There is no `array` type.

```js
> typeof([])
'object'
> typeof(new Array())
'object'
```

And even in the same file at the `tojson` function it's not used:

https://github.com/mongodb/mongo/blob/2b0bab0e2355bba3276cb80e05d03812300d86b2/src/mongo/shell/types.js#L627-L662