### PR TITLE
exit 1 on error

### DIFF
--- a/src/third_party/mozjs/gen-config.sh
+++ b/src/third_party/mozjs/gen-config.sh
@@ -7,7 +7,7 @@ set -x
 if [ $# -ne 2 ]
 then
     echo "Please supply an arch: x86_64, i386, etc and a platform: osx, linux, windows, etc"
-    exit 0;
+    exit 1;
 fi
 
 _BuiltPathPrefix="mozilla-release/js/src/_build/js/src"


### PR DESCRIPTION
My build continued after wrong parameters which of course ended up in a harder to correlate failure later in the build. Fail early would have saved me some time debugging.

Anything in this description will be included in the commit message. Replace or delete this text before merging. Add links to testing in the comments of the PR.
