### PR TITLE
Fix build errors

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -83,7 +83,7 @@ fail to build since the build system treats compiler warnings as
 errors. To ignore the warnings, pass the switch
 `--disable-warnings-as-errors` to scons.
 
-    $ python3 buildscripts/scons.py install-mongod --disable-warnings-as-errors
+    $ python3 buildscripts/scons.py install-mongod --disable-warnings-as-errors=configure --disable-warnings-as-errors=source
 
 **_Note_**: On memory-constrained systems, you may run into an error such as `g++: fatal error: Killed signal terminated program cc1plus`. To use less memory during building, pass the parameter `-j1` to scons. This can be incremented to `-j2`, `-j3`, and higher as appropriate to find the fastest working option on your system.
 

--- a/src/third_party/asio-master/asio/include/asio/detail/type_traits.hpp
+++ b/src/third_party/asio-master/asio/include/asio/detail/type_traits.hpp
@@ -58,7 +58,7 @@ template <typename> struct result_of;
 template <typename F, typename... Args>
 struct result_of<F(Args...)> : std::invoke_result<F, Args...> {};
 #else // defined(ASIO_HAS_STD_INVOKE_RESULT)
-using std::result_of;
+using std::invoke_result;
 #endif // defined(ASIO_HAS_STD_INVOKE_RESULT)
 using std::true_type;
 #else // defined(ASIO_HAS_STD_TYPE_TRAITS)

--- a/src/third_party/asio-master/asio/include/asio/impl/use_future.hpp
+++ b/src/third_party/asio-master/asio/include/asio/impl/use_future.hpp
@@ -799,9 +799,9 @@ class async_result<detail::packaged_token<Function, Allocator>, Result(Args...)>
 public:
   explicit async_result(
     typename detail::packaged_async_result<Function, Allocator,
-      typename result_of<Function(Args...)>::type>::completion_handler_type& h)
+      typename boost::result_of<Function(Args...)>::type>::completion_handler_type& h)
     : detail::packaged_async_result<Function, Allocator,
-        typename result_of<Function(Args...)>::type>(h)
+        typename boost::result_of<Function(Args...)>::type>(h)
   {
   }
 };

--- a/src/third_party/boost/boost/container_hash/hash.hpp
+++ b/src/third_party/boost/boost/container_hash/hash.hpp
@@ -129,7 +129,7 @@ namespace boost
         };
 #else
         template <typename T>
-        struct hash_base : std::unary_function<T, std::size_t> {};
+        struct hash_base : std::__unary_function<T, std::size_t> {};
 #endif
 
         struct enable_hash_value { typedef std::size_t type; };

--- a/src/third_party/boost/boost/mpl/aux_/integral_wrapper.hpp
+++ b/src/third_party/boost/boost/mpl/aux_/integral_wrapper.hpp
@@ -56,7 +56,7 @@ struct AUX_WRAPPER_NAME
 // have to #ifdef here: some compilers don't like the 'N + 1' form (MSVC),
 // while some other don't like 'value + 1' (Borland), and some don't like
 // either
-#if BOOST_WORKAROUND(__EDG_VERSION__, <= 243)
+#if 1 // BOOST_WORKAROUND(__EDG_VERSION__, <= 243)
  private:
     BOOST_STATIC_CONSTANT(AUX_WRAPPER_VALUE_TYPE, next_value = BOOST_MPL_AUX_STATIC_CAST(AUX_WRAPPER_VALUE_TYPE, (N + 1)));
     BOOST_STATIC_CONSTANT(AUX_WRAPPER_VALUE_TYPE, prior_value = BOOST_MPL_AUX_STATIC_CAST(AUX_WRAPPER_VALUE_TYPE, (N - 1)));


### PR DESCRIPTION
1. Fix `--disable-warnings-as-errors` flag invocation as defined in https://github.com/mongodb/mongo/blob/f0687f351f07bd139a5ae0ad94a6d0ab406a0bd8/SConstruct#L1788-L1801
2. Fix build error
```
In file included from src/third_party/boost/boost/functional/hash.hpp:6:
src/third_party/boost/boost/container_hash/hash.hpp:132:33: error: no template named 'unary_function' in namespace 'std'; did you mean '__unary_function'?
        struct hash_base : std::unary_function<T, std::size_t> {};
                           ~~~~~^~~~~~~~~~~~~~
                                __unary_function
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/__functional/unary_function.h:46:1: note: '__unary_function' declared here
using __unary_function = __unary_function_keep_layout_base<_Arg, _Result>;
^
1 error generated.
```
3. Fix build error
```
In file included from src/third_party/boost/boost/mpl/integral_c.hpp:32:
src/third_party/boost/boost/mpl/aux_/integral_wrapper.hpp:73:31: error: integer value -1 is outside the valid range of values [0, 3] for this enumeration type [-Wenum-constexpr-conversion]
    typedef AUX_WRAPPER_INST( BOOST_MPL_AUX_STATIC_CAST(AUX_WRAPPER_VALUE_TYPE, (value - 1)) ) prior;
                              ^
src/third_party/boost/boost/mpl/aux_/static_cast.hpp:24:47: note: expanded from macro 'BOOST_MPL_AUX_STATIC_CAST'
#   define BOOST_MPL_AUX_STATIC_CAST(T, expr) static_cast<T>(expr)
                                              ^
```
4. Fix build error
```
In file included from src/third_party/asio-master/asio/include/asio/use_future.hpp:155:
src/third_party/asio-master/asio/include/asio/impl/use_future.hpp:804:18: error: no template named 'result_of'; did you mean 'boost::result_of'?
        typename result_of<Function(Args...)>::type>(h)
                 ^~~~~~~~~
                 boost::result_of
src/third_party/boost/boost/utility/result_of.hpp:72:29: note: 'boost::result_of' declared here
template<typename F> struct result_of;
                            ^
```

## How to reproduce

```bash
$ g++ --version
Apple clang version 15.0.0 (clang-1500.3.9.4)
Target: arm64-apple-darwin23.5.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
$ python3 buildscripts/scons.py install-mongod --disable-warni
ngs-as-errors=configure --disable-warnings-as-errors=source
```