### PR TITLE
scope0 POC: wire server+mongot Evergreen tasks to urpcli versionset

### DIFF
--- a/evergreen/install_urpcli.sh
+++ b/evergreen/install_urpcli.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# install_urpcli.sh — bootstrap urpcli binary for Evergreen tasks
+#
+# Usage: source this script or run it directly before any urpcli calls.
+# Skips download if urpcli is already present, or if SKIP_URPCLI_INSTALL=true
+# (set that env var when urpcli is provided by the URP Evergreen module).
+
+set -o errexit
+set -o pipefail
+
+URPCLI_INSTALL_DIR="${workdir:-$HOME}/bin"
+URPCLI_BIN="${URPCLI_INSTALL_DIR}/urpcli"
+
+if [[ "${SKIP_URPCLI_INSTALL:-false}" == "true" ]]; then
+    echo "SKIP_URPCLI_INSTALL=true — skipping urpcli download"
+    return 0 2>/dev/null || exit 0
+fi
+
+if [[ -f "${URPCLI_BIN}" ]]; then
+    echo "urpcli already present at ${URPCLI_BIN} — skipping download"
+    return 0 2>/dev/null || exit 0
+fi
+
+# Determine platform + arch for the download URL
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    _urpcli_os="linux"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    _urpcli_os="darwin"
+else
+    echo "install_urpcli.sh: unsupported OS: ${OSTYPE}" >&2
+    exit 1
+fi
+
+_urpcli_arch=$(uname -m)
+case "${_urpcli_arch}" in
+    x86_64)  _urpcli_arch_tag="x86_64" ;;
+    aarch64) _urpcli_arch_tag="arm64" ;;
+    arm64)   _urpcli_arch_tag="arm64" ;;
+    *)
+        echo "install_urpcli.sh: unsupported architecture: ${_urpcli_arch}" >&2
+        exit 1
+        ;;
+esac
+
+URPCLI_URL="https://s3.amazonaws.com/urp-releases-prod/urpcli/latest/urpcli-${_urpcli_os}-${_urpcli_arch_tag}"
+
+echo "Downloading urpcli from ${URPCLI_URL} to ${URPCLI_BIN}"
+mkdir -p "${URPCLI_INSTALL_DIR}"
+curl --retry 3 --retry-delay 5 --fail --silent --show-error -o "${URPCLI_BIN}" "${URPCLI_URL}"
+chmod +x "${URPCLI_BIN}"
+
+# Make sure it's on PATH for the rest of this task
+export PATH="${URPCLI_INSTALL_DIR}:${PATH}"
+echo "urpcli installed: $(${URPCLI_BIN} --version 2>/dev/null || echo '(version unavailable)')"

--- a/evergreen/prelude_db_contrib_tool.sh
+++ b/evergreen/prelude_db_contrib_tool.sh
@@ -7,12 +7,94 @@ function setup_db_contrib_tool {
     $python evergreen/download_db_contrib_tool.py
 }
 
+function use_urpcli_versionset_mongot {
+    # Scope 1 path: use urpcli versionset materialize to resolve the mongot artifact URL
+    # from the versionless-staging version set, then download it directly.
+    # Writes version_set.yaml to CWD as the task artifact.
+
+    local urpcli_bin
+    urpcli_bin="${workdir:-$HOME}/bin/urpcli"
+    if [[ ! -f "${urpcli_bin}" ]]; then
+        urpcli_bin="urpcli"
+    fi
+
+    echo "Materializing version set: urpcli versionset materialize versionless-staging"
+    "${urpcli_bin}" versionset materialize versionless-staging
+
+    if [[ ! -f "version_set.yaml" ]]; then
+        echo "use_urpcli_versionset_mongot: version_set.yaml not written after materialize" >&2
+        exit 1
+    fi
+
+    # Determine platform key used in version_set.yaml
+    local vs_platform
+    local arch
+    arch=$(uname -m)
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        if [[ "${arch}" == "aarch64"* ]]; then
+            vs_platform="linux-aarch64"
+        else
+            vs_platform="linux-x86_64"
+        fi
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        # macOS arm64 runs mongot under x86_64 emulation (Rosetta)
+        vs_platform="macos-x86_64"
+    else
+        echo "use_urpcli_versionset_mongot: unsupported OS: ${OSTYPE}" >&2
+        exit 1
+    fi
+
+    # Extract the mongot artifact URL for this platform from version_set.yaml using Python
+    local mongot_url
+    mongot_url=$(python3 - "${vs_platform}" <<'PYEOF'
+import sys
+import yaml
+
+platform_key = sys.argv[1]
+
+with open("version_set.yaml") as f:
+    vs = yaml.safe_load(f)
+
+# Expected structure:
+#   artifacts:
+#     search/mongot:
+#       platforms:
+#         linux-x86_64:
+#           url: "https://..."
+try:
+    url = vs["artifacts"]["search/mongot"]["platforms"][platform_key]["url"]
+    print(url)
+except KeyError as e:
+    sys.stderr.write(f"use_urpcli_versionset_mongot: key not found in version_set.yaml: {e}\n")
+    sys.exit(1)
+PYEOF
+)
+
+    if [[ -z "${mongot_url}" ]]; then
+        echo "use_urpcli_versionset_mongot: could not resolve mongot URL for platform=${vs_platform}" >&2
+        exit 1
+    fi
+
+    echo "Downloading mongot artifact: ${mongot_url}"
+    mkdir -p ./mongot-localdev
+    curl --retry 3 --retry-delay 5 --fail --show-error "${mongot_url}" | tar xvz -C ./mongot-localdev --strip-components=1
+}
+
 function use_db_contrib_tool_mongot {
     # Checking that this is not a downstream patch on mongod created by mongot's patch trigger.
     # In the case that it's not, download latest (eg HEAD of 10gen/mongot) or the
     # release (eg currently running in production on Atlas) mongot binary.
     arch=$(uname -i)
     if [[ ! $(declare -p linux_x86_64_mongot_localdev_binary linux_aarch64_mongot_localdev_binary macos_x86_64_mongot_localdev_binary 2>/dev/null) ]]; then
+
+        # USE_URP_VERSION_SET=true opts into the Scope 1 urpcli-based path.
+        # When not set, the existing db-contrib-tool behavior is preserved unchanged.
+        if [[ "${USE_URP_VERSION_SET:-false}" == "true" ]]; then
+            use_urpcli_versionset_mongot
+            # Hack to remove BUILD.bazel file that can be lying around in mongot
+            rm -f ./mongot-localdev/bin/jdk/BUILD.bazel
+            return 0
+        fi
 
         if [ "${download_mongot_release}" = "true" ]; then
             mongot_version="release"

--- a/evergreen/report_version_set_results.sh
+++ b/evergreen/report_version_set_results.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# report_version_set_results.sh — task teardown: report server+mongot e2e results to URP
+#
+# Called at task teardown when a task may have used urpcli versionset materialize.
+# Silently skips if version_set.yaml is not present (task did not use version sets).
+# Does NOT fail the task if report-results fails — this is best-effort reporting.
+#
+# Expected env vars (set by Evergreen):
+#   task_exit_code  — the exit code of the test step (default: 0 if unset)
+
+set -o pipefail
+
+VERSION_SET_YAML="${workdir:-$PWD}/version_set.yaml"
+
+if [[ ! -f "${VERSION_SET_YAML}" ]]; then
+    echo "report_version_set_results.sh: version_set.yaml not found — skipping result report"
+    exit 0
+fi
+
+URPCLI_BIN="${workdir:-$HOME}/bin/urpcli"
+if [[ ! -f "${URPCLI_BIN}" ]]; then
+    # Fall back to PATH
+    URPCLI_BIN="urpcli"
+fi
+
+_exit_code="${task_exit_code:-0}"
+
+echo "Reporting version set results: test-name=server-mongot-e2e exit-code=${_exit_code}"
+"${URPCLI_BIN}" versionset report-results \
+    --test-name server-mongot-e2e \
+    --exit-code "${_exit_code}" || {
+    echo "report_version_set_results.sh: urpcli versionset report-results failed (non-fatal)" >&2
+}
+
+exit 0


### PR DESCRIPTION
## POC — Scope 1: Test Version Coordination (Server + mongot)

Bead: Version Sets Design-ozl6s | Epic: Version Sets Design-00jna

> **POC branch** — pushed from rtimmons/mongodb fork. Not for merge until B&V DRI is named
> and devprod-urp scope0 PR is merged. See open questions in bead notes.

### What this PR does

Adds scripts to integrate `urpcli versionset` into server+mongot cross-product Evergreen tasks.
The existing `db-contrib-tool` path is **preserved unchanged** — new path is opt-in only.

**`evergreen/prelude_db_contrib_tool.sh`** (modified)
- New `use_urpcli_versionset_mongot` function: calls `urpcli versionset materialize versionless-staging`,
  parses the resulting `version_set.yaml` for the `search/mongot` artifact URL, downloads and extracts to `./mongot-localdev/`
- Guard in `use_db_contrib_tool_mongot`: if `USE_URP_VERSION_SET=true`, delegates to new function; otherwise unchanged

**`evergreen/install_urpcli.sh`** (new)
- Downloads `urpcli` binary from `s3://urp-releases-prod/urpcli/latest/urpcli-{os}-{arch}`
- Skips if already present or `SKIP_URPCLI_INSTALL=true`

**`evergreen/report_version_set_results.sh`** (new)
- Teardown script: calls `urpcli versionset report-results --test-name server-mongot-e2e --exit-code ${task_exit_code:-0}`
- Silently skips if `version_set.yaml` absent; never fails the task

### What is NOT in this PR (requires B&V DRI)
- Evergreen YAML task config changes to actually call these scripts (those are in the project `.yml` files that B&V owns)
- Setting `USE_URP_VERSION_SET=true` in any live task variants

### Acceptance criteria
- [ ] `USE_URP_VERSION_SET=true` + valid `versionless-staging` YAML in S3 → mongot binary downloaded from version set URL (not db-contrib-tool)
- [ ] `USE_URP_VERSION_SET` unset → existing `db-contrib-tool` path runs unchanged
- [ ] `version_set.yaml` present in task working directory after `use_urpcli_versionset_mongot` runs
- [ ] `report_version_set_results.sh` runs without failing the task even if `urpcli report-results` errors
- [ ] At least one `test/server-mongot-e2e` variant runs end-to-end via these scripts in a real Evergreen patch

### Test plan
1. **Unit**: `bash -n evergreen/prelude_db_contrib_tool.sh` — syntax check passes
2. **Unit**: `bash -n evergreen/install_urpcli.sh && bash -n evergreen/report_version_set_results.sh`
3. **Local dry-run**: set `USE_URP_VERSION_SET=true`, mock `urpcli` as a script that writes a minimal `version_set.yaml`, source `prelude_db_contrib_tool.sh` and call `use_db_contrib_tool_mongot` — verify it reaches the new path
4. **Evergreen patch**: B&V DRI wires `install_urpcli.sh` + `USE_URP_VERSION_SET=true` into one `mongot_e2e_*` task variant in a patch build and confirms mongot downloads from the version set URL
5. **Regression**: existing task variants without `USE_URP_VERSION_SET` continue to pass

### Open questions (blocking full rollout)
1. B&V DRI for Evergreen task YAML changes must be named before wiring tasks (bead `nvfhb`)
2. urpcli distribution mechanism in Evergreen confirmed (bead `748ha`)