### PR TITLE
SERVER-84018 Add multiPlannerFallbackEngaged flag to slow query log

### DIFF
--- a/jstests/noPassthrough/query/query_settings_fallback_profiler.js
+++ b/jstests/noPassthrough/query/query_settings_fallback_profiler.js
@@ -1,0 +1,75 @@
+/**
+ * Tests that the multiPlannerFallbackEngaged flag is correctly set in the profiler when
+ * query settings fail to produce a valid plan and the planner falls back to multi-planning.
+ * @tags: [
+ *   requires_profiling,
+ * ]
+ */
+
+import {after, before, describe, it} from "jstests/libs/mochalite.js";
+import {getLatestProfilerEntry} from "jstests/libs/profiler.js";
+import {QuerySettingsUtils} from "jstests/libs/query/query_settings_utils.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+describe("multiPlannerFallbackEngaged profiler flag", function() {
+    let rst;
+    let testDB;
+    let coll;
+    let qsutils;
+    const profileEntryFilter = {op: "query", "command.find": "test"};
+
+    before(function() {
+        rst = new ReplSetTest({nodes: 1});
+        rst.startSet({setParameter: {logComponentVerbosity: tojson({query: {verbosity: 2}})}});
+        rst.initiate();
+
+        testDB = rst.getPrimary().getDB(jsTestName());
+        coll = testDB.getCollection("test");
+
+        assert.commandWorked(coll.createIndex({a: 1}));
+        assert.commandWorked(coll.createIndex({b: 1}));
+        for (let i = 0; i < 5; ++i) {
+            assert.commandWorked(coll.insert({a: i, b: i}));
+        }
+
+        qsutils = new QuerySettingsUtils(testDB, coll.getName());
+    });
+
+    after(function() {
+        rst.stopSet();
+    });
+
+    /**
+     * Helper to clear the plan cache and profiler, ensuring a clean state for each test.
+     */
+    function resetProfiler() {
+        coll.getPlanCache().clear();
+        assert.commandWorked(testDB.setProfilingLevel(0));
+        testDB.system.profile.drop();
+        assert.commandWorked(testDB.setProfilingLevel(2));
+    }
+
+    it("should be true when query settings fallback is engaged", function() {
+        const ns = {db: testDB.getName(), coll: coll.getName()};
+        const querySettingsQuery = qsutils.makeFindQueryInstance({filter: {a: 1, b: 1}});
+        const settings = {indexHints: {ns, allowedIndexes: ["doesnotexist"]}};
+
+        qsutils.withQuerySettings(querySettingsQuery, settings, () => {
+            resetProfiler();
+            // Use find().toArray() instead of findOne() to avoid the express fast path
+            // which bypasses the planner and would not trigger the fallback.
+            const results = coll.find({a: 1, b: 1}).toArray();
+            assert.gt(results.length, 0);
+            const profileObj = getLatestProfilerEntry(testDB, profileEntryFilter);
+            assert.eq(profileObj.multiPlannerFallbackEngaged, true, profileObj);
+        });
+    });
+
+    it("should be absent when no query settings are present", function() {
+        resetProfiler();
+        const results = coll.find({a: 1, b: 1}).toArray();
+        assert.gt(results.length, 0);
+        const profileObj = getLatestProfilerEntry(testDB, profileEntryFilter);
+        assert(!profileObj.hasOwnProperty("multiPlannerFallbackEngaged"), profileObj);
+    });
+});

--- a/src/mongo/db/op_debug.cpp
+++ b/src/mongo/db/op_debug.cpp
@@ -346,6 +346,8 @@ void OpDebug::report(OperationContext* opCtx,
     OPDEBUG_TOATTR_HELP_OPTIONAL("keysInserted", additiveMetrics.keysInserted);
     OPDEBUG_TOATTR_HELP_OPTIONAL("keysDeleted", additiveMetrics.keysDeleted);
 
+    OPDEBUG_TOATTR_HELP_BOOL_NAMED("multiPlannerFallbackEngaged", multiPlannerFallbackEngaged);
+
     if (prepareReadConflicts > 0) {
         pAttrs->add("prepareReadConflicts", prepareReadConflicts);
     }
@@ -628,6 +630,7 @@ void OpDebug::append(OperationContext* opCtx,
     OPDEBUG_APPEND_BOOL2(b, "hasSortStage", additiveMetrics.hasSortStage);
     OPDEBUG_APPEND_BOOL2(b, "usedDisk", additiveMetrics.usedDisk);
     OPDEBUG_APPEND_BOOL2(b, "fromMultiPlanner", additiveMetrics.fromMultiPlanner);
+    OPDEBUG_APPEND_BOOL2(b, "multiPlannerFallbackEngaged", multiPlannerFallbackEngaged);
     OPDEBUG_APPEND_BOOL2(b, "fromPlanCache", additiveMetrics.fromPlanCache.value_or(false));
     if (replanReason) {
         bool replanned = true;

--- a/src/mongo/db/op_debug.h
+++ b/src/mongo/db/op_debug.h
@@ -671,6 +671,10 @@ public:
     // Stores storage statistics from the spill engine.
     std::unique_ptr<StorageStats> spillStorageStats;
 
+    // True if the query had applicable query settings that failed to produce a plan,
+    // causing a fallback to multi-planning without query settings.
+    bool multiPlannerFallbackEngaged{false};
+
     bool waitingForFlowControl{false};
 
     // Records the WC that was waited on during the operation. (The WC in opCtx can't be used

--- a/src/mongo/db/query/get_executor_helpers.cpp
+++ b/src/mongo/db/query/get_executor_helpers.cpp
@@ -215,7 +215,7 @@ std::unique_ptr<PlannerInterface> retryMakePlanner(
                         "querySettings"_attr = querySettings,
                         "reason"_attr = exception.reason(),
                         "code"_attr = exception.codeString());
-
+            CurOp::get(canonicalQuery->getExpCtx()->getOperationContext())->debug().multiPlannerFallbackEngaged = true;
             plannerOptions |= QueryPlannerParams::IGNORE_QUERY_SETTINGS;
             // Propagate the params to the next iteration.
             plannerParams = makeQueryPlannerParams(*canonicalQuery, plannerOptions, replanningData);


### PR DESCRIPTION
## Summary
- Adds a `multiPlannerFallbackEngaged` boolean flag to the slow query log and database profiler output
- The flag is set to `true` when query settings exist for a query shape but fail to produce a valid execution plan, causing the planner to fall back to multi-planning without those settings
- Does not apply to plan cached queries since they bypass the planner entirely

## Changes
- **op_debug.h**: Added `multiPlannerFallbackEngaged` field directly on `OpDebug`
- **op_debug.cpp**: Emit the flag in `report()` (slow query log) and `append()` (profiler)
- **get_executor_helpers.cpp**: Set the flag in the `NoQueryExecutionPlans` catch block when query settings are removed and planning is retried
- **query_settings_fallback_profiler.js**: Integration test verifying the flag is present when fallback occurs and absent otherwise

## Test plan
- [x] Query with inapplicable query settings (non-existent index) triggers fallback → flag is `true` in profiler
- [x] Query without query settings → flag is absent
- [x] Functional testing via `query_settings_fallback_profiler.js` integration test
- [x] Build compiles and test passes locally