### PR TITLE
SERVER-126549 Add TLA+ spec + jstest for range-deletion stale-metadata across rename

### DIFF
--- a/jstests/sharding/range_deletion_stale_metadata_after_rename.js
+++ b/jstests/sharding/range_deletion_stale_metadata_after_rename.js
@@ -1,0 +1,167 @@
+/**
+ * SERVER-114326 reproduction: a RangeDeletionTask must not observe stale
+ * CollectionShardingRuntime metadata while a rename is in flight.
+ *
+ * The rename coordinator commits in two oplog entries:
+ *   (1) the rewrite of every pending RangeDeletionTask's collectionUuid from
+ *       the pre-rename UUID to the post-rename UUID, and
+ *   (2) the FilteringMetadataClearer pass that drops the cached CSR metadata
+ *       entry for the renamed namespace.
+ *
+ * Empirically the gap between (1) and (2) has been measured at ~300 ms.
+ * Within that window RangeDeleterServiceOpObserver::onUpdate fires on (1)
+ * and reads a task stamped with the new UUID while the metadataTracker held
+ * by the CSR is still pinned to the old UUID. SERVER-113667 short-circuits
+ * the invalidateRangePreservers call when the UUIDs disagree; this test
+ * pins the underlying ordering invariant by driving the window directly via
+ * failpoints and asserting that no mismatched invalidation ever fires.
+ *
+ * @tags: [
+ *   requires_fcv_80,
+ *   requires_sharding,
+ *   requires_majority_read_concern,
+ *   featureFlagRangeDeleterRenameSafety,
+ * ]
+ */
+
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {funWithArgs} from "jstests/libs/parallel_shell_helpers.js";
+import {ShardingTest} from "jstests/libs/shardingtest.js";
+
+TestData.skipCheckingUUIDsConsistentAcrossCluster = true;
+
+const dbName = "test";
+const sourceCollName = "rangedel_rename_source";
+const targetCollName = "rangedel_rename_target";
+const sourceNss = dbName + "." + sourceCollName;
+const targetNss = dbName + "." + targetCollName;
+
+const st = new ShardingTest({
+    shards: 2,
+    rs: {nodes: 2},
+    other: {
+        configOptions: {setParameter: {orphanCleanupDelaySecs: 0}},
+        rsOptions: {setParameter: {orphanCleanupDelaySecs: 0, rangeDeleterBatchSize: 16}},
+    },
+});
+
+const mongos = st.s;
+const shard0 = st.shard0;
+const shard1 = st.shard1;
+const shard0Primary = st.rs0.getPrimary();
+
+// Set up the source collection: sharded by {x: 1}, split at {x: 0}, one chunk
+// on each shard so a moveChunk creates a RangeDeletionTask on shard0.
+assert.commandWorked(mongos.adminCommand({enableSharding: dbName, primaryShard: shard0.shardName}));
+assert.commandWorked(mongos.adminCommand({shardCollection: sourceNss, key: {x: 1}}));
+assert.commandWorked(mongos.adminCommand({split: sourceNss, middle: {x: 0}}));
+
+const sourceColl = mongos.getCollection(sourceNss);
+let bulk = sourceColl.initializeUnorderedBulkOp();
+for (let i = -200; i < 200; i++) {
+    bulk.insert({x: i, payload: "abcdefghij"});
+}
+assert.commandWorked(bulk.execute());
+
+// Suspend range deletion on shard0 so the RangeDeletionTask remains pending
+// after the moveChunk completes. This guarantees there is a task in
+// config.rangeDeletions whose collectionUuid the rename coordinator will
+// later rewrite.
+const suspendDeletion = configureFailPoint(shard0Primary, "suspendRangeDeletion");
+
+assert.commandWorked(mongos.adminCommand({
+    moveChunk: sourceNss,
+    find: {x: 100},
+    to: shard1.shardName,
+    _waitForDelete: false,
+}));
+
+const rangeDeletionsBeforeRename =
+    shard0Primary.getDB("config").getCollection("rangeDeletions").find({nss: sourceNss}).toArray();
+assert.gte(rangeDeletionsBeforeRename.length, 1,
+           "expected at least one pending RangeDeletionTask on shard0 before rename");
+const preRenameCollUuid = rangeDeletionsBeforeRename[0].collectionUuid;
+jsTest.log("Pre-rename RangeDeletionTask UUID on shard0: " + tojson(preRenameCollUuid));
+
+// Drop the target so the rename has a clear destination.
+assert.commandWorked(mongos.getDB(dbName).runCommand({drop: targetCollName}));
+
+// Open the 300 ms TOCTOU window. hangBeforeFilteringMetadataClearer pauses
+// after the rename coordinator has committed the rangeDeletions UUID rewrite
+// but before the CSR metadata clear has been applied. This is the production
+// window in which onUpdate may observe a (newUUID, oldUUID) pair.
+const hangBeforeMetadataClear =
+    configureFailPoint(shard0Primary, "hangBeforeFilteringMetadataClearerOnRename");
+
+const renameShell = startParallelShell(funWithArgs(function(dbName, fromColl, toColl) {
+    assert.commandWorked(db.getSiblingDB("admin").runCommand({
+        renameCollection: dbName + "." + fromColl,
+        to: dbName + "." + toColl,
+        dropTarget: true,
+    }));
+}, dbName, sourceCollName, targetCollName), mongos.port);
+
+hangBeforeMetadataClear.wait();
+jsTest.log("Reached pre-FilteringMetadataClearer hang; UUID rewrite has committed.");
+
+// Within the window: confirm the RangeDeletionTask now carries the new UUID
+// while the CSR for the original namespace is either still cached against
+// the old UUID or has not yet been refreshed.
+const rangeDeletionsInWindow =
+    shard0Primary.getDB("config").getCollection("rangeDeletions").find({}).toArray();
+assert.gte(rangeDeletionsInWindow.length, 1,
+           "expected RangeDeletionTask still present inside the TOCTOU window");
+const inWindowCollUuid = rangeDeletionsInWindow[0].collectionUuid;
+jsTest.log("In-window RangeDeletionTask UUID on shard0: " + tojson(inWindowCollUuid));
+assert.neq(bsonWoCompare(inWindowCollUuid, preRenameCollUuid), 0,
+           "rename coordinator should have rewritten the RangeDeletionTask UUID by now");
+
+// Drive a range-deleter pass while the window is open. The fix (paired with
+// the SERVER-113667 quick-fix) is to refuse invalidation when task.uuid
+// disagrees with metadata.uuid, and to defer task processing until the
+// metadata has been refreshed. Either way, no mismatched invalidation
+// should be logged.
+const beforeInvalidationCount = (function () {
+    const log = assert.commandWorked(shard0Primary.adminCommand({getLog: "global"})).log;
+    return log.filter(line => line.indexOf("invalidateRangePreservers") !== -1
+                              && line.indexOf("UUID mismatch") !== -1).length;
+})();
+
+suspendDeletion.off();
+
+// Hold the window open long enough for the deleter to observe the in-flight
+// state. 300 ms matches the empirical gap in the ticket; we wait 1 s to be
+// generous against slow CI hosts.
+sleep(1000);
+
+// Close the window: let FilteringMetadataClearer run.
+hangBeforeMetadataClear.off();
+renameShell();
+
+// Validate the headline invariant: the range deleter never invalidated
+// preservers with mismatched UUIDs.
+const afterInvalidationCount = (function () {
+    const log = assert.commandWorked(shard0Primary.adminCommand({getLog: "global"})).log;
+    return log.filter(line => line.indexOf("invalidateRangePreservers") !== -1
+                              && line.indexOf("UUID mismatch") !== -1).length;
+})();
+assert.eq(afterInvalidationCount, beforeInvalidationCount,
+          "RangeDeleter must not invalidate preservers with mismatched UUIDs across rename");
+
+// Validate post-rename steady state: the renamed namespace is reachable,
+// the source namespace is gone, and the RangeDeletionTask either drained or
+// carries the post-rename UUID consistently with the cached metadata.
+assert.eq(mongos.getDB(dbName).getCollectionInfos({name: sourceCollName}).length, 0,
+          "source collection should no longer exist after rename");
+assert.eq(mongos.getDB(dbName).getCollectionInfos({name: targetCollName}).length, 1,
+          "target collection should exist after rename");
+
+const finalRangeDeletions =
+    shard0Primary.getDB("config").getCollection("rangeDeletions").find({}).toArray();
+for (const doc of finalRangeDeletions) {
+    assert.neq(bsonWoCompare(doc.collectionUuid, preRenameCollUuid), 0,
+               "no RangeDeletionTask should still carry the pre-rename UUID after rename: "
+               + tojson(doc));
+}
+
+st.stop();

--- a/src/mongo/tla_plus/Sharding/RangeDeletionRenameRace/MCRangeDeletionRenameRace.cfg
+++ b/src/mongo/tla_plus/Sharding/RangeDeletionRenameRace/MCRangeDeletionRenameRace.cfg
@@ -1,0 +1,18 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    OldUUID = "uuid-old"
+    NewUUID = "uuid-new"
+    AllowCommitBeforeMetadataClear = FALSE
+
+INVARIANT
+    TypeOK
+    RangeDeleterMetadataMatchesCollectionUUID
+    ObserverSnapshotsCoherent
+    PostRenameMetadataIsFresh
+
+PROPERTIES
+    EventuallyRenameCompletes
+    EventuallyObserverDecides
+    EventuallyMetadataIsFresh
+    Termination

--- a/src/mongo/tla_plus/Sharding/RangeDeletionRenameRace/MCRangeDeletionRenameRace.tla
+++ b/src/mongo/tla_plus/Sharding/RangeDeletionRenameRace/MCRangeDeletionRenameRace.tla
@@ -1,0 +1,20 @@
+
+\* Copyright 2025 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+------------------------------ MODULE MCRangeDeletionRenameRace ------------------------------
+
+EXTENDS RangeDeletionRenameRace
+
+(**************************************************************************************************)
+(* Counterexample bait: assert the observer never reaches DECIDED so that TLC produces a trace    *)
+(* showing how the bug interleaving completes. Wired into the .cfg only when desired.             *)
+(**************************************************************************************************)
+
+BaitObserverNeverDecides ==
+    observerState # "DECIDED"
+
+====================================================================================================

--- a/src/mongo/tla_plus/Sharding/RangeDeletionRenameRace/MCRangeDeletionRenameRace_bug.cfg
+++ b/src/mongo/tla_plus/Sharding/RangeDeletionRenameRace/MCRangeDeletionRenameRace_bug.cfg
@@ -1,0 +1,10 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    OldUUID = "uuid-old"
+    NewUUID = "uuid-new"
+    AllowCommitBeforeMetadataClear = TRUE
+
+INVARIANT
+    TypeOK
+    RangeDeleterMetadataMatchesCollectionUUID

--- a/src/mongo/tla_plus/Sharding/RangeDeletionRenameRace/OWNERS.yml
+++ b/src/mongo/tla_plus/Sharding/RangeDeletionRenameRace/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-sharding

--- a/src/mongo/tla_plus/Sharding/RangeDeletionRenameRace/README.md
+++ b/src/mongo/tla_plus/Sharding/RangeDeletionRenameRace/README.md
@@ -1,0 +1,55 @@
+# RangeDeletionRenameRace
+
+TLA+ specification of the rename / range-deleter / FilteringMetadataClearer race
+described in **SERVER-114326**. SERVER-113667 shipped a symptom-level
+quick-fix (skip `RangeDeleter` invalidation when the CSR UUID disagrees with the
+`RangeDeletionTask` UUID); the spec models the underlying ordering bug that
+makes the mismatch observable in the first place.
+
+## What the spec models
+
+Three threads share state on a single shard:
+
+1. **RenameCoordinator** — commits the rename via two oplog entries:
+   `COMMIT_RENAME` rewrites every pending `RangeDeletionTask.collectionUuid`
+   from `OldUUID` to `NewUUID`; `CLEAR_METADATA` replaces the cached
+   `CollectionShardingRuntime` metadata UUID.
+2. **RangeDeleterServiceOpObserver** — fires `onUpdate` on
+   `config.rangeDeletions` and reads `(task.uuid, metadata.uuid)` before
+   deciding whether to invoke `invalidateRangePreservers()`.
+3. **FilteringMetadataClearer** — applies the metadata clear/refresh that
+   closes the window.
+
+The shared state is `taskUUID` and `metadataUUID`. The bug toggle
+`AllowCommitBeforeMetadataClear` controls whether `CLEAR_METADATA` may be
+deferred past the observer's reads. With the toggle off, the spec models the
+fix: the clear is sequenced before any observer action.
+
+## Invariants
+
+- `RangeDeleterMetadataMatchesCollectionUUID` (headline) — when the observer
+  invokes `invalidateRangePreservers`, the task UUID it observed must equal the
+  metadata UUID it observed.
+- `ObserverSnapshotsCoherent` — after the observer has decided, its two
+  snapshots must agree.
+- `PostRenameMetadataIsFresh` — once the coordinator reaches `DONE`, the
+  cached metadata UUID equals the task UUID.
+
+## Configurations
+
+| File                                  | Toggle                              | Expected outcome                                                        |
+|---------------------------------------|-------------------------------------|-------------------------------------------------------------------------|
+| `MCRangeDeletionRenameRace.cfg`       | `AllowCommitBeforeMetadataClear=FALSE` | All invariants hold; liveness holds.                                  |
+| `MCRangeDeletionRenameRace_bug.cfg`   | `AllowCommitBeforeMetadataClear=TRUE`  | `RangeDeleterMetadataMatchesCollectionUUID` violated with counterexample. |
+
+## Running
+
+```sh
+cd src/mongo/tla_plus
+./model-check.sh Sharding/RangeDeletionRenameRace
+```
+
+## Paired jstest
+
+`jstests/sharding/range_deletion_stale_metadata_after_rename.js` exercises the
+300ms TOCTOU window described in the ticket against a real `ShardingTest`.

--- a/src/mongo/tla_plus/Sharding/RangeDeletionRenameRace/RangeDeletionRenameRace.tla
+++ b/src/mongo/tla_plus/Sharding/RangeDeletionRenameRace/RangeDeletionRenameRace.tla
@@ -1,0 +1,253 @@
+
+\* Copyright 2025 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+--------------------------- MODULE RangeDeletionRenameRace ---------------------------
+(**************************************************************************************************)
+(* This specification models the race condition between a collection rename and the range deleter *)
+(* service on a single shard. It corresponds to SERVER-114326 (root cause; SERVER-113667 shipped a *)
+(* symptom-level skip when the CSR and the RangeDeletionTask UUIDs disagree).                     *)
+(*                                                                                                *)
+(* The bug is a TOCTOU window between two oplog entries emitted by the rename coordinator:        *)
+(*    (1) the update to config.rangeDeletions that rewrites every pending task's collectionUUID   *)
+(*        from the old (pre-rename) UUID to the new (post-rename) UUID, and                       *)
+(*    (2) the metadata refresh that causes FilteringMetadataClearer to drop the cached            *)
+(*        CollectionShardingRuntime entry for the renamed namespace.                              *)
+(*                                                                                                *)
+(* Empirically the gap between (1) and (2) has been observed at ~300ms, long enough for the       *)
+(* RangeDeleterServiceOpObserver::onUpdate hook to fire on (1) and read a RangeDeletionTask       *)
+(* stamped with the new UUID while the metadataTracker held by the CSR is still pinned to the    *)
+(* old UUID. invalidateRangePreservers() is then called with mismatching UUIDs, which used to     *)
+(* invalidate the wrong range preservers; SERVER-113667 short-circuits that path. The deeper      *)
+(* invariant -- that the range deleter never observes a (task, metadata) pair with disjoint       *)
+(* UUIDs -- is what this spec captures.                                                           *)
+(*                                                                                                *)
+(* Threads modelled:                                                                              *)
+(*   - RenameCoordinator: commits the rename in two oplog entries: COMMIT_RENAME then            *)
+(*     CLEAR_METADATA. The two entries land in the oplog in order but the metadata clearer must  *)
+(*     still observe and apply the second entry before the cached metadata is dropped.            *)
+(*   - RangeDeleterOpObserver: fires onUpdate when (1) lands. Reads the updated task plus the    *)
+(*     currently-cached metadata UUID. Decides whether to invalidate range preservers based on    *)
+(*     the (task.uuid, metadata.uuid) pair.                                                       *)
+(*   - FilteringMetadataClearer: applies (2). Replaces the cached metadata UUID with the new     *)
+(*     post-rename UUID (modelled as a clear-then-refresh).                                       *)
+(*                                                                                                *)
+(* RenameCoordinator transitions:                                                                 *)
+(*   - INIT -> RENAME_COMMITTED -> METADATA_CLEARED -> DONE                                       *)
+(*                                                                                                *)
+(* RangeDeleterOpObserver transitions:                                                            *)
+(*   - INIT -> TASK_READ -> METADATA_READ -> DECIDED                                              *)
+(*                                                                                                *)
+(* The bug is reproduced by toggling AllowCommitBeforeMetadataClear. When TRUE, the op-observer  *)
+(* may fire its read-task and read-metadata steps in the gap between RENAME_COMMITTED and        *)
+(* METADATA_CLEARED. When FALSE, the spec models the corrected ordering: the metadata clear is    *)
+(* sequenced before any onUpdate-triggered observer reads, restoring the safety invariant.        *)
+(**************************************************************************************************)
+
+EXTENDS Integers, FiniteSets, Sequences, TLC
+
+CONSTANTS
+    OldUUID,                                \* UUID of the collection before rename
+    NewUUID,                                \* UUID of the collection after rename
+    AllowCommitBeforeMetadataClear          \* Bug toggle: TRUE = reproduce the race
+
+ASSUME OldUUID # NewUUID
+
+(* Modelled UUIDs. NoUUID is used to represent "no metadata cached" (post-clear, pre-refresh). *)
+NoUUID == "NoUUID"
+UUIDs == {OldUUID, NewUUID, NoUUID}
+
+(* Rename coordinator states. *)
+RenameStates == {"INIT", "RENAME_COMMITTED", "METADATA_CLEARED", "DONE"}
+
+(* Op-observer states. *)
+ObserverStates == {"INIT", "TASK_READ", "METADATA_READ", "DECIDED"}
+
+(* Range deletion task as stored in config.rangeDeletions. The task's collectionUuid field is    *)
+(* mutated in place by the rename coordinator at RENAME_COMMITTED.                               *)
+VARIABLES
+    taskUUID,                               \* UUID stamped on the RangeDeletionTask document
+    metadataUUID,                           \* UUID held by the CSR metadataTracker
+    renameState,                            \* Rename coordinator's state machine
+    observerState,                          \* Op-observer's state machine
+    observerTaskRead,                       \* Snapshot of taskUUID at TASK_READ
+    observerMetadataRead,                   \* Snapshot of metadataUUID at METADATA_READ
+    invalidationFired,                      \* TRUE iff invalidateRangePreservers was called
+    invalidationMismatch                    \* TRUE iff invalidation fired with task.uuid # metadata.uuid
+
+vars == <<taskUUID, metadataUUID, renameState, observerState,
+          observerTaskRead, observerMetadataRead,
+          invalidationFired, invalidationMismatch>>
+
+Init ==
+    /\ taskUUID = OldUUID
+    /\ metadataUUID = OldUUID
+    /\ renameState = "INIT"
+    /\ observerState = "INIT"
+    /\ observerTaskRead = NoUUID
+    /\ observerMetadataRead = NoUUID
+    /\ invalidationFired = FALSE
+    /\ invalidationMismatch = FALSE
+
+(**************************************************************************************************)
+(* Type invariant.                                                                                 *)
+(**************************************************************************************************)
+
+TypeOK ==
+    /\ taskUUID \in UUIDs
+    /\ metadataUUID \in UUIDs
+    /\ renameState \in RenameStates
+    /\ observerState \in ObserverStates
+    /\ observerTaskRead \in UUIDs
+    /\ observerMetadataRead \in UUIDs
+    /\ invalidationFired \in BOOLEAN
+    /\ invalidationMismatch \in BOOLEAN
+
+(**************************************************************************************************)
+(* Actions: RenameCoordinator.                                                                     *)
+(**************************************************************************************************)
+
+COMMIT_RENAME ==
+(* The rename coordinator commits the rename. The first oplog entry rewrites every               *)
+(* RangeDeletionTask document's collectionUuid from OldUUID to NewUUID.                          *)
+    /\ renameState = "INIT"
+    /\ renameState' = "RENAME_COMMITTED"
+    /\ taskUUID' = NewUUID
+    /\ UNCHANGED <<metadataUUID, observerState, observerTaskRead, observerMetadataRead,
+                   invalidationFired, invalidationMismatch>>
+
+CLEAR_METADATA ==
+(* FilteringMetadataClearer applies the second oplog entry. The cached metadata UUID is dropped  *)
+(* and replaced with the post-rename UUID. In production this is itself a two-step               *)
+(* clear-then-refresh, but for the purpose of modelling the rename / range-deleter race a       *)
+(* single atomic transition is sufficient: what matters is whether this transition is sequenced *)
+(* relative to the op-observer's reads, not its internal structure.                              *)
+    /\ renameState = "RENAME_COMMITTED"
+    /\ renameState' = "METADATA_CLEARED"
+    /\ metadataUUID' = NewUUID
+    /\ UNCHANGED <<taskUUID, observerState, observerTaskRead, observerMetadataRead,
+                   invalidationFired, invalidationMismatch>>
+
+RENAME_DONE ==
+    /\ renameState = "METADATA_CLEARED"
+    /\ renameState' = "DONE"
+    /\ UNCHANGED <<taskUUID, metadataUUID, observerState, observerTaskRead, observerMetadataRead,
+                   invalidationFired, invalidationMismatch>>
+
+(**************************************************************************************************)
+(* Actions: RangeDeleterServiceOpObserver.                                                         *)
+(*                                                                                                *)
+(* The op-observer fires onUpdate when the RangeDeletionTask document is rewritten by the         *)
+(* coordinator. It reads the task body and the cached CSR metadata, then decides whether to       *)
+(* call invalidateRangePreservers based on the (task.uuid, metadata.uuid) pair.                   *)
+(**************************************************************************************************)
+
+OBS_READ_TASK ==
+(* onUpdate fires after the rangeDeletions document update lands. The observer reads the         *)
+(* current task body.                                                                            *)
+(*                                                                                                *)
+(* The bug toggle controls precisely the ordering between the COMMIT_RENAME oplog entry and the  *)
+(* onUpdate hook reading the cached metadata. When AllowCommitBeforeMetadataClear is TRUE the   *)
+(* observer is permitted to fire as soon as the rename has committed, which is the production    *)
+(* behaviour described in SERVER-114326 -- the onUpdate hook fires off the back of the           *)
+(* rangeDeletions update and may race the FilteringMetadataClearer. When the toggle is FALSE the *)
+(* fix is in place: the observer is gated until renameState reaches METADATA_CLEARED, so the     *)
+(* (task, metadata) snapshots cannot diverge.                                                    *)
+    /\ observerState = "INIT"
+    /\ \/ /\ AllowCommitBeforeMetadataClear
+          /\ renameState \in {"RENAME_COMMITTED", "METADATA_CLEARED", "DONE"}
+       \/ /\ ~AllowCommitBeforeMetadataClear
+          /\ renameState \in {"METADATA_CLEARED", "DONE"}
+    /\ observerState' = "TASK_READ"
+    /\ observerTaskRead' = taskUUID
+    /\ UNCHANGED <<taskUUID, metadataUUID, renameState, observerMetadataRead,
+                   invalidationFired, invalidationMismatch>>
+
+OBS_READ_METADATA ==
+(* Observer reads the cached metadata UUID from the CSR. In the buggy interleaving this read    *)
+(* returns OldUUID even though the task already carries NewUUID.                                  *)
+    /\ observerState = "TASK_READ"
+    /\ observerState' = "METADATA_READ"
+    /\ observerMetadataRead' = metadataUUID
+    /\ UNCHANGED <<taskUUID, metadataUUID, renameState, observerTaskRead,
+                   invalidationFired, invalidationMismatch>>
+
+OBS_DECIDE ==
+(* The observer decides whether to invoke invalidateRangePreservers. The decision is made on    *)
+(* the snapshot it just read. The bug is that invalidation may fire with mismatched UUIDs.       *)
+    /\ observerState = "METADATA_READ"
+    /\ observerState' = "DECIDED"
+    /\ invalidationFired' = TRUE
+    /\ invalidationMismatch' = (observerTaskRead # observerMetadataRead)
+    /\ UNCHANGED <<taskUUID, metadataUUID, renameState, observerTaskRead, observerMetadataRead>>
+
+(**************************************************************************************************)
+(* Termination.                                                                                    *)
+(**************************************************************************************************)
+
+TERMINATING ==
+    /\ renameState = "DONE"
+    /\ observerState = "DECIDED"
+    /\ UNCHANGED vars
+
+Next ==
+    \/ COMMIT_RENAME
+    \/ CLEAR_METADATA
+    \/ RENAME_DONE
+    \/ OBS_READ_TASK
+    \/ OBS_READ_METADATA
+    \/ OBS_DECIDE
+    \/ TERMINATING
+
+Fairness ==
+    /\ WF_vars(COMMIT_RENAME)
+    /\ WF_vars(CLEAR_METADATA)
+    /\ WF_vars(RENAME_DONE)
+    /\ WF_vars(OBS_READ_TASK)
+    /\ WF_vars(OBS_READ_METADATA)
+    /\ WF_vars(OBS_DECIDE)
+    /\ WF_vars(TERMINATING)
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+(**************************************************************************************************)
+(* Safety properties.                                                                              *)
+(*                                                                                                *)
+(* The headline invariant captures the root cause of SERVER-114326: at any moment the range      *)
+(* deleter observes a RangeDeletionTask and the CSR metadata together, those two UUIDs must       *)
+(* agree. The action OBS_DECIDE writes invalidationMismatch from the local snapshots, so the     *)
+(* invariant inspects those rather than the live values.                                          *)
+(**************************************************************************************************)
+
+RangeDeleterMetadataMatchesCollectionUUID ==
+    invalidationMismatch = FALSE
+
+(* A weaker invariant: whenever the observer has finished its reads, the snapshots must agree   *)
+(* with the global state. Useful for spotting incoherent interleavings even when invalidation    *)
+(* itself was skipped.                                                                            *)
+ObserverSnapshotsCoherent ==
+    (observerState = "DECIDED") =>
+        (observerTaskRead = observerMetadataRead)
+
+(* Cleanup invariant: by the time the rename coordinator declares DONE, the cached metadata     *)
+(* UUID must equal the task UUID. Without this, a later range deleter wakeup would still see   *)
+(* a stale CSR entry.                                                                            *)
+PostRenameMetadataIsFresh ==
+    (renameState = "DONE") => (metadataUUID = taskUUID)
+
+(**************************************************************************************************)
+(* Liveness properties.                                                                            *)
+(**************************************************************************************************)
+
+EventuallyRenameCompletes == <>(renameState = "DONE")
+EventuallyObserverDecides == <>(observerState = "DECIDED")
+EventuallyMetadataIsFresh == <>(metadataUUID = NewUUID)
+
+Termination ==
+    /\ <>(renameState = "DONE")
+    /\ <>(observerState = "DECIDED")
+
+====================================================================================================


### PR DESCRIPTION
## Summary

TLA+ spec + jstest for the SERVER-114326 root-cause race: after a rename commits but before `FilteringMetadataClearer` runs, the range deleter reads the updated `RangeDeletionTask` (new UUID) while `metadataTracker → metadata → getUUID()` still holds the old one. SERVER-113667 patched a symptom; the underlying TOCTOU is open.

**Jira:** https://jira.mongodb.org/browse/SERVER-126549
**Related:** https://jira.mongodb.org/browse/SERVER-114326

## TLC verdicts

| Cfg | Result |
|---|---|
| Green | No error; 10 distinct states, depth 7 |
| Bug (`AllowCommitBeforeMetadataClear=TRUE`) | 5-state counterexample at depth 5 — `invalidationMismatch=TRUE`, `taskUUID="uuid-new"`, `metadataUUID="uuid-old"` |

## Files

- `src/mongo/tla_plus/Sharding/RangeDeletionRenameRace/RangeDeletionRenameRace.tla` (253 lines)
- `src/mongo/tla_plus/Sharding/RangeDeletionRenameRace/MCRangeDeletionRenameRace.{tla,cfg}` (green) + `MCRangeDeletionRenameRace_bug.cfg`
- `src/mongo/tla_plus/Sharding/RangeDeletionRenameRace/OWNERS.yml` (`10gen/server-sharding`)
- `src/mongo/tla_plus/Sharding/RangeDeletionRenameRace/README.md` (262 words)
- `jstests/sharding/range_deletion_stale_metadata_after_rename.js` (167 lines)

## Verify

```
cd src/mongo/tla_plus
./download-tlc.sh
./model-check.sh Sharding/RangeDeletionRenameRace
```

jstest drives the 300ms TOCTOU via `suspendRangeDeletion` + `hangBeforeFilteringMetadataClearerOnRename` failpoints; asserts (a) in-window task carries the new UUID, (b) no mismatched-UUID invalidations logged, (c) no task retains the pre-rename UUID after completion.

## Note

If `hangBeforeFilteringMetadataClearerOnRename` doesn't exist under that exact name, a one-line addition is needed in `range_deleter_service_op_observer.cpp` or the rename coordinator's metadata-clear path. Spec is failpoint-independent.

## Draft status

Opened as Draft.
