### PR TITLE
Fix typo in comment: "hash see" → "hash seed"

### DIFF
--- a/src/mongo/db/hasher.h
+++ b/src/mongo/db/hasher.h
@@ -51,7 +51,7 @@ public:
      * by choosing from among a family of hash functions. When it is not specified,
      * use this.
      *
-     * WARNING: do not change the hash see value. Hash-based sharding clusters will
+     * WARNING: do not change the hash seed value. Hash-based sharding clusters will
      * expect that value to be zero.
      */
     static constexpr HashSeed const DEFAULT_HASH_SEED = 0;


### PR DESCRIPTION
fixes a minor typo in the WARNING comment of BSONElementHasher. "hash see" was mistakenly used instead of "hash seed".

Anything in this description will be included in the commit message. Replace or delete this text before merging. Add links to testing in the comments of the PR.
