### PR TITLE
Wrong link, possible URL fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,4 +56,4 @@ modules_poc/**
 
 ### Required Response for Non-Matching Files:
 
-"I cannot complete this task without generating code where I'm not allowed to (see http://go/codegen-rules). The file `{filepath}` does not match any allowed pattern. I can only write to test files, mock files, benchmark files, build configuration, and scripts."
+"I cannot complete this task without generating code where I'm not allowed to (see https://docs.codegen.com/settings/repo-rules). The file `{filepath}` does not match any allowed pattern. I can only write to test files, mock files, benchmark files, build configuration, and scripts."


### PR DESCRIPTION
I'm just pointing out wrong link, not sure this is correct one, need no credit for the PR.

Anything in this description will be included in the commit message. Replace or delete this text before merging. Add links to testing in the comments of the PR.

EDIT: I see this might be some internal go URL shortener link... Then just close, if it works for you. I would still be intrigued to know if you're really pointing to that or other public external link. I'm not sure what (Claude or other) Agents have access to, if run locally or not, so it may well be wrong for you actually... and I'm informing myself on agent tech.
