### PR TITLE
SERVER-126550 Add TLA+ spec + jstest for transitionToDedicatedConfigServer orphans

### DIFF
--- a/jstests/sharding/transition_to_dedicated_in_flight_migration_orphan.js
+++ b/jstests/sharding/transition_to_dedicated_in_flight_migration_orphan.js
@@ -1,0 +1,163 @@
+/**
+ * SERVER-125663: orphans accumulate on the former config-server-shard when
+ * `transitionToDedicatedConfigServer` races with a migration commit and drops
+ * `config.rangeDeletions` between the donor registering the in-memory range-deletion task and
+ * `markAsReadyRangeDeletionTaskLocally` running.
+ *
+ * Exercises the interleaving by hanging the donor inside `markAsReadyRangeDeletionTaskLocally` via
+ * the `hangInReadyRangeDeletionLocallyInterruptible` failpoint, then runs
+ * `transitionToDedicatedConfigServer` to completion (which drops `config.rangeDeletions` on the
+ * config-server-shard), then releases the failpoint and asserts that:
+ *
+ *   1. No in-memory range-deletion task remains wedged in `pending = true` state.
+ *   2. No orphan documents remain on the former config-server-shard.
+ *   3. The `moveChunk` invocation that triggered the race did not hang (it was issued without
+ *      `waitForDelete`, so a hang would surface as a client-side timeout).
+ *
+ * Companion to TLA+ spec `src/mongo/tla_plus/Sharding/ConfigServerTransitionOrphan`.
+ *
+ * @tags: [
+ *   requires_fcv_83,
+ *   does_not_support_stepdowns,
+ * ]
+ */
+
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {funWithArgs} from "jstests/libs/parallel_shell_helpers.js";
+import {ShardingTest} from "jstests/libs/shardingtest.js";
+
+const kDbName = "transition_orphan_db";
+const kCollName = "orphans";
+const kNs = kDbName + "." + kCollName;
+
+// Bring up a 2-shard cluster with an embedded config server. The config server is also `shard0`
+// (the config-server-shard); `shard1` is a dedicated data shard.
+const st = new ShardingTest({
+    name: "transitionOrphan",
+    shards: 2,
+    other: {
+        configShard: true,
+        rsOptions: {
+            setParameter: {
+                orphanCleanupDelaySecs: 0,
+                // Block the range deleter actually running so the test deterministically observes
+                // the in-memory task state across the race. Released at end of test.
+                "failpoint.suspendRangeDeletion": tojson({mode: "alwaysOn"}),
+            },
+        },
+    },
+});
+
+const mongos = st.s;
+const configShardName = "config";
+const recipientShardName = st.shard1.shardName;
+
+jsTest.log.info("Seed sharded collection on the config-server-shard");
+assert.commandWorked(mongos.adminCommand({enableSharding: kDbName, primaryShard: configShardName}));
+assert.commandWorked(mongos.adminCommand({shardCollection: kNs, key: {x: 1}}));
+const seeded = mongos.getDB(kDbName)[kCollName];
+const kDocs = 50;
+let bulk = seeded.initializeUnorderedBulkOp();
+for (let i = 0; i < kDocs; i++) {
+    bulk.insert({x: i, payload: "p".repeat(64)});
+}
+assert.commandWorked(bulk.execute());
+
+jsTest.log.info("Hang the donor inside markAsReadyRangeDeletionTaskLocally on the config shard");
+const configPrimary = st.configRS.getPrimary();
+const hangMarkAsReady =
+    configureFailPoint(configPrimary, "hangInReadyRangeDeletionLocallyInterruptible");
+
+jsTest.log.info("Start a moveChunk in a parallel shell (donor = config, recipient = shard1)");
+const moveChunkAwait = startParallelShell(
+    funWithArgs(function (ns, recipient) {
+        // No waitForDelete: SERVER-125663 also affects the in-flight migration through the same
+        // wedged future, but we keep this test scoped to the orphan accumulation symptom.
+        assert.commandWorked(db.getSiblingDB("admin").runCommand({
+            moveChunk: ns,
+            find: {x: 0},
+            to: recipient,
+        }));
+    }, kNs, recipientShardName),
+    mongos.port,
+);
+
+jsTest.log.info("Wait for the donor to reach the failpoint");
+hangMarkAsReady.wait();
+
+jsTest.log.info("Run transitionToDedicatedConfigServer concurrently (drops config.rangeDeletions)");
+assert.commandWorked(mongos.adminCommand({startTransitionToDedicatedConfigServer: 1}));
+
+// movePrimary of any unsharded data hosted on the config shard so the transition can complete.
+// In this test no other database has the config-server-shard as primary, so this is a no-op safety
+// net.
+
+assert.soon(
+    () => {
+        const status = mongos.adminCommand({getTransitionToDedicatedConfigServerStatus: 1});
+        if (!status.ok) {
+            jsTest.log.info({msg: "transition status not ok yet", status});
+            return false;
+        }
+        return status.state === "drainingComplete";
+    },
+    "transition draining never reached drainingComplete",
+    5 * 60 * 1000,
+);
+
+jsTest.log.info("Commit transition: this drops config.rangeDeletions on the config-server-shard");
+assert.commandWorked(mongos.adminCommand({commitTransitionToDedicatedConfigServer: 1}));
+
+jsTest.log.info("Release the failpoint -- donor now runs markAsReadyRangeDeletionTaskLocally");
+hangMarkAsReady.off();
+
+moveChunkAwait();
+
+jsTest.log.info("Allow the range deleter to actually drain orphans");
+assert.commandWorked(configPrimary.adminCommand({
+    configureFailPoint: "suspendRangeDeletion",
+    mode: "off",
+}));
+
+jsTest.log.info("Assert no in-memory range-deletion task remains wedged in pending state");
+// After SERVER-125663 is fixed, the donor must either: (a) keep `config.rangeDeletions` writable
+// until in-flight migrations drain, or (b) be told `clearPending` synchronously even when the
+// $unset matches no document. Either way, the in-memory pending-task count must reach 0.
+const cfgPendingPath = "shardingStatistics.rangeDeleterTasks";
+assert.soon(
+    () => {
+        const serverStatus = configPrimary.adminCommand({serverStatus: 1});
+        assert.commandWorked(serverStatus);
+        const rdStats = serverStatus.shardingStatistics &&
+            serverStatus.shardingStatistics.rangeDeleterTasks;
+        // The exact field name has varied across versions; we accept either `pending` or
+        // `numPending` keys.
+        const pending = rdStats &&
+            (rdStats.pending !== undefined ? rdStats.pending :
+                                             rdStats.numPending !== undefined ? rdStats.numPending : 0);
+        return pending === 0;
+    },
+    "in-memory range-deletion task remained pending after transition (SERVER-125663 regression)",
+    60 * 1000,
+);
+
+jsTest.log.info("Assert no orphan documents remain on the former config-server-shard");
+const formerConfigShardConn = st.rs0.getPrimary();
+assert.soon(
+    () => {
+        // The collection itself still exists on the former config-server-shard until it is
+        // dropped by `cleanupOrphaned` / range deleter. Use the rangeDeleterStats orphan count.
+        const stats = formerConfigShardConn.getDB(kDbName).runCommand({collStats: kCollName});
+        if (!stats.ok) {
+            // Collection has already been removed entirely -- 0 orphans.
+            return true;
+        }
+        const numOrphans = stats.numOrphanDocs !== undefined ? stats.numOrphanDocs : stats.count;
+        jsTest.log.info({msg: "orphan-poll", numOrphans});
+        return numOrphans === 0;
+    },
+    "orphan documents remained on former config-server-shard (SERVER-125663 regression)",
+    2 * 60 * 1000,
+);
+
+st.stop();

--- a/src/mongo/tla_plus/Sharding/ConfigServerTransitionOrphan/ConfigServerTransitionOrphan.tla
+++ b/src/mongo/tla_plus/Sharding/ConfigServerTransitionOrphan/ConfigServerTransitionOrphan.tla
@@ -1,0 +1,260 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+------------------------ MODULE ConfigServerTransitionOrphan ---------------------------------------
+\* This specification models the interleaving between two concurrent activities on a
+\* config-server-shard (the cluster member that hosts both the config server and a data shard, see
+\* SERVER-103990):
+\*
+\*   (a) A chunk migration committing on the donor. The donor:
+\*       1. persists the commit decision and registers an on-disk range-deletion task document in
+\*          `config.rangeDeletions` with a `pending: true` field.
+\*       2. registers an in-memory range-deletion task with the RangeDeleterService in the
+\*          `Pending` state.
+\*       3. invokes `markAsReadyRangeDeletionTaskLocally`, which `$unset`s the `pending` field on
+\*          the on-disk doc. The OpObserver for that update calls `clearPending()` on the
+\*          in-memory task, releasing the deletion chain so it can run.
+\*
+\*   (b) A `transitionToDedicatedConfigServer` command running concurrently. As part of the
+\*       transition the config-server-shard drops `config.rangeDeletions` (SERVER-103990).
+\*
+\* The bug (SERVER-125663): if the drop in (b.4) is interleaved between (a.2) and (a.3), then the
+\* update in `markAsReadyRangeDeletionTaskLocally` raises `NoMatchingDocument`. The exception is
+\* swallowed by the catch-block in `range_deletion_util.cpp`. `clearPending()` is never called on
+\* the in-memory task, so the deletion chain stalls forever and the orphan documents on the former
+\* config-server-shard accumulate. A secondary effect: if the migration was issued with
+\* `waitForDelete = true` it blocks on the never-completing future and only unwinds when the op
+\* context is killed externally.
+\*
+\* The spec models the four steps as four actions and uses a CONSTANT flag `AllowDropBeforeMarkReady`
+\* to selectively enable the racing interleaving. With the flag set to FALSE the deletion-chain
+\* invariant `EveryPendingRangeEventuallyCleared` holds. With the flag set to TRUE TLC produces a
+\* counterexample exhibiting the SERVER-125663 hazard, demonstrating the falsifier landed where the
+\* bug actually lives.
+\*
+\* The spec deliberately reduces the surface area of MoveRange.tla: it does not model the routing
+\* protocol, recipient, or ownership filters. Those are covered upstream by MoveRange.tla. This spec
+\* covers exclusively the donor-side range-deletion-readiness handoff and the transition drop.
+\*
+\* To run the model-checker, from `src/mongo/tla_plus`:
+\*     ./model-check.sh Sharding/ConfigServerTransitionOrphan
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+
+CONSTANTS
+    Ranges,                     \* Set of ranges that may be migrated off the config-server-shard.
+    AllowDropBeforeMarkReady    \* Bug toggle. When TRUE, the transition may drop
+                                \* `config.rangeDeletions` after a task has been registered
+                                \* in-memory but before `markAsReadyRangeDeletionTaskLocally`
+                                \* has run, reproducing SERVER-125663.
+
+ASSUME Cardinality(Ranges) > 0
+ASSUME AllowDropBeforeMarkReady \in BOOLEAN
+
+\* Per-range states for the donor's range-deletion lifecycle.
+\* Possible transitions (green path):
+\*   Unset -> Committed -> Registered -> Ready -> Cleared
+\* Bug path (only reachable when `AllowDropBeforeMarkReady = TRUE`):
+\*   Unset -> Committed -> Registered -> StuckPending   (terminal)
+RangeUnset       == "unset"        \* No migration in flight for this range.
+RangeCommitted   == "committed"    \* Donor persisted a `config.rangeDeletions` doc with `pending`.
+RangeRegistered  == "registered"   \* In-memory task registered in `Pending` state.
+RangeReady       == "ready"        \* `pending` field $unset; OpObserver fired `clearPending()`.
+RangeCleared     == "cleared"      \* Deletion chain ran to completion. Orphans gone.
+RangeStuckPending == "stuckPending" \* Bug terminal: in-memory task forever in `Pending` state.
+
+RangeStates == {RangeUnset, RangeCommitted, RangeRegistered, RangeReady, RangeCleared,
+                RangeStuckPending}
+
+\* State of `config.rangeDeletions` on the config-server-shard.
+RangeDeletionsCollPresent == "present"
+RangeDeletionsCollDropped == "dropped"
+RangeDeletionsCollStates  == {RangeDeletionsCollPresent, RangeDeletionsCollDropped}
+
+\* State of the transition itself.
+\* Possible transitions:
+\*   NotStarted -> Draining -> DroppingRangeDeletions -> Done
+TransitionNotStarted             == "notStarted"
+TransitionDraining               == "draining"
+TransitionDroppingRangeDeletions == "droppingRangeDeletions"
+TransitionDone                   == "done"
+TransitionStates == {TransitionNotStarted, TransitionDraining,
+                     TransitionDroppingRangeDeletions, TransitionDone}
+
+VARIABLES
+    rangeState,             \* rangeState[r] in RangeStates -- per-range lifecycle.
+    onDiskPending,          \* onDiskPending[r] in BOOLEAN -- the on-disk `pending` field. Only
+                            \* meaningful while rangeDeletionsColl = present.
+    rangeDeletionsColl,     \* Current state of `config.rangeDeletions` on the config-server-shard.
+    transitionState         \* Current state of `transitionToDedicatedConfigServer`.
+
+vars == <<rangeState, onDiskPending, rangeDeletionsColl, transitionState>>
+
+Init ==
+    /\ rangeState         = [r \in Ranges |-> RangeUnset]
+    /\ onDiskPending      = [r \in Ranges |-> FALSE]
+    /\ rangeDeletionsColl = RangeDeletionsCollPresent
+    /\ transitionState    = TransitionNotStarted
+
+(* --------------------------------------------------------------------------------------------- *)
+(* Migration-coordinator actions                                                                 *)
+(* --------------------------------------------------------------------------------------------- *)
+
+\* Step 1: the donor persists the commit decision and inserts a `config.rangeDeletions` doc with
+\* `pending: true`. Modelled by `persistCommitDecision` followed by the insertion of the
+\* `RangeDeletionTask` document in `migration_coordinator.cpp::completeMigration`.
+\*
+\* We require the on-disk collection to still be present. If the transition has already dropped
+\* `config.rangeDeletions` before the migration reaches this step the migration coordinator either
+\* hits a different error path or never starts; either way it is not the SERVER-125663 hazard. We
+\* therefore exclude that interleaving from the model and document it explicitly.
+CommitMigration(r) ==
+    /\ rangeState[r] = RangeUnset
+    /\ rangeDeletionsColl = RangeDeletionsCollPresent
+    /\ rangeState'    = [rangeState    EXCEPT ![r] = RangeCommitted]
+    /\ onDiskPending' = [onDiskPending EXCEPT ![r] = TRUE]
+    /\ UNCHANGED <<rangeDeletionsColl, transitionState>>
+
+\* Step 2: register the in-memory range-deletion task with `RangeDeleterService::registerTask` in
+\* `TaskPending::kPending`. This sets up the completion future that downstream code awaits.
+RegisterInMemoryTask(r) ==
+    /\ rangeState[r] = RangeCommitted
+    /\ rangeState'   = [rangeState EXCEPT ![r] = RangeRegistered]
+    /\ UNCHANGED <<onDiskPending, rangeDeletionsColl, transitionState>>
+
+\* Step 3 (green path): `markAsReadyRangeDeletionTaskLocally` runs while `config.rangeDeletions` is
+\* still present. The `$unset` of the `pending` field succeeds; the OpObserver fires and calls
+\* `clearPending()` on the in-memory task. The deletion chain becomes runnable.
+MarkAsReady_Success(r) ==
+    /\ rangeState[r] = RangeRegistered
+    /\ rangeDeletionsColl = RangeDeletionsCollPresent
+    /\ onDiskPending[r] = TRUE
+    /\ rangeState'    = [rangeState    EXCEPT ![r] = RangeReady]
+    /\ onDiskPending' = [onDiskPending EXCEPT ![r] = FALSE]
+    /\ UNCHANGED <<rangeDeletionsColl, transitionState>>
+
+\* Step 3 (bug path): if `config.rangeDeletions` has been dropped while the in-memory task is in
+\* `Registered`, the update raises `NoMatchingDocument`. The catch-block at
+\* `range_deletion_util.cpp:759` swallows the exception. `clearPending()` is never called and the
+\* in-memory task is wedged in the `Pending` state forever.
+MarkAsReady_NoMatchingDocument(r) ==
+    /\ rangeState[r] = RangeRegistered
+    /\ rangeDeletionsColl = RangeDeletionsCollDropped
+    /\ rangeState' = [rangeState EXCEPT ![r] = RangeStuckPending]
+    /\ UNCHANGED <<onDiskPending, rangeDeletionsColl, transitionState>>
+
+\* Step 4: the deletion chain runs to completion once `clearPending()` has unblocked it. Orphans
+\* are removed. This is the only path that satisfies the safety invariant.
+RunDeletionChain(r) ==
+    /\ rangeState[r] = RangeReady
+    /\ rangeState' = [rangeState EXCEPT ![r] = RangeCleared]
+    /\ UNCHANGED <<onDiskPending, rangeDeletionsColl, transitionState>>
+
+(* --------------------------------------------------------------------------------------------- *)
+(* transitionToDedicatedConfigServer actions                                                     *)
+(* --------------------------------------------------------------------------------------------- *)
+
+\* Operator issues `startTransitionToDedicatedConfigServer`.
+StartTransition ==
+    /\ transitionState = TransitionNotStarted
+    /\ transitionState' = TransitionDraining
+    /\ UNCHANGED <<rangeState, onDiskPending, rangeDeletionsColl>>
+
+\* The transition reaches the step where it is about to drop `config.rangeDeletions`. Modelled as
+\* an explicit pre-state because TLC needs to see a step where the decision is irreversible and the
+\* in-memory state hasn't been disturbed.
+BeginDropRangeDeletions ==
+    /\ transitionState = TransitionDraining
+    /\ transitionState' = TransitionDroppingRangeDeletions
+    /\ UNCHANGED <<rangeState, onDiskPending, rangeDeletionsColl>>
+
+\* The transition drops `config.rangeDeletions`. The bug toggle restricts whether the drop is
+\* allowed to happen with an in-memory task still in `Registered` state.
+\*
+\* * Green path (`AllowDropBeforeMarkReady = FALSE`): the drop is only permitted after every
+\*   in-memory task has been cleared or is back to `Unset`. This models a hypothetical fix in
+\*   which the transition coordinator drains in-flight migrations before dropping the collection.
+\* * Bug path (`AllowDropBeforeMarkReady = TRUE`): the drop is unconditional, reproducing the
+\*   current production behaviour where the transition is not aware of in-flight migrations.
+DropRangeDeletions ==
+    /\ transitionState = TransitionDroppingRangeDeletions
+    /\ rangeDeletionsColl = RangeDeletionsCollPresent
+    /\ \/ AllowDropBeforeMarkReady = TRUE
+       \/ \A r \in Ranges : rangeState[r] \in {RangeUnset, RangeReady, RangeCleared}
+    /\ rangeDeletionsColl' = RangeDeletionsCollDropped
+    /\ onDiskPending'      = [r \in Ranges |-> FALSE] \* dropped collection -> no on-disk pending.
+    /\ UNCHANGED <<rangeState, transitionState>>
+
+\* Operator commits the transition. Terminal step.
+CommitTransition ==
+    /\ transitionState = TransitionDroppingRangeDeletions
+    /\ rangeDeletionsColl = RangeDeletionsCollDropped
+    /\ transitionState' = TransitionDone
+    /\ UNCHANGED <<rangeState, onDiskPending, rangeDeletionsColl>>
+
+(* --------------------------------------------------------------------------------------------- *)
+(* Next-state relation                                                                           *)
+(* --------------------------------------------------------------------------------------------- *)
+
+Next ==
+    \/ \E r \in Ranges : CommitMigration(r)
+    \/ \E r \in Ranges : RegisterInMemoryTask(r)
+    \/ \E r \in Ranges : MarkAsReady_Success(r)
+    \/ \E r \in Ranges : MarkAsReady_NoMatchingDocument(r)
+    \/ \E r \in Ranges : RunDeletionChain(r)
+    \/ StartTransition
+    \/ BeginDropRangeDeletions
+    \/ DropRangeDeletions
+    \/ CommitTransition
+
+Fairness ==
+    /\ WF_vars(\E r \in Ranges : CommitMigration(r))
+    /\ WF_vars(\E r \in Ranges : RegisterInMemoryTask(r))
+    /\ WF_vars(\E r \in Ranges : MarkAsReady_Success(r))
+    /\ WF_vars(\E r \in Ranges : MarkAsReady_NoMatchingDocument(r))
+    /\ WF_vars(\E r \in Ranges : RunDeletionChain(r))
+    /\ WF_vars(StartTransition)
+    /\ WF_vars(BeginDropRangeDeletions)
+    /\ WF_vars(DropRangeDeletions)
+    /\ WF_vars(CommitTransition)
+
+Spec == /\ Init /\ [][Next]_vars /\ Fairness
+
+----------------------------------------------------------------------------------------------------
+(**************************************************************************************************)
+(* Type invariant                                                                                 *)
+(**************************************************************************************************)
+
+TypeOK ==
+    /\ rangeState         \in [Ranges -> RangeStates]
+    /\ onDiskPending      \in [Ranges -> BOOLEAN]
+    /\ rangeDeletionsColl \in RangeDeletionsCollStates
+    /\ transitionState    \in TransitionStates
+
+(**************************************************************************************************)
+(* Safety -- the deletion chain that backs orphan cleanup is never permanently wedged.            *)
+(**************************************************************************************************)
+
+\* Every range that was committed for migration is either still in flight or has been cleared.
+\* Ranges may reach `StuckPending` only transiently; if they remain there forever the in-memory
+\* task is permanently in the `Pending` state and orphans accumulate (SERVER-125663).
+NoRangePermanentlyStuck == \A r \in Ranges : rangeState[r] # RangeStuckPending
+
+(**************************************************************************************************)
+(* Liveness                                                                                       *)
+(**************************************************************************************************)
+
+\* The headline correctness property: every range that the donor begins to migrate eventually
+\* either reaches `Cleared` (deletion chain ran) or stays at `Unset` (migration never started).
+\* SERVER-125663 falsifies this because `StuckPending` is a terminal sink under the bug path.
+EveryPendingRangeEventuallyCleared ==
+    \A r \in Ranges : []((rangeState[r] = RangeCommitted) => <>(rangeState[r] = RangeCleared))
+
+\* The transition itself eventually completes. Included to make sure the green-path config doesn't
+\* trivially satisfy `EveryPendingRangeEventuallyCleared` by simply never running the transition.
+TransitionEventuallyCommits == <>(transitionState = TransitionDone)
+
+====================================================================================================

--- a/src/mongo/tla_plus/Sharding/ConfigServerTransitionOrphan/MCConfigServerTransitionOrphan.cfg
+++ b/src/mongo/tla_plus/Sharding/ConfigServerTransitionOrphan/MCConfigServerTransitionOrphan.cfg
@@ -1,0 +1,21 @@
+\* Green path: the transition only drops `config.rangeDeletions` after every in-flight migration
+\* has reached `Ready` or `Cleared`. Both safety and liveness must hold.
+\*
+\* CHECK_DEADLOCK is disabled because the model has explicit terminal states
+\* (transitionState = "done", all ranges \in {unset, cleared}). TLC would otherwise flag those
+\* terminal states as deadlocks even though they are the intended end of behaviour.
+
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    Ranges = {r1, r2}
+    AllowDropBeforeMarkReady = FALSE
+
+INVARIANT
+    TypeOK
+    NoRangePermanentlyStuck
+
+PROPERTIES
+    EveryPendingRangeEventuallyCleared
+    TransitionEventuallyCommits

--- a/src/mongo/tla_plus/Sharding/ConfigServerTransitionOrphan/MCConfigServerTransitionOrphan.tla
+++ b/src/mongo/tla_plus/Sharding/ConfigServerTransitionOrphan/MCConfigServerTransitionOrphan.tla
@@ -1,0 +1,43 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+---------------------------- MODULE MCConfigServerTransitionOrphan ---------------------------------
+\* Model-checking instance for ConfigServerTransitionOrphan.tla.
+\*
+\* Two configurations are checked from the same module:
+\*
+\*   * Green path  (MCConfigServerTransitionOrphan.cfg):
+\*       AllowDropBeforeMarkReady = FALSE
+\*     The drop of `config.rangeDeletions` is gated on all in-flight migrations having reached
+\*     `Ready` or `Cleared`. Safety + liveness invariants hold.
+\*
+\*   * Bug path    (MCConfigServerTransitionOrphan_Bug.cfg):
+\*       AllowDropBeforeMarkReady = TRUE
+\*     The drop is unconditional, modelling current master (HEAD post-SERVER-103990). TLC produces
+\*     a counterexample to `NoRangePermanentlyStuck` and to `EveryPendingRangeEventuallyCleared`,
+\*     reproducing SERVER-125663.
+
+EXTENDS ConfigServerTransitionOrphan
+
+(**************************************************************************************************)
+(* Symmetry over Ranges -- ranges are interchangeable for the purposes of this race.              *)
+(**************************************************************************************************)
+Symmetry == Permutations(Ranges)
+
+(**************************************************************************************************)
+(* Counterexample-baiting invariants. Run with `-invariant` to surface specific reachability      *)
+(* claims; not part of the default `cfg` invariant list.                                          *)
+(**************************************************************************************************)
+
+\* TLC will produce a trace showing the bug as soon as any range reaches StuckPending.
+BaitNoStuckPending == \A r \in Ranges : rangeState[r] # RangeStuckPending
+
+\* TLC will produce a trace showing the drop happening with an in-memory task in `Registered`.
+BaitNoConcurrentDrop ==
+    ~(rangeDeletionsColl = RangeDeletionsCollDropped
+      /\ \E r \in Ranges : rangeState[r] = RangeRegistered)
+
+====================================================================================================

--- a/src/mongo/tla_plus/Sharding/ConfigServerTransitionOrphan/MCConfigServerTransitionOrphan_Bug.cfg
+++ b/src/mongo/tla_plus/Sharding/ConfigServerTransitionOrphan/MCConfigServerTransitionOrphan_Bug.cfg
@@ -1,0 +1,17 @@
+\* Bug path (SERVER-125663): drop `config.rangeDeletions` unconditionally. TLC produces a
+\* counterexample to NoRangePermanentlyStuck and to EveryPendingRangeEventuallyCleared.
+
+SPECIFICATION Spec
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    Ranges = {r1}
+    AllowDropBeforeMarkReady = TRUE
+
+INVARIANT
+    TypeOK
+    NoRangePermanentlyStuck
+
+\* Liveness is also expected to fail under the bug; left enabled so the trace shows both layers.
+PROPERTIES
+    EveryPendingRangeEventuallyCleared

--- a/src/mongo/tla_plus/Sharding/ConfigServerTransitionOrphan/OWNERS.yml
+++ b/src/mongo/tla_plus/Sharding/ConfigServerTransitionOrphan/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-sharding

--- a/src/mongo/tla_plus/Sharding/ConfigServerTransitionOrphan/README.md
+++ b/src/mongo/tla_plus/Sharding/ConfigServerTransitionOrphan/README.md
@@ -1,0 +1,54 @@
+# ConfigServerTransitionOrphan
+
+Models the race between `transitionToDedicatedConfigServer` and an in-flight chunk migration
+committing on the config-server-shard. Companion to [SERVER-125663][ticket].
+
+[ticket]: https://jira.mongodb.org/browse/SERVER-125663
+
+## Background
+
+After SERVER-103990, the cluster member that hosts both the config server and a data shard drops
+`config.rangeDeletions` as part of `transitionToDedicatedConfigServer`. A donor-side migration
+commit performs four ordered steps:
+
+1. Persist the commit decision and insert a `config.rangeDeletions` document with `pending: true`.
+2. Register an in-memory `RangeDeletion` task in `TaskPending::kPending`.
+3. Call `markAsReadyRangeDeletionTaskLocally`, which `$unset`s `pending` on the on-disk document.
+   The OpObserver for that update calls `clearPending()` on the in-memory task and unblocks the
+   deletion chain.
+4. The deletion chain runs and orphan documents are removed.
+
+If the transition drops `config.rangeDeletions` between steps 2 and 3, the `$unset` in step 3
+raises `NoMatchingDocument`. The catch-block at `range_deletion_util.cpp:759` swallows it. The
+OpObserver never fires, `clearPending()` is never called, the in-memory task is wedged in
+`Pending` forever, and orphans on the former config-server-shard accumulate. A migration issued
+with `waitForDelete = true` additionally blocks on the never-completing future.
+
+## What this spec proves
+
+* **Invariant `NoRangePermanentlyStuck`**: no in-memory range-deletion task ends in
+  `StuckPending`.
+* **Property `EveryPendingRangeEventuallyCleared`**: every committed migration's deletion chain
+  eventually runs to completion.
+
+A `CONSTANT AllowDropBeforeMarkReady` toggles the bug. With `FALSE` (green cfg) the transition
+must wait for all in-flight migrations to reach `Ready` or `Cleared` before dropping the
+collection; both properties hold. With `TRUE` (`_Bug.cfg`) the drop is unconditional and TLC
+produces a 7-step counterexample exhibiting the SERVER-125663 hazard, anchoring the falsifier on
+the real code path.
+
+## Running the model-checker
+
+```sh
+cd src/mongo/tla_plus
+./model-check.sh Sharding/ConfigServerTransitionOrphan                              # green
+./model-check.sh Sharding/ConfigServerTransitionOrphan _Bug                         # bug
+```
+
+## Scope
+
+The spec models the donor-side handoff and the transition drop only. Recipient-side logic,
+routing, the critical section, and the wider migration protocol are covered by `MoveRange.tla`
+and the `RangeDeletionsSecondaryNodes.tla` spec in this directory. The on-disk `pending` field
+collapse is modelled as a boolean per range; the spec assumes the OpObserver's call to
+`clearPending` is observable as the transition from `RangeRegistered` to `RangeReady`.


### PR DESCRIPTION
## Summary

TLA+ spec + jstest for SERVER-125663 (BF=200, master-affected): orphans on the former config-server-shard never cleaned because `markAsReadyRangeDeletionTaskLocally` throws `NoMatchingDocument` after `config.rangeDeletions` is dropped. The exception is swallowed silently; `clearPending()` is never called.

**Jira:** https://jira.mongodb.org/browse/SERVER-126550
**Related:** https://jira.mongodb.org/browse/SERVER-125663

## TLC verdicts

| Cfg | Result |
|---|---|
| Green (`Ranges={r1,r2}`, `AllowDropBeforeMarkReady=FALSE`) | 93 distinct states, no error; all temporal properties satisfied |
| Bug (`Ranges={r1}`, `AllowDropBeforeMarkReady=TRUE`) | 7-state counterexample to `NoRangePermanentlyStuck`; ends `MarkAsReady_NoMatchingDocument(r1)` → `stuckPending` |

## Files

- `src/mongo/tla_plus/Sharding/ConfigServerTransitionOrphan/ConfigServerTransitionOrphan.tla` (260 lines)
- `src/mongo/tla_plus/Sharding/ConfigServerTransitionOrphan/MCConfigServerTransitionOrphan.tla` (43) + `MCConfigServerTransitionOrphan.cfg` (green) + `MCConfigServerTransitionOrphan_Bug.cfg`
- `src/mongo/tla_plus/Sharding/ConfigServerTransitionOrphan/OWNERS.yml` (`10gen/server-sharding`)
- `src/mongo/tla_plus/Sharding/ConfigServerTransitionOrphan/README.md` (331 words)
- `jstests/sharding/transition_to_dedicated_in_flight_migration_orphan.js` (163 lines)

## Verify

```
cd src/mongo/tla_plus
./download-tlc.sh
./model-check.sh Sharding/ConfigServerTransitionOrphan
```

jstest uses `hangInReadyRangeDeletionLocallyInterruptible` failpoint + parallel-shell `moveChunk` + `transitionToDedicatedConfigServer` interleaving, asserts pending-task count returns to 0 and orphan-doc count reaches 0.

## Draft status

Opened as Draft.
