### PR TITLE
SERVER-106714 fix: add quotes around 'bazel run' in evergreen task config 

### DIFF
--- a/etc/evergreen_yml_components/tasks/compile_tasks.yml
+++ b/etc/evergreen_yml_components/tasks/compile_tasks.yml
@@ -336,7 +336,7 @@ tasks:
       - func: "bazel compile"
         vars:
           targets: compiledb
-      - func: bazel run
+      - func: "bazel run"
         vars:
           target: //evergreen:validate_compile_commands
 


### PR DESCRIPTION
This PR fixes the inconsistent use of quotes around the `func` values in the Evergreen task configuration for `run_bazel_compiledb`.

Related JIRA ticket: SERVER-106714