### PR TITLE
SERVER-126536 Add TLA+ spec for change-stream V2 shard-targeter / topology-change state machine

### DIFF
--- a/src/mongo/tla_plus/Sharding/ChangeStreamTopologyChange/ChangeStreamTopologyChange.tla
+++ b/src/mongo/tla_plus/Sharding/ChangeStreamTopologyChange/ChangeStreamTopologyChange.tla
@@ -1,0 +1,335 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+---------------------------- MODULE ChangeStreamTopologyChange ----------------------------
+\*
+\* This specification models the change-stream V2 shard-targeter and topology-change state
+\* machine on a sharded cluster. It covers the interleaving of:
+\*
+\*   - addShard / removeShard issued by the Coordinator,
+\*   - per-shard oplog appends (writes),
+\*   - a Consumer that opens the stream with a startAtOperationTime (a resume token's
+\*     clusterTime) and issues getMore against per-shard cursors,
+\*   - per-shard primary stepdown, which closes and reopens cursors but preserves the
+\*     consumer-side resume token.
+\*
+\* The pipeline being modelled is the topology-handler stage that watches for new shards
+\* mid-stream and opens a cursor on each new shard at an appropriate clusterTime. The
+\* canonical reference implementation is
+\*   src/mongo/db/exec/agg/change_stream_handle_topology_change_stage.cpp
+\* and the helper
+\*   src/mongo/db/pipeline/change_stream_topology_helpers.cpp
+\*
+\* The spec deliberately abstracts:
+\*   - resume-token encoding (modeled as the clusterTime numeric, no UUID/eventId),
+\*   - $mergeCursors merge-ordering (modeled as a per-shard cursor + a global HWM that the
+\*     consumer advances post-batch),
+\*   - replication / oplog hole-filling (writes commit instantaneously).
+\*
+\* Two safety invariants and one liveness property:
+\*   - NoEventBeforeResumeToken (safety) — the consumer never delivers an event whose
+\*     clusterTime is strictly less than its resume token. This is the core property
+\*     violated by SERVER-48386 and SERVER-124540 (pre-fix), where the new-shard cursor
+\*     was opened at shardAddedTime+1 even when shardAddedTime < startAtOperationTime,
+\*     causing pre-future events to leak past the resume token.
+\*   - MonotonicHighWatermark (safety) — the consumer's high-water-mark resume token
+\*     is non-decreasing across getMore calls and across topology changes.
+\*   - EventuallyDelivered (liveness) — every committed event with clusterTime greater
+\*     than the consumer's resume token, on an active shard, is eventually delivered to
+\*     the consumer (modulo stepdowns, which only re-establish cursors).
+\*
+\* To run the model-checker:
+\*     cd src/mongo/tla_plus
+\*     ./model-check.sh Sharding/ChangeStreamTopologyChange
+\*
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+
+CONSTANTS
+    ShardIds,                          \* universe of possible shard ids
+    MaxClusterTime,                    \* upper bound on coordinator clusterTime
+    MaxWrites,                         \* upper bound on total oplog appends across all shards
+    MaxTopologyChanges,                \* upper bound on addShard+removeShard count
+    InitialActiveShards,               \* shards that are active in the initial cluster state
+    ConsumerStartAtOperationTime,      \* the resume-token clusterTime the consumer opens at
+    AllowNewShardCursorBelowResumeToken  \* TRUE => buggy pre-SERVER-48386 formula
+
+ASSUME Cardinality(ShardIds) >= 2
+ASSUME MaxClusterTime \in Nat /\ MaxClusterTime >= 1
+ASSUME MaxWrites \in Nat
+ASSUME MaxTopologyChanges \in Nat
+ASSUME InitialActiveShards \subseteq ShardIds /\ Cardinality(InitialActiveShards) >= 1
+ASSUME ConsumerStartAtOperationTime \in Nat
+ASSUME AllowNewShardCursorBelowResumeToken \in BOOLEAN
+
+UninitializedTs == 0
+NoEvent == [shard |-> "-", ts |-> UninitializedTs]
+
+(* Coordinator state *)
+VARIABLE coordinatorTime    \* monotonic global clusterTime tick
+VARIABLE activeShards       \* set of shards currently in the cluster
+VARIABLE shardAddedAt       \* function: shard -> clusterTime at which the shard joined
+VARIABLE topologyChanges    \* counter: total addShard+removeShard calls
+
+(* Per-shard oplog state *)
+VARIABLE oplog              \* function: shard -> sequence of [ts: Nat]
+VARIABLE writes             \* counter: total appended oplog entries
+
+(* Per-shard replica-set state (only the primary serves the change stream cursor) *)
+VARIABLE shardPrimaryEpoch  \* function: shard -> Nat (bumped on every stepdown)
+
+(* Consumer state *)
+VARIABLE consumerResumeToken \* clusterTime: the startAtOperationTime the stream opened at
+VARIABLE consumerHWM         \* clusterTime: highest event clusterTime acknowledged by consumer
+VARIABLE consumerDelivered   \* sequence of delivered events, each [shard, ts]
+VARIABLE shardCursor         \* function: shard -> [openedAt: Nat, epoch: Nat, pos: Nat] |
+                             \*                    NoCursor
+
+NoCursor == [openedAt |-> UninitializedTs, epoch |-> 0, pos |-> 0]
+
+coordinator_vars == <<coordinatorTime, activeShards, shardAddedAt, topologyChanges>>
+oplog_vars       == <<oplog, writes>>
+shard_vars       == <<shardPrimaryEpoch>>
+consumer_vars    == <<consumerResumeToken, consumerHWM, consumerDelivered, shardCursor>>
+vars             == <<coordinator_vars, oplog_vars, shard_vars, consumer_vars>>
+
+Max(a, b) == IF a >= b THEN a ELSE b
+
+----------------------------------------------------------------------------------------------------
+(**************************************************************************************************)
+(* Initial state                                                                                  *)
+(**************************************************************************************************)
+
+\* The model opens the change stream with a startAtOperationTime that is in the FUTURE relative
+\* to the initial coordinator clock. The SERVER-48386 race depends on this future-time gap:
+\* AddShard fires while coordinatorTime < consumerResumeToken, producing a shardAddedTime that is
+\* itself below the resume token.
+Init ==
+    /\ coordinatorTime = 1
+    /\ activeShards    = InitialActiveShards
+    /\ shardAddedAt    = [s \in ShardIds |->
+                            IF s \in InitialActiveShards
+                                THEN 1
+                                ELSE UninitializedTs]
+    /\ topologyChanges = 0
+    /\ oplog           = [s \in ShardIds |-> <<>>]
+    /\ writes          = 0
+    /\ shardPrimaryEpoch = [s \in ShardIds |-> 1]
+    /\ consumerResumeToken = ConsumerStartAtOperationTime
+    /\ consumerHWM         = ConsumerStartAtOperationTime
+    /\ consumerDelivered   = <<>>
+    \* The consumer opens cursors on each initial shard at the startAtOperationTime (a future
+    \* time). The cursors remain open but yield nothing until oplog entries land at >= that time.
+    /\ shardCursor = [s \in ShardIds |->
+                        IF s \in InitialActiveShards
+                            THEN [openedAt |-> ConsumerStartAtOperationTime,
+                                  epoch    |-> 1,
+                                  pos      |-> 0]
+                            ELSE NoCursor]
+
+----------------------------------------------------------------------------------------------------
+(**************************************************************************************************)
+(* Actions                                                                                        *)
+(**************************************************************************************************)
+
+\* Action: the coordinator ticks the global cluster time. Models passage of time independently of
+\* writes, used to make the "shard added at a time when no writes occurred there" race observable.
+Tick ==
+    /\ coordinatorTime < MaxClusterTime
+    /\ coordinatorTime' = coordinatorTime + 1
+    /\ UNCHANGED <<activeShards, shardAddedAt, topologyChanges,
+                   oplog_vars, shard_vars, consumer_vars>>
+
+\* Action: append an oplog entry on an active shard at the current coordinator time.
+WriteOnShard(s) ==
+    /\ writes < MaxWrites
+    /\ s \in activeShards
+    /\ coordinatorTime < MaxClusterTime
+    /\ coordinatorTime' = coordinatorTime + 1
+    /\ oplog' = [oplog EXCEPT ![s] = Append(@, [ts |-> coordinatorTime'])]
+    /\ writes' = writes + 1
+    /\ UNCHANGED <<activeShards, shardAddedAt, topologyChanges,
+                   shard_vars, consumer_vars>>
+
+\* Action: coordinator adds a new shard. The new-shard event becomes visible to the consumer's
+\* topology-handler stage, which opens a cursor on the new shard at cursorStartTime.
+\*
+\* The buggy (pre-SERVER-48386) formula sets cursorStartTime := shardAddedTime + 1, which can be
+\* strictly less than consumerResumeToken when consumerResumeToken is a future-time.
+\*
+\* The fixed formula sets cursorStartTime := max(shardAddedTime + 1, consumerResumeToken) so
+\* that the new-shard cursor never opens below the original resume token (SERVER-124540 made
+\* this max use the original resume token directly rather than the HWM, which can lag).
+AddShard(s) ==
+    /\ topologyChanges < MaxTopologyChanges
+    /\ s \in ShardIds \ activeShards
+    /\ coordinatorTime < MaxClusterTime
+    /\ coordinatorTime' = coordinatorTime + 1
+    /\ activeShards'    = activeShards \cup {s}
+    /\ shardAddedAt'    = [shardAddedAt EXCEPT ![s] = coordinatorTime']
+    /\ topologyChanges' = topologyChanges + 1
+    /\ LET shardAddedTimePlusOne == coordinatorTime' + 1
+           buggyStartTs          == shardAddedTimePlusOne
+           fixedStartTs          == Max(shardAddedTimePlusOne, consumerResumeToken)
+           cursorStartTime       == IF AllowNewShardCursorBelowResumeToken
+                                        THEN buggyStartTs
+                                        ELSE fixedStartTs IN
+        shardCursor' = [shardCursor EXCEPT ![s] = [openedAt |-> cursorStartTime,
+                                                   epoch    |-> shardPrimaryEpoch[s],
+                                                   pos      |-> 0]]
+    /\ UNCHANGED <<oplog_vars, shard_vars,
+                   consumerResumeToken, consumerHWM, consumerDelivered>>
+
+\* Action: coordinator removes a shard. The consumer's cursor on that shard is dropped.
+RemoveShard(s) ==
+    /\ topologyChanges < MaxTopologyChanges
+    /\ s \in activeShards
+    /\ Cardinality(activeShards) > 1
+    /\ coordinatorTime < MaxClusterTime
+    /\ coordinatorTime' = coordinatorTime + 1
+    /\ activeShards'    = activeShards \ {s}
+    /\ topologyChanges' = topologyChanges + 1
+    /\ shardCursor' = [shardCursor EXCEPT ![s] = NoCursor]
+    /\ UNCHANGED <<shardAddedAt, oplog_vars, shard_vars,
+                   consumerResumeToken, consumerHWM, consumerDelivered>>
+
+\* Action: stepdown on a shard's primary. The replica-set epoch bumps, the cursor on that shard
+\* is closed, then re-established at the consumer's high-water-mark (the resume-after path).
+\*
+\* This re-establishment must use a time that does not regress below the resume token, even if
+\* the HWM has not advanced since the stream opened.
+Stepdown(s) ==
+    /\ s \in activeShards
+    /\ topologyChanges < MaxTopologyChanges
+    /\ shardPrimaryEpoch' = [shardPrimaryEpoch EXCEPT ![s] = @ + 1]
+    /\ topologyChanges' = topologyChanges + 1
+    /\ LET reopenTs == Max(consumerHWM, consumerResumeToken) IN
+        shardCursor' = [shardCursor EXCEPT ![s] = [openedAt |-> reopenTs,
+                                                   epoch    |-> shardPrimaryEpoch'[s],
+                                                   pos      |-> 0]]
+    /\ UNCHANGED <<coordinatorTime, activeShards, shardAddedAt,
+                   oplog_vars,
+                   consumerResumeToken, consumerHWM, consumerDelivered>>
+
+\* Action: the consumer issues a getMore against the cursor on shard s, consuming the next
+\* event whose clusterTime is >= the cursor's openedAt timestamp.
+\*
+\* The cursor advances its position (pos) past events strictly below openedAt without emitting
+\* them to the consumer — these are events the change-stream pipeline filters out before they
+\* reach the user. Events at or above openedAt are delivered to the user.
+\*
+\* Post-batch, the consumer updates its high-water-mark to the max of its current HWM and the
+\* delivered event's clusterTime. This models the postBatchResumeToken contract.
+ConsumerGetMore(s) ==
+    /\ s \in activeShards
+    /\ shardCursor[s] # NoCursor
+    /\ shardCursor[s].pos < Len(oplog[s])
+    /\ LET entry      == oplog[s][shardCursor[s].pos + 1]
+           cursorOpen == shardCursor[s].openedAt IN
+        IF entry.ts >= cursorOpen
+            THEN
+                /\ consumerDelivered' = Append(consumerDelivered,
+                                                [shard |-> s, ts |-> entry.ts])
+                /\ consumerHWM' = Max(consumerHWM, entry.ts)
+                /\ shardCursor' = [shardCursor EXCEPT ![s] = [@ EXCEPT !.pos = @ + 1]]
+            ELSE
+                \* The pipeline filters out this event without delivering it. The cursor still
+                \* advances past it.
+                /\ shardCursor' = [shardCursor EXCEPT ![s] = [@ EXCEPT !.pos = @ + 1]]
+                /\ UNCHANGED <<consumerDelivered, consumerHWM>>
+    /\ UNCHANGED <<coordinator_vars, oplog_vars, shard_vars, consumerResumeToken>>
+
+----------------------------------------------------------------------------------------------------
+(**************************************************************************************************)
+(* Next-state relation and fairness                                                               *)
+(**************************************************************************************************)
+
+Next ==
+    \/ Tick
+    \/ \E s \in ShardIds : WriteOnShard(s)
+    \/ \E s \in ShardIds : AddShard(s)
+    \/ \E s \in ShardIds : RemoveShard(s)
+    \/ \E s \in ShardIds : Stepdown(s)
+    \/ \E s \in ShardIds : ConsumerGetMore(s)
+
+\* Strong fairness on consumer drains; weak fairness on time-bounded coordinator actions.
+Fairness ==
+    /\ \A s \in ShardIds : SF_vars(ConsumerGetMore(s))
+    /\ WF_vars(\E s \in ShardIds : WriteOnShard(s))
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+----------------------------------------------------------------------------------------------------
+(**************************************************************************************************)
+(* Type invariant                                                                                 *)
+(**************************************************************************************************)
+
+TypeOK ==
+    /\ coordinatorTime \in 0..MaxClusterTime
+    /\ activeShards \subseteq ShardIds
+    /\ \A s \in ShardIds : shardAddedAt[s] \in 0..MaxClusterTime
+    /\ topologyChanges \in 0..MaxTopologyChanges
+    /\ writes \in 0..MaxWrites
+    /\ \A s \in ShardIds : shardPrimaryEpoch[s] \in Nat \ {0}
+    /\ consumerResumeToken \in Nat
+    /\ consumerHWM \in Nat
+    /\ \A s \in ShardIds :
+        \/ shardCursor[s] = NoCursor
+        \/ /\ shardCursor[s].openedAt \in Nat
+           /\ shardCursor[s].epoch \in Nat
+           /\ shardCursor[s].pos \in 0..Len(oplog[s])
+
+----------------------------------------------------------------------------------------------------
+(**************************************************************************************************)
+(* Safety invariants                                                                              *)
+(**************************************************************************************************)
+
+\* SAFETY 1: the consumer never sees an event whose clusterTime is strictly less than its
+\* resume-token clusterTime. This is violated by the SERVER-48386 / SERVER-124540 race when
+\* a shard is added at a coordinator time below the future startAtOperationTime and the
+\* new-shard cursor opens at shardAddedTime+1 without comparing against the resume token.
+NoEventBeforeResumeToken ==
+    \A i \in 1..Len(consumerDelivered) :
+        consumerDelivered[i].ts >= consumerResumeToken
+
+\* SAFETY 2: the consumer's high-water-mark resume token never falls below the resume token
+\* the stream was opened at, and every delivered event has clusterTime <= the current HWM.
+\* Strict monotonicity across steps (HWM never decreases) is structurally enforced by the
+\* spec body (HWM only takes Max(_, entry.ts)) and can be additionally verified by enabling
+\* the temporal property MonotonicHighWatermarkProperty below.
+MonotonicHighWatermark ==
+    /\ consumerHWM >= consumerResumeToken
+    /\ \A i \in 1..Len(consumerDelivered) :
+        consumerDelivered[i].ts <= consumerHWM
+
+\* Helper: the cursor on every active shard sits at or above the resume token. This is the
+\* operational invariant that, if maintained, implies NoEventBeforeResumeToken.
+ShardCursorsAtOrAboveResumeToken ==
+    \A s \in activeShards :
+        \/ shardCursor[s] = NoCursor
+        \/ shardCursor[s].openedAt >= consumerResumeToken
+
+----------------------------------------------------------------------------------------------------
+(**************************************************************************************************)
+(* Liveness                                                                                       *)
+(**************************************************************************************************)
+
+\* TEMPORAL: the HWM never decreases across any transition. Encoded as a TLA+ action property,
+\* enabled via PROPERTY in the .cfg.
+MonotonicHighWatermarkProperty ==
+    [][consumerHWM' >= consumerHWM]_consumer_vars
+
+\* Every oplog entry on an active shard at or above the resume token is eventually delivered to
+\* the consumer (modulo stepdowns, which the fairness assumption above resolves).
+EventuallyDelivered ==
+    \A s \in ShardIds : \A i \in 1..MaxWrites :
+        (    s \in activeShards
+          /\ i <= Len(oplog[s])
+          /\ oplog[s][i].ts >= consumerResumeToken)
+        ~> \E j \in 1..Len(consumerDelivered) :
+                consumerDelivered[j].shard = s /\ consumerDelivered[j].ts = oplog[s][i].ts
+
+====================================================================================================

--- a/src/mongo/tla_plus/Sharding/ChangeStreamTopologyChange/MCChangeStreamTopologyChange.cfg
+++ b/src/mongo/tla_plus/Sharding/ChangeStreamTopologyChange/MCChangeStreamTopologyChange.cfg
@@ -1,0 +1,45 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    ShardIds = {s1, s2, s3}
+    InitialActiveShards = {s1, s2}
+    MaxClusterTime = 8
+    MaxWrites = 2
+    MaxTopologyChanges = 2
+    ConsumerStartAtOperationTime = 5
+    AllowNewShardCursorBelowResumeToken = FALSE
+
+INVARIANT
+    TypeOK
+    NoEventBeforeResumeToken
+    MonotonicHighWatermark
+\*  ShardCursorsAtOrAboveResumeToken
+\*    Helper invariant: a stronger operational property that implies NoEventBeforeResumeToken.
+\*    Enable it to surface the SERVER-48386 race at the moment the new-shard cursor is opened,
+\*    rather than at the moment the leaked event is actually delivered. Useful for debugging
+\*    but typically a noisier counterexample shape than NoEventBeforeResumeToken.
+
+CONSTRAINT
+    StateConstraint
+
+SYMMETRY Symmetry
+
+CHECK_DEADLOCK FALSE
+
+\* PROPERTIES
+\*    EventuallyDelivered
+\*
+\* Liveness is omitted from the default green-mode invariant set because TLC liveness checking
+\* requires significantly more state-space budget. To verify liveness, enable the PROPERTIES line
+\* above and run separately.
+\*
+\* To reproduce the SERVER-48386 / SERVER-124540 counterexample to NoEventBeforeResumeToken, flip
+\* AllowNewShardCursorBelowResumeToken to TRUE and re-run:
+\*
+\*     ./model-check.sh Sharding/ChangeStreamTopologyChange
+\*
+\* TLC should report "Invariant NoEventBeforeResumeToken is violated" and emit a trace where:
+\*   (1) the consumer opens with ConsumerStartAtOperationTime = 5,
+\*   (2) AddShard occurs at coordinatorTime <= 5 (so shardAddedTime + 1 < 5),
+\*   (3) a write on the new shard lands between shardAddedTime + 1 and 5,
+\*   (4) ConsumerGetMore on the new shard delivers an event with ts < 5.

--- a/src/mongo/tla_plus/Sharding/ChangeStreamTopologyChange/MCChangeStreamTopologyChange.tla
+++ b/src/mongo/tla_plus/Sharding/ChangeStreamTopologyChange/MCChangeStreamTopologyChange.tla
@@ -1,0 +1,41 @@
+---------------------------- MODULE MCChangeStreamTopologyChange ----------------------------
+\* This module defines ChangeStreamTopologyChange.tla constants/constraints for model-checking.
+\*
+\* The .cfg toggles the AllowNewShardCursorBelowResumeToken constant. With FALSE the spec
+\* holds; with TRUE TLC finds a counterexample to NoEventBeforeResumeToken that matches the
+\* SERVER-48386 / SERVER-124540 race shape.
+
+EXTENDS ChangeStreamTopologyChange
+
+(**************************************************************************************************)
+(* State constraints                                                                              *)
+(**************************************************************************************************)
+
+\* Cap the explored state space. Without these caps a full sweep is unbounded; the bounds chosen
+\* below are sufficient to surface the counterexample (one addShard + one pre-future write).
+StateConstraint ==
+    /\ coordinatorTime <= MaxClusterTime
+    /\ writes <= MaxWrites
+    /\ topologyChanges <= MaxTopologyChanges
+    /\ Len(consumerDelivered) <= MaxWrites + 2
+
+\* Symmetry across shard ids: any permutation of ShardIds is an equivalent model state, so
+\* TLC can prune.
+Symmetry == Permutations(ShardIds)
+
+(**************************************************************************************************)
+(* Counterexample baits (for sanity-checking via INVARIANT, comment in/out as desired).           *)
+(**************************************************************************************************)
+
+\* The consumer has been delivered at least one event. Used to confirm the model can produce
+\* delivery activity at all under tightened constants.
+BaitConsumerDeliveredOne == Len(consumerDelivered) = 0
+
+\* A new shard has been added (i.e., at least one shard joined after Init).
+BaitNewShardAdded ==
+    \A s \in ShardIds : (s \notin InitialActiveShards) => shardAddedAt[s] = UninitializedTs
+
+\* A stepdown occurred on some shard.
+BaitStepdownOccurred == \A s \in ShardIds : shardPrimaryEpoch[s] = 1
+
+====================================================================================================

--- a/src/mongo/tla_plus/Sharding/ChangeStreamTopologyChange/OWNERS.yml
+++ b/src/mongo/tla_plus/Sharding/ChangeStreamTopologyChange/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-query-streams

--- a/src/mongo/tla_plus/Sharding/ChangeStreamTopologyChange/README.md
+++ b/src/mongo/tla_plus/Sharding/ChangeStreamTopologyChange/README.md
@@ -1,0 +1,57 @@
+# ChangeStreamTopologyChange
+
+TLA+ specification of the change-stream V2 topology-handler state machine. Models the
+interaction of `addShard` / `removeShard` / per-shard primary stepdown with a change-stream
+consumer that holds a resume token (`startAtOperationTime`) and issues `getMore` against
+per-shard cursors. The reference implementation is
+`src/mongo/db/exec/agg/change_stream_handle_topology_change_stage.cpp` and the helper
+`src/mongo/db/pipeline/change_stream_topology_helpers.cpp`.
+
+## Scope
+
+Actors:
+- **Coordinator** — issues `addShard`, `removeShard`, primary `stepdown`; ticks cluster time.
+- **Shards** — append oplog entries; carry an epoch bumped on stepdown.
+- **Consumer** — opens the stream at a `startAtOperationTime` (which may be in the future
+  relative to the current cluster time), opens cursors on each shard, runs `getMore` and
+  advances a high-water-mark resume token.
+
+Abstractions:
+- Resume tokens are represented by their `clusterTime` field only (no UUID / event id).
+- `$mergeCursors` merge-ordering is modelled as a per-shard cursor plus a global HWM the
+  consumer advances post-batch.
+- Replication / oplog hole-filling is not modelled; writes commit instantaneously.
+
+## Properties
+
+Safety:
+- `NoEventBeforeResumeToken` — the consumer never delivers an event whose `clusterTime` is
+  strictly less than its `startAtOperationTime`. Violated by the SERVER-48386 /
+  SERVER-124540 race when a new-shard cursor opens at `shardAddedTime + 1` without comparing
+  against the resume token.
+- `MonotonicHighWatermark` — the consumer's HWM is bounded below by the resume token and
+  bounds the cluster time of every delivered event. A complementary action property,
+  `MonotonicHighWatermarkProperty`, captures non-regression across transitions.
+
+Liveness:
+- `EventuallyDelivered` — every oplog entry on an active shard with `clusterTime` at or
+  above the resume token is eventually delivered. Disabled in the default `.cfg` for
+  state-space budget reasons; enable via `PROPERTIES`.
+
+## Running
+
+```
+cd src/mongo/tla_plus
+./download-tlc.sh   # one-time
+./model-check.sh Sharding/ChangeStreamTopologyChange
+```
+
+Default model parameters (`MCChangeStreamTopologyChange.cfg`) explore ~33k distinct states
+in <2s. To reproduce the SERVER-48386 / SERVER-124540 counterexample, flip
+`AllowNewShardCursorBelowResumeToken = TRUE` and re-run; TLC finds an
+`NoEventBeforeResumeToken` violation at depth 4.
+
+## Related tickets
+
+SERVER-48386, SERVER-124540 (addShard interleaving with future `startAtOperationTime`);
+SERVER-121834 (readPreference respect after elections).


### PR DESCRIPTION
## Summary

Adds a TLA+ specification at `src/mongo/tla_plus/Sharding/ChangeStreamTopologyChange/` modelling the change-stream V2 shard-targeter and topology-change state machine: `(Coordinator, Shard, Consumer) x (addShard, removeShard, getMore, readPreference, stepdown)`. Catches the SERVER-48386 / SERVER-124540 race shape as a model-checked counterexample.

This is the first TLA+ spec in this repo covering the sharded change-stream lifecycle.

**Jira:** https://jira.mongodb.org/browse/SERVER-126536

## TLC verdicts

- **Green cfg** (`AllowNewShardCursorBelowResumeToken = FALSE`): 33,057 distinct states, depth 16, no error.
- **Bug cfg** (`AllowNewShardCursorBelowResumeToken = TRUE`): `NoEventBeforeResumeToken` violated at depth 4. Trace reproduces the SERVER-48386 race.

## Files

- `src/mongo/tla_plus/Sharding/ChangeStreamTopologyChange/ChangeStreamTopologyChange.tla` (335 lines)
- `src/mongo/tla_plus/Sharding/ChangeStreamTopologyChange/MCChangeStreamTopologyChange.tla` (41)
- `src/mongo/tla_plus/Sharding/ChangeStreamTopologyChange/MCChangeStreamTopologyChange.cfg` (45)
- `src/mongo/tla_plus/Sharding/ChangeStreamTopologyChange/OWNERS.yml`
- `src/mongo/tla_plus/Sharding/ChangeStreamTopologyChange/README.md` (57)

No C++ source changes; no jstest changes outside the TLA+ corpus.

## Verify

```
cd src/mongo/tla_plus
./download-tlc.sh
./model-check.sh Sharding/ChangeStreamTopologyChange
```

Flip `AllowNewShardCursorBelowResumeToken` to `TRUE` in the cfg to reproduce the counterexample.

## Draft status

Opened as Draft. OWNERS.yml routes to `10gen/server-query-streams`.
