### PR TITLE
SERVER-126548 Add TLA+ spec + jstest for fsyncLock durableOpTime stuck

### DIFF
--- a/jstests/replsets/fsync_lock_durable_optime_stuck.js
+++ b/jstests/replsets/fsync_lock_durable_optime_stuck.js
@@ -1,0 +1,155 @@
+/**
+ * Regression test for SERVER-126254: fsyncLock leaves durableOpTime stuck behind lastWritten.
+ *
+ * Companion to the TLA+ spec
+ *     src/mongo/tla_plus/Replication/FsyncLockDurableOpTime/FsyncLockDurableOpTime.tla
+ *
+ * The spec models the wedge as a liveness counterexample: in the buggy code path, an oplog entry
+ * that has committed in memory (w:1, j:false) but not yet been fsynced sits in the
+ * committed-but-not-durable window when fsyncLock acquires Global S. With Global S held, the
+ * JournalFlusher cannot advance durableOpTime, so any snapshot or majority read with
+ * afterClusterTime past the wedged optime hangs indefinitely until fsyncUnlock. The fix decouples
+ * the journal-flush advancement of durableOpTime from Global S acquisition.
+ *
+ * This jstest promotes the deterministic single-node repro attached to SERVER-126254 to a
+ * regression. The repro is:
+ *
+ *     1. Pause the JournalFlusher (pauseJournalFlusherBeforeFlush failpoint).
+ *     2. Issue a w:1, j:false insert. lastWritten advances; durableOpTime does not.
+ *     3. Call fsyncLock. Global S is acquired with the entry still in the pending-durable window.
+ *     4. Release the JournalFlusher failpoint. On the fix this is enough for durableOpTime to
+ *        catch up to lastWritten. On the bug, durableOpTime stays wedged because the flusher's
+ *        storage-side dependency cannot be satisfied while Global S is held.
+ *     5. Assert durableOpTime catches up to lastWritten within a finite timeout. Without the fix,
+ *        this assertion fails and the test fails fast rather than hanging the suite.
+ *     6. fsyncUnlock. Cleanup.
+ *
+ * @tags: [
+ *     requires_persistence,
+ *     requires_replication,
+ *     requires_fsync,
+ * ]
+ */
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+// Single-node replica set: the bug is observable on a primary in isolation; secondaries are not
+// required and would only widen the state space without adding signal.
+const rst = new ReplSetTest({
+    name: "fsync_lock_durable_optime_stuck",
+    nodes: 1,
+    nodeOptions: {
+        // Disable background checkpoints so only the JournalFlusher can advance the durable
+        // timestamp. Mirrors the configuration used by
+        // jstests/replsets/majority_writes_wait_for_all_durable_timestamp.js.
+        syncdelay: 0,
+    },
+});
+rst.startSet();
+rst.initiate();
+
+const primary = rst.getPrimary();
+const dbName = "test";
+const collName = "fsync_lock_durable_optime_stuck";
+const adminDB = primary.getDB("admin");
+const testDB = primary.getDB(dbName);
+const testColl = testDB[collName];
+
+assert.commandWorked(testDB.createCollection(collName, {writeConcern: {w: 1}}));
+
+// Helper. Returns the current durableOpTime / lastWrittenOpTime tuple from replSetGetStatus.
+function getOpTimes() {
+    const status = assert.commandWorked(adminDB.runCommand({replSetGetStatus: 1}));
+    const self = status.members.find((m) => m.self === true);
+    return {
+        durable: self.optimeDurable || self.optime,
+        written: self.optimeWritten || self.optime,
+        appliedTs: status.optimes ? status.optimes.appliedOpTime : null,
+        durableTs: status.optimes ? status.optimes.durableOpTime : null,
+        lastWrittenTs: status.optimes ? status.optimes.lastWrittenOpTime : null,
+    };
+}
+
+function tsLessThan(a, b) {
+    if (a.t !== b.t) {
+        return a.t < b.t;
+    }
+    return timestampCmp(a.ts, b.ts) < 0;
+}
+
+jsTest.log("Step 1: pause JournalFlusher so durableOpTime cannot advance.");
+const journalFlusherFP = configureFailPoint(primary, "pauseJournalFlusherBeforeFlush");
+journalFlusherFP.wait();
+
+let lockedNode = null;
+try {
+    jsTest.log("Step 2: w:1, j:false insert. lastWritten advances; durableOpTime does not.");
+    assert.commandWorked(testColl.insert({_id: 0, x: 1}, {writeConcern: {w: 1, j: false}}));
+
+    const beforeLock = getOpTimes();
+    jsTest.log("Pre-fsyncLock optimes: " + tojson(beforeLock));
+    assert(
+        beforeLock.lastWrittenTs && beforeLock.durableTs,
+        "replSetGetStatus must surface lastWrittenOpTime and durableOpTime on this build",
+    );
+    assert(
+        tsLessThan(beforeLock.durableTs, beforeLock.lastWrittenTs),
+        "Pre-condition: durableOpTime must be strictly behind lastWrittenOpTime before fsyncLock. " +
+            "If this assertion fails, the JournalFlusher pause failpoint is not effective. " +
+            "beforeLock=" + tojson(beforeLock),
+    );
+
+    jsTest.log("Step 3: fsyncLock. Acquires Global S with one entry pending-durable.");
+    const fsyncLockResult = assert.commandWorked(adminDB.runCommand({fsync: 1, lock: 1}));
+    lockedNode = primary;
+    jsTest.log("fsyncLock result: " + tojson(fsyncLockResult));
+
+    jsTest.log("Step 4: release JournalFlusher pause. On the fix, durableOpTime will catch up.");
+    journalFlusherFP.off();
+
+    jsTest.log(
+        "Step 5: assert durableOpTime catches up to lastWrittenOpTime within 30s. " +
+            "Without the fix, durableOpTime stays wedged at the pre-lock value and this hangs.",
+    );
+    assert.soon(
+        function () {
+            const now = getOpTimes();
+            if (!tsLessThan(now.durableTs, now.lastWrittenTs)) {
+                jsTest.log("durableOpTime caught up: " + tojson(now));
+                return true;
+            }
+            return false;
+        },
+        function () {
+            return (
+                "durableOpTime stayed wedged behind lastWrittenOpTime while fsyncLock held " +
+                "Global S; SERVER-126254 regression. final=" + tojson(getOpTimes())
+            );
+        },
+        /* timeout */ 30 * 1000,
+        /* interval */ 250,
+    );
+
+    jsTest.log("Step 6: fsyncUnlock.");
+    assert.commandWorked(adminDB.runCommand({fsyncUnlock: 1}));
+    lockedNode = null;
+} finally {
+    // Defensive cleanup. If any assertion above failed, we still need to release the journal
+    // flusher and the fsync lock so ReplSetTest.stopSet does not hang.
+    if (journalFlusherFP) {
+        try {
+            journalFlusherFP.off();
+        } catch (e) {
+            jsTest.log("journalFlusherFP.off() raised during cleanup: " + tojson(e));
+        }
+    }
+    if (lockedNode !== null) {
+        try {
+            assert.commandWorked(lockedNode.getDB("admin").runCommand({fsyncUnlock: 1}));
+        } catch (e) {
+            jsTest.log("fsyncUnlock raised during cleanup: " + tojson(e));
+        }
+    }
+}
+
+rst.stopSet();

--- a/src/mongo/tla_plus/Replication/FsyncLockDurableOpTime/FsyncLockDurableOpTime.tla
+++ b/src/mongo/tla_plus/Replication/FsyncLockDurableOpTime/FsyncLockDurableOpTime.tla
@@ -1,0 +1,203 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+------------------------ MODULE FsyncLockDurableOpTime ------------------------
+\* Specification for SERVER-126254: fsyncLock leaves durableOpTime stuck behind
+\* lastWritten.
+\*
+\* Background. On a primary, write operations advance the in-memory "lastWritten"
+\* optime when the WiredTiger WriteUnitOfWork commits, while the JournalFlusher
+\* thread independently advances "durableOpTime" when oplog entries are fsynced
+\* to disk. fsyncLock acquires Global S and blocks new writes; however, oplog
+\* entries that have already committed in memory (w:1, j:false) at the moment
+\* fsyncLock is invoked sit in the committed-but-not-yet-durable window.
+\*
+\* In the buggy code path, the JournalFlusher's attempt to advance durableOpTime
+\* is itself contingent on storage state guarded by Global IS, which it cannot
+\* acquire while Global S is held. The result is a documented stable
+\* equilibrium: lastWritten is ahead, durableOpTime is wedged, and nothing on
+\* the primary can advance durableOpTime until fsyncUnlock releases Global S.
+\* Snapshot/majority reads with afterClusterTime past the wedged optime hang
+\* indefinitely.
+\*
+\* The fix decouples the journal-flush advancement of durableOpTime from Global
+\* S acquisition. Modelled here by the FixedAdvanceDurable variant of the
+\* AdvanceDurable action: the green model (BugEnabled = FALSE) allows
+\* durableOpTime to advance while Global S is held; the buggy model
+\* (BugEnabled = TRUE) blocks it. The liveness property
+\*
+\*     lastWritten advances ~> durableOpTime catches up
+\*
+\* holds under the green model and is violated under the buggy model. The
+\* counterexample TLC produces matches the deterministic single-node repro
+\* attached to SERVER-126254 step-for-step (pause JournalFlusher, w:1 j:false
+\* insert, fsyncLock, observe wedge).
+\*
+\* To run the model-checker, first edit MCFsyncLockDurableOpTime.cfg if desired,
+\* then:
+\*     cd src/mongo/tla_plus
+\*     ./model-check.sh Replication/FsyncLockDurableOpTime
+\*
+\* The bug toggle is the BugEnabled constant; both MCFsyncLockDurableOpTime.cfg
+\* (green) and MCFsyncLockDurableOpTimeBug.cfg (red) are checked in.
+
+EXTENDS Integers, FiniteSets, Sequences, TLC
+
+\* The maximum optime any timestamp variable can reach during model-checking.
+\* Bounds the state space for TLC. Two is enough to expose the wedge: the first
+\* write puts a value in the committed-but-not-durable window, the second write
+\* (or the fix) clears it.
+CONSTANT MaxOpTime
+
+\* When TRUE, AdvanceDurable is gated by ~globalSLockHeld (the bug). When FALSE,
+\* AdvanceDurable can fire regardless of globalSLockHeld (the fix).
+CONSTANT BugEnabled
+
+----
+\* State variables.
+
+\* The most recent optime committed by a WriteUnitOfWork on the primary. Monotone
+\* non-decreasing. Maps to repl::ReplicationCoordinatorImpl::_setMyLastWrittenOpTime.
+VARIABLE lastWritten
+
+\* The most recent optime durably fsynced to the journal. Monotone non-decreasing.
+\* Always TimestampLTE(durableOpTime, lastWritten). Maps to
+\* repl::ReplicationCoordinatorImpl::_setMyLastDurableOpTime.
+VARIABLE durableOpTime
+
+\* TRUE iff Global S has been acquired via fsyncLock. While TRUE, no new writes
+\* can commit (CommitWUOW is gated). In the buggy model, AdvanceDurable is also
+\* gated; in the fixed model, it is not.
+VARIABLE globalSLockHeld
+
+vars == <<lastWritten, durableOpTime, globalSLockHeld>>
+
+----
+\* Helpers.
+
+\* The set of optimes that have been written but not yet made durable. This is
+\* the committed-but-not-durable window. When fsyncLock fires with this set
+\* non-empty in the buggy code path, the contents are wedged.
+PendingDurable == lastWritten - durableOpTime
+
+----
+\* Initial state. No writes, no lock.
+
+Init ==
+    /\ lastWritten = 0
+    /\ durableOpTime = 0
+    /\ globalSLockHeld = FALSE
+
+----
+\* Actions.
+
+\* ACTION
+\* The primary commits one write. Advances lastWritten by 1. Requires
+\* ~globalSLockHeld because fsyncLock blocks new writes.
+CommitWUOW ==
+    /\ ~globalSLockHeld
+    /\ lastWritten < MaxOpTime
+    /\ lastWritten' = lastWritten + 1
+    /\ UNCHANGED <<durableOpTime, globalSLockHeld>>
+
+\* ACTION
+\* fsyncLock acquires Global S. Idempotent: re-acquiring while held is a no-op
+\* but does not enable additional behavior, so we forbid it to keep the state
+\* graph trim.
+AcquireGlobalS ==
+    /\ ~globalSLockHeld
+    /\ globalSLockHeld' = TRUE
+    /\ UNCHANGED <<lastWritten, durableOpTime>>
+
+\* ACTION
+\* fsyncUnlock releases Global S. Modelled so the spec is closed under recovery
+\* and is not vacuously stuck after AcquireGlobalS. The liveness property holds
+\* trivially after release, so it is the gap *before* release that the bug
+\* exposes.
+ReleaseGlobalS ==
+    /\ globalSLockHeld
+    /\ globalSLockHeld' = FALSE
+    /\ UNCHANGED <<lastWritten, durableOpTime>>
+
+\* ACTION
+\* The JournalFlusher advances durableOpTime to catch up with lastWritten.
+\* This is the action whose firing is contingent on BugEnabled.
+\*
+\* In the buggy model (BugEnabled = TRUE), the JournalFlusher's storage-side
+\* dependency means it cannot fire while Global S is held: durableOpTime is
+\* wedged until fsyncUnlock. In the fixed model (BugEnabled = FALSE), the
+\* advancement is decoupled from Global S and fires freely.
+AdvanceDurable ==
+    /\ durableOpTime < lastWritten
+    /\ (BugEnabled => ~globalSLockHeld)
+    /\ durableOpTime' = durableOpTime + 1
+    /\ UNCHANGED <<lastWritten, globalSLockHeld>>
+
+----
+\* Next-state relation.
+
+Next ==
+    \/ CommitWUOW
+    \/ AcquireGlobalS
+    \/ ReleaseGlobalS
+    \/ AdvanceDurable
+
+\* Weak fairness on the actions that drive forward progress. AdvanceDurable
+\* models the JournalFlusher thread, which is naturally weakly-fair.
+\* ReleaseGlobalS models a finite-duration fsyncLock; without weak fairness here
+\* the operator could hold the lock forever and the liveness property would
+\* hold only vacuously. CommitWUOW does not need fairness; we only require that
+\* IF lastWritten advances THEN durableOpTime catches up.
+Spec ==
+    /\ Init
+    /\ [][Next]_vars
+    /\ WF_vars(AdvanceDurable)
+    /\ WF_vars(ReleaseGlobalS)
+
+----
+\* Safety invariants.
+
+\* Type invariant.
+TypeOK ==
+    /\ lastWritten \in 0..MaxOpTime
+    /\ durableOpTime \in 0..MaxOpTime
+    /\ globalSLockHeld \in BOOLEAN
+
+\* durableOpTime never overtakes lastWritten. This is the structural invariant
+\* of the WiredTiger / replication storage interface and must hold in both the
+\* green and the buggy models.
+DurableNeverAheadOfWritten == durableOpTime <= lastWritten
+
+\* The two timestamps are always non-negative and monotone in any reachable
+\* state (the actions only ever +1 them).
+MonotoneOpTimes == lastWritten >= 0 /\ durableOpTime >= 0
+
+----
+\* Liveness properties.
+
+\* The headline liveness property. If lastWritten ever sits ahead of
+\* durableOpTime, then durableOpTime eventually catches up. Under the green
+\* model this holds. Under the buggy model TLC produces a counterexample of
+\* length 3 (CommitWUOW, AcquireGlobalS, stuttering forever) because
+\* AdvanceDurable is structurally disabled by globalSLockHeld and no
+\* ReleaseGlobalS can fire either if we drop its fairness in the buggy cfg.
+\*
+\* In practice we keep ReleaseGlobalS fair in both cfgs so the property holds
+\* on the green cfg by the fix, and is violated on the bug cfg by the wedge
+\* *before* release: between AcquireGlobalS and ReleaseGlobalS, the system is
+\* in the stable equilibrium documented on the ticket.
+DurableEventuallyCatchesUp ==
+    (lastWritten > durableOpTime) ~> (lastWritten = durableOpTime)
+
+\* A stricter formulation suitable as a wedge-window detector: whenever Global S
+\* is held with pending-durable entries, the pending count must eventually drop
+\* to zero. This is the property the buggy code path violates within the
+\* lock-held window. We keep it as an alternative to DurableEventuallyCatchesUp
+\* for diagnostic counterexample reading.
+NoWedgeUnderGlobalS ==
+    (globalSLockHeld /\ PendingDurable > 0) ~> (PendingDurable = 0)
+
+===============================================================================

--- a/src/mongo/tla_plus/Replication/FsyncLockDurableOpTime/MCFsyncLockDurableOpTime.cfg
+++ b/src/mongo/tla_plus/Replication/FsyncLockDurableOpTime/MCFsyncLockDurableOpTime.cfg
@@ -1,0 +1,17 @@
+\* Config file to run TLC on FsyncLockDurableOpTime.tla in the GREEN model
+\* (BugEnabled = FALSE). The fix is in place; the liveness property holds.
+\*
+\* See FsyncLockDurableOpTime.tla for instructions.
+
+CONSTANT MaxOpTime = 2
+CONSTANT BugEnabled = FALSE
+
+INVARIANT TypeOK
+INVARIANT DurableNeverAheadOfWritten
+INVARIANT MonotoneOpTimes
+
+PROPERTY DurableEventuallyCatchesUp
+PROPERTY NoWedgeUnderGlobalS
+
+CONSTRAINT StateConstraint
+SPECIFICATION Spec

--- a/src/mongo/tla_plus/Replication/FsyncLockDurableOpTime/MCFsyncLockDurableOpTime.tla
+++ b/src/mongo/tla_plus/Replication/FsyncLockDurableOpTime/MCFsyncLockDurableOpTime.tla
@@ -1,0 +1,15 @@
+---- MODULE MCFsyncLockDurableOpTime ----
+\* Model-checking harness for FsyncLockDurableOpTime.tla.
+\* See FsyncLockDurableOpTime.tla for instructions.
+
+EXTENDS FsyncLockDurableOpTime
+
+\* State-space bound. lastWritten and durableOpTime both live in 0..MaxOpTime,
+\* so this is enforced statically by the variable type already; we keep the
+\* explicit constraint for clarity and to make tightening the bound during
+\* exploratory runs a one-line change.
+StateConstraint ==
+    /\ lastWritten <= MaxOpTime
+    /\ durableOpTime <= MaxOpTime
+
+=============================================================================

--- a/src/mongo/tla_plus/Replication/FsyncLockDurableOpTime/MCFsyncLockDurableOpTimeBug.cfg
+++ b/src/mongo/tla_plus/Replication/FsyncLockDurableOpTime/MCFsyncLockDurableOpTimeBug.cfg
@@ -1,0 +1,20 @@
+\* Config file to run TLC on FsyncLockDurableOpTime.tla in the BUG model
+\* (BugEnabled = TRUE). The fix is not in place; TLC should report
+\* "Temporal properties were violated" with a counterexample matching the
+\* SERVER-126254 repro (CommitWUOW; AcquireGlobalS; stutter forever with
+\* lastWritten = 1, durableOpTime = 0).
+\*
+\* See FsyncLockDurableOpTime.tla for instructions.
+
+CONSTANT MaxOpTime = 2
+CONSTANT BugEnabled = TRUE
+
+INVARIANT TypeOK
+INVARIANT DurableNeverAheadOfWritten
+INVARIANT MonotoneOpTimes
+
+PROPERTY DurableEventuallyCatchesUp
+PROPERTY NoWedgeUnderGlobalS
+
+CONSTRAINT StateConstraint
+SPECIFICATION SpecBug

--- a/src/mongo/tla_plus/Replication/FsyncLockDurableOpTime/MCFsyncLockDurableOpTimeBug.tla
+++ b/src/mongo/tla_plus/Replication/FsyncLockDurableOpTime/MCFsyncLockDurableOpTimeBug.tla
@@ -1,0 +1,27 @@
+---- MODULE MCFsyncLockDurableOpTimeBug ----
+\* Model-checking harness for FsyncLockDurableOpTime.tla in the BUG model.
+\*
+\* This harness is identical to MCFsyncLockDurableOpTime in operator content;
+\* a separate harness module is required because TLC binds one .cfg per .tla
+\* module name. The .cfg pinned to this module flips BugEnabled to TRUE and
+\* drops weak fairness on ReleaseGlobalS so the wedge-before-release window is
+\* observable as a liveness counterexample.
+\*
+\* See FsyncLockDurableOpTime.tla for instructions.
+
+EXTENDS FsyncLockDurableOpTime
+
+StateConstraint ==
+    /\ lastWritten <= MaxOpTime
+    /\ durableOpTime <= MaxOpTime
+
+\* Specification used by the bug cfg: drops WF on ReleaseGlobalS so TLC can
+\* exhibit the stable-equilibrium wedge between AcquireGlobalS and
+\* ReleaseGlobalS as a permanent counterexample, rather than waiting for the
+\* lock to be released by fairness.
+SpecBug ==
+    /\ Init
+    /\ [][Next]_vars
+    /\ WF_vars(AdvanceDurable)
+
+=============================================================================

--- a/src/mongo/tla_plus/Replication/FsyncLockDurableOpTime/OWNERS.yml
+++ b/src/mongo/tla_plus/Replication/FsyncLockDurableOpTime/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-replication-reviewers

--- a/src/mongo/tla_plus/Replication/FsyncLockDurableOpTime/README.md
+++ b/src/mongo/tla_plus/Replication/FsyncLockDurableOpTime/README.md
@@ -1,0 +1,66 @@
+# FsyncLockDurableOpTime
+
+TLA+ specification of SERVER-126254: `fsyncLock` leaves `durableOpTime` stuck
+behind `lastWritten`.
+
+## What this spec models
+
+A single-node primary with three pieces of state:
+
+- `lastWritten` — most recent optime committed by a `WriteUnitOfWork` in memory.
+- `durableOpTime` — most recent optime fsynced to the journal.
+- `globalSLockHeld` — whether `fsyncLock` is holding Global S.
+
+Three actions drive forward progress: `CommitWUOW` advances `lastWritten`,
+`AcquireGlobalS` flips the lock, `AdvanceDurable` catches `durableOpTime` up
+to `lastWritten`. `ReleaseGlobalS` is the dual of `AcquireGlobalS` so the
+state graph is closed under recovery.
+
+The bug is toggled by the `BugEnabled` constant. When `TRUE`, `AdvanceDurable`
+is gated by `~globalSLockHeld` — the JournalFlusher cannot advance
+`durableOpTime` while Global S is held, matching the documented stable
+equilibrium. When `FALSE`, the gate is removed; this is the fix.
+
+## Properties checked
+
+Safety:
+
+- `DurableNeverAheadOfWritten` — `durableOpTime <= lastWritten` always.
+- `TypeOK`, `MonotoneOpTimes` — sanity.
+
+Liveness:
+
+- `DurableEventuallyCatchesUp` — `lastWritten > durableOpTime ~> equal`.
+- `NoWedgeUnderGlobalS` — diagnostic variant scoped to the lock-held window.
+
+Both liveness properties hold under the green cfg (`MCFsyncLockDurableOpTime.cfg`,
+`BugEnabled = FALSE`) and are violated under the bug cfg
+(`MCFsyncLockDurableOpTimeBug.cfg`, `BugEnabled = TRUE`).
+
+## Running
+
+```
+cd src/mongo/tla_plus
+./download-tlc.sh                                    # one-time
+./model-check.sh Replication/FsyncLockDurableOpTime  # green
+```
+
+To check the bug cfg, point TLC at the bug harness directly:
+
+```
+cd src/mongo/tla_plus/Replication/FsyncLockDurableOpTime
+java -cp ../../tla2tools.jar tlc2.TLC -workers auto \
+    -config MCFsyncLockDurableOpTimeBug.cfg MCFsyncLockDurableOpTimeBug.tla
+```
+
+TLC should report "Temporal properties were violated" with a counterexample of
+length 3 (CommitWUOW; AcquireGlobalS; stutter), which is the wedge between
+`fsyncLock` acquisition and `fsyncUnlock` release exactly as captured in the
+deterministic repro on the ticket.
+
+## Companion regression test
+
+`jstests/replsets/fsync_lock_durable_optime_stuck.js` promotes the
+attached SERVER-126254 repro to a regression test. The jstest pauses the
+`JournalFlusher` thread via failpoint, issues a `w:1, j:false` insert,
+calls `fsyncLock`, asserts the wedge, and verifies the fix's release path.


### PR DESCRIPTION
## Summary

TLA+ spec + jstest pinning the SERVER-126254 stable wedge: when fsyncLock holds Global S, nothing on the primary can advance `durableOpTime` even though `lastWritten` can still advance via concurrent `w:1 j:false` writes.

**Jira:** https://jira.mongodb.org/browse/SERVER-126548
**Related:** https://jira.mongodb.org/browse/SERVER-126254

## TLC verdicts

| Cfg | Result | States |
|---|---|---|
| Green (`BugEnabled=FALSE`) | No errors | 12 distinct, <1s |
| Bug (`BugEnabled=TRUE`) | Temporal property violated; wedge `(lastWritten=2, durableOpTime=1, globalSLockHeld=TRUE)` step-for-step |

## Files

- `src/mongo/tla_plus/Replication/FsyncLockDurableOpTime/FsyncLockDurableOpTime.tla` (203 lines)
- `src/mongo/tla_plus/Replication/FsyncLockDurableOpTime/MCFsyncLockDurableOpTime.{tla,cfg}` + `MCFsyncLockDurableOpTimeBug.{tla,cfg}`
- `src/mongo/tla_plus/Replication/FsyncLockDurableOpTime/OWNERS.yml` (`10gen/server-replication-reviewers`)
- `src/mongo/tla_plus/Replication/FsyncLockDurableOpTime/README.md`
- `jstests/replsets/fsync_lock_durable_optime_stuck.js` (155 lines)

## Verify

```
cd src/mongo/tla_plus
./download-tlc.sh
./model-check.sh Replication/FsyncLockDurableOpTime
```

jstest promotes the ticket's attached repro: `pauseJournalFlusherBeforeFlush` failpoint → `w:1 j:false` insert → assert `durable < written` → `fsyncLock` → release failpoint → `assert.soon` durable catches up within 30s.

## Draft status

Opened as Draft.
