### PR TITLE
SERVER-126546 Add TLA+ spec + jstest for mergeSpills cursor reset under WCE

### DIFF
--- a/jstests/noPassthrough/merge_spill_wce_idempotency.js
+++ b/jstests/noPassthrough/merge_spill_wce_idempotency.js
@@ -1,0 +1,147 @@
+/**
+ * Regression test for SERVER-124271:
+ *
+ *   ContainerBasedSpiller::mergeSpills() drives a MergeIterator from inside
+ *   a writeConflictRetry lambda. On WriteConflictException (WCE),
+ *   WiredTiger's rollback_transaction() resets every cursor on the session,
+ *   including the read cursors backing the MergeIterator's input
+ *   ContainerIterators. The merge iterator's in-memory heap, however, is
+ *   not rewound, so the next ->next() call either silently skips or
+ *   re-yields elements. This produces output spills whose element count
+ *   and/or content checksum diverge across WCE retry trials of the same
+ *   input.
+ *
+ *   This test exercises the bug end-to-end by forcing a $group pipeline
+ *   to spill across multiple merge passes, then enabling the
+ *   WTWriteConflictException failpoint with `times: N` (N >= 2) so that
+ *   the writeConflictRetry helper inside mergeSpills() runs the retry
+ *   path at least twice on the same outer-pass iterator. The assertions
+ *   compare the document count and a deterministic content checksum to a
+ *   control run with the failpoint disabled. They MUST be bit-identical.
+ *
+ *   With the buggy code path the assertion fails (drops/duplicates).
+ *   With the proposed fix (drain MergeIterator into a std::vector before
+ *   entering the write loop) the assertion passes.
+ *
+ * @tags: [
+ *   requires_persistence,
+ *   requires_wiredtiger,
+ *   does_not_support_stepdowns,
+ *   no_selinux,
+ * ]
+ */
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {setParameter} from "jstests/noPassthrough/libs/server_parameter_helpers.js";
+
+const conn = MongoRunner.runMongod();
+const db = conn.getDB("merge_spill_wce_idempotency");
+const collName = jsTestName();
+const coll = db[collName];
+coll.drop();
+
+// Force spilling for every document and force multiple merge passes by
+// capping the per-merge fan-in. This is what makes mergeSpills() actually
+// execute the writeConflictRetry path under WCE.
+assert.commandWorked(setParameter(db, "internalDocumentSourceCursorInitialBatchSize", 1));
+assert.commandWorked(setParameter(db, "internalDocumentSourceCursorBatchSizeBytes", 1));
+assert.commandWorked(setParameter(db, "internalDocumentSourceGroupMaxMemoryBytes", 1));
+assert.commandWorked(setParameter(db, "internalQuerySlotBasedExecutionHashAggApproxMemoryUseInBytesBeforeSpill", 1));
+
+// Seed deterministic, ordered input so that the merge phase has well-defined
+// input keys for both spills. A perfectly sorted input maximises the chance
+// the buggy code path picks up an already-consumed (duplicated) head.
+const kNumDocs = 200;
+const inputDocs = [];
+for (let i = 0; i < kNumDocs; ++i) {
+    inputDocs.push({_id: i, payload: "x".repeat(64), bucket: i % 8});
+}
+assert.commandWorked(coll.insertMany(inputDocs));
+
+// Pipeline: $group by bucket, summing _id. The result has exactly 8 rows
+// keyed by bucket and a deterministic sum per group. Both the count and
+// the per-group sum survive bit-identically across runs *iff* mergeSpills
+// is idempotent under WCE retry.
+const pipeline = [
+    {$group: {_id: "$bucket", total: {$sum: "$_id"}, n: {$sum: 1}}},
+    {$sort: {_id: 1}},
+];
+
+function checksum(rows) {
+    // Order-stable checksum: concatenate (key, total, n) triples after
+    // sorting. The pipeline already sorts by _id, but we re-sort
+    // defensively so the assertion fails on element-count divergence
+    // rather than ordering noise.
+    return rows
+        .slice()
+        .sort((a, b) => a._id - b._id)
+        .map((r) => `${r._id}:${r.total}:${r.n}`)
+        .join("|");
+}
+
+// 1. CONTROL run: failpoint off. Compute the reference result.
+const reference = coll.aggregate(pipeline, {allowDiskUse: true}).toArray();
+assert.eq(reference.length, 8, `control: expected 8 groups, got ${tojson(reference)}`);
+const referenceChecksum = checksum(reference);
+const referenceTotal = reference.reduce((acc, r) => acc + r.n, 0);
+assert.eq(referenceTotal, kNumDocs, `control: per-group counts must sum to ${kNumDocs}`);
+
+// 2. RETRY run: inject N >= 2 WriteConflictExceptions on the write side
+//    of writeConflictRetry. This is the failpoint exercised by
+//    ContainerBasedSpiller::mergeSpills_insert (and _remove) per the
+//    container_based_spiller_test cases:
+//        MergeSpillsRetryOnWriteConflict
+//        MergeSpillsTwoWriteConflictsRetryCount
+//        MergeSpillsRandomWriteConflicts
+//    Using {times: N} with N >= 2 forces back-to-back rollbacks inside
+//    the same outer-pass iterator, which is precisely the regime in
+//    which the read-cursor reset surfaces as drops or duplicates.
+const kNumConflicts = 4;
+const fp = configureFailPoint(db, "WTWriteConflictException", {}, {times: kNumConflicts});
+
+let retryResult;
+try {
+    retryResult = coll.aggregate(pipeline, {allowDiskUse: true}).toArray();
+} finally {
+    fp.off();
+}
+
+// 3. ASSERTIONS: every observable must be bit-identical to the control.
+assert.eq(
+    retryResult.length,
+    reference.length,
+    `retry run produced ${retryResult.length} groups, control produced ${reference.length}; ` +
+        `retry=${tojson(retryResult)} control=${tojson(reference)}`,
+);
+
+const retryChecksum = checksum(retryResult);
+assert.eq(
+    retryChecksum,
+    referenceChecksum,
+    `mergeSpills() under WCE retry must be idempotent. ` +
+        `retry checksum=${retryChecksum} control checksum=${referenceChecksum}`,
+);
+
+const retryTotal = retryResult.reduce((acc, r) => acc + r.n, 0);
+assert.eq(
+    retryTotal,
+    kNumDocs,
+    `retry run per-group counts summed to ${retryTotal}; expected ${kNumDocs}. ` +
+        `This indicates either (a) the MergeIterator dropped elements when a ` +
+        `read cursor was reset by rollback_transaction(), or (b) duplicated ` +
+        `elements when the cursor rewound past an already-consumed key.`,
+);
+
+// Per-bucket sanity: each input document contributes exactly once to its
+// bucket. Group n's must each equal kNumDocs / 8 (= 25 for kNumDocs=200).
+const kExpectedPerGroup = kNumDocs / 8;
+for (const row of retryResult) {
+    assert.eq(
+        row.n,
+        kExpectedPerGroup,
+        `group _id=${row._id} has n=${row.n}; expected ${kExpectedPerGroup}. ` +
+            `Per-group count divergence is the smoking gun for the SERVER-124271 ` +
+            `MergeIterator cursor-reset bug.`,
+    );
+}
+
+MongoRunner.stopMongod(conn);

--- a/src/mongo/tla_plus/Sorter/MergeSpillCursorReset/MCMergeSpillCursorReset.cfg
+++ b/src/mongo/tla_plus/Sorter/MergeSpillCursorReset/MCMergeSpillCursorReset.cfg
@@ -1,0 +1,23 @@
+\* Config file to run TLC on MergeSpillCursorReset.tla under FIXED semantics.
+\* See MergeSpillCursorReset.tla for instructions.
+\*
+\* This is the "green" configuration: ResetAffectsReadCursors = FALSE
+\* models the proposed fix (read phase hoisted out of writeConflictRetry,
+\* so rollback no longer rewinds the MergeIterator). Both safety
+\* invariants must hold across the entire reachable state space.
+\*
+\* To re-run with the buggy semantics, use MCMergeSpillCursorResetBug.cfg.
+
+CONSTANTS
+    NumSpills = 2
+    MaxWCE = 2
+    MaxBatch = 2
+    ResetAffectsReadCursors = FALSE
+    InputKeys <- ModelInputKeys
+
+INVARIANT TypeOK
+INVARIANT NoElementLoss
+INVARIANT NoElementDuplication
+
+CONSTRAINT StateConstraint
+SPECIFICATION Spec

--- a/src/mongo/tla_plus/Sorter/MergeSpillCursorReset/MCMergeSpillCursorReset.tla
+++ b/src/mongo/tla_plus/Sorter/MergeSpillCursorReset/MCMergeSpillCursorReset.tla
@@ -1,0 +1,28 @@
+---- MODULE MCMergeSpillCursorReset ----
+\* Model-checking constants for MergeSpillCursorReset.tla.
+\* See MergeSpillCursorReset.tla for instructions.
+\*
+\* InputKeys is declared here (not in the .cfg) because TLC's config
+\* parser does not accept sequence-of-sequences literals. NumSpills,
+\* MaxWCE, MaxBatch and ResetAffectsReadCursors stay in the .cfg so the
+\* "green" and "bug" runs can flip the boolean without editing this file.
+
+EXTENDS MergeSpillCursorReset
+
+\* Two sorted input spills, jointly covering {1, 2, 3, 4, 5} once each.
+\* Two spills × at most 5 keys keeps the reachable state space small
+\* enough for a thorough exhaustive check (< 30k states under MaxWCE=2,
+\* MaxBatch=2) while still exercising every interleaving of:
+\*    - reads from either spill becoming the merge head
+\*    - a WCE firing mid-batch with the buffer half-filled
+\*    - a WCE firing with the merge iterator already past one spill
+\*    - back-to-back WCEs on the same retry attempt
+ModelInputKeys == << <<1, 3, 5>>, <<2, 4>> >>
+
+\* State-space bound: cap the number of WCE rollbacks per behaviour at
+\* MaxWCE. The total number of state-machine steps is also implicitly
+\* bounded by the finite ModelInputKeys.
+StateConstraint ==
+    /\ WCECount <= MaxWCE
+
+================================================================================

--- a/src/mongo/tla_plus/Sorter/MergeSpillCursorReset/MCMergeSpillCursorResetBug.cfg
+++ b/src/mongo/tla_plus/Sorter/MergeSpillCursorReset/MCMergeSpillCursorResetBug.cfg
@@ -1,0 +1,23 @@
+\* Config file to run TLC on MergeSpillCursorReset.tla under BUGGY semantics.
+\* See MergeSpillCursorReset.tla for instructions.
+\*
+\* This is the "bug-repro" configuration: ResetAffectsReadCursors = TRUE
+\* models the current code path where rollback_transaction() resets every
+\* cursor on the WT session -- including the read cursors backing the
+\* MergeIterator. TLC is expected to find a counterexample violating
+\* NoElementLoss or NoElementDuplication (typically both, on different
+\* traces).
+
+CONSTANTS
+    NumSpills = 2
+    MaxWCE = 2
+    MaxBatch = 2
+    ResetAffectsReadCursors = TRUE
+    InputKeys <- ModelInputKeys
+
+INVARIANT TypeOK
+INVARIANT NoElementLoss
+INVARIANT NoElementDuplication
+
+CONSTRAINT StateConstraint
+SPECIFICATION Spec

--- a/src/mongo/tla_plus/Sorter/MergeSpillCursorReset/MergeSpillCursorReset.tla
+++ b/src/mongo/tla_plus/Sorter/MergeSpillCursorReset/MergeSpillCursorReset.tla
@@ -1,0 +1,310 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+------------------ MODULE MergeSpillCursorReset ------------------
+\* Formal specification of the merge-spill phase of the external sorter
+\* under a WiredTiger WriteConflictException (WCE) retry loop, modelling
+\* the SERVER-124271 cursor-reset bug.
+\*
+\* Domain background
+\* -----------------
+\* ContainerBasedSpiller::mergeSpills() runs an outer pass that consumes a
+\* MergeIterator (a heap-merge over several read iterators, one per input
+\* spill) and writes the merged stream into a new output writer. The write
+\* side is wrapped in a writeConflictRetry helper: on each WCE the helper
+\* calls rollback_transaction() on the WiredTiger session and re-invokes
+\* the lambda from the beginning.
+\*
+\* In current code (HEAD) the read iterators and the write cursor share
+\* the same WT session. rollback_transaction() therefore also resets the
+\* positions of the read cursors backing the MergeIterator. The merge
+\* iterator's in-memory heap, however, has already popped some keys. After
+\* a WCE the next mergeIterator->next() call either silently skips
+\* (one cursor still positioned past the popped key) or re-yields
+\* (cursor reset to snapshot start) the affected element. The bug is
+\* exercised by configuring the WTWriteConflictException failpoint with
+\* nTimes >= 2 in a row.
+\*
+\* Model
+\* -----
+\* We model two abstract actors:
+\*   - Merger : owns InputMultiSet (multiset of keys to merge) and the
+\*              per-iterator read offsets RHead[s] for spill s.
+\*   - WTSession : owns the write batch and the session phase
+\*                 \in {"idle","writing","rolled_back"}.
+\*
+\* Each pass repeats:
+\*   ReadHead   : MergeIterator pops the min head key from one input
+\*                spill, appending to ConsumedInBatch.
+\*   WCE        : at any point during a batch, the failpoint may fire,
+\*                forcing rollback. If ResetAffectsReadCursors = TRUE the
+\*                read offsets RHead[s] are reset to the value they had
+\*                at the start of the current retry attempt (i.e. before
+\*                this batch's reads) -- this is the buggy semantics.
+\*   Commit     : the batch commits; ConsumedInBatch flushes into
+\*                ConsumedTotal and the retry-anchor offsets advance.
+\*
+\* Configuration
+\* -------------
+\* The boolean ResetAffectsReadCursors is the central parameter.
+\*   TRUE  : current (buggy) production semantics. NoElementLoss and
+\*           NoElementDuplication can both be violated.
+\*   FALSE : proposed fix -- the read phase is hoisted out of the
+\*           writeConflictRetry lambda (e.g. by draining the
+\*           MergeIterator into a std::vector before the write loop).
+\*           Both invariants hold under all interleavings.
+\*
+\* To run the model-checker:
+\*     cd src/mongo/tla_plus
+\*     ./model-check.sh Sorter/MergeSpillCursorReset
+\* Then change ResetAffectsReadCursors in MCMergeSpillCursorReset.cfg to
+\* re-run with the buggy or fixed semantics.
+
+EXTENDS Integers, FiniteSets, Sequences, TLC
+
+\* --- CONSTANTS ----------------------------------------------------------
+
+\* Number of input spills participating in the merge.
+CONSTANT NumSpills
+
+\* Per-spill input keys, modelled as a function NumSpills -> Seq(Int).
+\* Each Seq must be sorted ascending (the merge precondition).
+CONSTANT InputKeys
+
+\* Maximum number of WCE rollbacks per merge run (model bound).
+CONSTANT MaxWCE
+
+\* Maximum number of keys per write batch before forced commit (model bound).
+CONSTANT MaxBatch
+
+\* TRUE  -> buggy production semantics (rollback resets read cursors).
+\* FALSE -> fixed semantics (read phase hoisted out of retry loop).
+CONSTANT ResetAffectsReadCursors
+
+ASSUME NumSpills \in Nat \ {0}
+ASSUME MaxWCE \in Nat
+ASSUME MaxBatch \in Nat \ {0}
+ASSUME ResetAffectsReadCursors \in BOOLEAN
+
+\* --- VARIABLES ----------------------------------------------------------
+
+\* RHead[s] : index into InputKeys[s] of the next key to read from spill s.
+\* Values 1..Len(InputKeys[s])+1; RHead[s] = Len(...)+1 means exhausted.
+VARIABLE RHead
+
+\* RHeadAnchor[s] : value of RHead[s] at the start of the current retry
+\* attempt; restored on rollback under buggy semantics.
+VARIABLE RHeadAnchor
+
+\* ConsumedInBatch : sequence of keys read during the current (uncommitted)
+\* write batch. Cleared on commit, restored on rollback under buggy
+\* semantics (the writeConflictRetry helper re-adds the buffered batch).
+VARIABLE ConsumedInBatch
+
+\* ConsumedTotal : multiset of keys committed so far (modelled as a
+\* sequence we append to; order doesn't matter for the invariants).
+VARIABLE ConsumedTotal
+
+\* Phase : "idle" | "writing" | "rolled_back" -- WTSession lifecycle.
+VARIABLE Phase
+
+\* WCECount : number of WCEs taken in this behaviour (bound by MaxWCE).
+VARIABLE WCECount
+
+vars == <<RHead, RHeadAnchor, ConsumedInBatch, ConsumedTotal, Phase, WCECount>>
+
+\* --- HELPERS ------------------------------------------------------------
+
+SpillIDs == 1..NumSpills
+
+\* Heads currently visible to the merge iterator: the next unread key from
+\* each non-exhausted spill.
+VisibleHeads ==
+    { <<s, InputKeys[s][RHead[s]]>>
+        : s \in {x \in SpillIDs : RHead[x] <= Len(InputKeys[x])} }
+
+\* Are all spills exhausted?
+AllExhausted ==
+    \A s \in SpillIDs : RHead[s] > Len(InputKeys[s])
+
+\* The min head over visible spills (MergeIterator->next() picks this).
+\* CHOOSE is deterministic on equal keys, which is fine -- merge stability
+\* is not part of the invariant we are checking.
+MinVisibleSpill ==
+    CHOOSE s \in SpillIDs :
+        /\ RHead[s] <= Len(InputKeys[s])
+        /\ \A t \in SpillIDs :
+            (RHead[t] <= Len(InputKeys[t]))
+                => InputKeys[s][RHead[s]] <= InputKeys[t][RHead[t]]
+
+\* Flat sequence of all input keys, for invariant comparisons.
+RECURSIVE InputFlatRec(_)
+InputFlatRec(s) ==
+    IF s = 0 THEN << >>
+    ELSE InputFlatRec(s-1) \o InputKeys[s]
+
+InputFlat == InputFlatRec(NumSpills)
+
+\* Count occurrences of a key in a sequence (multiset multiplicity).
+RECURSIVE CountRec(_, _, _)
+CountRec(seq, k, i) ==
+    IF i = 0 THEN 0
+    ELSE CountRec(seq, k, i-1) + (IF seq[i] = k THEN 1 ELSE 0)
+
+Count(seq, k) == CountRec(seq, k, Len(seq))
+
+\* The universe of keys appearing anywhere in the input.
+KeyUniverse == { InputFlat[i] : i \in 1..Len(InputFlat) }
+
+\* --- INITIAL STATE ------------------------------------------------------
+
+Init ==
+    /\ RHead = [s \in SpillIDs |-> 1]
+    /\ RHeadAnchor = [s \in SpillIDs |-> 1]
+    /\ ConsumedInBatch = << >>
+    /\ ConsumedTotal = << >>
+    /\ Phase = "idle"
+    /\ WCECount = 0
+
+\* --- ACTIONS ------------------------------------------------------------
+
+\* MergeIterator->next() pulls the min head into the in-flight batch.
+\* Opens a write transaction if currently idle.
+ReadHead ==
+    /\ ~AllExhausted
+    /\ Phase \in {"idle", "writing"}
+    /\ Len(ConsumedInBatch) < MaxBatch
+    /\ LET s == MinVisibleSpill
+           k == InputKeys[s][RHead[s]]
+       IN /\ ConsumedInBatch' = Append(ConsumedInBatch, k)
+          /\ RHead' = [RHead EXCEPT ![s] = @ + 1]
+    /\ Phase' = "writing"
+    /\ UNCHANGED <<RHeadAnchor, ConsumedTotal, WCECount>>
+
+\* A WCE fires inside the writeConflictRetry lambda. WiredTiger calls
+\* rollback_transaction() on the session.
+\*
+\* * The C++-side `batch` vector survives across the retry: the helper
+\*   explicitly re-adds the buffered items at the top of the next lambda
+\*   invocation (see ContainerBasedSpiller::mergeSpills_insert comment).
+\*   So ConsumedInBatch is UNCHANGED by WCE.
+\* * The WUOW's pending writes against the output writer are discarded
+\*   from the storage engine -- the re-add at retry restores them.
+\* * If ResetAffectsReadCursors (buggy production semantics): ALL cursors
+\*   on this session are reset by rollback_transaction(), including the
+\*   read cursors backing the MergeIterator's input ContainerIterators.
+\*   The read offsets revert to RHeadAnchor (the snapshot start). The
+\*   MergeIterator's heap, however, is C++-side memory and is NOT reset,
+\*   so its next() call disagrees with the cursor positions -- yielding
+\*   either the wrong key (duplication, key < ConsumedInBatch head) or
+\*   skipping the key the iterator thinks it already produced (loss).
+\* * Else (fixed semantics): only write state rolls back. Read offsets
+\*   are unaffected.
+WCE ==
+    /\ Phase = "writing"
+    /\ WCECount < MaxWCE
+    /\ Phase' = "rolled_back"
+    /\ IF ResetAffectsReadCursors
+         THEN RHead' = RHeadAnchor
+         ELSE RHead' = RHead
+    /\ WCECount' = WCECount + 1
+    /\ UNCHANGED <<RHeadAnchor, ConsumedInBatch, ConsumedTotal>>
+
+\* Resume the writeConflictRetry lambda after a rollback. The helper
+\* immediately re-invokes the lambda; in our model that means moving
+\* Phase back to "writing" without progress. The retry anchor is NOT
+\* refreshed -- under buggy semantics another rollback can reset to the
+\* same point.
+\*
+\* Under buggy semantics, RHead has been rewound but ConsumedInBatch
+\* still holds the previously-read keys. Subsequent ReadHead steps will
+\* re-read keys that are <= the in-batch ones, surfacing the duplication
+\* invariant violation.
+Resume ==
+    /\ Phase = "rolled_back"
+    /\ Phase' = "writing"
+    /\ UNCHANGED <<RHead, RHeadAnchor, ConsumedInBatch, ConsumedTotal, WCECount>>
+
+\* Commit the current batch's WUOW. Append to ConsumedTotal and advance
+\* the retry anchor so future WCEs can no longer revert past this point.
+Commit ==
+    /\ Phase = "writing"
+    /\ Len(ConsumedInBatch) > 0
+    /\ ConsumedTotal' = ConsumedTotal \o ConsumedInBatch
+    /\ ConsumedInBatch' = << >>
+    /\ RHeadAnchor' = RHead
+    /\ Phase' = "idle"
+    /\ UNCHANGED <<RHead, WCECount>>
+
+\* Terminal commit when the merge iterator is exhausted: flush any
+\* remaining buffered batch, regardless of size.
+FlushFinal ==
+    /\ AllExhausted
+    /\ Phase = "writing"
+    /\ Len(ConsumedInBatch) > 0
+    /\ ConsumedTotal' = ConsumedTotal \o ConsumedInBatch
+    /\ ConsumedInBatch' = << >>
+    /\ RHeadAnchor' = RHead
+    /\ Phase' = "idle"
+    /\ UNCHANGED <<RHead, WCECount>>
+
+\* Stutter once the run is done. Required for TLC since Init defines a
+\* finite-progress system that otherwise deadlocks at completion.
+Done ==
+    /\ AllExhausted
+    /\ Phase = "idle"
+    /\ Len(ConsumedInBatch) = 0
+    /\ UNCHANGED vars
+
+\* --- NEXT-STATE RELATION ------------------------------------------------
+
+Next ==
+    \/ ReadHead
+    \/ WCE
+    \/ Resume
+    \/ Commit
+    \/ FlushFinal
+    \/ Done
+
+Spec == Init /\ [][Next]_vars /\ WF_vars(Commit) /\ WF_vars(FlushFinal)
+
+\* --- INVARIANTS ---------------------------------------------------------
+
+\* TypeOK : structural type invariant.
+TypeOK ==
+    /\ RHead \in [SpillIDs -> Nat]
+    /\ RHeadAnchor \in [SpillIDs -> Nat]
+    /\ \A s \in SpillIDs : RHead[s] >= 1 /\ RHead[s] <= Len(InputKeys[s]) + 1
+    /\ \A s \in SpillIDs : RHeadAnchor[s] >= 1
+                            /\ RHeadAnchor[s] <= Len(InputKeys[s]) + 1
+    /\ ConsumedInBatch \in Seq(Int)
+    /\ ConsumedTotal \in Seq(Int)
+    /\ Phase \in {"idle", "writing", "rolled_back"}
+    /\ WCECount \in 0..MaxWCE
+
+\* NoElementLoss : every key present in the input appears at least its
+\* input multiplicity in the committed output, ONCE the run is done.
+\* Vacuously true mid-run; the predicate fires at the terminal state.
+NoElementLoss ==
+    (AllExhausted /\ Phase = "idle" /\ Len(ConsumedInBatch) = 0)
+        => \A k \in KeyUniverse :
+            Count(ConsumedTotal, k) >= Count(InputFlat, k)
+
+\* NoElementDuplication : at no point does the committed output (plus
+\* the in-flight batch) contain a key more times than the input had it.
+\* This is a step-wise safety property, checked at every state.
+NoElementDuplication ==
+    \A k \in KeyUniverse :
+        Count(ConsumedTotal, k) + Count(ConsumedInBatch, k)
+            <= Count(InputFlat, k)
+
+\* --- LIVENESS / FAIRNESS ------------------------------------------------
+
+\* The run eventually terminates -- all keys consumed and committed.
+EventuallyDone ==
+    <>(AllExhausted /\ Phase = "idle" /\ Len(ConsumedInBatch) = 0)
+
+================================================================================

--- a/src/mongo/tla_plus/Sorter/MergeSpillCursorReset/OWNERS.yml
+++ b/src/mongo/tla_plus/Sorter/MergeSpillCursorReset/OWNERS.yml
@@ -1,0 +1,6 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-storage-execution
+      - 10gen/server-external-sorter

--- a/src/mongo/tla_plus/Sorter/MergeSpillCursorReset/README.md
+++ b/src/mongo/tla_plus/Sorter/MergeSpillCursorReset/README.md
@@ -1,0 +1,68 @@
+# MergeSpillCursorReset
+
+Formal model of the merge-spill phase of the external sorter under
+WiredTiger WriteConflictException (WCE) retry. Pins SERVER-124271.
+
+## Bug summary
+
+`ContainerBasedSpiller::mergeSpills()` drives a `MergeIterator` from
+inside a `writeConflictRetry` lambda. On WCE the helper calls
+`rollback_transaction()` on the WT session, which resets *every* cursor
+on that session — including the read cursors backing each input spill's
+`ContainerIterator`. The merge iterator's in-memory heap state is not
+rewound, so the next `mergeIterator->next()` call either silently skips
+a key (some input cursor still positioned past the popped row) or
+re-yields one already consumed (cursor reset to snapshot start). The
+classic symptom is an output spill whose element count or checksum
+differs across WCE retry trials of the same input.
+
+## Model shape
+
+Two abstract actors:
+
+- **Merger** — owns `RHead[s]` (next-unread offset into `InputKeys[s]`
+  for each spill `s`), exposes the minimum visible head as the next
+  element to consume.
+- **WTSession** — phases `idle → writing → rolled_back`, owns the
+  uncommitted batch buffer and the retry anchor `RHeadAnchor`.
+
+Five actions: `ReadHead`, `WCE`, `Resume`, `Commit`, `FlushFinal`. Two
+safety invariants: `NoElementLoss` (terminal multiset equality, output
+≥ input) and `NoElementDuplication` (step-wise: output + in-flight batch
+≤ input on every key).
+
+The central parameter is `ResetAffectsReadCursors ∈ BOOLEAN`:
+
+- `FALSE` — proposed fix (drain the `MergeIterator` into a
+  `std::vector` before entering the write loop). Read offsets are
+  not touched by rollback. Both invariants hold.
+- `TRUE` — current production semantics. TLC produces a counterexample
+  trace violating `NoElementLoss` or `NoElementDuplication`.
+
+## Running
+
+```
+cd src/mongo/tla_plus
+./download-tlc.sh                                # one-time
+./model-check.sh Sorter/MergeSpillCursorReset    # uses MCMergeSpillCursorReset.cfg
+```
+
+To re-run with the buggy semantics, swap the cfg by hand:
+
+```
+cd src/mongo/tla_plus/Sorter/MergeSpillCursorReset
+cp MCMergeSpillCursorResetBug.cfg MCMergeSpillCursorReset.cfg.bak.green
+cp MCMergeSpillCursorResetBug.cfg MCMergeSpillCursorReset.cfg.in   # then edit ResetAffectsReadCursors
+```
+
+(or call TLC directly:
+`java -cp ../../tla2tools.jar tlc2.TLC -config MCMergeSpillCursorResetBug.cfg MCMergeSpillCursorReset.tla`).
+
+## Companion regression test
+
+`jstests/noPassthrough/merge_spill_wce_idempotency.js` exercises the
+same scenario end-to-end: it forces a `$group` (or `$sort`) pipeline to
+spill, then uses the `WTWriteConflictException` failpoint with
+`nTimes >= 2` to drive multiple merge-spill rollbacks and asserts that
+the output document count and content checksum are bit-identical to a
+control run with the failpoint off.


### PR DESCRIPTION
## Summary

TLA+ spec + regression jstest pinning the SERVER-124271 idempotency violation: `ContainerBasedSpiller::mergeSpills()` drives a `MergeIterator` from inside a `writeConflictRetry` lambda. A WCE-driven `rollback_transaction()` resets the read cursors backing the merge while the iterator's in-memory heap state is unchanged — yielding silent drops or duplicates on retry.

**Jira:** https://jira.mongodb.org/browse/SERVER-126546
**Related:** https://jira.mongodb.org/browse/SERVER-124271

## TLC verdicts

| Cfg | Result | States |
|---|---|---|
| Green (`ResetAffectsReadCursors=FALSE`) | No error | 98 / 61 distinct / depth 13 |
| Bug (`ResetAffectsReadCursors=TRUE`) | `NoElementDuplication` violated | 5-state trace: ReadHead → WCE → Resume → ReadHead → buffer=<<1,1>> |

## Files

- `src/mongo/tla_plus/Sorter/MergeSpillCursorReset/MergeSpillCursorReset.tla` (310 lines)
- `src/mongo/tla_plus/Sorter/MergeSpillCursorReset/MCMergeSpillCursorReset.{tla,cfg}` + `MCMergeSpillCursorResetBug.cfg`
- `src/mongo/tla_plus/Sorter/MergeSpillCursorReset/OWNERS.yml` (`10gen/server-storage-execution` + `10gen/server-external-sorter`)
- `src/mongo/tla_plus/Sorter/MergeSpillCursorReset/README.md`
- `jstests/noPassthrough/merge_spill_wce_idempotency.js` (147 lines)

## Verify

```
cd src/mongo/tla_plus
./download-tlc.sh
./model-check.sh Sorter/MergeSpillCursorReset
```

jstest forces a `$group` pipeline to spill (per-doc batching, 1-byte group memory cap), runs a control aggregate, configures `WTWriteConflictException` failpoint with `times: 4` and re-runs. Asserts bit-identical group count + per-group `n` + content checksum across the two runs.

## Draft status

Opened as Draft.
