### PR TITLE
SERVER-98187: Remove ANSI ESC code from subprocess.run output, causing regex failure to match

### DIFF
--- a/site_scons/mongo/pip_requirements.py
+++ b/site_scons/mongo/pip_requirements.py
@@ -62,11 +62,15 @@ def verify_requirements(silent: bool = False, executable=sys.executable):
             f"    buildscripts/poetry_sync.sh -p '{executable}'\n"
         )
 
+    # Remove ANSI escape codes from the output
+    ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
+    clean_output = ansi_escape.sub('', poetry_dry_run_proc.stdout)
+
     # String match should look like the following
     # Package operations: 2 installs, 3 updates, 0 removals, 165 skipped
     match = re.search(
         r"Package operations: (\d+) \w+, (\d+) \w+, (\d+) \w+, (\d+) \w+",
-        poetry_dry_run_proc.stdout,
+        clean_output,
     )
     verbose("Requirements list:")
     verbose(poetry_dry_run_proc.stdout)

--- a/site_scons/site_tools/integrate_bazel.py
+++ b/site_scons/site_tools/integrate_bazel.py
@@ -494,6 +494,7 @@ def bazel_build_thread_func(env, log_dir: str, verbose: bool, ninja_generate: bo
 
     if ninja_generate:
         for file in glob.glob("bazel-out/**/*.gen_source_list", recursive=True):
+            os.chmod(file, stat.S_IWRITE)
             os.remove(file)
         extra_args += ["--build_tag_filters=scons_link_lists"]
         bazel_cmd = Globals.bazel_base_build_command + extra_args + ["//src/..."]


### PR DESCRIPTION
python buildscripts/scons.py mongod fails because regex failure to match "Package operations:"  with "[39;1mPackage operations[39;22m:". Add escape suppression
