### PR TITLE
SERVER-122356 Fix HMAC_Init_ex when reusing key context

### DIFF
--- a/src/mongo/crypto/hash_block.cpp
+++ b/src/mongo/crypto/hash_block.cpp
@@ -53,8 +53,9 @@ int HmacContext::hmacCtxInitFn(const EVP_MD* md, const uint8_t* key, size_t keyL
     int ret;
     if (getReuseKey() && useCount() >= 1) {
         ret = HMAC_Init_ex(get(), nullptr, 0, md, nullptr);
+    } else {
+        ret = HMAC_Init_ex(get(), key, keyLen, md, nullptr);
     }
-    ret = HMAC_Init_ex(get(), key, keyLen, md, nullptr);
     if (getReuseKey()) {
         use++;
     }


### PR DESCRIPTION
When reuse key is enabled and the context has already been used, the code intended to call HMAC_Init_ex with a null key to reuse the existing key. An unconditional second HMAC_Init_ex call always re-passed the key, overwriting that path.

Use an else branch so only one initialization runs, matching the reuse semantics and aligning with similar crypto context lifecycle fixes (e.g. SERVER-119317 for MD5 hash state).

Anything in this description will be included in the commit message. Replace or delete this text before merging. Add links to testing in the comments of the PR.
