### PR TITLE
SERVER-119885 Fix handling of the "max" value in cgroup v2 "memory.max"

### DIFF
--- a/src/mongo/util/processinfo_linux.cpp
+++ b/src/mongo/util/processinfo_linux.cpp
@@ -496,6 +496,8 @@ public:
         if (f != nullptr) {
             if (fgets(fstr, 1023, f) != nullptr)
                 fstr[strlen(fstr) < 1 ? 0 : strlen(fstr) - 1] = '\0';
+            else
+                fstr[0] = '\0';
             fclose(f);
         }
         return fstr;

--- a/src/third_party/tcmalloc/dist/tcmalloc/cpu_cache.cc
+++ b/src/third_party/tcmalloc/dist/tcmalloc/cpu_cache.cc
@@ -43,6 +43,8 @@ std::string parseLineFromFile(const char* fname) {
     if (f != nullptr) {
         if (fgets(fstr, 1023, f) != nullptr)
             fstr[strlen(fstr) < 1 ? 0 : strlen(fstr) - 1] = '\0';
+        else
+            fstr[0] = '\0';
         fclose(f);
     }
 
@@ -69,7 +71,8 @@ unsigned long long getMemorySizeLimitInBytes() {
         unsigned long long groupMemBytes = 0;
         std::string groupLimit = parseLineFromFile(file);
 
-        if (!groupLimit.empty() ) {
+        // The "max" value in cgroups v2 means no limit.
+        if (!groupLimit.empty() && groupLimit != "max") {
             return std::min(systemMemBytes, (unsigned long long)atoll(groupLimit.c_str()));
         }
     }


### PR DESCRIPTION
The "max" value in cgroups v2 means no limit. It should be handled in the same way as if the `groupLimit` string is empty. Otherwise the `atoll` returns zero and tcmalloc is misconfigured assuming no memory is available.