### PR TITLE
SERVER-103029: explodeForSort: Consider partial explosions

### DIFF
--- a/src/mongo/db/query/planner_analysis.cpp
+++ b/src/mongo/db/query/planner_analysis.cpp
@@ -1036,6 +1036,11 @@ bool QueryPlannerAnalysis::explodeForSort(const CanonicalQuery& query,
             if (!isOilExplodable(oil, iet)) {
                 break;
             }
+            // We need not explode the fields in the desired sort order
+            auto elem = *kpIt;
+            if (elem.fieldNameStringData() == desiredSort.begin()->fieldNameStringData()) {
+                break;
+            }
             numScans *= oil.intervals.size();
             kpIt.next();
             ++boundsIdx;


### PR DESCRIPTION
explodeForSort used to either explode all the explodable fields or give up entirely. This MR adds support for partial explosions, where possible and appropriate.

Fixes https://jira.mongodb.org/browse/SERVER-103029