### PR TITLE
Use modern distro API for platform info

### DIFF
--- a/buildscripts/resmokelib/hang_analyzer/hang_analyzer.py
+++ b/buildscripts/resmokelib/hang_analyzer/hang_analyzer.py
@@ -278,7 +278,12 @@ class HangAnalyzer(Subcommand):
             if sys.platform in ["win32", "cygwin"]:
                 self.root_logger.info("Windows Distribution: %s", platform.win32_ver())
             else:
-                self.root_logger.info("Linux Distribution: %s", distro.linux_distribution())
+                self.root_logger.info(
+                    "Linux Distribution: %s %s (%s)",
+                    distro.name(),
+                    distro.version(),
+                    distro.codename(),
+                )
 
         except AttributeError:
             self.root_logger.warning("Cannot determine Linux distro since Python is too old")
@@ -320,7 +325,7 @@ class HangAnalyzerPlugin(PluginInterface):
             default="contains",
             help="Type of match for process names (-p & -g), specify 'contains', or"
             " 'exact'. Note that the process name match performs the following"
-            " conversions: change all process names to lowecase, strip off the file"
+            " conversions: change all process names to lowercase, strip off the file"
             " extension, like '.exe' on Windows. Default is 'contains'.",
         )
         parser.add_argument(


### PR DESCRIPTION
# PR Summary
This small PR resolves the `distro` deprecation warning:
```python
DeprecationWarning: distro.linux_distribution() is deprecated. It should only be used as a compatibility shim with Python's platform.linux_distribution(). Please use distro.id(), distro.version() and distro.name() instead.
```
The formatted output example:
> Linux Distribution: Ubuntu 22.04 (jammy)

It also fixes a small typo along the way.