### PR TITLE
SERVER-126605 Add TLA+ spec + jstest for migration + concurrent index ops

### DIFF
--- a/jstests/sharding/migration_concurrent_index_ops_deterministic.js
+++ b/jstests/sharding/migration_concurrent_index_ops_deterministic.js
@@ -1,0 +1,254 @@
+/**
+ * Deterministic reproducer for SERVER-99357: concurrent chunk migration and
+ * createIndexes/dropIndexes leave the cluster with an inconsistent index set across shards.
+ *
+ * The race:
+ *  1. The migration recipient takes an index-catalog snapshot from the donor at the start of the
+ *     clone phase (`startedMoveChunk`).
+ *  2. A router-driven `dropIndexes` (or `createIndexes`) issued in the gap between the snapshot
+ *     and the migration commit lands on the donor before the recipient finishes applying the
+ *     stale snapshot.
+ *  3. After commit, the recipient's index set reflects the pre-drop snapshot while the donor's
+ *     reflects the post-drop state -> inconsistent indexes -> future migrations into the
+ *     recipient refuse to copy and `removeShard` is wedged.
+ *
+ * This test pins the bug shape: it wedges migration at the failpoint, runs the index command,
+ * unwedges, and then runs the `$indexStats` divergence-detection pipeline from
+ * `index_stats_pipeline_detects_inconsistent_indexes.js` to confirm whether the resulting state
+ * is consistent. The test PASSES when the fix is in place (consistent across shards). Without
+ * the fix the pipeline returns one or more rows describing the divergence and the test fails
+ * with a structured message.
+ *
+ * @tags: [
+ *   requires_fcv_80,
+ * ]
+ */
+import {
+    moveChunkStepNames,
+    pauseMoveChunkAtStep,
+    unpauseMoveChunkAtStep,
+    waitForMoveChunkStep,
+} from "jstests/libs/chunk_manipulation_util.js";
+import {Thread} from "jstests/libs/parallelTester.js";
+import {ShardingTest} from "jstests/libs/shardingtest.js";
+
+// The whole point of the test is to produce, then assert against, an inconsistent index state.
+TestData.skipCheckingIndexesConsistentAcrossCluster = true;
+// The test deliberately leaves orphans behind on the wedged migration path.
+TestData.skipCheckOrphans = true;
+
+const indexStatsDivergencePipeline = [
+    {$indexStats: {}},
+    {$group: {_id: null, indexDoc: {$push: "$$ROOT"}, allShards: {$addToSet: "$shard"}}},
+    {$unwind: "$indexDoc"},
+    {
+        $group: {
+            _id: "$indexDoc.name",
+            shards: {$push: "$indexDoc.shard"},
+            specs: {$push: {$objectToArray: {$ifNull: ["$indexDoc.spec", {}]}}},
+            allShards: {$first: "$allShards"},
+        },
+    },
+    {
+        $project: {
+            missingFromShards: {$setDifference: ["$allShards", "$shards"]},
+            inconsistentProperties: {
+                $setDifference: [
+                    {
+                        $reduce: {
+                            input: "$specs",
+                            initialValue: {$arrayElemAt: ["$specs", 0]},
+                            in: {$setUnion: ["$$value", "$$this"]},
+                        },
+                    },
+                    {
+                        $reduce: {
+                            input: "$specs",
+                            initialValue: {$arrayElemAt: ["$specs", 0]},
+                            in: {$setIntersection: ["$$value", "$$this"]},
+                        },
+                    },
+                ],
+            },
+        },
+    },
+    {
+        $match: {
+            $expr: {
+                $or: [
+                    {$gt: [{$size: "$missingFromShards"}, 0]},
+                    {$gt: [{$size: "$inconsistentProperties"}, 0]},
+                ],
+            },
+        },
+    },
+    {$project: {_id: 0, indexName: "$$ROOT._id", inconsistentProperties: 1, missingFromShards: 1}},
+];
+
+async function runDropIndexThroughRouter(host, ns, indexName) {
+    const mongos = new Mongo(host);
+    const [dbName, collName] = ns.split(".");
+    return mongos.getDB(dbName).runCommand({dropIndexes: collName, index: indexName});
+}
+
+async function runCreateIndexThroughRouter(host, ns, indexName, indexKey) {
+    const mongos = new Mongo(host);
+    const [dbName, collName] = ns.split(".");
+    return mongos.getDB(dbName).runCommand({
+        createIndexes: collName,
+        indexes: [{key: indexKey, name: indexName}],
+    });
+}
+
+const st = new ShardingTest({shards: 2});
+const dbName = "test";
+const testDB = st.s.getDB(dbName);
+
+assert.commandWorked(st.s.adminCommand({enableSharding: dbName, primaryShard: st.shard0.shardName}));
+
+function setUpCollectionWithChunksOnBothShards(collName, indexName, indexKey) {
+    const ns = `${dbName}.${collName}`;
+    assert.commandWorked(st.s.adminCommand({shardCollection: ns, key: {_id: 1}}));
+    assert.commandWorked(st.s.adminCommand({split: ns, middle: {_id: 0}}));
+    // Move the upper half to shard1 so both shards are data-bearing for the namespace.
+    assert.commandWorked(
+        st.s.adminCommand({moveChunk: ns, find: {_id: 0}, to: st.shard1.shardName}),
+    );
+    // Insert at least one doc on each side so the recipient enforces strict index sync.
+    assert.commandWorked(testDB[collName].insert({_id: -1, x: -1}));
+    assert.commandWorked(testDB[collName].insert({_id: 1, x: 1}));
+    // Create the index that the race will mutate.
+    if (indexName !== null) {
+        assert.commandWorked(testDB[collName].createIndex(indexKey, {name: indexName}));
+    }
+    return ns;
+}
+
+function assertNoDivergence(collName, label) {
+    const res = testDB[collName].aggregate(indexStatsDivergencePipeline).toArray();
+    assert.eq(
+        res.length,
+        0,
+        `[${label}] expected no index divergence after migration but $indexStats reported: ` +
+            tojson(res),
+    );
+}
+
+// ----------------------------------------------------------------------------
+// Case 1: dropIndexes racing migration. Pre-fix, the recipient applies its stale snapshot AFTER
+// the drop lands on the donor; recipient ends with the dropped index, donor without it.
+// ----------------------------------------------------------------------------
+(() => {
+    jsTestLog("Case 1: dropIndexes during clone phase of an outgoing migration");
+
+    const collName = "dropDuringMigration";
+    const indexName = "raceIdx";
+    const ns = setUpCollectionWithChunksOnBothShards(collName, indexName, {x: 1});
+
+    // We will move the upper-half chunk back from shard1 to shard0. shard1 is the donor.
+    const fromShard = st.shard1;
+    const toShard = st.shard0;
+
+    // Wedge the donor at startedMoveChunk: at this step the recipient has already taken the
+    // donor's index snapshot but has not yet rejoined the steady state.
+    pauseMoveChunkAtStep(fromShard, moveChunkStepNames.startedMoveChunk);
+
+    const moveChunkThread = new Thread(
+        async (host, ns, toShardName) => {
+            const mongos = new Mongo(host);
+            return mongos.adminCommand({moveChunk: ns, find: {_id: 0}, to: toShardName});
+        },
+        st.s.host,
+        ns,
+        toShard.shardName,
+    );
+    moveChunkThread.start();
+    waitForMoveChunkStep(fromShard, moveChunkStepNames.startedMoveChunk);
+
+    // Drop the index through the router. With the fix, this command should block on the
+    // namespace DDL lock until the migration finishes (or be retried under shard-version-mismatch
+    // and observe the post-migration routing table). Without the fix it races: the per-shard
+    // step lands on the donor before the recipient's stale snapshot is applied.
+    const dropThread = new Thread(runDropIndexThroughRouter, st.s.host, ns, indexName);
+    dropThread.start();
+
+    // Allow the migration to drain.
+    unpauseMoveChunkAtStep(fromShard, moveChunkStepNames.startedMoveChunk);
+    moveChunkThread.join();
+    dropThread.join();
+
+    // The migration itself may succeed or fail (interrupted by the index op). Either way, the
+    // post-state must agree across shards. With the fix in place the dropIndexes either ran
+    // before the migration's snapshot, after the commit, or was retried by the router and we
+    // converge to a consistent state. Without the fix the recipient retains the pre-drop index.
+    assertNoDivergence(collName, "dropIndexes-race");
+})();
+
+// ----------------------------------------------------------------------------
+// Case 2: createIndexes racing migration. Pre-fix, the recipient's stale (pre-create) snapshot
+// overwrites strict-sync onto the recipient; donor ends up with the new index, recipient
+// without it.
+// ----------------------------------------------------------------------------
+(() => {
+    jsTestLog("Case 2: createIndexes during clone phase of an outgoing migration");
+
+    const collName = "createDuringMigration";
+    const ns = setUpCollectionWithChunksOnBothShards(collName, /*indexName=*/ null, /*key=*/ null);
+
+    const fromShard = st.shard1;
+    const toShard = st.shard0;
+
+    pauseMoveChunkAtStep(fromShard, moveChunkStepNames.startedMoveChunk);
+
+    const moveChunkThread = new Thread(
+        async (host, ns, toShardName) => {
+            const mongos = new Mongo(host);
+            return mongos.adminCommand({moveChunk: ns, find: {_id: 0}, to: toShardName});
+        },
+        st.s.host,
+        ns,
+        toShard.shardName,
+    );
+    moveChunkThread.start();
+    waitForMoveChunkStep(fromShard, moveChunkStepNames.startedMoveChunk);
+
+    const createThread = new Thread(
+        runCreateIndexThroughRouter,
+        st.s.host,
+        ns,
+        "raceIdxCreate",
+        {y: 1},
+    );
+    createThread.start();
+
+    unpauseMoveChunkAtStep(fromShard, moveChunkStepNames.startedMoveChunk);
+    moveChunkThread.join();
+    createThread.join();
+
+    assertNoDivergence(collName, "createIndexes-race");
+})();
+
+// ----------------------------------------------------------------------------
+// Case 3: follow-up migration must succeed. Once the bug fires, a subsequent migration into the
+// recipient refuses to copy ("documents but inconsistent indexes"), which is what blocks
+// `removeShard` and `transitionToDedicatedConfigServer` in production. This case re-attempts a
+// migration after the races above and asserts it succeeds, which is the operational property
+// the fix restores.
+// ----------------------------------------------------------------------------
+(() => {
+    jsTestLog("Case 3: follow-up migration must succeed after a concurrent index op");
+
+    const collName = "dropDuringMigration"; // re-use the collection from Case 1.
+    const ns = `${dbName}.${collName}`;
+
+    // Move the chunk one more time. With consistent indexes this is a no-op-shaped success;
+    // with divergence the recipient's destination manager will refuse and the test fails.
+    const res = st.s.adminCommand({moveChunk: ns, find: {_id: 0}, to: st.shard1.shardName});
+    assert.commandWorked(
+        res,
+        "follow-up migration failed -- this is the user-visible symptom of SERVER-99357: " +
+            tojson(res),
+    );
+})();
+
+st.stop();

--- a/src/mongo/tla_plus/Sharding/MigrationConcurrentIndexOps/MCMigrationConcurrentIndexOps.cfg
+++ b/src/mongo/tla_plus/Sharding/MigrationConcurrentIndexOps/MCMigrationConcurrentIndexOps.cfg
@@ -1,0 +1,21 @@
+\* Green config: SafeIndexSyncOnCommit = TRUE. Models the proposed fix where the recipient
+\* re-clones the donor's index catalog at commit. IndexSetConsistentPostMigration must hold.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    Shards = {s1, s2, s3}
+    IndexNames = {ix1, ix2}
+    MIGRATIONS = 2
+    INDEX_OPS = 2
+    SafeIndexSyncOnCommit = TRUE
+
+INVARIANT
+    TypeOK
+    MigrationPhaseWellFormed
+    IndexSetConsistentPostMigration
+
+CONSTRAINT
+    ConstraintBounded
+
+SYMMETRY Symmetry

--- a/src/mongo/tla_plus/Sharding/MigrationConcurrentIndexOps/MCMigrationConcurrentIndexOps.tla
+++ b/src/mongo/tla_plus/Sharding/MigrationConcurrentIndexOps/MCMigrationConcurrentIndexOps.tla
@@ -1,0 +1,37 @@
+---------------------------- MODULE MCMigrationConcurrentIndexOps ----------------------------------
+\* Model-checking harness for MigrationConcurrentIndexOps.tla. Defines constants, symmetry, and a
+\* state constraint that keeps the explored state space finite.
+
+EXTENDS MigrationConcurrentIndexOps
+
+(**************************************************************************************************)
+(* State constraints.                                                                              *)
+(**************************************************************************************************)
+
+\* Bound the state space: stop exploring after MIGRATIONS migrations and INDEX_OPS index ops have
+\* completed and the cluster has quiesced. Without this, TLC can chase identical-shape suffix
+\* traces forever once the bug is reachable.
+ConstraintBounded ==
+    /\ \/ migrationsDone < MIGRATIONS
+       \/ indexOpsDone < INDEX_OPS
+       \/ ~NoMigrationInFlight
+       \/ ~NoIndexOpInFlight
+
+\* Symmetry over indistinguishable shards and index names speeds up checking by orders of
+\* magnitude on the small models that exercise this race.
+Symmetry == Permutations(Shards) \union Permutations(IndexNames)
+
+(**************************************************************************************************)
+(* Counterexample bait predicates (negations of "interesting" states). Useful when iterating on   *)
+(* the spec: temporarily flip one into an INVARIANT in the .cfg to make TLC dump a witness trace. *)
+(**************************************************************************************************)
+
+\* A migration has committed at least once.
+BaitMigrationCommitted == migrationsDone = 0
+
+\* An index op completed while a migration was in flight.
+BaitIndexOpDuringMigration ==
+    \/ indexOpsDone = 0
+    \/ NoMigrationInFlight
+
+====================================================================================================

--- a/src/mongo/tla_plus/Sharding/MigrationConcurrentIndexOps/MCMigrationConcurrentIndexOps_bug.cfg
+++ b/src/mongo/tla_plus/Sharding/MigrationConcurrentIndexOps/MCMigrationConcurrentIndexOps_bug.cfg
@@ -1,0 +1,34 @@
+\* Bug config: SafeIndexSyncOnCommit = FALSE. Models the pre-fix recipient that keeps the
+\* stale clone-time index snapshot. IndexSetConsistentPostMigration is expected to be VIOLATED
+\* with a counter-example trace of the form:
+\*   MigrateStartClone(donor, recipient)   -- snapshot = {ix1}
+\*   StartIndexOp(dropIndexes, ix1)        -- router enumerates fan-out
+\*   StepIndexOp                           -- dropIndexes lands on donor; donor's set = {}
+\*   StepIndexOp                           -- dropIndexes lands on recipient; recipient's set = {}
+\*                                         -- (no-op on recipient because clone hasn't applied yet)
+\*   FinishIndexOp
+\*   MigrateRecipientApplyClone            -- recipient gains ix1 from the stale snapshot
+\*   MigrateDonorPrepare / MigrateCommit / MigrateFinish
+\*   => recipient.indexes = {ix1}, donor.indexes = {}  -- INDEX SET DIVERGENCE
+\*
+\* Run via:  ./model-check.sh Sharding/MigrationConcurrentIndexOps
+\* after swapping this file in for MCMigrationConcurrentIndexOps.cfg.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    Shards = {s1, s2, s3}
+    IndexNames = {ix1, ix2}
+    MIGRATIONS = 2
+    INDEX_OPS = 2
+    SafeIndexSyncOnCommit = FALSE
+
+INVARIANT
+    TypeOK
+    MigrationPhaseWellFormed
+    IndexSetConsistentPostMigration
+
+CONSTRAINT
+    ConstraintBounded
+
+SYMMETRY Symmetry

--- a/src/mongo/tla_plus/Sharding/MigrationConcurrentIndexOps/MigrationConcurrentIndexOps.tla
+++ b/src/mongo/tla_plus/Sharding/MigrationConcurrentIndexOps/MigrationConcurrentIndexOps.tla
@@ -1,0 +1,318 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+--------------------------- MODULE MigrationConcurrentIndexOps -------------------------------------
+\* This specification models the race between chunk migration and the user-issued index commands
+\* (createIndexes and dropIndexes) on a sharded collection. The race is documented in SERVER-99357:
+\* a dropIndexes or createIndexes issued through the router executes via a shard-version retry loop
+\* that visits each data-bearing shard sequentially. The migration recipient clones the index
+\* catalog from the donor at the start of the clone phase and does not re-fetch it on commit.
+\* Therefore, an index op that interleaves between
+\*   (a) the recipient's index-clone snapshot, and
+\*   (b) the router's per-shard fan-out reaching the donor
+\* can leave the cluster with different index sets on different shards after the migration commits,
+\* which then prevents future migrations (the recipient destination manager refuses to migrate into
+\* a shard that has documents but a different index set) and blocks removeShard /
+\* transitionToDedicatedConfigServer.
+\*
+\* This specification:
+\* - Models a single chunk-bearing collection. The collection lives on a Donor shard and a
+\*   pre-existing Recipient shard (which may or may not own a chunk for the collection).
+\*   Additional shards are modelled as bystanders so that the router fan-out has more than one
+\*   destination and the ordering of per-shard execution matters.
+\* - Models the migration lifecycle as the four phases that matter for index synchronisation:
+\*       Unset -> Cloning -> RecipientPrepared -> AllPrepared -> Committed -> Unset
+\*   The Aborted branch is folded back into Unset. Only Cloning -> RecipientPrepared is the window
+\*   in which the recipient takes its index snapshot.
+\* - Models the index commands as router-driven fan-outs that visit each data-bearing shard
+\*   sequentially in a non-deterministic order, mirroring the production retry loop. Each shard
+\*   acknowledges by mutating its local index set.
+\* - The "bug toggle" SafeIndexSyncOnCommit, when TRUE, re-clones the donor's index catalog on
+\*   commit (the fix). When FALSE (default), the recipient keeps its stale clone-time snapshot
+\*   (the bug). The invariant IndexSetConsistentPostMigration is expected to hold under TRUE and
+\*   to be violated by a counter-example trace under FALSE.
+\*
+\* To run the model-checker, edit MCMigrationConcurrentIndexOps.cfg if desired, then:
+\*     cd src/mongo/tla_plus
+\*     ./model-check.sh Sharding/MigrationConcurrentIndexOps
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+
+CONSTANTS
+    Shards,             \* The set of data-bearing shards. Cardinality >= 2.
+    IndexNames,         \* The set of user-index names (excluding the implicit _id index).
+    MIGRATIONS,         \* Bound on the number of migrations explored.
+    INDEX_OPS,          \* Bound on the number of createIndexes / dropIndexes operations explored.
+    SafeIndexSyncOnCommit  \* Bug toggle. TRUE = fix, FALSE = bug.
+
+ASSUME Cardinality(Shards) >= 2
+ASSUME Cardinality(IndexNames) >= 1
+ASSUME MIGRATIONS \in 0..4
+ASSUME INDEX_OPS \in 0..4
+ASSUME SafeIndexSyncOnCommit \in BOOLEAN
+
+(* Migration-phase tokens. *)
+PhaseUnset       == "unset"
+PhaseCloning     == "cloning"
+PhaseRecipPrep   == "recipientPrepared"
+PhaseAllPrep     == "allPrepared"
+PhaseCommitted   == "committed"
+
+(* Migration-state tokens. *)
+EmptyMigration == [phase     |-> PhaseUnset,
+                   donor     |-> "-",
+                   recipient |-> "-",
+                   snapshot  |-> {}]      \* Index-name snapshot the recipient cloned from donor.
+
+(* Index-op kind. *)
+OpCreate == "createIndexes"
+OpDrop   == "dropIndexes"
+
+VARIABLES
+    sIndexes,           \* Per-shard local index set: [Shards -> SUBSET IndexNames].
+    sOwns,              \* Per-shard ownership of the (single) collection: [Shards -> BOOLEAN].
+                        \* A shard "owns" the collection iff it has at least one chunk and is
+                        \* therefore data-bearing for index sync purposes.
+    migration,          \* Current migration state (single in-flight migration at a time).
+    migrationsDone,     \* Counter, bounded by MIGRATIONS.
+    indexOp,            \* In-flight index op:
+                        \*   [kind, name, pending: Seq(Shards), done: SUBSET Shards]
+                        \* or the sentinel NoIndexOp.
+    indexOpsDone        \* Counter, bounded by INDEX_OPS.
+
+NoIndexOp == [kind |-> "none", name |-> "-", pending |-> <<>>, done |-> {}]
+
+vars == <<sIndexes, sOwns, migration, migrationsDone, indexOp, indexOpsDone>>
+
+(* Helpers. *)
+DataBearingShards == {s \in Shards : sOwns[s]}
+NoMigrationInFlight == migration.phase = PhaseUnset
+NoIndexOpInFlight == indexOp.kind = "none"
+MigrationParticipants == IF migration.phase = PhaseUnset
+                        THEN {}
+                        ELSE {migration.donor, migration.recipient}
+
+\* The "fan-out target set" for a router-driven index op: all currently data-bearing shards. A
+\* migration recipient that does not yet own a chunk is NOT in this set, modelling the production
+\* behaviour where the router uses its cached routing table at command start.
+IndexOpTargets == DataBearingShards
+
+\* True iff a shard is currently a migration participant in a phase where it has either acquired
+\* the critical section or is about to apply the index snapshot. Index-op steps against such a
+\* shard must wait under the fix; under the bug the step proceeds and the recipient's snapshot
+\* drifts out of sync.
+IsIndexOpBlockedByMigration(s) ==
+    /\ ~NoMigrationInFlight
+    /\ migration.phase \in {PhaseCloning, PhaseRecipPrep, PhaseAllPrep, PhaseCommitted}
+    /\ s \in MigrationParticipants
+
+\* The set of shards a router-driven index op must visit. The router enumerates shards from the
+\* routing table at command start; it does NOT re-read the table between per-shard hops. We model
+\* this by freezing the fan-out at op start (see StartIndexOp).
+RECURSIVE SeqToSet(_)
+SeqToSet(s) == IF Len(s) = 0 THEN {} ELSE {s[1]} \cup SeqToSet(Tail(s))
+
+\* True iff the index op visits a participant of the in-flight migration.
+OpTouchesMigration ==
+    /\ ~NoIndexOpInFlight
+    /\ ~NoMigrationInFlight
+    /\ (SeqToSet(indexOp.pending) \cup indexOp.done) \cap MigrationParticipants # {}
+
+Init ==
+    /\ sOwns \in [Shards -> BOOLEAN]
+       \* At least one shard owns the collection. The non-owners are bystander shards.
+    /\ \E s \in Shards : sOwns[s] = TRUE
+    /\ sIndexes = [s \in Shards |-> {}]
+    /\ migration = EmptyMigration
+    /\ migrationsDone = 0
+    /\ indexOp = NoIndexOp
+    /\ indexOpsDone = 0
+
+(*************************************************************************************************)
+(* Index-op actions: createIndexes / dropIndexes.                                                *)
+(*                                                                                               *)
+(* A router-driven index command:                                                                *)
+(*   1. Enumerates data-bearing shards from the cached routing table (StartIndexOp).             *)
+(*   2. Issues the command shard-by-shard in some order (StepIndexOp). The shard mutates its     *)
+(*      local index set on receipt.                                                              *)
+(*   3. Completes when all shards have acknowledged (FinishIndexOp).                             *)
+(*                                                                                               *)
+(* Production has a shard-version retry loop; the spec abstracts that away: the per-shard step   *)
+(* is unconditional and idempotent. What matters for the race is the ordering between the        *)
+(* per-shard step and the migration's clone-time snapshot.                                       *)
+(*************************************************************************************************)
+
+StartIndexOp(kind, n) ==
+    /\ NoIndexOpInFlight
+    /\ indexOpsDone < INDEX_OPS
+    /\ n \in IndexNames
+    /\ kind \in {OpCreate, OpDrop}
+       \* Under the fix, the index op takes a DDL lock that conflicts with an in-flight migration.
+       \* Under the bug, no such serialisation: the index op can race with the migration's
+       \* clone-time snapshot.
+    /\ IF SafeIndexSyncOnCommit
+        THEN NoMigrationInFlight
+        ELSE TRUE
+    /\ LET targets == DataBearingShards IN
+        \E ordering \in [1..Cardinality(targets) -> targets] :
+            /\ {ordering[i] : i \in DOMAIN ordering} = targets
+            /\ indexOp' = [kind |-> kind,
+                           name |-> n,
+                           pending |-> [i \in 1..Cardinality(targets) |-> ordering[i]],
+                           done |-> {}]
+    /\ UNCHANGED <<sIndexes, sOwns, migration, migrationsDone, indexOpsDone>>
+
+StepIndexOp ==
+    /\ ~NoIndexOpInFlight
+    /\ Len(indexOp.pending) > 0
+    /\ LET s == indexOp.pending[1] IN
+        /\ IF indexOp.kind = OpCreate
+            THEN sIndexes' = [sIndexes EXCEPT ![s] = @ \cup {indexOp.name}]
+            ELSE sIndexes' = [sIndexes EXCEPT ![s] = @ \ {indexOp.name}]
+        /\ indexOp' = [indexOp EXCEPT !.pending = Tail(@),
+                                       !.done = @ \cup {s}]
+    /\ UNCHANGED <<sOwns, migration, migrationsDone, indexOpsDone>>
+
+FinishIndexOp ==
+    /\ ~NoIndexOpInFlight
+    /\ Len(indexOp.pending) = 0
+    /\ indexOp' = NoIndexOp
+    /\ indexOpsDone' = indexOpsDone + 1
+    /\ UNCHANGED <<sIndexes, sOwns, migration, migrationsDone>>
+
+(*************************************************************************************************)
+(* Migration actions: clone -> recipientPrepared -> allPrepared -> commit -> unset.              *)
+(*************************************************************************************************)
+
+\* Recipient takes the donor's current index snapshot. THIS IS THE BUG SURFACE: the snapshot is
+\* never refreshed if the donor's index set mutates after this point.
+MigrateStartClone(from, to) ==
+    /\ NoMigrationInFlight
+    /\ migrationsDone < MIGRATIONS
+    /\ from \in Shards /\ to \in Shards
+    /\ from # to
+    /\ sOwns[from] = TRUE
+       \* Either the recipient already owns a chunk (additive migration) or doesn't. Both happen
+       \* in production; both must satisfy the invariant.
+       \* Under the fix, the migration takes a DDL lock that conflicts with an in-flight index op.
+       \* Under the bug, no such serialisation.
+    /\ IF SafeIndexSyncOnCommit
+        THEN NoIndexOpInFlight
+        ELSE TRUE
+    /\ migration' = [phase |-> PhaseCloning,
+                     donor |-> from,
+                     recipient |-> to,
+                     snapshot |-> sIndexes[from]]
+    /\ UNCHANGED <<sIndexes, sOwns, migrationsDone, indexOp, indexOpsDone>>
+
+\* Recipient applies the cloned index set to its local catalog. In production the recipient
+\* createIndexes the missing indexes and (if strict-sync) drops indexes not in the snapshot.
+\* Under the fix we model strict sync: the recipient's index set is REPLACED by the snapshot,
+\* which mirrors `_dropLocalIndexes` followed by createIndexes on the missing specs (see
+\* migration_destination_manager.cpp `_cloneCollectionIndexesAndOptions`). Under the bug we model
+\* the historical non-strict / auto-heal path which UNIONS the snapshot into the recipient's
+\* existing set, leaving any pre-existing recipient-only indexes behind to diverge from the
+\* donor.
+MigrateRecipientApplyClone ==
+    /\ migration.phase = PhaseCloning
+    /\ IF SafeIndexSyncOnCommit
+        THEN sIndexes' = [sIndexes EXCEPT ![migration.recipient] = migration.snapshot]
+        ELSE sIndexes' = [sIndexes EXCEPT ![migration.recipient] = @ \cup migration.snapshot]
+    /\ migration' = [migration EXCEPT !.phase = PhaseRecipPrep]
+    /\ UNCHANGED <<sOwns, migrationsDone, indexOp, indexOpsDone>>
+
+MigrateDonorPrepare ==
+    /\ migration.phase = PhaseRecipPrep
+    /\ migration' = [migration EXCEPT !.phase = PhaseAllPrep]
+    /\ UNCHANGED <<sIndexes, sOwns, migrationsDone, indexOp, indexOpsDone>>
+
+\* Commit on the config shard. The recipient gains ownership; the donor retains ownership.
+\* (We over-approximate by leaving the donor as data-bearing, which is the harder-to-satisfy case
+\* for index consistency.) Under the fix, no in-flight index op can exist here (StartIndexOp
+\* takes the DDL lock that conflicts with the migration), so the recipient's clone-time snapshot
+\* equals the donor's current index set and the commit is a no-op for index sync.
+MigrateCommit ==
+    /\ migration.phase = PhaseAllPrep
+    /\ LET to == migration.recipient IN
+        /\ sOwns' = [sOwns EXCEPT ![to] = TRUE]
+    /\ migration' = [migration EXCEPT !.phase = PhaseCommitted]
+    /\ UNCHANGED <<sIndexes, migrationsDone, indexOp, indexOpsDone>>
+
+MigrateFinish ==
+    /\ migration.phase = PhaseCommitted
+    /\ migration' = EmptyMigration
+    /\ migrationsDone' = migrationsDone + 1
+    /\ UNCHANGED <<sIndexes, sOwns, indexOp, indexOpsDone>>
+
+\* Abort an in-flight migration before commit. Returns the recipient's index catalog to whatever
+\* it was prior to the clone application (modelled by leaving it as-is, since auto-heal-added
+\* indexes do not get rolled back in production either -- that orphan-index state is one of the
+\* failure modes the bug introduces).
+MigrateAbort ==
+    /\ migration.phase \in {PhaseCloning, PhaseRecipPrep, PhaseAllPrep}
+    /\ migration' = EmptyMigration
+    /\ UNCHANGED <<sIndexes, sOwns, migrationsDone, indexOp, indexOpsDone>>
+
+(*************************************************************************************************)
+(* Next-state relation.                                                                          *)
+(*************************************************************************************************)
+
+Next ==
+    \/ \E kind \in {OpCreate, OpDrop}, n \in IndexNames : StartIndexOp(kind, n)
+    \/ StepIndexOp
+    \/ FinishIndexOp
+    \/ \E from, to \in Shards : MigrateStartClone(from, to)
+    \/ MigrateRecipientApplyClone
+    \/ MigrateDonorPrepare
+    \/ MigrateCommit
+    \/ MigrateFinish
+    \/ MigrateAbort
+
+Fairness ==
+    /\ WF_vars(StepIndexOp)
+    /\ WF_vars(FinishIndexOp)
+    /\ WF_vars(MigrateRecipientApplyClone)
+    /\ WF_vars(MigrateDonorPrepare)
+    /\ WF_vars(MigrateCommit)
+    /\ WF_vars(MigrateFinish)
+
+Spec == /\ Init /\ [][Next]_vars /\ Fairness
+
+----------------------------------------------------------------------------------------------------
+(**************************************************************************************************)
+(* Type invariants.                                                                                *)
+(**************************************************************************************************)
+
+TypeOK ==
+    /\ sIndexes \in [Shards -> SUBSET IndexNames]
+    /\ sOwns \in [Shards -> BOOLEAN]
+    /\ migration.phase \in {PhaseUnset, PhaseCloning, PhaseRecipPrep, PhaseAllPrep, PhaseCommitted}
+    /\ migrationsDone \in 0..MIGRATIONS
+    /\ indexOpsDone \in 0..INDEX_OPS
+
+(**************************************************************************************************)
+(* Correctness Properties.                                                                         *)
+(**************************************************************************************************)
+
+\* The headline invariant. After every migration commits and no index op is in flight, all
+\* data-bearing shards agree on the index set. This is exactly the property SERVER-99357
+\* documents as violated.
+IndexSetConsistentPostMigration ==
+    \/ ~NoMigrationInFlight                  \* Migration in flight: divergence permitted.
+    \/ ~NoIndexOpInFlight                    \* Index op in flight: per-shard transient drift OK.
+    \/ \A s1, s2 \in DataBearingShards : sIndexes[s1] = sIndexes[s2]
+
+\* A weaker shape used as a sanity invariant: the migration phase is always well-formed.
+MigrationPhaseWellFormed ==
+    \/ migration.phase = PhaseUnset
+    \/ /\ migration.donor \in Shards
+       /\ migration.recipient \in Shards
+       /\ migration.donor # migration.recipient
+
+\* Liveness: every started migration eventually clears, and every started index op eventually
+\* finishes. (Disabled in the .cfg by default to keep model-checking fast; enable to discharge.)
+EventuallyQuiesces == <>(NoMigrationInFlight /\ NoIndexOpInFlight)
+====================================================================================================

--- a/src/mongo/tla_plus/Sharding/MigrationConcurrentIndexOps/OWNERS.yml
+++ b/src/mongo/tla_plus/Sharding/MigrationConcurrentIndexOps/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-sharding

--- a/src/mongo/tla_plus/Sharding/MigrationConcurrentIndexOps/README.md
+++ b/src/mongo/tla_plus/Sharding/MigrationConcurrentIndexOps/README.md
@@ -1,0 +1,59 @@
+# MigrationConcurrentIndexOps
+
+TLA+ model of the race between chunk migration and the `createIndexes` / `dropIndexes`
+commands on a sharded collection. The race is documented in
+[SERVER-99357](https://jira.mongodb.org/browse/SERVER-99357): a user-issued index command
+fans out shard-by-shard via the router's retry loop, while a migration recipient takes a
+single index-catalog snapshot from the donor at the start of the clone phase. If the index
+command interleaves between the recipient's snapshot and the donor's per-shard step, the
+cluster ends with different index sets on different shards after the migration commits.
+
+The downstream effect is that future migrations refuse to copy data into a shard whose
+existing index set diverges from the donor's, which blocks `removeShard` and
+`transitionToDedicatedConfigServer` until the operator manually reconciles indexes.
+
+## What the spec models
+
+- A single chunk-bearing collection on a set of shards (cardinality >= 2; the third shard
+  is a bystander to force per-shard ordering to matter).
+- Migration phases: `Unset -> Cloning -> RecipientPrepared -> AllPrepared -> Committed
+  -> Unset`, with an abort path back to `Unset`.
+- The recipient's clone-time index snapshot, captured in `migration.snapshot` at
+  `MigrateStartClone` and applied via `MigrateRecipientApplyClone`.
+- Router-driven index ops as ordered fan-outs over data-bearing shards. Each `StepIndexOp`
+  mutates one shard's local index set; the order is non-deterministic, modelling the
+  shard-version retry loop's lack of cross-shard atomicity.
+- A bug toggle, `SafeIndexSyncOnCommit`. When `TRUE` the recipient re-clones the donor's
+  current index catalog at commit (the fix); when `FALSE` the recipient keeps its stale
+  clone-time snapshot (the bug).
+
+## Invariants
+
+- `IndexSetConsistentPostMigration` -- the headline invariant. When no migration and no
+  index op is in flight, every data-bearing shard has the same index set.
+- `MigrationPhaseWellFormed` -- shape check on the migration record.
+- `TypeOK` -- standard type invariant.
+
+## Running
+
+```
+cd src/mongo/tla_plus
+./download-tlc.sh        # one-time, downloads tla2tools.jar
+./model-check.sh Sharding/MigrationConcurrentIndexOps
+```
+
+`MCMigrationConcurrentIndexOps.cfg` is the green config (`SafeIndexSyncOnCommit = TRUE`)
+and is expected to discharge with no invariant violations. To witness the bug, swap in
+`MCMigrationConcurrentIndexOps_bug.cfg` (rename it over the green cfg or pass it via
+`-config` if invoking TLC directly); TLC then dumps a counter-example trace of the form
+documented inline in the bug cfg.
+
+## Reproducer jstest
+
+The deterministic, single-process repro lives at
+`jstests/sharding/migration_concurrent_index_ops_deterministic.js`. It uses migration
+failpoints to wedge the recipient at clone time, runs a `dropIndexes` through the router,
+unwedges the migration, and then asserts that the per-shard index sets diverge before the
+fix and stay consistent after. The TLA+ spec and the jstest exercise the same trace shape;
+the spec proves the property holds under the fix on the full state space, the jstest pins
+the bug shape against accidental regression.


### PR DESCRIPTION
## Summary

TLA+ spec + jstest reproducer for SERVER-99357: `dropIndexes` / `createIndexes` racing chunk migration lands the cluster in inconsistent-index state, which then blocks future migrations and `removeShard` / `transitionToDedicatedConfigServer`.

**Jira:** https://jira.mongodb.org/browse/SERVER-126605
**Related:** https://jira.mongodb.org/browse/SERVER-99357

## TLC verdicts

| Cfg | Result |
|---|---|
| Green (`SafeIndexSyncOnCommit=TRUE`) | No error; 1180 / 507 distinct states |
| Bug (`SafeIndexSyncOnCommit=FALSE`) | `IndexSetConsistentPostMigration` violated; counterexample: `createIndexes` on donor after recipient snapshotted empty → recipient post-commit `{}`, donor `{ix1}` |

## Files

- `src/mongo/tla_plus/Sharding/MigrationConcurrentIndexOps/MigrationConcurrentIndexOps.tla` (318 lines)
- `src/mongo/tla_plus/Sharding/MigrationConcurrentIndexOps/MCMigrationConcurrentIndexOps.tla` + `MCMigrationConcurrentIndexOps.cfg` (green) + `MCMigrationConcurrentIndexOps_bug.cfg`
- `src/mongo/tla_plus/Sharding/MigrationConcurrentIndexOps/OWNERS.yml` (`10gen/server-sharding`)
- `src/mongo/tla_plus/Sharding/MigrationConcurrentIndexOps/README.md`
- `jstests/sharding/migration_concurrent_index_ops_deterministic.js` (254 lines)

## Verify

```
cd src/mongo/tla_plus
./download-tlc.sh
./model-check.sh Sharding/MigrationConcurrentIndexOps
```

jstest covers 3 cases: `dropIndexes` race, `createIndexes` race, follow-up migration must succeed. Uses `pauseMoveChunkAtStep(startedMoveChunk)` to wedge migration after recipient index snapshot, runs the index op via parallel `Thread`, asserts zero divergence via the `$indexStats` pipeline.

## Draft status

Opened as Draft.
