### PR TITLE
SERVER-126545 Change streams: sparse-shard resume token lag + heartbeat design

### DIFF
--- a/jstests/change_streams/sparse_shard_resume_token_lag.js
+++ b/jstests/change_streams/sparse_shard_resume_token_lag.js
@@ -1,0 +1,178 @@
+/**
+ * SERVER-80427 regression test: change-stream resume-token lag on sparse-write shards.
+ *
+ * In a sharded cluster, the cluster-wide change-stream high-water-mark advances only when every
+ * shard reports progress. A shard that does not see writes only advances its oplog via the
+ * periodic-noop writer, whose default cadence is 10s (`periodicNoopIntervalSecs`). Under a
+ * sparse-write workload (writes concentrated on a subset of shards), consumers observe the
+ * `postBatchResumeToken` (PBRT) lag behind the cluster's current time by up to one noop interval,
+ * even though the producing shard is writing continuously.
+ *
+ * This test pins the lag empirically. It is expected to FAIL on a build that does not include the
+ * fix proposed in `src/mongo/db/pipeline/SPARSE_SHARD_HEARTBEAT_DESIGN.md` (heartbeat-driven PBRT
+ * advancement that does not require an oplog write on every shard). Once that fix lands, the
+ * threshold below should be tightened to a small constant (e.g. <= 2s) and the
+ * `expectedToFailToday` flag flipped.
+ *
+ * @tags: [
+ *   requires_sharding,
+ *   requires_majority_read_concern,
+ *   uses_change_streams,
+ *   __TEMPORARILY_DISABLED__,
+ * ]
+ */
+import {ShardingTest} from "jstests/libs/shardingtest.js";
+
+// The fix is not yet in place; this test is a regression pin and is expected to fail today.
+const expectedToFailToday = true;
+
+// Default `periodicNoopIntervalSecs` is 10s. We pick a lag threshold below that ceiling but well
+// above any realistic per-batch processing time, so a passing run on a fixed build is unambiguous.
+const lagThresholdSeconds = 5;
+
+// Sample the resume token this many times after the initial settle. Each sample is one getMore
+// round-trip on the change-stream cursor; lag is measured at each sample.
+const numSamples = 20;
+const sampleSpacingMs = 500;
+const settleMs = 1000;
+
+// Write rate on the active shard. Sparse enough that we are not stress-testing throughput, dense
+// enough that the active shard's oplog is always advancing.
+const writeIntervalMs = 100; // ~10 writes/s on shard0
+const totalActiveWrites = ((numSamples * sampleSpacingMs) + settleMs) / writeIntervalMs;
+
+// Use the production default for periodicNoopIntervalSecs (10s) so the test reproduces the
+// production complaint. Tests that want to lower this knob to verify a workaround should clone
+// this file and adjust this parameter alone.
+const st = new ShardingTest({
+    shards: 3,
+    mongos: 1,
+    rs: {
+        nodes: 1,
+        setParameter: {
+            writePeriodicNoops: true,
+            periodicNoopIntervalSecs: 10,
+        },
+    },
+});
+
+const dbName = jsTestName();
+const collName = jsTestName();
+const mongosDB = st.s0.getDB(dbName);
+const mongosColl = mongosDB[collName];
+
+// Shard on {_id: 1} so we can pin every test write to shard0 with negative ids while the other
+// two shards stay write-idle.
+assert.commandWorked(mongosDB.adminCommand({enableSharding: dbName, primaryShard: st.rs0.getURL()}));
+assert.commandWorked(mongosDB.adminCommand({shardCollection: mongosColl.getFullName(), key: {_id: 1}}));
+
+// Three chunks across three shards. Negative ids live on shard0; the other ranges live on shards
+// 1 and 2 and will receive zero writes during the test window.
+assert.commandWorked(mongosDB.adminCommand({split: mongosColl.getFullName(), middle: {_id: 0}}));
+assert.commandWorked(mongosDB.adminCommand({split: mongosColl.getFullName(), middle: {_id: 1000000}}));
+assert.commandWorked(
+    mongosDB.adminCommand({moveChunk: mongosColl.getFullName(), find: {_id: 1}, to: st.rs1.getURL()}),
+);
+assert.commandWorked(
+    mongosDB.adminCommand({moveChunk: mongosColl.getFullName(), find: {_id: 2000000}, to: st.rs2.getURL()}),
+);
+
+// Open a whole-cluster change stream on mongos. The PBRT it reports must merge the high-water-mark
+// of all three shards; on shards 1 and 2 that mark only ticks when the periodic-noop writer fires.
+const csCursor = mongosColl.watch([], {cursor: {batchSize: 0}});
+
+// Initial settle: wait for the stream to publish its first PBRT before driving any writes.
+sleep(settleMs);
+const initialPBRT = csCursor.getResumeToken();
+assert.neq(undefined, initialPBRT, "stream did not report an initial postBatchResumeToken");
+
+// Start a writer that touches only shard0. We deliberately do not synchronise it with the sampler
+// thread; the test is interested in the lag between mongos's wall clock and the PBRT clusterTime,
+// not in any per-write causal relationship.
+const writerSpec = {
+    host: st.s0.host,
+    dbName,
+    collName,
+    totalWrites: Math.ceil(totalActiveWrites) + numSamples,
+    intervalMs: writeIntervalMs,
+};
+const writerThread = new Thread(function (spec) {
+    const conn = new Mongo(spec.host);
+    const coll = conn.getDB(spec.dbName)[spec.collName];
+    for (let i = 0; i < spec.totalWrites; ++i) {
+        // Negative ids guarantee placement on shard0.
+        assert.commandWorked(coll.insert({_id: -1 - i, t: new Date()}));
+        sleep(spec.intervalMs);
+    }
+}, writerSpec);
+writerThread.start();
+
+// `getResumeToken` returns `{_data: <hex>}` once decoded by mongos. The resume-token's
+// clusterTime is the first 8 bytes of the keyString-encoded `_data`, but the shell does not export
+// `decodeResumeToken` from `change_stream_util.js` in every passthrough; we fall back on the cheap
+// trick of asking the cluster for `$$CLUSTER_TIME` via `hello` and comparing it against the PBRT's
+// extractable clusterTime via the `_internalChangeStreamSplitLargeEvent` no-op marker. To keep the
+// test self-contained we instead use the helper exposed on the cursor: `csCursor.getResumeToken()`
+// is monotonic in clusterTime, so we sample (wall clock at mongos, PBRT) pairs and assert the
+// elapsed wall-clock distance between a freshly-issued mongos `hello` and the latest PBRT.
+function nowClusterTimeSeconds() {
+    const helloRes = assert.commandWorked(mongosDB.adminCommand({hello: 1}));
+    // $clusterTime.clusterTime is a Timestamp; .getTime() yields seconds.
+    return helloRes.$clusterTime.clusterTime.getTime();
+}
+
+function pbrtClusterTimeSeconds(token) {
+    // The resume token's _data encodes the binary keyString; the top of that keyString is the
+    // clusterTime. We re-derive it via a comparison probe: open a one-shot stream with
+    // `startAfter: token` and ask for its operationTime, which equals the token's clusterTime.
+    const probeRes = assert.commandWorked(
+        mongosDB.runCommand({
+            aggregate: collName,
+            pipeline: [{$changeStream: {startAfter: token}}],
+            cursor: {batchSize: 0},
+        }),
+    );
+    const probeCursor = new DBCommandCursor(mongosDB, probeRes);
+    const ts = probeRes.operationTime;
+    probeCursor.close();
+    return ts.getTime();
+}
+
+const samples = [];
+for (let i = 0; i < numSamples; ++i) {
+    sleep(sampleSpacingMs);
+    const pbrt = csCursor.getResumeToken();
+    const nowTs = nowClusterTimeSeconds();
+    const pbrtTs = pbrtClusterTimeSeconds(pbrt);
+    const lagSecs = nowTs - pbrtTs;
+    samples.push({sample: i, nowTs, pbrtTs, lagSecs});
+    jsTestLog(`sample[${i}] now=${nowTs} pbrt=${pbrtTs} lag=${lagSecs}s`);
+}
+
+writerThread.join();
+csCursor.close();
+
+const maxLag = samples.reduce((m, s) => Math.max(m, s.lagSecs), 0);
+const meanLag = samples.reduce((acc, s) => acc + s.lagSecs, 0) / samples.length;
+jsTestLog(`SERVER-80427 sparse-shard PBRT lag: max=${maxLag}s mean=${meanLag.toFixed(2)}s`);
+
+const failureMsg =
+    `SERVER-80427 regression pin: max PBRT lag ${maxLag}s exceeds threshold ${lagThresholdSeconds}s. ` +
+    `Two of three shards saw zero writes; PBRT was throttled to the periodic-noop cadence. ` +
+    `samples=${tojsononeline(samples)}`;
+
+try {
+    assert.lt(
+        maxLag,
+        lagThresholdSeconds,
+        failureMsg,
+    );
+} catch (e) {
+    if (expectedToFailToday) {
+        jsTestLog(`EXPECTED FAILURE (will pass with proposed fix): ${e.message}`);
+    } else {
+        throw e;
+    }
+}
+
+st.stop();

--- a/src/mongo/db/pipeline/SPARSE_SHARD_HEARTBEAT_DESIGN.md
+++ b/src/mongo/db/pipeline/SPARSE_SHARD_HEARTBEAT_DESIGN.md
@@ -1,0 +1,124 @@
+# Sparse-Shard Change-Stream Heartbeat
+
+**Status:** Draft proposal, contribution against SERVER-80427.
+**Owner:** Query Execution (heartbeat protocol) + Replication (oplog interaction).
+**Test pin:** `jstests/change_streams/sparse_shard_resume_token_lag.js`.
+
+## 1. Motivation
+
+SERVER-80427 documents a long-standing complaint: in a sharded cluster, the
+cluster-wide change-stream high-water-mark (the `postBatchResumeToken`, "PBRT"
+hereafter) advances only when every shard reports progress. The mongos-side
+merge stage (`DocumentSourceChangeStreamHandleTopologyChangeV2`, running on
+`HostTypeRequirement::kRouter`) takes the minimum across per-shard cursors,
+which is the only safe choice for total ordering of events. The consequence is
+that a shard which sees no writes only advances its oplog via the
+`NoopWriter` (`src/mongo/db/repl/noop_writer.cpp`), whose default cadence is
+`periodicNoopIntervalSecs = 10s`. Consumers therefore see a 5-10s steady-state
+PBRT lag on any sparse-write workload — even though the actively-written shard
+is producing events at line rate. The current workaround (write a TTL'd dummy
+document to every shard on a cron) is operationally awkward and trains
+operators to keep `periodicNoopIntervalSecs = 1` everywhere, which has measurable
+journal-IO and oplog-growth cost on otherwise-quiet shards.
+
+## 2. Proposed Approaches
+
+### Approach A: Server-Level Heartbeat → No-Op Oplog Writes
+
+A new server-level thread on each primary periodically writes a typed no-op
+oplog entry whenever the shard is idle, at a cadence shorter than
+`periodicNoopIntervalSecs` (a new tunable, `changeStreamHeartbeatIntervalMs`,
+default 500ms). The entry is shape-distinguishable from existing periodic
+noops (e.g. `o: {msg: "changeStreamHeartbeat"}`) so that secondary apply, oplog
+fetchers, and existing change-stream filters can ignore it cheaply, but the
+oplog timestamp it produces is observable through the change-stream
+high-water-mark just like any other event.
+
+- **Pros:** Zero changes to the mongos merge path or wire protocol. Reuses the
+  existing `NoopWriter` plumbing. Causality and total ordering are preserved
+  by construction (the heartbeat IS an oplog entry).
+- **Cons:** Write-amplification. Every shard pays a steady-state write at the
+  new cadence, increasing journal IO, oplog size, and (for nodes that drive
+  followers) replication network traffic. The cost is proportional to
+  shard count, not load.
+
+### Approach B: Synthetic High-Water-Mark Events at the Router
+
+Each shard's mongod exposes a lightweight `_getResumeToken` command that
+returns its current oplog timestamp without writing. Mongos polls this command
+on a `changeStreamHeartbeatIntervalMs` cadence and feeds the result into the
+PBRT merge logic as a synthetic, non-event "topology heartbeat" sortKey. The
+resulting PBRT advances as the slowest shard's oplog timestamp advances,
+regardless of whether the shard wrote.
+
+- **Pros:** No oplog writes. Zero steady-state cost on quiet shards. The
+  cadence becomes a pure router-side concern and can be tuned per cluster.
+- **Cons:** Mongos must learn each shard's clock authoritatively and survive
+  shard restarts, stepdowns, and topology changes; the heartbeat poll path
+  becomes a new failure mode independent of the data path. Resume tokens
+  produced from synthetic heartbeats must remain wire-compatible with tokens
+  produced from real events so that `resumeAfter` / `startAfter` round-trip
+  correctly on any release.
+
+## 3. Recommendation: Approach A with a Targeted Optimisation
+
+We recommend **Approach A**, on three grounds:
+
+1. **Causality is local.** Resume tokens are oplog timestamps. Generating
+   them at the shard that owns the clock avoids inventing a new distributed
+   coordination protocol with its own failure modes (the well-known
+   correctness gap behind several historical change-stream incidents).
+2. **The write-amplification cost is bounded and tunable.** A 500ms heartbeat
+   on a 3-shard cluster is six oplog entries per second, dwarfed by realistic
+   workloads. Operators who want zero idle write traffic can disable the
+   feature per-shard via the existing `writePeriodicNoops` parameter.
+3. **Approach B re-implements something we already have.** The periodic-noop
+   writer was added precisely to bridge this gap; the fix is to make it
+   adaptive, not to bypass it.
+
+The targeted optimisation: make the heartbeat write **conditional**. The
+heartbeat thread only writes when `(now - lastAppliedOpTime) >
+changeStreamHeartbeatIntervalMs` AND there is at least one open change-stream
+cursor on the node (tracked via the existing
+`CursorManager` notification on cursor registration). A shard with no open
+cursors pays nothing; a shard with open cursors but active writes also pays
+nothing (because `lastAppliedOpTime` is fresh). The steady-state cost falls to
+zero on every shard except the genuinely-idle ones that have a consumer
+waiting on them — exactly the population we are trying to serve.
+
+## 4. Wire-Format Implications
+
+**Additive only.** Both the heartbeat oplog entry and the PBRT it produces use
+existing schemas:
+
+- Heartbeat oplog entry: `{op: "n", o: {msg: "changeStreamHeartbeat"}}`,
+  filtered out by `DocumentSourceChangeStreamCheckTopologyChange` and
+  `DocumentSourceChangeStreamUnwindTransaction` exactly like the existing
+  `periodic noop` entries.
+- PBRT: unchanged. The resume token already carries a clusterTime; the
+  heartbeat just keeps that clusterTime fresh.
+
+A new server parameter `changeStreamHeartbeatIntervalMs` is added behind a
+default-off feature flag `featureFlagChangeStreamSparseShardHeartbeat`. With
+the flag off, behaviour is bit-identical to today.
+
+## 5. Testing Strategy
+
+1. **Regression pin (this PR):**
+   `jstests/change_streams/sparse_shard_resume_token_lag.js` — a 3-shard
+   cluster with writes confined to shard 0, asserts max PBRT lag < 5s. Fails
+   today (default `periodicNoopIntervalSecs = 10s`); passes with the
+   heartbeat enabled at 500ms.
+2. **Cadence parameterisation:** sweep `changeStreamHeartbeatIntervalMs ∈
+   {100, 500, 1000, 5000}` and assert the lag tracks the cadence linearly.
+3. **Zero-cursor invariant:** with no open change-stream cursors on any
+   shard, assert oplog growth on idle shards is unchanged versus today
+   (the conditional gate must hold).
+4. **Topology change interaction:** open a cluster-wide stream, add a shard
+   mid-stream, assert the new shard's first heartbeat advances the PBRT
+   within one cadence interval (no extra wait for the first real write on
+   that shard).
+5. **Resume across heartbeats:** capture a PBRT produced solely from
+   heartbeat entries (no real writes on any shard during the capture window)
+   and assert `resumeAfter` and `startAfter` both succeed and produce a
+   stream that delivers the next real event without loss.


### PR DESCRIPTION
## Summary

Adds (a) a regression jstest pinning SERVER-80427's sparse-shard resume-token lag at HEAD and (b) a design doc for an opt-in heartbeat mechanism that fixes the lag without unconditional write-amplification.

**Jira:** https://jira.mongodb.org/browse/SERVER-126545

## Issue

Change streams on sharded clusters show steady-state `postBatchResumeToken` lag of `periodicNoopIntervalSecs` (default 10s) when one or more shards see no writes. Operators currently work around it by issuing TTL'd dummy writes to every shard or by lowering `periodicNoopIntervalSecs` cluster-wide (at the cost of oplog-growth and journal-IO on otherwise-quiet shards).

## jstest

3-shard `ShardingTest` with `periodicNoopIntervalSecs: 10`. Background thread writes ~10 ops/s only to shard 0; shards 1 and 2 stay write-idle. Whole-cluster `mongosColl.watch()` opened. 20 samples at 500ms spacing of `(mongos $clusterTime via hello, PBRT clusterTime via probe stream's operationTime)`. **Asserts `maxLag < 5s`.** Wrapped in `expectedToFailToday` so it logs an EXPECTED FAILURE rather than red-failing CI; tagged `__TEMPORARILY_DISABLED__`.

## Design doc

Two approaches compared:
- **Approach A** — periodic no-op oplog writes on idle shards via new `changeStreamHeartbeatIntervalMs` parameter extending the existing `NoopWriter`. Tradeoff: write-amplification proportional to shard count.
- **Approach B** — synthetic high-water-mark events polled by mongos from each shard without writing. Tradeoff: new distributed coordination protocol with independent failure modes.

**Recommendation:** Approach A with a **conditional gate** — heartbeat fires only when `(now − lastAppliedOpTime) > heartbeatInterval` AND ≥1 open change-stream cursor on the node. Zero steady-state cost on idle shards without consumers; fixes lag only for shards with waiting consumers.

## Wire-format impact

Additive only. Heartbeat oplog entry shape-distinguishable (`{op:"n", o:{msg:"changeStreamHeartbeat"}}`), filtered out by existing change-stream stages. Gated by default-off `featureFlagChangeStreamSparseShardHeartbeat`; bit-identical to today with the flag off.

## Files

- `jstests/change_streams/sparse_shard_resume_token_lag.js` (178)
- `src/mongo/db/pipeline/SPARSE_SHARD_HEARTBEAT_DESIGN.md` (124)

## Verify

```
node --input-type=module --check < jstests/change_streams/sparse_shard_resume_token_lag.js
```

## Draft status

Opened as Draft.
