### PR TITLE
SERVER-126544 Change streams: renameCollection with dropTarget:true must emit a drop event

### DIFF
--- a/jstests/change_streams/rename_drop_target_emits_drop.js
+++ b/jstests/change_streams/rename_drop_target_emits_drop.js
@@ -1,0 +1,165 @@
+/**
+ * Regression test for SERVER-53478: when `renameCollection` is invoked with `dropTarget: true`,
+ * the target collection is implicitly dropped to make room for the rename. A change stream open
+ * on the (about-to-be-overwritten) target collection currently receives nothing for that drop --
+ * it sees no `drop` event and no `invalidate`, which means any consumer that relies on `drop`
+ * events to invalidate downstream state silently skips the overwritten collection.
+ *
+ * Desired behaviour (per SERVER-53478 / SERVER-98496):
+ *   1. A change stream open on the *original* target collection receives a synthetic `drop` event
+ *      (followed by `invalidate`) when that collection is overwritten by `renameCollection
+ *      ..., {dropTarget: true}`.
+ *   2. A whole-database change stream observes both a `drop` event (for the overwritten target)
+ *      AND a `rename` event (for src -> dst), in that order, in the same oplog cluster time.
+ *
+ * Before the fix lands this test is expected to FAIL on the `drop` assertion in case (1) and on
+ * the ordered-events assertion in case (2). After the fix, all assertions hold.
+ *
+ * Do not run in whole-cluster passthroughs: a db-scoped change stream is part of the contract.
+ * Sharded collections cannot be renamed, so skip on sharded fixtures.
+ *
+ * @tags: [
+ *   do_not_run_in_whole_cluster_passthrough,
+ *   requires_fcv_63,
+ *   assumes_unsharded_collection,
+ * ]
+ */
+import {
+    assertCreateCollection,
+    assertDropCollection,
+} from "jstests/libs/collection_drop_recreate.js";
+import {FixtureHelpers} from "jstests/libs/fixture_helpers.js";
+import {ChangeStreamTest} from "jstests/libs/query/change_stream_util.js";
+
+const testDb = db.getSiblingDB(jsTestName());
+
+// Sharded collections cannot be renamed; skip on sharded fixtures.
+if (FixtureHelpers.isSharded(testDb["__probe"])) {
+    jsTestLog("Skipping SERVER-53478 regression test on sharded fixture");
+    quit();
+}
+
+const srcCollName = "rename_src";
+const dstCollName = "rename_dst";
+
+// Reset state from any previous run.
+assertDropCollection(testDb, srcCollName);
+assertDropCollection(testDb, dstCollName);
+
+// Seed both collections so the rename has a real target to overwrite.
+const srcColl = assertCreateCollection(testDb, srcCollName);
+const dstColl = assertCreateCollection(testDb, dstCollName);
+assert.commandWorked(srcColl.insert({_id: "src-doc"}));
+assert.commandWorked(dstColl.insert({_id: "dst-doc-to-be-dropped"}));
+
+// ---------------------------------------------------------------------------
+// Case 1: change stream open on the *target* collection sees the synthetic
+// drop + invalidate when the target is overwritten by `dropTarget: true`.
+// ---------------------------------------------------------------------------
+{
+    const cst = new ChangeStreamTest(testDb);
+    const cursor = cst.startWatchingChanges({
+        collection: dstCollName,
+        pipeline: [{$changeStream: {}}],
+    });
+
+    // Trigger the rename that drops the existing target.
+    assert.commandWorked(srcColl.renameCollection(dstCollName, true /* dropTarget */));
+
+    // We expect: drop (synthetic, for the overwritten dst) -> invalidate.
+    // Before SERVER-53478 is fixed this assertion fails: the watcher sees nothing.
+    const expectedChanges = [
+        {
+            operationType: "drop",
+            ns: {db: testDb.getName(), coll: dstCollName},
+        },
+        {operationType: "invalidate"},
+    ];
+    cst.assertNextChangesEqual({
+        cursor: cursor,
+        expectedChanges: expectedChanges,
+        expectInvalidate: true,
+    });
+
+    cst.cleanUp();
+}
+
+// ---------------------------------------------------------------------------
+// Case 2: db-scoped change stream observes both `drop` (for the overwritten
+// target) AND `rename` (for src -> dst) from the same rename command, with
+// `drop` ordered before `rename` so downstream consumers see the
+// invalidation of the old target before the rename of the new occupant.
+// ---------------------------------------------------------------------------
+{
+    // Reset.
+    assertDropCollection(testDb, srcCollName);
+    assertDropCollection(testDb, dstCollName);
+    const srcCollV2 = assertCreateCollection(testDb, srcCollName);
+    const dstCollV2 = assertCreateCollection(testDb, dstCollName);
+    assert.commandWorked(srcCollV2.insert({_id: "src-doc-v2"}));
+    assert.commandWorked(dstCollV2.insert({_id: "dst-doc-v2-to-be-dropped"}));
+
+    const cst = new ChangeStreamTest(testDb);
+    const cursor = cst.startWatchingChanges({
+        collection: 1,  // db-scoped change stream
+        pipeline: [
+            {$changeStream: {showExpandedEvents: true}},
+            {$match: {operationType: {$in: ["drop", "rename"]}}},
+        ],
+    });
+
+    assert.commandWorked(srcCollV2.renameCollection(dstCollName, true /* dropTarget */));
+
+    const expectedChanges = [
+        {
+            operationType: "drop",
+            ns: {db: testDb.getName(), coll: dstCollName},
+        },
+        {
+            operationType: "rename",
+            ns: {db: testDb.getName(), coll: srcCollName},
+            to: {db: testDb.getName(), coll: dstCollName},
+        },
+    ];
+    cst.assertNextChangesEqual({cursor: cursor, expectedChanges: expectedChanges});
+
+    cst.cleanUp();
+}
+
+// ---------------------------------------------------------------------------
+// Case 3 (negative): dropTarget:true with NO existing target must NOT emit a
+// synthetic drop. The synthetic event is gated on the oplog `o.dropTarget`
+// UUID actually being present, which the server only writes when an existing
+// collection was overwritten.
+// ---------------------------------------------------------------------------
+{
+    assertDropCollection(testDb, srcCollName);
+    assertDropCollection(testDb, dstCollName);
+    const srcCollV3 = assertCreateCollection(testDb, srcCollName);
+    assert.commandWorked(srcCollV3.insert({_id: "src-doc-v3"}));
+
+    const cst = new ChangeStreamTest(testDb);
+    const cursor = cst.startWatchingChanges({
+        collection: 1,
+        pipeline: [
+            {$changeStream: {}},
+            {$match: {operationType: {$in: ["drop", "rename"]}}},
+        ],
+    });
+
+    // dropTarget:true but no existing target: this is a plain rename. The server
+    // omits `o.dropTarget` from the oplog entry, so no synthetic drop should be
+    // emitted.
+    assert.commandWorked(srcCollV3.renameCollection(dstCollName, true /* dropTarget */));
+
+    const expectedChanges = [
+        {
+            operationType: "rename",
+            ns: {db: testDb.getName(), coll: srcCollName},
+            to: {db: testDb.getName(), coll: dstCollName},
+        },
+    ];
+    cst.assertNextChangesEqual({cursor: cursor, expectedChanges: expectedChanges});
+
+    cst.cleanUp();
+}

--- a/src/mongo/db/pipeline/RENAME_DROP_EVENT_FIX.md
+++ b/src/mongo/db/pipeline/RENAME_DROP_EVENT_FIX.md
@@ -1,0 +1,120 @@
+# SERVER-53478: emit a synthetic `drop` event on `renameCollection ..., {dropTarget: true}`
+
+## Bug
+
+When a client issues `db.runCommand({renameCollection: src, to: dst, dropTarget: true})`
+and `dst` already exists, the server records a single oplog `c` entry whose
+`o` object contains `renameCollection`, `to`, and `dropTarget` (a UUID of the
+overwritten target). The change-stream pipeline currently materialises only a
+`rename` event from this oplog entry; the implicit drop of `dst` is invisible
+to any watcher of `dst` or of the parent database.
+
+Consumers that rely on `drop` events to invalidate downstream state
+(materialised views, projection caches, search indexes) therefore silently
+skip the dropped collection. The watcher of `dst` also never receives an
+`invalidate`, so its cursor is left dangling against a namespace that no
+longer points to the document set it was tracking.
+
+## Proposed fix location
+
+`src/mongo/db/pipeline/change_stream_event_transform.cpp`, in the
+`kCommand` arm of `ChangeStreamEventTransformer::applyTransformation` --
+specifically the branch that handles `o.renameCollection` (currently
+lines 474-495). Emit a **synthetic `drop` event** for the overwritten
+target whenever `o.dropTarget` is present in the same oplog entry, before
+returning the rename event.
+
+The transformer returns a single `Document` per oplog entry today. The
+cleanest shape change is to make the rename branch return *two* documents
+when `dropTarget` is set: the synthetic drop first, then the rename. The
+caller (`DocumentSourceChangeStreamTransform::doGetNext`) already expects
+to be able to buffer fan-out events (it does so today for resharding and
+shard-topology change), so the plumbing exists.
+
+The synthetic `drop` event must:
+
+1. Carry `ns = {db, coll}` of the **overwritten target** (from `o.to`).
+2. Carry `clusterTime`, `wallTime`, `lsid`, `txnNumber` identical to the
+   originating rename oplog entry (so the two events share an
+   `operationTime` and resume tokens sort deterministically).
+3. Carry a resume token that orders strictly before the rename's resume
+   token. The cleanest path: reuse the rename's `ts` and `applyOpsIndex`
+   but mint a fresh `eventIdentifier` for the synthetic drop so the two
+   tokens differ. The companion change in
+   `src/mongo/db/pipeline/resume_token.cpp` is a one-liner: add a
+   `kSyntheticDropFromRename` discriminator to the
+   `eventIdentifier` enum.
+4. Be gated on `!oField.getField("dropTarget").missing()` so a plain rename
+   (no overwrite, `dropTarget:true` flag but no existing target) does not
+   emit a spurious drop. The server only writes `o.dropTarget` when an
+   existing collection was actually overwritten.
+
+## Unified-diff sketch (do not apply -- approximate, ~30 lines)
+
+```diff
+--- a/src/mongo/db/pipeline/change_stream_event_transform.cpp
++++ b/src/mongo/db/pipeline/change_stream_event_transform.cpp
+@@ -474,6 +474,29 @@ Document ChangeStreamEventTransformer::applyTransformation(...) {
+             } else if (auto nssField = oField.getField("renameCollection"_sd);
+                        !nssField.missing()) {
+                 operationType = DocumentSourceChangeStream::kRenameCollectionOpType;
+
+                 // The "o.renameCollection" field contains the namespace of the original collection.
+                 nss = createNamespaceStringFromOplogEntry(nssField.getStringData());
+
+                 // The "to" field contains the target namespace for the rename.
+                 const auto renameTargetNss =
+                     createNamespaceStringFromOplogEntry(oField["to"_sd].getStringData());
+                 const auto renameTarget = makeChangeStreamNsField(renameTargetNss);
+
++                // SERVER-53478: if the rename overwrote an existing target collection
++                // (signalled by `o.dropTarget` carrying the overwritten target's UUID),
++                // synthesise a `drop` event for that target so watchers of the
++                // about-to-be-overwritten namespace, and database-scoped watchers, are
++                // notified before the rename lands. The synthetic event shares the
++                // rename's clusterTime/wallTime so the pair appears atomic; it sorts
++                // strictly before the rename via a `kSyntheticDropFromRename`
++                // eventIdentifier discriminator on the resume token.
++                if (!oField.getField("dropTarget"_sd).missing()) {
++                    MutableDocument syntheticDrop;
++                    syntheticDrop.addField(DocumentSourceChangeStream::kOperationTypeField,
++                                           Value(DocumentSourceChangeStream::kDropCollectionOpType));
++                    syntheticDrop.addField(DocumentSourceChangeStream::kNamespaceField,
++                                           renameTarget);
++                    syntheticDrop.addField(DocumentSourceChangeStream::kClusterTimeField,
++                                           Value(ts));
++                    syntheticDrop.addField(DocumentSourceChangeStream::kWallTimeField,
++                                           Value(wallTime));
++                    syntheticDrop.addField(DocumentSourceChangeStream::kIdField,
++                                           Value(makeResumeToken(
++                                               ts, uuid, /*eventIdentifier*/ Value(),
++                                               DocumentSourceChangeStream::kDropCollectionOpType,
++                                               ResumeTokenData::FromInvalidate::kNotFromInvalidate,
++                                               ResumeTokenData::EventIdentifierType::
++                                                   kSyntheticDropFromRename)));
++                    _bufferedSyntheticEvents.push_back(syntheticDrop.freezeToValue());
++                }
++
+                 // The 'to' field predates the 'operationDescription' field which was added in 5.3.
+                 // We keep the top-level 'to' field for backwards-compatibility.
+                 doc.addField(DocumentSourceChangeStream::kRenameTargetNssField, renameTarget);
+```
+
+`_bufferedSyntheticEvents` is a new `std::deque<Value>` member on the
+transformer; `applyTransformation` drains it before computing the next
+oplog-derived event. The caller in
+`DocumentSourceChangeStreamTransform::doGetNext` already loops on
+transformer output, so no changes are needed there.
+
+## Test coverage
+
+`jstests/change_streams/rename_drop_target_emits_drop.js` (this PR)
+exercises three cases: (1) collection-scoped watcher of the overwritten
+target receives `drop` -> `invalidate`; (2) db-scoped watcher receives
+`drop` then `rename` from the same command; (3) plain rename with no
+existing target emits no spurious drop.
+
+The unit test in `document_source_change_stream_test.cpp:1880`
+(`TransformRenameShowExpandedEvents`) must be extended to assert that the
+synthetic drop is the *first* document returned by the transformer when
+`o.dropTarget` is present.


### PR DESCRIPTION
## Summary

Regression jstest + design doc for SERVER-53478. When `renameCollection(srcNs, dstNs, {dropTarget: true})` overwrites an existing `dst`, the change-stream pipeline emits only a `rename` event — the implicit drop of the overwritten target is invisible to:

- Watchers of the target collection (no `drop`, no `invalidate`; cursor left dangling)
- Database- and cluster-scoped watchers (no `drop` alongside the `rename`)

Downstream consumers that rely on `drop` events to invalidate materialised views, projection caches, or search indexes silently skip the overwritten collection.

**Jira:** https://jira.mongodb.org/browse/SERVER-126544

## Reproduction

```javascript
const src = db.getSiblingDB('t').src;
const dst = db.getSiblingDB('t').dst;
src.insertOne({_id: 1});
dst.insertOne({_id: 1});

const watcher = dst.watch();
src.renameCollection('dst', true /* dropTarget */);

// Expected: watcher.next() returns {operationType: 'drop'} then 'invalidate'.
// Actual:   watcher.next() blocks forever; no events are produced.
```

## Desired behaviour

1. Collection-scoped watcher on the about-to-be-overwritten target receives a synthetic `drop` event followed by `invalidate`.
2. Db- or cluster-scoped watcher observes `drop` (overwritten target) ordered strictly before `rename` (src → dst), both carrying the same `clusterTime`.
3. A plain `dropTarget: true` rename whose target does NOT exist emits only `rename` (no spurious drop). Gating on `o.dropTarget` presence, not on the flag.

## Proposed fix

In `src/mongo/db/pipeline/change_stream_event_transform.cpp`, the `kCommand → o.renameCollection` branch (lines 474-495) emits one document per oplog entry today. Extend it to buffer a synthetic `drop` document when `o.dropTarget` is present, ordered before the rename. Resume-token ordering preserved via a new `kSyntheticDropFromRename` discriminator in `resume_token.cpp`.

~30 lines in `change_stream_event_transform.cpp` + 1 line in `resume_token.cpp` + extension to `TransformRenameShowExpandedEvents` in `document_source_change_stream_test.cpp:1880`.

**No C++ modified in this PR** — repro + design only.

## Files

- `jstests/change_streams/rename_drop_target_emits_drop.js` (165) — three cases: collection-scoped, db-scoped, negative no-target
- `src/mongo/db/pipeline/RENAME_DROP_EVENT_FIX.md` (120)

## Verify

```
node --input-type=module --check < jstests/change_streams/rename_drop_target_emits_drop.js
```

## Draft status

Opened as Draft.
