### PR TITLE
SERVER-98727 Add write permission to files about to be deleted, preventing PermissionError access is denied in windows 11

### DIFF
--- a/site_scons/site_tools/integrate_bazel.py
+++ b/site_scons/site_tools/integrate_bazel.py
@@ -604,6 +604,7 @@ def bazel_build_thread_func(env, log_dir: str, verbose: bool, ninja_generate: bo
 
     if ninja_generate:
         for file in glob.glob("bazel-out/**/*.gen_source_list", recursive=True):
+            os.chmod(file, stat.S_IWRITE)
             os.remove(file)
         extra_args += ["--build_tag_filters=scons_link_lists"]
         bazel_cmd = Globals.bazel_base_build_command + extra_args + ["//src/..."]


### PR DESCRIPTION
PermissionError: [WinError 5] Access is denied: 'bazel-out\\x64_windows-dbg\\bin\\src\\mongo\\bson\\bson_validate_gen_gen_source_tag.gen_source_list'
Bazel Build failed with 1!

The files can't be deleted due to read-only permission, the commit changes permissions before the os.remove.
