### PR TITLE
SERVER-109781: Add cross DB support for $lookup

### DIFF
--- a/jstests/sharding/query/lookup/lookup.js
+++ b/jstests/sharding/query/lookup/lookup.js
@@ -32,8 +32,8 @@ function compareId(a, b) {
 
 // Helper for testing that pipeline returns correct set of results.
 function testPipeline(pipeline, expectedResult, collection) {
-    arrayEq(collection.aggregate(pipeline).toArray().sort(compareId),
-            expectedResult.sort(compareId));
+    assert.eq(arrayEq(collection.aggregate(pipeline).toArray().sort(compareId),
+            expectedResult.sort(compareId)), true);
 }
 
 function runTest(coll, from, thirdColl, fourthColl) {
@@ -459,7 +459,7 @@ function runTest(coll, from, thirdColl, fourthColl) {
     assert.commandWorked(
         from.getDB().runCommand({create: "fromView", viewOn: "from", pipeline: []}));
     let fromView = undefined;
-    if (fromNS.typeof === "object") {
+    if (from.getDB() != coll.getDB()) {
         fromView = {db: from.getDB().getName(), coll: "fromView"};
     } else {
         fromView = "fromView";

--- a/src/mongo/db/pipeline/document_source_lookup.cpp
+++ b/src/mongo/db/pipeline/document_source_lookup.cpp
@@ -134,9 +134,16 @@ void lookupPipeValidator(const Pipeline& pipeline) {
 
 // Parses $lookup 'from' field. The 'from' field must be a string or an object with the following syntax
 // {from: {db: "dbName", coll: "collName"}, ...}
+//
+// In a view defintion, we only allow the object format when the namespace is either
+// {from: {db: "config", coll: "cache.chunks.*"}}
+// {from: {fb: "local", coll: "oplog.rs"}}
+// because a view cycle could not be detected in the general case when the 'from' field is an object due to However
+// sharded view resolution works.
 NamespaceString parseLookupFromAndResolveNamespace(const BSONElement& elem,
                                                    const DatabaseName& defaultDb,
-                                                   bool allowGenericForeignDbLookup) {
+                                                   bool allowGenericForeignDbLookup,
+                                                   bool isView) {
     uassert(ErrorCodes::FailedToParse,
             str::stream() << "$lookup 'from' field must be a string or object, but found "
                           << typeName(elem.type()),
@@ -145,6 +152,7 @@ NamespaceString parseLookupFromAndResolveNamespace(const BSONElement& elem,
     if (elem.type() == BSONType::string) {
         return NamespaceStringUtil::deserialize(defaultDb, elem.valueStringData());
     }
+
 
     const auto tenantId = defaultDb.tenantId();
     const auto vts = tenantId
@@ -157,6 +165,18 @@ NamespaceString parseLookupFromAndResolveNamespace(const BSONElement& elem,
         elem.embeddedObject());
     auto nss = NamespaceStringUtil::deserialize(spec.getDb().value_or(DatabaseName()),
                                                 spec.getColl().value_or(""));
+
+    // If we are in a view definition, we can only allow the cases nss == config.collections and nss == config.chunks
+    // to avoid possible undetectable view cycles. This could be relaxed to other known namespaces in the future, but
+    // these are maintained to not create a breaking change with past behavior.
+    bool isConfigSvrSupportedCollection = nss == NamespaceString::kConfigsvrCollectionsNamespace ||
+        nss == NamespaceString::kConfigsvrChunksNamespace;
+    uassert(
+        ErrorCodes::FailedToParse,
+        str::stream() << "$lookup with syntax {from: {db:<>, coll:<>},..} is not supported for db: '"
+                      << nss.dbName().toStringForErrorMsg() << "' and coll: '" << nss.coll() << "' in a view definition",
+        !isView || nss.isConfigDotCacheDotChunks() || nss == NamespaceString::kRsOplogNamespace ||
+            isConfigSvrSupportedCollection || allowGenericForeignDbLookup);
     return nss;
 }
 
@@ -458,7 +478,7 @@ std::unique_ptr<DocumentSourceLookUp::LiteParsed> DocumentSourceLookUp::LitePars
         fromNss = NamespaceString::makeCollectionlessAggregateNSS(nss.dbName());
     } else {
         fromNss = parseLookupFromAndResolveNamespace(
-            fromElement, nss.dbName(), options.allowGenericForeignDbLookup);
+            fromElement, nss.dbName(), options.allowGenericForeignDbLookup, false);
     }
     uassert(ErrorCodes::InvalidNamespace,
             str::stream() << "invalid $lookup namespace: " << fromNss.toStringForErrorMsg(),
@@ -1578,7 +1598,8 @@ boost::intrusive_ptr<DocumentSource> DocumentSourceLookUp::createFromBson(
     if (lookupSpec.getFrom().has_value()) {
         fromNs = parseLookupFromAndResolveNamespace(lookupSpec.getFrom().value().getElement(),
                                                     pExpCtx->getNamespaceString().dbName(),
-                                                    pExpCtx->getAllowGenericForeignDbLookup());
+                                                    pExpCtx->getAllowGenericForeignDbLookup(),
+                                                    pExpCtx->getIsParsingViewDefinition());
     }
 
     as = std::string{lookupSpec.getAs()};

--- a/src/mongo/db/pipeline/document_source_lookup.cpp
+++ b/src/mongo/db/pipeline/document_source_lookup.cpp
@@ -132,7 +132,7 @@ void lookupPipeValidator(const Pipeline& pipeline) {
     }
 }
 
-// Parses $lookup 'from' field. The 'from' field must be a string object with the following syntax
+// Parses $lookup 'from' field. The 'from' field must be a string or an object with the following syntax
 // {from: {db: "dbName", coll: "collName"}, ...}
 NamespaceString parseLookupFromAndResolveNamespace(const BSONElement& elem,
                                                    const DatabaseName& defaultDb,

--- a/src/mongo/db/pipeline/document_source_lookup_test.cpp
+++ b/src/mongo/db/pipeline/document_source_lookup_test.cpp
@@ -117,9 +117,9 @@ public:
 };
 
 auto makeLookUpFromBson(BSONElement elem, const boost::intrusive_ptr<ExpressionContext>& expCtx) {
-    auto docSource = DocumentSourceLookUp::createFromBson(elem, expCtx);              
-    auto lookup = static_cast<DocumentSourceLookUp*>(docSource.detach());                                      
-    return std::unique_ptr<DocumentSourceLookUp, DocumentSourceDeleter>(lookup,                                                                                                         
+    auto docSource = DocumentSourceLookUp::createFromBson(elem, expCtx);
+    auto lookup = static_cast<DocumentSourceLookUp*>(docSource.detach());
+    return std::unique_ptr<DocumentSourceLookUp, DocumentSourceDeleter>(lookup,
                                                                         DocumentSourceDeleter());
 }
 


### PR DESCRIPTION
Related JIRA ticket: [SERVER-106714](https://jira.mongodb.org/browse/SERVER-109781)

This just removes asserts on the specific namespaces allowed for cross db $lookup, which actually works with the current implementation of sharding/view resolution, as is shown by the modification to the sharding lookup js test.
