### PR TITLE
Fix typo in logAttrs function Call in logging.md file

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -514,7 +514,7 @@ implemented as a friend function in a class with the following signature:
 ##### Examples
 
     const AnyUserType& t = ...;
-    LOGV2(2001, "Log of user type", logAttr(t));
+    LOGV2(2001, "Log of user type", logAttrs(t));
 
 ## Multiple attributes
 


### PR DESCRIPTION
Corrected a typo in the function call logAttr(t) to logAttrs(t) within the "Attribute naming abstraction" section of the documentation. This ensures consistency and clarity in the usage of function names throughout the document.
[Here is the typo](https://github.com/mongodb/mongo/blob/master/docs/logging.md?plain=1#L517)
