### PR TITLE
SERVER-126547 Add TLA+ spec + jstest for oplog visibility thread concurrent start/stop

### DIFF
--- a/jstests/replsets/oplog_visibility_concurrent_start_stop.js
+++ b/jstests/replsets/oplog_visibility_concurrent_start_stop.js
@@ -1,0 +1,150 @@
+/**
+ * SERVER-122142: exercise the oplog visibility thread's lifecycle while
+ * multiple readers call getRecordStore() against the oplog and a durable
+ * recovery is being forced by DDL on the oplog and a paused JournalFlusher.
+ *
+ * The oplog visibility thread is owned by WiredTigerOplogManager and is
+ * started/stopped as a side effect of WiredTigerRecordStore::Oplog
+ * construction/destruction. When DDL on the oplog forces collections to go
+ * through a durable recovery from disk, each concurrent query requesting the
+ * oplog can trigger independent start/stop cycles of the visibility thread.
+ * This test drives the conditions under which the race is reachable and
+ * asserts that oplog reads remain available end-to-end.
+ *
+ * The race is described as "effectively impossible to hit in practice"
+ * because DDL on the oplog is exceedingly rare, so this test exists to pin
+ * the scenario down empirically; the TLA+ companion at
+ * src/mongo/tla_plus/Replication/OplogVisibilityThread proves the lifecycle
+ * invariants under the fix.
+ *
+ * @tags: [
+ *   requires_persistence,
+ *   requires_replication,
+ *   requires_wiredtiger,
+ * ]
+ */
+
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+
+const rst = new ReplSetTest({
+    name: jsTestName(),
+    nodes: 1,
+    nodeOptions: {
+        setParameter: {
+            logComponentVerbosity: tojson({storage: {recovery: 2}, replication: 1}),
+        },
+    },
+});
+
+rst.startSet();
+rst.initiate();
+
+const primary = rst.getPrimary();
+const localDB = primary.getDB("local");
+const adminDB = primary.getDB("admin");
+
+// Seed the oplog with enough traffic that reverse-cursor reads have content
+// to walk during the race window.
+jsTestLog("Seeding the oplog");
+const seedColl = primary.getDB(jsTestName())["seed"];
+for (let i = 0; i < 200; i++) {
+    assert.commandWorked(seedColl.insert({_id: i, payload: "x".repeat(64)}));
+}
+
+// Pause the JournalFlusher to widen the window in which the OplogManager's
+// visibility thread can be observed in a transitional state. This is the
+// same lever used by commit_point_propagation_with_oplog_exhaust_cursor.js
+// and override_chaining_allowed_false_if_necessary.js.
+jsTestLog("Pausing the JournalFlusher thread on the primary");
+const journalFp = configureFailPoint(primary, "pauseJournalFlusherThread");
+journalFp.wait();
+
+// Spin up a small fleet of concurrent readers that repeatedly issue
+// reverse-cursor scans of the oplog. Each invocation walks through
+// getRecordStore() and (if a recovery is in flight) takes the
+// thread-lifecycle path under test.
+const numReaders = 8;
+const readerDurationMs = 6 * 1000;
+const readerThreads = [];
+
+jsTestLog(`Launching ${numReaders} concurrent oplog readers`);
+for (let i = 0; i < numReaders; i++) {
+    const t = new Thread(function(host, durationMs) {
+        const conn = new Mongo(host);
+        const localDB = conn.getDB("local");
+        const deadline = Date.now() + durationMs;
+        let reads = 0;
+        let errors = 0;
+        while (Date.now() < deadline) {
+            try {
+                // Reverse cursor, no limit on visibility -- this is the path
+                // that walks the WiredTigerOplogCursor and forces interaction
+                // with the visibility thread.
+                const cur = localDB.oplog.rs.find().sort({$natural: -1}).limit(8);
+                while (cur.hasNext()) {
+                    cur.next();
+                }
+                reads++;
+            } catch (e) {
+                errors++;
+            }
+        }
+        return {reads, errors};
+    }, primary.host, readerDurationMs);
+    t.start();
+    readerThreads.push(t);
+}
+
+// While readers hammer the oplog, attempt DDL-style operations that the
+// system permits on local collections. We cannot drop or rename the live
+// oplog (see drop_oplog.js), but creating and dropping sibling collections
+// in `local` exercises adjacent catalog paths and keeps the catalog mutex
+// busy. We also poke the oplog manager directly by issuing
+// `replSetResizeOplog`, which forces the OplogManager to re-evaluate state.
+jsTestLog("Driving DDL on local + repeated replSetResizeOplog");
+const ddlDeadline = Date.now() + readerDurationMs - 500;
+let resizeCount = 0;
+while (Date.now() < ddlDeadline) {
+    const aux = "aux_" + Math.floor(Math.random() * 1000);
+    assert.commandWorked(localDB.createCollection(aux));
+    assert.commandWorked(localDB.runCommand({drop: aux}));
+    assert.commandWorked(adminDB.runCommand({
+        replSetResizeOplog: 1,
+        size: (1000 + (resizeCount % 8) * 64),
+    }));
+    resizeCount++;
+}
+
+jsTestLog(`Issued ${resizeCount} replSetResizeOplog calls`);
+
+// Resume the JournalFlusher so readers and the visibility thread can settle.
+jsTestLog("Resuming the JournalFlusher thread");
+journalFp.off();
+
+// Join readers. Every reader must have completed without throwing; a torn-
+// down visibility thread under a pinned reader would surface as
+// CursorNotFound / OperationFailed here.
+jsTestLog("Joining reader threads");
+let totalReads = 0;
+let totalErrors = 0;
+for (const t of readerThreads) {
+    t.join();
+    const result = t.returnData();
+    totalReads += result.reads;
+    totalErrors += result.errors;
+}
+
+jsTestLog(`Total reader iterations: ${totalReads}, errors: ${totalErrors}`);
+assert.gt(totalReads, 0, "expected at least one reader iteration");
+assert.eq(totalErrors, 0, "no reader should observe a failed oplog read");
+
+// Final sanity: a fresh reverse-cursor scan should complete and the oplog
+// manager should report a non-zero latestVisibleTimestamp.
+const tail = localDB.oplog.rs.find().sort({$natural: -1}).limit(1).toArray();
+assert.eq(tail.length, 1, "oplog should contain at least one entry");
+
+const serverStatus = adminDB.runCommand({serverStatus: 1});
+assert.commandWorked(serverStatus);
+
+rst.stopSet();

--- a/src/mongo/tla_plus/Replication/OplogVisibilityThread/MCOplogVisibilityThread.cfg
+++ b/src/mongo/tla_plus/Replication/OplogVisibilityThread/MCOplogVisibilityThread.cfg
@@ -1,0 +1,24 @@
+\* Green configuration: AllowConcurrentStartStop = FALSE. This models the
+\* fix in which the catalog serializes the start/stop side effect of
+\* getRecordStore(). All invariants must hold.
+\*
+\* To exercise the bug, swap AllowConcurrentStartStop to TRUE in this file
+\* (or use MCOplogVisibilityThread_bug.cfg). With the bug enabled,
+\* AtMostOneStartStopInFlight and NoThreadTeardownWhileReaderPinned will
+\* both fail with a counterexample trace.
+
+SPECIFICATION Spec
+
+CONSTANTS
+Readers = {r1, r2, r3}
+MaxOps = 4
+AllowConcurrentStartStop = FALSE
+
+SYMMETRY ReaderSymmetry
+CONSTRAINT StateConstraint
+
+INVARIANT TypeOK
+INVARIANT AtMostOneStartStopInFlight
+INVARIANT NoThreadTeardownWhileReaderPinned
+INVARIANT PinnedReaderSeesRunningThread
+INVARIANT EpochMonotonic

--- a/src/mongo/tla_plus/Replication/OplogVisibilityThread/MCOplogVisibilityThread.tla
+++ b/src/mongo/tla_plus/Replication/OplogVisibilityThread/MCOplogVisibilityThread.tla
@@ -1,0 +1,13 @@
+---- MODULE MCOplogVisibilityThread ----
+\* Model-checking harness for OplogVisibilityThread.tla. The .cfg file selects
+\* which scenario to run (green or bug).
+
+EXTENDS OplogVisibilityThread
+
+\* Constrain the state space. opsCount is already bounded by MaxOps, but TLC
+\* benefits from an explicit StateConstraint so the inductive search short-
+\* circuits early.
+StateConstraint == opsCount <= MaxOps
+
+ReaderSymmetry == Permutations(Readers)
+====================================================================

--- a/src/mongo/tla_plus/Replication/OplogVisibilityThread/MCOplogVisibilityThread_bug.cfg
+++ b/src/mongo/tla_plus/Replication/OplogVisibilityThread/MCOplogVisibilityThread_bug.cfg
@@ -1,0 +1,27 @@
+\* Bug configuration: AllowConcurrentStartStop = TRUE. TLC should produce a
+\* counterexample for AtMostOneStartStopInFlight and
+\* NoThreadTeardownWhileReaderPinned.
+\*
+\* Invoke directly (rather than via model-check.sh) since model-check.sh
+\* picks up MCOplogVisibilityThread.cfg by convention:
+\*
+\*   cd src/mongo/tla_plus/Replication/OplogVisibilityThread
+\*   java -cp ../../tla2tools.jar tlc2.TLC \
+\*       -config MCOplogVisibilityThread_bug.cfg \
+\*       MCOplogVisibilityThread.tla
+
+SPECIFICATION Spec
+
+CONSTANTS
+Readers = {r1, r2, r3}
+MaxOps = 4
+AllowConcurrentStartStop = TRUE
+
+SYMMETRY ReaderSymmetry
+CONSTRAINT StateConstraint
+
+INVARIANT TypeOK
+INVARIANT AtMostOneStartStopInFlight
+INVARIANT NoThreadTeardownWhileReaderPinned
+INVARIANT PinnedReaderSeesRunningThread
+INVARIANT EpochMonotonic

--- a/src/mongo/tla_plus/Replication/OplogVisibilityThread/OWNERS.yml
+++ b/src/mongo/tla_plus/Replication/OplogVisibilityThread/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-storage-execution

--- a/src/mongo/tla_plus/Replication/OplogVisibilityThread/OplogVisibilityThread.tla
+++ b/src/mongo/tla_plus/Replication/OplogVisibilityThread/OplogVisibilityThread.tla
@@ -1,0 +1,285 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+------------------------- MODULE OplogVisibilityThread -------------------------
+\*
+\* A specification of the oplog visibility thread lifecycle as it is driven by
+\* the side effect of getRecordStore() during durable recovery of the oplog.
+\*
+\* Background (SERVER-122142):
+\*   The WiredTigerOplogManager owns a single visibility thread. The thread is
+\*   started by WiredTigerRecordStore::Oplog::Oplog(...) and stopped by the
+\*   destructor. When DDL on the oplog forces a durable recovery from disk, any
+\*   reader that calls getRecordStore() can cause a new Oplog instance to be
+\*   constructed: that construction stops any prior thread and starts a fresh
+\*   one. Multiple concurrent readers can therefore drive start/stop overlap on
+\*   the same OplogManager without the catalog enforcing single-writer
+\*   ordering. The intended behavior is that exactly one start/stop is in
+\*   flight at any moment and no reader sees the thread torn down while it
+\*   still holds a pin on the underlying Oplog record store.
+\*
+\* Variables track:
+\*   - threadState:   "stopped" | "starting" | "running" | "stopping"
+\*   - inflight:      count of start/stop operations currently mutating state
+\*   - pinned:        set of readers that have pinned the current Oplog
+\*                    instance (i.e. they hold a cursor / are mid-read)
+\*   - readerPC:      per-reader program counter ("idle", "acquired",
+\*                    "recovering", "starting", "stopping", "pinned", "done")
+\*   - oplogEpoch:    monotonically increasing tag for the current Oplog
+\*                    instance; bumped on each (re)construction
+\*   - readerEpoch:   the epoch each reader observed when it pinned
+\*   - opsCount:      bounded counter so model-checking terminates
+\*
+\* Bug toggle:
+\*   AllowConcurrentStartStop = TRUE  models the buggy state today: readers
+\*   can race through getRecordStore() and overlap each other's start/stop.
+\*   AllowConcurrentStartStop = FALSE models the fix where the catalog
+\*   serializes the side-effecting transition with a coarse lock.
+\*
+\* Invariants of interest (see below):
+\*   AtMostOneStartStopInFlight
+\*   NoThreadTeardownWhileReaderPinned
+\*   PinnedReaderSeesRunningThread
+\*   EpochMonotonic
+\*
+
+EXTENDS Integers, FiniteSets, Sequences, TLC
+
+CONSTANTS
+    \* Set of reader operation IDs.
+    Readers,
+    \* Maximum number of recovery-triggering operations before model-checking
+    \* halts. Bounds the state space.
+    MaxOps,
+    \* If TRUE, the spec permits two readers to enter the start/stop critical
+    \* section simultaneously (the SERVER-122142 bug). If FALSE, the spec
+    \* requires the transition to be serialized.
+    AllowConcurrentStartStop
+
+(***************************************************************************)
+(* Variables.                                                              *)
+(***************************************************************************)
+
+\* The visibility thread's lifecycle state.
+VARIABLE threadState
+
+\* Number of readers currently inside the start/stop critical section.
+VARIABLE inflight
+
+\* The set of readers that have pinned the current Oplog instance.
+VARIABLE pinned
+
+\* Per-reader program counter.
+VARIABLE readerPC
+
+\* Tag identifying the current Oplog instance. Incremented on every
+\* (re)construction.
+VARIABLE oplogEpoch
+
+\* Each reader's observed epoch at the moment it pinned the oplog.
+VARIABLE readerEpoch
+
+\* Bounded global op counter.
+VARIABLE opsCount
+
+vars == <<threadState, inflight, pinned, readerPC, oplogEpoch,
+          readerEpoch, opsCount>>
+
+(***************************************************************************)
+(* Helpers.                                                                *)
+(***************************************************************************)
+
+ThreadStates == {"stopped", "starting", "running", "stopping"}
+
+ReaderPCStates ==
+    {"idle", "acquired", "recovering", "starting", "stopping",
+     "pinned", "done"}
+
+NoReader == CHOOSE r : r \notin Readers
+
+(***************************************************************************)
+(* Initial state.                                                          *)
+(***************************************************************************)
+
+Init ==
+    /\ threadState = "stopped"
+    /\ inflight = 0
+    /\ pinned = {}
+    /\ readerPC = [r \in Readers |-> "idle"]
+    /\ oplogEpoch = 0
+    /\ readerEpoch = [r \in Readers |-> 0]
+    /\ opsCount = 0
+
+(***************************************************************************)
+(* Actions.                                                                *)
+(***************************************************************************)
+
+\* A reader r enters getRecordStore() and acquires the catalog handle. This
+\* models a query that has just resolved the oplog namespace.
+AcquireHandle(r) ==
+    /\ readerPC[r] = "idle"
+    /\ opsCount < MaxOps
+    /\ readerPC' = [readerPC EXCEPT ![r] = "acquired"]
+    /\ opsCount' = opsCount + 1
+    /\ UNCHANGED <<threadState, inflight, pinned, oplogEpoch, readerEpoch>>
+
+\* The reader observes that the oplog requires durable recovery (DDL has
+\* occurred and the cached RecordStore is gone). The reader is now committed
+\* to (re)constructing the Oplog instance, which side-effects start/stop.
+NeedRecovery(r) ==
+    /\ readerPC[r] = "acquired"
+    /\ readerPC' = [readerPC EXCEPT ![r] = "recovering"]
+    /\ UNCHANGED <<threadState, inflight, pinned, oplogEpoch, readerEpoch,
+                   opsCount>>
+
+\* The reader has a handle and the cached Oplog is alive: pin it without
+\* triggering recovery. This is the common-case path that should be
+\* unaffected by the bug.
+PinExistingOplog(r) ==
+    /\ readerPC[r] = "acquired"
+    /\ threadState = "running"
+    /\ readerPC' = [readerPC EXCEPT ![r] = "pinned"]
+    /\ pinned' = pinned \cup {r}
+    /\ readerEpoch' = [readerEpoch EXCEPT ![r] = oplogEpoch]
+    /\ UNCHANGED <<threadState, inflight, oplogEpoch, opsCount>>
+
+\* Begin tearing the old visibility thread down. This is the
+\* WiredTigerRecordStore::Oplog::~Oplog() side of recovery: it calls
+\* OplogManager::stop().
+\*
+\* The bug allows this transition even while another reader is also
+\* mid-transition (inflight > 0) or still pinned. The fix forces both
+\* inflight = 0 and pinned = {}, modeling a coarse catalog lock that
+\* serializes the side effect and waits for in-flight readers to drain.
+BeginStop(r) ==
+    /\ readerPC[r] = "recovering"
+    /\ threadState \in {"running", "starting"}
+    /\ \/ AllowConcurrentStartStop
+       \/ /\ inflight = 0
+          /\ pinned = {}
+    /\ threadState' = "stopping"
+    /\ inflight' = inflight + 1
+    /\ readerPC' = [readerPC EXCEPT ![r] = "stopping"]
+    /\ UNCHANGED <<pinned, oplogEpoch, readerEpoch, opsCount>>
+
+\* Finish tearing the visibility thread down. The bug allows this even when
+\* pinned # {} (i.e. a reader is still using the old oplog); the fix forbids
+\* it.
+FinishStop(r) ==
+    /\ readerPC[r] = "stopping"
+    /\ threadState = "stopping"
+    /\ \/ AllowConcurrentStartStop
+       \/ pinned = {}
+    /\ threadState' = "stopped"
+    /\ inflight' = inflight - 1
+    /\ readerPC' = [readerPC EXCEPT ![r] = "recovering"]
+    /\ UNCHANGED <<pinned, oplogEpoch, readerEpoch, opsCount>>
+
+\* Begin starting a new visibility thread. This is the
+\* WiredTigerRecordStore::Oplog::Oplog() side of recovery: it calls
+\* OplogManager::start() against the newly-constructed RecordStore.
+BeginStart(r) ==
+    /\ readerPC[r] = "recovering"
+    /\ threadState = "stopped"
+    /\ \/ AllowConcurrentStartStop
+       \/ inflight = 0
+    /\ threadState' = "starting"
+    /\ inflight' = inflight + 1
+    /\ oplogEpoch' = oplogEpoch + 1
+    /\ readerPC' = [readerPC EXCEPT ![r] = "starting"]
+    /\ UNCHANGED <<pinned, readerEpoch, opsCount>>
+
+\* Finish starting the visibility thread. The reader that drove the recovery
+\* pins the freshly-constructed Oplog (it owns the construction frame).
+FinishStart(r) ==
+    /\ readerPC[r] = "starting"
+    /\ threadState = "starting"
+    /\ threadState' = "running"
+    /\ inflight' = inflight - 1
+    /\ readerPC' = [readerPC EXCEPT ![r] = "pinned"]
+    /\ pinned' = pinned \cup {r}
+    /\ readerEpoch' = [readerEpoch EXCEPT ![r] = oplogEpoch]
+    /\ UNCHANGED <<oplogEpoch, opsCount>>
+
+\* Reader unpins (its cursor closes / it completes its read).
+Unpin(r) ==
+    /\ readerPC[r] = "pinned"
+    /\ readerPC' = [readerPC EXCEPT ![r] = "done"]
+    /\ pinned' = pinned \ {r}
+    /\ UNCHANGED <<threadState, inflight, oplogEpoch, readerEpoch, opsCount>>
+
+\* Reader resets and may be re-issued.
+Reset(r) ==
+    /\ readerPC[r] = "done"
+    /\ readerPC' = [readerPC EXCEPT ![r] = "idle"]
+    /\ UNCHANGED <<threadState, inflight, pinned, oplogEpoch, readerEpoch,
+                   opsCount>>
+
+\* Quiescent stutter: once the op budget is exhausted and every reader has
+\* settled back to "idle", stutter forever rather than report a deadlock.
+\* This is a model-checking convenience; nothing in the system under test
+\* changes.
+Quiesce ==
+    /\ opsCount >= MaxOps
+    /\ \A r \in Readers : readerPC[r] \in {"idle", "done"}
+    /\ UNCHANGED vars
+
+Next ==
+    \/ \E r \in Readers :
+        \/ AcquireHandle(r)
+        \/ NeedRecovery(r)
+        \/ PinExistingOplog(r)
+        \/ BeginStop(r)
+        \/ FinishStop(r)
+        \/ BeginStart(r)
+        \/ FinishStart(r)
+        \/ Unpin(r)
+        \/ Reset(r)
+    \/ Quiesce
+
+Spec == Init /\ [][Next]_vars
+
+(***************************************************************************)
+(* Invariants.                                                             *)
+(***************************************************************************)
+
+\* AtMostOneStartStopInFlight: only one reader at a time may be mutating the
+\* OplogManager's lifecycle. This invariant is VIOLATED when
+\* AllowConcurrentStartStop = TRUE.
+AtMostOneStartStopInFlight == inflight <= 1
+
+\* NoThreadTeardownWhileReaderPinned: a reader holding a pin on the current
+\* Oplog must never observe the visibility thread torn down beneath it.
+\* Captured as: if any reader is pinned at the latest epoch, threadState is
+\* not "stopped" or "stopping".
+NoThreadTeardownWhileReaderPinned ==
+    \A r \in pinned :
+        readerEpoch[r] = oplogEpoch =>
+            threadState \in {"running", "starting"}
+
+\* PinnedReaderSeesRunningThread: a reader that pinned at the current epoch
+\* either sees "running" or "starting" (a started-and-not-yet-stopped thread).
+PinnedReaderSeesRunningThread ==
+    \A r \in pinned :
+        readerEpoch[r] = oplogEpoch =>
+            threadState # "stopped"
+
+\* EpochMonotonic: epoch never decreases.
+EpochMonotonic == oplogEpoch >= 0
+
+\* TypeOK: variable types. The epoch can grow up to one per BeginStart, and
+\* BeginStart is bounded by NeedRecovery -> AcquireHandle, which is bounded
+\* by MaxOps; we leave generous headroom.
+TypeOK ==
+    /\ threadState \in ThreadStates
+    /\ inflight \in 0..Cardinality(Readers)
+    /\ pinned \subseteq Readers
+    /\ readerPC \in [Readers -> ReaderPCStates]
+    /\ oplogEpoch \in 0..(MaxOps * 2)
+    /\ readerEpoch \in [Readers -> 0..(MaxOps * 2)]
+    /\ opsCount \in 0..MaxOps
+
+================================================================================

--- a/src/mongo/tla_plus/Replication/OplogVisibilityThread/README.md
+++ b/src/mongo/tla_plus/Replication/OplogVisibilityThread/README.md
@@ -1,0 +1,64 @@
+# OplogVisibilityThread
+
+TLA+ specification of the oplog visibility thread lifecycle, driven by the
+side effect of `WiredTigerRecordStore::Oplog::Oplog(...)` / `~Oplog()`, which
+call `WiredTigerOplogManager::start()` / `::stop()`.
+
+## What this models
+
+A single `WiredTigerOplogManager` owns one visibility thread. The thread is
+started when a fresh `Oplog` record store is constructed (today: as a side
+effect of `getRecordStore()` during durable recovery) and stopped when that
+record store is destroyed. When DDL on the oplog forces a recovery, multiple
+concurrent queries that call `getRecordStore()` can race through the
+construction path. Without serialization at the catalog level, two readers
+can interleave `start()` and `stop()` on the same `OplogManager`, and the
+visibility thread can be torn down while a reader still holds a pin on the
+record store.
+
+`OplogVisibilityThread.tla` models a small set of `Readers` driving the
+lifecycle. The boolean constant `AllowConcurrentStartStop` toggles the bug:
+
+- `FALSE` (green) -- the start/stop critical section is serialized; all
+  invariants hold.
+- `TRUE` (bug) -- readers race; TLC produces counterexamples for both
+  `AtMostOneStartStopInFlight` and `NoThreadTeardownWhileReaderPinned`.
+
+## Invariants
+
+- `AtMostOneStartStopInFlight` -- only one reader at a time mutates the
+  manager's lifecycle.
+- `NoThreadTeardownWhileReaderPinned` -- a pinned reader never observes
+  `threadState` in `stopped` or `stopping`.
+- `PinnedReaderSeesRunningThread` -- a reader that pinned at the current
+  epoch never sees `threadState = "stopped"`.
+- `EpochMonotonic` -- `oplogEpoch` is non-decreasing.
+- `TypeOK` -- variable types.
+
+## Running
+
+```
+cd src/mongo/tla_plus
+./download-tlc.sh                            # one-time
+./model-check.sh Replication/OplogVisibilityThread
+```
+
+For the bug configuration:
+
+```
+cd src/mongo/tla_plus/Replication/OplogVisibilityThread
+java -cp ../../tla2tools.jar tlc2.TLC \
+    -config MCOplogVisibilityThread_bug.cfg \
+    MCOplogVisibilityThread.tla
+```
+
+Green run prints `Model checking completed. No error has been found.`; bug
+run halts with an invariant-violation trace.
+
+## Companion jstest
+
+`jstests/replsets/oplog_visibility_concurrent_start_stop.js` exercises the
+race via `pauseJournalFlusherThread`, repeated `replSetResizeOplog`, and
+concurrent reverse-cursor oplog readers; asserts reads stay available.
+
+Tracked under SERVER-122142.


### PR DESCRIPTION
## Summary

TLA+ specification + regression jstest pinning the SERVER-122142 lifecycle race: `getRecordStore()` side-effects start/stop on `WiredTigerOplogManager` during durable recovery, and multiple concurrent readers can race the visibility thread's start/stop cycle.

**Jira:** https://jira.mongodb.org/browse/SERVER-126547
**Related:** https://jira.mongodb.org/browse/SERVER-122142

## TLC verdicts

| Cfg | Result | States |
|---|---|---|
| Green (`AllowConcurrentStartStop=FALSE`) | No error | 2726 / 1129 distinct |
| Bug (`AllowConcurrentStartStop=TRUE`) | `AtMostOneStartStopInFlight` violated | 248 / 105 distinct |

## Invariants

- `AtMostOneStartStopInFlight`, `NoThreadTeardownWhileReaderPinned`, `PinnedReaderSeesRunningThread`, `EpochMonotonic`, `TypeOK`

## Files

- `src/mongo/tla_plus/Replication/OplogVisibilityThread/OplogVisibilityThread.tla` (285 lines)
- `src/mongo/tla_plus/Replication/OplogVisibilityThread/MCOplogVisibilityThread.{tla,cfg}` + `MCOplogVisibilityThread_bug.cfg`
- `src/mongo/tla_plus/Replication/OplogVisibilityThread/OWNERS.yml` (`10gen/server-storage-execution`)
- `src/mongo/tla_plus/Replication/OplogVisibilityThread/README.md`
- `jstests/replsets/oplog_visibility_concurrent_start_stop.js` (150 lines)

## Verify

```
cd src/mongo/tla_plus
./download-tlc.sh
./model-check.sh Replication/OplogVisibilityThread
```

jstest pauses `JournalFlusher`, drives sibling-collection DDL in `local` plus repeated `replSetResizeOplog`, hammers the oplog with 8 concurrent reverse-cursor readers, asserts no `CursorNotFound` / `OperationFailed` surfaced from a torn-down visibility thread.

## Draft status

Opened as Draft.
