### PR TITLE
SERVER-94430: SConstruct: add PATH, otherwise can't find clang in Gentoo

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1724,7 +1724,7 @@ envDict = dict(
 if get_option("build-tools") == "next":
     SCons.Tool.DefaultToolpath.insert(0, os.path.abspath("site_scons/site_tools/next"))
 
-env = Environment(variables=env_vars, **envDict)
+env = Environment(variables=env_vars, ENV={'PATH': os.environ['PATH']}, **envDict)
 del envDict
 env.AddMethod(lambda env, name, **kwargs: add_option(name, **kwargs), "AddOption")
 


### PR DESCRIPTION
can't build mongodb w/ clang in Gentoo w/o add PATH to ENV, see also https://bugs.gentoo.org/829340

CXX is clang++
clang++ found in $PATH at /usr/lib/llvm/17/bin/clang++ /usr/lib/llvm/17/bin/clang++ resolves to /usr/lib/llvm/17/bin/clang-17 Checking if C++ compiler "clang++" is GCC... no
Checking if C++ compiler "clang++" is clang... no
Couldn't identify the C++ compiler
See /var/tmp/portage/dev-db/mongodb-5.0.26/work/mongo-r5.0.26/build/scons/config.log for details

contents of config.log:

> file /var/tmp/portage/dev-db/mongodb-5.0.26/work/mongo-r5.0.26/SConstruct,line 1495:
>         Configure(confdir = build/scons/gentoo/sconf_temp)
> scons: Configure: Checking if C++ compiler "clang++" is GCC...
> build/scons/gentoo/sconf_temp/conftest_4f0e9b4472e273623d18770138ab2253_0.cpp <-
>   |
>   |#if defined(__GNUC__) && !defined(__clang__)
>   |/* we are using toolchain defined(__GNUC__) && !defined(__clang__) */
>   |#else
>   |#error
>   |#endif
>   |
> clang++ -o build/scons/gentoo/sconf_temp/conftest_4f0e9b4472e273623d18770138ab2253_0_bf756d0b642c06f55c557d1e7a12e115.o -c -O2 -pipe -g build/scons/gentoo/sconf_temp/conftest_4f0e9b4472e273623d18770138ab2253_0.cpp
> sh: line 1: clang++: command not found
> scons: Configure: no
>
> scons: Configure: Checking if C++ compiler "clang++" is clang...
> build/scons/gentoo/sconf_temp/conftest_56dbca75d2b38c18eda0185f2b5712b2_0.cpp <-
>   |
>   |#if defined(__clang__)
>   |/* we are using toolchain defined(__clang__) */
>   |#else
>   |#error
>   |#endif
>   |
> clang++ -o build/scons/gentoo/sconf_temp/conftest_56dbca75d2b38c18eda0185f2b5712b2_0_64374e7b0ab36c54170c0449be4380a4.o -c -O2 -pipe -g build/scons/gentoo/sconf_temp/conftest_56dbca75d2b38c18eda0185f2b5712b2_0.cpp
> sh: line 1: clang++: command not found
> scons: Configure: no