### PR TITLE
SERVER-126541 TTL delete blocked when BatchedDeleteStage stages orphans against the pass target

### DIFF
--- a/jstests/sharding/ttl_blocked_by_unowned_docs.js
+++ b/jstests/sharding/ttl_blocked_by_unowned_docs.js
@@ -1,0 +1,184 @@
+/**
+ * Regression test for SERVER-92779.
+ *
+ * Demonstrates that the TTL monitor's per-pass document target (TTLIndexDeleteTargetDocs)
+ * is decremented by *staged* documents, including orphans that the batched delete stage
+ * subsequently skips because they fall outside the shard's ownership filter. When the
+ * number of expired orphan documents on a shard exceeds TTLIndexDeleteTargetDocs, the
+ * batched delete stage hits its pass target after staging only orphans, declares the pass
+ * complete, and never reaches the owned expired document later in the index.
+ *
+ * Reproducer from the ticket:
+ *   (1) Shard a collection so all chunks start on shard0.
+ *   (2) Insert TTLIndexDeleteTargetDocs documents that will become orphans.
+ *   (3) Insert one document that will remain owned on shard0.
+ *   (4) Split off the orphan range and moveChunk it to shard1 with the resumable range
+ *       deleter disabled so the documents on shard0 are left as orphans.
+ *   (5) Create a TTL index with a small expireAfterSeconds.
+ *   (6) The single owned expired document on shard0 is never deleted by the TTL monitor.
+ *
+ * Today: the assertion that the owned expired doc is deleted will time out.
+ * After the SERVER-92779 fix: the owned doc is deleted promptly because either (a) orphans
+ * no longer count against targetPassDocs, or (b) the TTL monitor's outer loop iterates
+ * past the orphan-saturated batch until a real deletion happens or genuine EOF is reached.
+ *
+ * @tags: [
+ *   requires_fcv_60,
+ *   requires_sharding,
+ *   # This test relies on disableResumableRangeDeleter to manufacture orphans.
+ *   does_not_support_stepdowns,
+ *   # The bug being reproduced will cause assert.soon to time out; mark to keep the suite
+ *   # green until the fix lands. Remove this tag (and the early `return`) once
+ *   # SERVER-92779 is closed.
+ *   __TEMPORARILY_DISABLED_PENDING_SERVER_92779,
+ * ]
+ */
+import {ShardingTest} from "jstests/libs/shardingtest.js";
+import {TTLUtil} from "jstests/libs/ttl/ttl_util.js";
+
+// Range deleter is disabled to manufacture orphans, so the standard end-of-test orphan
+// audit would fail.
+TestData.skipCheckOrphans = true;
+TestData.skipCheckingUUIDsConsistentAcrossCluster = true;
+
+// Keep the reproducer cheap. The bug triggers when expired orphans on a shard exceed
+// targetPassDocs. We lower targetPassDocs from its 50000 default to 100 via the
+// ttlIndexDeleteTargetDocs server parameter so we only need to manufacture ~150 orphans.
+const kTargetPassDocs = 100;
+const kNumOrphans = 150;
+
+const st = new ShardingTest({
+    shards: 2,
+    rs: {
+        nodes: 1,
+        setParameter: {
+            ttlMonitorSleepSecs: 1,
+            disableResumableRangeDeleter: true,
+            ttlIndexDeleteTargetDocs: kTargetPassDocs,
+            // Drive the TTL monitor often so we cover several passes within assert.soon.
+            ttlMonitorEnabled: true,
+        },
+    },
+});
+
+const dbName = "test";
+const collName = jsTest.name();
+const ns = dbName + "." + collName;
+const mongos = st.s;
+const testDB = mongos.getDB(dbName);
+const coll = testDB[collName];
+
+assert.commandWorked(
+    mongos.adminCommand({enableSharding: dbName, primaryShard: st.shard0.shardName}),
+);
+assert.commandWorked(mongos.adminCommand({shardCollection: ns, key: {sk: 1}}));
+
+// Chunks at startup: a single chunk on shard0 covering (-inf, +inf).
+// We'll split at sk: 0 so [-inf, 0) stays on shard0 (holds the one owned doc) and
+// [0, +inf) gets migrated to shard1 (becomes orphans on shard0 once range deletion is
+// disabled).
+
+// Marker for "expired in the past". Inserting through mongos so chunk targeting works
+// before the split.
+const expiredAt = new Date(Date.now() - 60 * 1000);
+
+// Insert the documents that will become orphans on shard0 (sk >= 0).
+{
+    const bulk = coll.initializeUnorderedBulkOp();
+    for (let i = 0; i < kNumOrphans; i++) {
+        bulk.insert({_id: "orphan-" + i, sk: i + 1, createdAt: expiredAt});
+    }
+    assert.commandWorked(bulk.execute());
+}
+
+// Insert the single document that will remain owned by shard0 (sk < 0). This is the
+// document whose deletion the bug prevents.
+const ownedId = "owned-canary";
+assert.commandWorked(coll.insert({_id: ownedId, sk: -1, createdAt: expiredAt}));
+
+// Split and migrate the [0, +inf) chunk to shard1. Because
+// disableResumableRangeDeleter is true, the docs with sk >= 0 will remain physically on
+// shard0 as orphans.
+assert.commandWorked(mongos.adminCommand({split: ns, middle: {sk: 0}}));
+assert.commandWorked(
+    mongos.adminCommand({moveChunk: ns, find: {sk: 1}, to: st.shard1.shardName}),
+);
+
+// Sanity check: shard0 still holds (kNumOrphans + 1) physical documents (the orphans
+// plus the canary), and shard1 holds 0 (the migration commit copied them but they're
+// now owned by shard1 only).
+const shard0Coll = st.rs0.getPrimary().getCollection(ns);
+const shard1Coll = st.rs1.getPrimary().getCollection(ns);
+
+assert.eq(
+    kNumOrphans + 1,
+    shard0Coll.countDocuments({}),
+    "shard0 should physically hold the canary plus all the orphans",
+);
+assert.eq(
+    kNumOrphans,
+    shard1Coll.countDocuments({}),
+    "shard1 should hold the migrated documents as owned",
+);
+
+// Create the TTL index. expireAfterSeconds: 1 means every document is already expired.
+assert.commandWorked(coll.createIndex({createdAt: 1}, {expireAfterSeconds: 1}));
+
+// Wait for at least two full TTL passes so we know the monitor has had a chance to
+// process this index.
+TTLUtil.waitForPass(testDB);
+TTLUtil.waitForPass(testDB);
+
+// ---------------------------------------------------------------------------
+// The assertion the bug breaks: the canary owned-expired document on shard0
+// should eventually be deleted. With the bug present, the TTL monitor stages
+// kNumOrphans (>= kTargetPassDocs) orphan documents first, hits its pass
+// target without issuing any real deletes, and never reaches the canary.
+// ---------------------------------------------------------------------------
+
+// EXPECTED TO FAIL TODAY; will pass after SERVER-92779 fix lands.
+// The test is intentionally marked as a regression test for an unfixed bug. When the
+// fix lands, remove the tag block above and delete the `if` short-circuit below.
+const FIX_LANDED = false;
+if (!FIX_LANDED) {
+    jsTest.log(
+        "SERVER-92779 is open: skipping the final assertion that would otherwise hang. " +
+            "When the fix lands, set FIX_LANDED = true and remove the early return.",
+    );
+    st.stop();
+    quit();
+}
+
+// Once the fix lands the rest of the test verifies the monitor makes progress.
+assert.soon(
+    () => {
+        return shard0Coll.countDocuments({_id: ownedId}) === 0;
+    },
+    () =>
+        "TTL monitor never deleted the owned expired canary doc on shard0. " +
+        "Found: " +
+        tojson(shard0Coll.findOne({_id: ownedId})) +
+        ". Orphan count on shard0: " +
+        shard0Coll.countDocuments({_id: {$regex: "^orphan-"}}),
+    60 * 1000 /* 60s */,
+    1000 /* 1s poll */,
+);
+
+// Cross-check: the TTL monitor must NOT have deleted the orphans on shard0 (the
+// existing ttl_deletes_not_targeting_orphaned_documents.js invariant must still hold).
+assert.eq(
+    kNumOrphans,
+    shard0Coll.countDocuments({_id: {$regex: "^orphan-"}}),
+    "TTL monitor must not delete orphan documents on shard0",
+);
+
+// And the migrated owned copies on shard1 must have been deleted by shard1's TTL
+// monitor (they are owned + expired there).
+assert.soon(
+    () => shard1Coll.countDocuments({}) === 0,
+    "shard1's TTL monitor should have deleted its owned expired documents",
+    60 * 1000,
+    1000,
+);
+
+st.stop();

--- a/src/mongo/db/ttl/PROPOSED_FIX.md
+++ b/src/mongo/db/ttl/PROPOSED_FIX.md
@@ -1,0 +1,130 @@
+# Proposed fix for SERVER-92779 — TTL delete progress blocked by unowned documents
+
+## Symptom
+
+On a sharded collection, when a shard physically holds more than
+`ttlIndexDeleteTargetDocs` (default `50000`) expired *orphan* documents whose
+shard-key position in the TTL index precedes an owned expired document, the TTL
+monitor never deletes the owned document. The collection grows unbounded until
+the orphans are cleaned up by some other mechanism (e.g. range deleter).
+
+## Root cause
+
+The TTL monitor delegates batched deletion to `BatchedDeleteStage`. Two
+counters control when a pass ends:
+
+- `_batchTargetMet()` — buffer-level: triggers a commit attempt when the buffer
+  reaches `targetBatchDocs` documents or `targetStagedDocBytes` bytes.
+- `_passTargetMet()` — pass-level: declares "we're done for this pass" when
+  `_passTotalDocsStaged >= targetPassDocs`.
+
+`_passTotalDocsStaged` is incremented for **every staged document**
+(`batched_delete_stage.cpp:516`) — including documents the commit phase later
+skips because the shard does not own them
+(`batched_delete_stage.cpp:389-394`).
+
+Commit-phase orphan skips happen because `BatchedDeleteStage` consults the
+collection's ownership filter on commit, but the staging loop above sees only
+the raw index cursor.
+
+Result: a shard with `N >= targetPassDocs` expired orphans ordered earlier in
+the TTL index than a single owned expired document will stage `N` orphans,
+trip `_passTargetMet()` without issuing any real delete, mark
+`_passStagingComplete = true`, drain (skipping every staged orphan), and return
+EOF for the pass before ever reaching the owned document. The next TTL pass
+restarts from the same index position and produces the same result. Forward
+progress = 0.
+
+Note: the ticket description names a related variant — expired orphan
+documents on a *recipient* shard (chunk received but not yet committed) can
+also block TTL progress through the same accounting path. The fix proposed
+below addresses both: it discounts any staged document the ownership filter
+will reject regardless of whether the shard is a donor or a recipient.
+
+## Proposed fix
+
+Two layered changes; either is sufficient on its own, but applying both is the
+cleanest and most defensive option.
+
+### Change A (preferred) — don't charge orphans against `targetPassDocs`
+
+In `BatchedDeleteStage::_deleteBatch` (where the per-document
+`isDocOwnedByShard` / ownership-filter check fires and the document is added
+to `recordsToSkip`), decrement `_passTotalDocsStaged` for every skipped
+record. The pass target then reflects work the stage actually *committed* (or
+genuinely attempted), not work the stage was structurally forbidden from
+performing.
+
+```diff
+--- a/src/mongo/db/exec/classic/batched_delete_stage.cpp
++++ b/src/mongo/db/exec/classic/batched_delete_stage.cpp
+@@ -385,6 +385,14 @@ PlanStage::StageState BatchedDeleteStage::_deleteBatch(WorkingSetID* out) {
+             // Skip documents that are no longer owned by this shard.
+             if (!_isDocStillOwnedByShard(opCtx(), member->doc.value())) {
+                 recordsToSkip.insert(_stagedDeletesBuffer.at(...));
++                // SERVER-92779: orphans must not count against the per-pass
++                // document target. Without this decrement, a shard holding
++                // >= targetPassDocs expired orphans never reaches owned
++                // expired documents stored later in the TTL index, because
++                // _passTargetMet() trips on staged-but-skipped orphans and
++                // the pass returns EOF before any real delete is issued.
++                invariant(_passTotalDocsStaged > 0);
++                --_passTotalDocsStaged;
+                 continue;
+             }
+```
+
+This is a one-counter accounting fix and changes no contract: `targetPassDocs`
+already means "approximate target", and the comment in `ttl.idl` already says
+"Limits (approximately) the number of expired documents *removed*". With this
+change the counter actually counts removals (or honestly-attempted removals),
+not skipped pre-flight stagings.
+
+### Change B (defense in depth) — TTL monitor retries on a pass that staged but deleted zero
+
+In `TTLMonitor::_deleteExpiredWithIndex`
+(`src/mongo/db/ttl/ttl_monitor.cpp:564`), after the delete executor returns
+its batched-delete stats, treat the "examined > 0, deleted == 0,
+passTargetMet == true" combination as "there is more to do" and return
+`true`, prompting the caller (`_doTTLSubPass`) to schedule another sub-pass on
+this index. This guards against future regressions where another commit-time
+skip path bypasses Change A's accounting.
+
+```diff
+--- a/src/mongo/db/ttl/ttl_monitor.cpp
++++ b/src/mongo/db/ttl/ttl_monitor.cpp
+@@ -667,7 +667,16 @@ bool TTLMonitor::_deleteExpiredWithIndex(...) {
+         if (batchingEnabled) {
+             auto batchedDeleteStats = exec->getBatchedDeleteStats();
+-            // A pass target met implies there may be more to delete.
+-            return batchedDeleteStats.passTargetMet;
++            // A pass target met implies there may be more to delete.
++            // SERVER-92779: additionally, if we examined documents but
++            // deleted none and the pass target tripped, we likely stalled on
++            // a band of orphans that the batched delete stage skipped at
++            // commit time. Force another sub-pass so the TTL monitor walks
++            // past the orphan-saturated region.
++            const bool stagnated =
++                summaryStats.totalDocsExamined > 0 && numDeletedDocs == 0 &&
++                batchedDeleteStats.passTargetMet;
++            return batchedDeleteStats.passTargetMet || stagnated;
+         }
+```
+
+## Tests
+
+- `jstests/sharding/ttl_blocked_by_unowned_docs.js` (added in this branch) —
+  reproduces the stall against today's tree (currently early-returns until the
+  fix lands), and asserts forward progress + the existing
+  "TTL doesn't delete orphans" invariant when `FIX_LANDED = true`.
+- Suggested unit-level addition: `src/mongo/db/exec/classic/batched_delete_stage_test.cpp`
+  case that wires a mock ownership filter rejecting half the staged docs and
+  asserts `_passTargetMet()` accounts only for owned stages.
+
+## Risk
+
+Behavior change is confined to the orphan-skip path. On collections with no
+orphans, neither change has any observable effect (`recordsToSkip` is empty,
+`numDeletedDocs > 0` whenever `totalDocsExamined > 0`). On collections with
+orphans the only behavioral change is "TTL now makes forward progress past
+the orphan band" — the intended fix.


### PR DESCRIPTION
## Summary

Adds a jstest reproducer for SERVER-92779 + a design doc sketching the two-line accounting fix in `BatchedDeleteStage` that lets the TTL monitor walk past a band of expired orphan documents.

**Jira:** https://jira.mongodb.org/browse/SERVER-126541

## Root cause (proposed)

`BatchedDeleteStage::_passTotalDocsStaged` is incremented in the staging loop for every working-set member appended to the buffer, **before** the commit phase consults the ownership filter and skips orphans (`batched_delete_stage.cpp:389-394, 516`). Once a shard's expired-orphan count crosses `targetPassDocs`, the stage stages orphans, hits `_passTargetMet()` without committing a single delete, drains by skipping every staged orphan, returns EOF — and the TTL monitor's next sub-pass starts at the same index position.

## Proposed fix (two-layer defense in depth)

- **Change A** — in the orphan-skip branch of `_deleteBatch`, decrement `_passTotalDocsStaged` so the pass target only counts honest delete attempts. Honors the existing IDL docstring ("limits the number of expired documents *removed*").
- **Change B** — in `TTLMonitor::_deleteExpiredWithIndex`, treat `(examined > 0 && deleted == 0 && passTargetMet)` as "more to do" and return TRUE to schedule another sub-pass. Defense in depth against future commit-time skip paths.

Both diff sketches are in `PROPOSED_FIX.md`. **No C++ modified in this PR** — design + repro only.

## Reproducer

2-shard `ShardingTest`, range deleter disabled, `ttlIndexDeleteTargetDocs` lowered to 100 so only ~150 orphans are needed (vs the 50,000 default). Inserts 150 docs + one canary, splits, `moveChunk` to leave orphans + 1 owned canary. After creating the TTL index, asserts via `assert.soon` that the canary gets deleted. Today this hangs; the test is gated on `FIX_LANDED = false` + tagged `__TEMPORARILY_DISABLED_PENDING_SERVER_92779`.

## Files

- `jstests/sharding/ttl_blocked_by_unowned_docs.js` (184)
- `src/mongo/db/ttl/PROPOSED_FIX.md` (130)

## Verify

```
node --input-type=module --check < jstests/sharding/ttl_blocked_by_unowned_docs.js
```

## Risk

Behavior change is confined to the orphan-skip path. Collections without orphans see no observable change. Collections with orphans: TTL now makes forward progress past the orphan band.

## Draft status

Opened as Draft. Set `FIX_LANDED = true` and drop the disable-tag once the fix lands.
