### PR TITLE
SERVER-126551 Add TLA+ spec for kNotIdempotent retry + minimum-safe NotPrimary subset

### DIFF
--- a/src/mongo/tla_plus/Networking/KNotIdempotentRetry/KNotIdempotentRetry.tla
+++ b/src/mongo/tla_plus/Networking/KNotIdempotentRetry/KNotIdempotentRetry.tla
@@ -1,0 +1,289 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+---- MODULE KNotIdempotentRetry ----
+\* Models the Shard::RetryPolicy::kNotIdempotent classifier in
+\* src/mongo/db/sharding_environment/client/shard.cpp, with the goal of
+\* disentangling which NotPrimary error subclasses are safe to retry under a
+\* non-idempotent write (or non-idempotent non-write, e.g. getMore).
+\*
+\* Motivation (SERVER-108482):
+\*   The current classifier returns true for the entire ErrorCodes::isNotPrimaryError
+\*   category. The error_codes.yml comment explicitly states that the category by
+\*   itself is INSUFFICIENT to determine whether a write actually occurred -- each
+\*   member code must be inspected individually.
+\*
+\*   PR #52940 attempted to remove the whole category from the kNotIdempotent retry
+\*   set and was reverted (#53185) because the all-or-nothing change broke tests
+\*   that relied on retrying NotWritablePrimary after retargeting (the
+\*   "rejected-before-apply" case is genuinely safe and is the load-bearing
+\*   reason kNotIdempotent retries NotPrimary at all).
+\*
+\* Modelling strategy:
+\*   Three orthogonal axes per request:
+\*     1. RequestState  in  {PreSend, SentUnknown, Applied, NotApplied}
+\*        -- where the request is in its life-cycle from the client's POV.
+\*     2. NotPrimarySub in  {NotWritablePrimary, NotPrimaryNoSecondaryOk,
+\*                           PrimarySteppedDown, InterruptedDueToReplStateChange,
+\*                           NoNotPrimary}
+\*        -- the precise error subclass returned to the client.
+\*     3. IdemClass     in  {NonIdempotentWrite, NonIdempotentNonWrite, Idempotent}
+\*        -- the operation's idempotency class as declared by the dispatcher.
+\*
+\*   The safety invariant NoDoubleApplication asserts that across any history
+\*   the same logical operation is Applied on the primary at most once even
+\*   when the retry classifier fires.
+\*
+\* Bug toggle:
+\*   The boolean constant AllowRetryOnAmbiguousNotPrimary models the pre-revert
+\*   (= currently-live) behaviour: when TRUE the classifier retries on the FULL
+\*   NotPrimary category, including PrimarySteppedDown and
+\*   InterruptedDueToReplStateChange. When FALSE the classifier retries on the
+\*   minimum-safe subset only -- NotWritablePrimary and NotPrimaryNoSecondaryOk
+\*   (i.e. the rejected-before-apply subset).
+\*
+\* This spec is deliberately scoped: it does not re-derive RaftMongo's election
+\* / commit-point logic. It models the single client request crossing a single
+\* primary boundary, because that is exactly the seam where the SERVER-108482
+\* bug lives.
+
+EXTENDS Integers, FiniteSets, Sequences, TLC
+
+CONSTANTS
+    MaxRequests,                          \* bound on Requests issued (model-check finite)
+    MaxRetries,                           \* bound on retry depth per request
+    AllowRetryOnAmbiguousNotPrimary       \* the bug toggle (TRUE = current code)
+
+ASSUME MaxRequests \in Nat /\ MaxRequests >= 1
+ASSUME MaxRetries  \in Nat /\ MaxRetries  >= 1
+ASSUME AllowRetryOnAmbiguousNotPrimary \in BOOLEAN
+
+\* --- Enumerations as model values ---------------------------------------
+
+RequestStates ==
+    {"PreSend",        \* dispatcher holds the request, not yet on the wire
+     "SentUnknown",    \* on the wire, outcome ambiguous until reply lands
+     "Applied",        \* primary applied the op (write committed locally or replicated)
+     "NotApplied"}     \* primary rejected the op before any side effect
+
+NotPrimarySubs ==
+    {"NotWritablePrimary",                 \* server rejected: was not writable primary
+     "NotPrimaryNoSecondaryOk",            \* server rejected: secondary read w/o secondaryOk
+     "PrimarySteppedDown",                 \* primary lost leadership mid-flight
+     "InterruptedDueToReplStateChange",    \* op interrupted by repl state transition
+     "NoNotPrimary"}                       \* a non-NotPrimary reply
+
+IdemClasses ==
+    {"NonIdempotentWrite",                 \* e.g. user-management write, $merge w/ user-set wc
+     "NonIdempotentNonWrite",              \* e.g. getMore on a cursor with side effects
+     "Idempotent"}                         \* covered by kIdempotent, included for completeness
+
+\* The rejected-before-apply subset. error_codes.yml's NotPrimaryError category
+\* mixes two semantics: codes that *guarantee* the server never reached the apply
+\* path (NotWritablePrimary, NotPrimaryNoSecondaryOk) and codes that *do not*
+\* (PrimarySteppedDown, InterruptedDueToReplStateChange). The minimum-safe subset
+\* is the first group only.
+RejectedBeforeApplySubset ==
+    {"NotWritablePrimary", "NotPrimaryNoSecondaryOk"}
+
+\* The ambiguous subset: server may or may not have applied; the client cannot tell
+\* without a NoWritesPerformed label (SERVER-66479).
+AmbiguousNotPrimarySubset ==
+    {"PrimarySteppedDown", "InterruptedDueToReplStateChange"}
+
+\* --- State ---------------------------------------------------------------
+
+VARIABLES
+    requests,        \* function: requestId -> request record
+    appliedCount,    \* function: requestId -> number of times op was Applied on primary
+    nextReqId        \* monotonic counter (bounded by MaxRequests)
+
+vars == <<requests, appliedCount, nextReqId>>
+
+RequestId == 1..MaxRequests
+
+\* Shape of a request record. attempts is the count of network sends for this op.
+\* state, lastError track the most recent outcome the client has observed.
+RequestRecord ==
+    [idem        : IdemClasses,
+     state       : RequestStates,
+     lastError   : NotPrimarySubs,
+     attempts    : 0..(MaxRetries + 1),
+     terminated  : BOOLEAN]
+
+TypeOK ==
+    /\ nextReqId \in 0..MaxRequests
+    /\ DOMAIN requests = 1..nextReqId
+    /\ DOMAIN appliedCount = 1..nextReqId
+    /\ \A r \in 1..nextReqId :
+        /\ requests[r] \in RequestRecord
+        /\ appliedCount[r] \in 0..(MaxRetries + 1)
+
+\* --- Initial state -------------------------------------------------------
+
+Init ==
+    /\ nextReqId    = 0
+    /\ requests     = <<>>
+    /\ appliedCount = <<>>
+
+\* --- Helpers -------------------------------------------------------------
+
+\* The retry classifier under test. Returns TRUE iff kNotIdempotent retries
+\* given the observed lastError. NoNotPrimary errors (timeouts, network errors,
+\* etc.) are out of scope for this spec; we model only the NotPrimary axis.
+ClassifierRetries(err) ==
+    CASE err = "NoNotPrimary"
+            -> FALSE
+      [] err \in RejectedBeforeApplySubset
+            -> TRUE                                  \* always safe
+      [] err \in AmbiguousNotPrimarySubset
+            -> AllowRetryOnAmbiguousNotPrimary       \* bug toggle
+      [] OTHER
+            -> FALSE
+
+\* Has the request reached a terminal state (success, fatal error, or retry-budget
+\* exhausted)?
+IsTerminal(rec) ==
+    \/ rec.terminated
+    \/ rec.attempts >= MaxRetries + 1
+
+\* --- Actions -------------------------------------------------------------
+
+\* The dispatcher issues a new request and immediately transitions it to
+\* SentUnknown (we collapse PreSend -> SentUnknown into one TLC step because
+\* the bug does not depend on what happens before the wire send).
+IssueRequest ==
+    /\ nextReqId < MaxRequests
+    /\ \E ic \in IdemClasses :
+        LET newId == nextReqId + 1
+            rec   == [idem       |-> ic,
+                      state      |-> "SentUnknown",
+                      lastError  |-> "NoNotPrimary",
+                      attempts   |-> 1,
+                      terminated |-> FALSE]
+        IN /\ nextReqId'    = newId
+           /\ requests'     = requests     @@ (newId :> rec)
+           /\ appliedCount' = appliedCount @@ (newId :> 0)
+
+\* The primary RECEIVED the request, REJECTED it before apply, and replied with
+\* a rejected-before-apply NotPrimary subclass. appliedCount is NOT incremented.
+\* Note: we deliberately do not gate Remote* on ~IsTerminal because once a
+\* request has been put on the wire the remote can always answer; the retry
+\* budget bounds retries, not in-flight responses.
+RemoteRejectsBeforeApply(r) ==
+    /\ r \in 1..nextReqId
+    /\ requests[r].state = "SentUnknown"
+    /\ ~requests[r].terminated
+    /\ \E sub \in RejectedBeforeApplySubset :
+        requests' = [requests EXCEPT ![r] =
+            [@ EXCEPT !.state = "NotApplied", !.lastError = sub]]
+    /\ UNCHANGED <<appliedCount, nextReqId>>
+
+\* The primary APPLIED the op and THEN failed (e.g. stepped down between apply
+\* and reply ack). This is the ambiguous case: from the client's POV the reply
+\* indicates a NotPrimary subclass that does not preclude apply.
+RemoteAppliesThenFails(r) ==
+    /\ r \in 1..nextReqId
+    /\ requests[r].state = "SentUnknown"
+    /\ ~requests[r].terminated
+    /\ \E sub \in AmbiguousNotPrimarySubset :
+        /\ requests' = [requests EXCEPT ![r] =
+                [@ EXCEPT !.state = "Applied", !.lastError = sub]]
+        /\ appliedCount' = [appliedCount EXCEPT ![r] = @ + 1]
+    /\ UNCHANGED <<nextReqId>>
+
+\* The primary APPLIED the op and replied success. Idempotency does not matter
+\* here -- the request terminates with state Applied and the classifier never
+\* fires. Kept so behaviours include the success path.
+RemoteAppliesAndAcks(r) ==
+    /\ r \in 1..nextReqId
+    /\ requests[r].state = "SentUnknown"
+    /\ ~requests[r].terminated
+    /\ requests' = [requests EXCEPT ![r] =
+            [@ EXCEPT !.state = "Applied", !.terminated = TRUE]]
+    /\ appliedCount' = [appliedCount EXCEPT ![r] = @ + 1]
+    /\ UNCHANGED <<nextReqId>>
+
+\* The dispatcher inspects the observed error and decides to retry.
+\* This is the action the classifier under test gates.
+\* When the request is re-sent we go back to SentUnknown so the primary can
+\* RemoteApplies* again -- if appliedCount climbs to 2, NoDoubleApplication
+\* fails.
+DispatcherRetries(r) ==
+    /\ r \in 1..nextReqId
+    /\ ~requests[r].terminated
+    /\ requests[r].state \in {"Applied", "NotApplied"}
+    /\ ClassifierRetries(requests[r].lastError)
+    /\ requests[r].idem \in {"NonIdempotentWrite", "NonIdempotentNonWrite"}
+    /\ requests[r].attempts < MaxRetries + 1
+    /\ requests' = [requests EXCEPT ![r] =
+            [@ EXCEPT !.state    = "SentUnknown",
+                      !.attempts = @ + 1]]
+    /\ UNCHANGED <<appliedCount, nextReqId>>
+
+\* The dispatcher surfaces the error to the caller (gives up retrying).
+\* Four reasons to give up:
+\*   1. The classifier says "no retry" for the observed error.
+\*   2. The retry budget is exhausted.
+\*   3. The request is Idempotent -- model scope is kNotIdempotent only, so an
+\*      Idempotent request that lands here simply terminates without modelling
+\*      kIdempotent's separate retry path.
+\*   4. The request received a non-NotPrimary reply that nonetheless landed
+\*      in NotApplied (catch-all so every reply path terminates the request).
+DispatcherGivesUp(r) ==
+    /\ r \in 1..nextReqId
+    /\ ~requests[r].terminated
+    /\ requests[r].state \in {"Applied", "NotApplied"}
+    /\ \/ ~ClassifierRetries(requests[r].lastError)
+       \/ requests[r].attempts >= MaxRetries + 1
+       \/ requests[r].idem = "Idempotent"
+    /\ requests' = [requests EXCEPT ![r] = [@ EXCEPT !.terminated = TRUE]]
+    /\ UNCHANGED <<appliedCount, nextReqId>>
+
+\* Self-stutter step: once every issued request has terminated and the budget
+\* of new requests is exhausted, there is nothing left to do. Without an
+\* explicit terminal stutter TLC reports the natural end-state as a deadlock
+\* error -- which is noise for a spec that legitimately has a finite life-cycle.
+Done ==
+    /\ nextReqId = MaxRequests
+    /\ \A r \in 1..nextReqId : requests[r].terminated
+    /\ UNCHANGED vars
+
+Next ==
+    \/ IssueRequest
+    \/ \E r \in 1..nextReqId :
+            \/ RemoteRejectsBeforeApply(r)
+            \/ RemoteAppliesThenFails(r)
+            \/ RemoteAppliesAndAcks(r)
+            \/ DispatcherRetries(r)
+            \/ DispatcherGivesUp(r)
+    \/ Done
+
+Spec == Init /\ [][Next]_vars /\ WF_vars(Next)
+
+\* --- Safety invariants ---------------------------------------------------
+
+\* The headline invariant: for any non-idempotent operation the primary must
+\* apply the op at most once across the entire retry history.
+NoDoubleApplication ==
+    \A r \in 1..nextReqId :
+        requests[r].idem \in {"NonIdempotentWrite", "NonIdempotentNonWrite"} =>
+            appliedCount[r] <= 1
+
+\* Sanity invariant: a request cannot exceed its retry budget.
+RetryBudgetRespected ==
+    \A r \in 1..nextReqId : requests[r].attempts <= MaxRetries + 1
+
+\* --- Liveness ------------------------------------------------------------
+
+\* Every request eventually terminates. This is a weak liveness property to
+\* make sure the dispatcher doesn't get stuck in an infinite retry loop on the
+\* same error -- which the MaxRetries budget already prevents structurally.
+AllRequestsEventuallyTerminate ==
+    \A r \in 1..MaxRequests :
+        (r <= nextReqId) ~> requests[r].terminated
+
+====

--- a/src/mongo/tla_plus/Networking/KNotIdempotentRetry/MCKNotIdempotentRetry-bug.cfg
+++ b/src/mongo/tla_plus/Networking/KNotIdempotentRetry/MCKNotIdempotentRetry-bug.cfg
@@ -1,0 +1,21 @@
+\* Config file to run TLC on KNotIdempotentRetry.tla in the BUG configuration:
+\* AllowRetryOnAmbiguousNotPrimary = TRUE (the currently-live, post-revert
+\* classifier that retries on the full NotPrimary category).
+\* Under this configuration NoDoubleApplication must FAIL -- TLC should print
+\* a counterexample trace where a non-idempotent write is applied twice.
+\* This is a deliberate negative test: it documents the bug as a falsifiable
+\* TLC verdict rather than prose.
+\* See KNotIdempotentRetry.tla for the specification.
+
+CONSTANTS
+    MaxRequests                       = 2
+    MaxRetries                        = 2
+    AllowRetryOnAmbiguousNotPrimary   = TRUE
+
+CONSTRAINT StateConstraint
+
+INVARIANT TypeOK
+INVARIANT NoDoubleApplication
+INVARIANT RetryBudgetRespected
+
+SPECIFICATION Spec

--- a/src/mongo/tla_plus/Networking/KNotIdempotentRetry/MCKNotIdempotentRetry.cfg
+++ b/src/mongo/tla_plus/Networking/KNotIdempotentRetry/MCKNotIdempotentRetry.cfg
@@ -1,0 +1,18 @@
+\* Config file to run TLC on KNotIdempotentRetry.tla in the GREEN configuration:
+\* AllowRetryOnAmbiguousNotPrimary = FALSE (the proposed minimum-safe classifier).
+\* Under this configuration NoDoubleApplication must hold.
+\* See KNotIdempotentRetry.tla for the specification.
+\* See MCKNotIdempotentRetry-bug.cfg for the bug-reproducing configuration.
+
+CONSTANTS
+    MaxRequests                       = 2
+    MaxRetries                        = 2
+    AllowRetryOnAmbiguousNotPrimary   = FALSE
+
+CONSTRAINT StateConstraint
+
+INVARIANT TypeOK
+INVARIANT NoDoubleApplication
+INVARIANT RetryBudgetRespected
+
+SPECIFICATION Spec

--- a/src/mongo/tla_plus/Networking/KNotIdempotentRetry/MCKNotIdempotentRetry.tla
+++ b/src/mongo/tla_plus/Networking/KNotIdempotentRetry/MCKNotIdempotentRetry.tla
@@ -1,0 +1,17 @@
+---- MODULE MCKNotIdempotentRetry ----
+\* Model-check configuration helper for KNotIdempotentRetry.tla.
+\* See KNotIdempotentRetry.tla for the specification.
+
+EXTENDS KNotIdempotentRetry
+
+\* Bound the state-space. With MaxRequests=2 and MaxRetries=2 TLC explores
+\* every interleaving of two concurrent requests where each request can be
+\* sent up to three times (initial + 2 retries). This is enough to expose
+\* NoDoubleApplication violations on the buggy classifier (one
+\* RemoteAppliesThenFails followed by a DispatcherRetries followed by a
+\* second RemoteAppliesThenFails is a 4-step witness).
+StateConstraint ==
+    /\ nextReqId <= MaxRequests
+    /\ \A r \in 1..nextReqId : requests[r].attempts <= MaxRetries + 1
+
+====

--- a/src/mongo/tla_plus/Networking/KNotIdempotentRetry/OWNERS.yml
+++ b/src/mongo/tla_plus/Networking/KNotIdempotentRetry/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-catalog-and-routing

--- a/src/mongo/tla_plus/Networking/KNotIdempotentRetry/README.md
+++ b/src/mongo/tla_plus/Networking/KNotIdempotentRetry/README.md
@@ -1,0 +1,64 @@
+# KNotIdempotentRetry
+
+TLA+ spec for [SERVER-108482][s108482]: the `Shard::RetryPolicy::kNotIdempotent`
+classifier retries on the full `ErrorCodes::isNotPrimaryError` category, but
+`error_codes.yml` documents that category as insufficient to determine whether
+a write occurred. PR [#52940][pr52940] removed the entire category and was
+reverted in [#53185][pr53185] because the all-or-nothing change broke tests
+that rely on retrying after retargeting.
+
+## What the spec models
+
+Three orthogonal axes per request, intersected against the classifier:
+
+1. `RequestState` ∈ {`PreSend`, `SentUnknown`, `Applied`, `NotApplied`}
+2. `NotPrimarySub` ∈ {`NotWritablePrimary`, `NotPrimaryNoSecondaryOk`,
+   `PrimarySteppedDown`, `InterruptedDueToReplStateChange`, `NoNotPrimary`}
+3. `IdemClass` ∈ {`NonIdempotentWrite`, `NonIdempotentNonWrite`, `Idempotent`}
+
+The classifier is gated by the bug toggle `AllowRetryOnAmbiguousNotPrimary`:
+
+- `FALSE` → retry only on `RejectedBeforeApplySubset`
+  = {`NotWritablePrimary`, `NotPrimaryNoSecondaryOk`}.
+- `TRUE` → retry on the full `NotPrimaryError` category
+  (the currently-live post-revert behaviour).
+
+The safety invariant `NoDoubleApplication` asserts that any non-idempotent
+operation is applied on the primary at most once across the whole retry
+history.
+
+## The minimum-safe NotPrimary subset
+
+Two semantic groups inside the `NotPrimaryError` category:
+
+| Subclass | Apply path reached? | Safe to retry as kNotIdempotent? |
+|----------|---------------------|----------------------------------|
+| `NotWritablePrimary`             | No, rejected at command entry  | Yes |
+| `NotPrimaryNoSecondaryOk`        | No, rejected before dispatch   | Yes |
+| `PrimarySteppedDown`             | Possibly, stepdown mid-flight  | No  |
+| `InterruptedDueToReplStateChange`| Possibly, kill mid-apply       | No  |
+
+`RejectedBeforeApplySubset` (the first two) is the minimum-safe set: the
+server guarantees no side effect occurred before returning these. The other
+two are the ambiguous set the original ticket flags and are exactly what
+`NoWritesPerformed` (SERVER-66479) was designed to disambiguate.
+
+This is also why PR #52940's all-or-nothing revert is wrong in both
+directions: keeping all four breaks `NoDoubleApplication`; dropping all four
+breaks `RunUserManagementWriteCommandNotWritablePrimaryRetrySuccess`, which
+legitimately retries after retargeting.
+
+## Running
+
+```sh
+cd src/mongo/tla_plus
+./download-tlc.sh
+./model-check.sh Networking/KNotIdempotentRetry          # green: invariant holds
+# To reproduce the bug counterexample, swap MCKNotIdempotentRetry.cfg with
+# MCKNotIdempotentRetry-bug.cfg and re-run; TLC will print a trace where a
+# non-idempotent write is Applied twice.
+```
+
+[s108482]: https://jira.mongodb.org/browse/SERVER-108482
+[pr52940]: https://github.com/10gen/mongo/pull/52940
+[pr53185]: https://github.com/10gen/mongo/pull/53185

--- a/src/mongo/tla_plus/Networking/OWNERS.yml
+++ b/src/mongo/tla_plus/Networking/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-catalog-and-routing


### PR DESCRIPTION
## Summary

TLA+ spec for SERVER-108482 (prior fix auto-reverted): the `kNotIdempotent` retry classifier is too permissive. This spec identifies the minimum-safe NotPrimary subset that disambiguates rejected-before-apply from after-apply failure modes.

**Jira:** https://jira.mongodb.org/browse/SERVER-126551
**Related:** https://jira.mongodb.org/browse/SERVER-108482

## TLC verdicts

| Cfg | Result |
|---|---|
| Green (`AllowRetryOnAmbiguousNotPrimary=FALSE`) | 13724 / 4971 distinct, depth 15, no error |
| Bug (`=TRUE`) | `NoDoubleApplication` violated; 5-step counterexample `NonIdempotentNonWrite → AppliesThenFails(PrimarySteppedDown, applied=1) → DispatcherRetries → AppliesThenFails (applied=2)` |

## Load-bearing finding — minimum-safe NotPrimary subset

**Retry-safe subset:** `{NotWritablePrimary, NotPrimaryNoSecondaryOk}` — the rejected-before-apply codes.

**Excluded:** `{PrimarySteppedDown, InterruptedDueToReplStateChange}` — these can fire after the apply path is entered and need `NoWritesPerformed` (SERVER-66479) to disambiguate.

This is why both prior approaches (drop everything / retry everything) were wrong; the safe behavior is rejected-before-apply pair only.

## Files

- `src/mongo/tla_plus/Networking/KNotIdempotentRetry/KNotIdempotentRetry.tla` (289 lines)
- `src/mongo/tla_plus/Networking/KNotIdempotentRetry/MCKNotIdempotentRetry.{tla,cfg}` (green) + `MCKNotIdempotentRetry-bug.cfg`
- `src/mongo/tla_plus/Networking/KNotIdempotentRetry/OWNERS.yml` (`10gen/server-catalog-and-routing`)
- `src/mongo/tla_plus/Networking/OWNERS.yml` (parent dir ownership)
- `src/mongo/tla_plus/Networking/KNotIdempotentRetry/README.md` (316 words)

## Verify

```
cd src/mongo/tla_plus
./download-tlc.sh
./model-check.sh Networking/KNotIdempotentRetry
```

## Draft status

Opened as Draft.
