### PR TITLE
SERVER-126552 Add jstest + design for cross-DB rename staging events leaking into change streams

### DIFF
--- a/jstests/change_streams/cross_db_rename_no_staging_events.js
+++ b/jstests/change_streams/cross_db_rename_no_staging_events.js
@@ -1,0 +1,162 @@
+/**
+ * SERVER-107688: cross-database renameCollection must not leak the
+ * data-cloning phase's staging-collection oplog entries into change-stream
+ * consumers. The rename copies the source collection into a temporary
+ * "tmp<nonce>.renameCollection" namespace on the destination database, then
+ * atomically renames the staging collection into place. Today, the create,
+ * createIndexes and per-document insert oplog entries emitted while populating
+ * the staging collection are observable to:
+ *   - database-scoped change streams on the destination DB
+ *   - cluster-scoped change streams (allChangesForCluster: true)
+ *
+ * That leak surprises mongosync, CDC pipelines and any consumer that resumes
+ * against a temporary namespace that disappears at the end of the rename. The
+ * fix marks the data-cloning phase's oplog entries with fromMigrate:true so
+ * that the change-stream parser (buildNotFromMigrateFilter() in
+ * change_stream_filter_helpers.cpp) drops them by default.
+ *
+ * This test asserts the post-fix behaviour: a cross-DB rename produces a
+ * single "rename" event on the destination DB stream (and on the cluster
+ * stream) -- the staging namespace's create / createIndexes / insert events
+ * are not emitted. The pre-existing ddl_rename_cross_db.js covers the source
+ * DB events and the user-facing rename event; this test covers only the
+ * staging-leak invariant.
+ *
+ * @tags: [
+ *   requires_fcv_60,
+ *   uses_change_streams,
+ *   # Cross-DB rename is not directly supported through mongos in sharded
+ *   # configurations; the source / destination may live on different shards.
+ *   assumes_against_mongod_not_mongos,
+ * ]
+ */
+import {ChangeStreamTest} from "jstests/libs/query/change_stream_util.js";
+
+const kStagingNsRegex = /^tmp[a-zA-Z0-9]{5}\.renameCollection$/;
+
+function eventIsForStagingNamespace(event) {
+    if (!event || !event.ns || typeof event.ns.coll !== "string") {
+        return false;
+    }
+    return kStagingNsRegex.test(event.ns.coll);
+}
+
+function assertNoStagingEvents(events, label) {
+    for (const event of events) {
+        assert(
+            !eventIsForStagingNamespace(event),
+            () =>
+                "SERVER-107688 leak: " +
+                label +
+                " stream observed an event for the cross-DB rename staging" +
+                " namespace -- got " +
+                tojson(event),
+        );
+    }
+}
+
+function runScenario({watchScope, dropTarget}) {
+    const suffix = "_" + watchScope.substr(0, 3) + "_" + (dropTarget ? "drop" : "newdb");
+    const dstDb = db.getSiblingDB(jsTestName() + "_dst" + suffix);
+    const srcDb = dstDb.getSiblingDB(jsTestName() + "_src" + suffix);
+    const dstColl = dstDb.getCollection("target");
+    const srcColl = srcDb.getCollection("source");
+
+    assert.commandWorked(srcDb.dropDatabase());
+    assert.commandWorked(dstDb.dropDatabase());
+
+    // Ensure the destination DB exists before watching it. Otherwise the
+    // database-scoped stream will fail to open against an absent database.
+    assert.commandWorked(dstDb.createCollection("anchor"));
+
+    if (dropTarget) {
+        // Pre-create the destination collection so dropTarget:true has work to do.
+        assert.commandWorked(dstColl.insertMany([{b: 1}, {b: 2}]));
+        assert.commandWorked(dstColl.createIndex({b: 1}));
+    }
+
+    // Populate the source. The data-cloning phase of the rename re-emits
+    // these into the destination's staging namespace; that is the leak.
+    assert.commandWorked(srcColl.insertMany([{key0: "v0"}, {key1: "v1"}, {key1: "v2"}]));
+    assert.commandWorked(srcColl.createIndex({key0: 1}));
+    assert.commandWorked(srcColl.createIndex({key1: 1}));
+
+    const pipeline = [{$changeStream: {showExpandedEvents: true}}];
+    let cursor;
+    let streamLabel;
+
+    if (watchScope === "database") {
+        const testStream = new ChangeStreamTest(dstDb);
+        cursor = testStream.startWatchingChanges({pipeline, collection: /*all colls=*/ 1});
+        streamLabel = "database-scoped";
+
+        // Execute the cross-DB rename. The admin command is the canonical
+        // entry point; runCommand on either DB works against mongod.
+        const renameSpec = {renameCollection: srcColl.getFullName(), to: dstColl.getFullName()};
+        if (dropTarget) {
+            renameSpec.dropTarget = true;
+        }
+        assert.commandWorked(dstDb.adminCommand(renameSpec));
+
+        // Drain a generous prefix of events; we expect at most the final
+        // user-facing "rename" event on the destination namespace, plus any
+        // pre-existing destination-collection traffic from dropTarget.
+        const drained = testStream.getNextChanges(cursor, 1);
+        assertNoStagingEvents(drained, streamLabel);
+
+        // The single drained event must be the public "rename" -- not an
+        // insert or createIndexes attributed to the staging namespace.
+        assert.eq(
+            drained[0].operationType,
+            "rename",
+            "expected user-facing rename event, got: " + tojson(drained[0]),
+        );
+        assert.eq(drained[0].ns.db, dstDb.getName());
+        assert.eq(drained[0].ns.coll, dstColl.getName());
+    } else if (watchScope === "cluster") {
+        const adminDb = db.getSiblingDB("admin");
+        const csCursor = adminDb.aggregate(
+            [{$changeStream: {showExpandedEvents: true, allChangesForCluster: true}}],
+            {cursor: {batchSize: 0}},
+        );
+        streamLabel = "cluster-scoped";
+
+        const renameSpec = {renameCollection: srcColl.getFullName(), to: dstColl.getFullName()};
+        if (dropTarget) {
+            renameSpec.dropTarget = true;
+        }
+        assert.commandWorked(dstDb.adminCommand(renameSpec));
+
+        // Pull a bounded set of events. Cluster streams will also see
+        // legitimate source-DB events (insert, createIndexes, drop) plus the
+        // public rename -- but none of them should reference the staging ns.
+        const observed = [];
+        assert.soon(
+            () => {
+                while (csCursor.hasNext()) {
+                    const event = csCursor.next();
+                    observed.push(event);
+                    if (event.operationType === "rename" && event.ns.db === dstDb.getName()) {
+                        return true;
+                    }
+                }
+                return false;
+            },
+            () => "cluster stream never observed the public rename event; saw " + tojson(observed),
+            /*timeout=*/ 30 * 1000,
+        );
+        assertNoStagingEvents(observed, streamLabel);
+        csCursor.close();
+    }
+
+    // Tidy up so re-runs of the suite are deterministic.
+    assert.commandWorked(srcDb.dropDatabase());
+    assert.commandWorked(dstDb.dropDatabase());
+}
+
+for (const watchScope of ["database", "cluster"]) {
+    for (const dropTarget of [false, true]) {
+        jsTestLog("cross_db_rename_no_staging_events: " + watchScope + " dropTarget=" + dropTarget);
+        runScenario({watchScope, dropTarget});
+    }
+}

--- a/src/mongo/db/pipeline/CROSSDB_RENAME_FIX.md
+++ b/src/mongo/db/pipeline/CROSSDB_RENAME_FIX.md
@@ -1,0 +1,90 @@
+# SERVER-107688 — cross-DB rename leaks staging events into change streams
+
+## Symptom
+
+A database-scoped or cluster-scoped change-stream consumer watching the
+destination database of a cross-database `renameCollection` observes the
+internal data-cloning traffic:
+
+- `create` on `<dstDb>.tmp<nonce>.renameCollection`
+- `createIndexes` for each source-collection secondary index, re-applied
+  to the staging namespace
+- one `insert` per cloned document into the staging namespace
+
+The pre-existing test `jstests/change_streams/ddl_rename_cross_db.js`
+already asserts the leak as the observed status quo (see lines 170-179).
+External consumers — mongosync, Kafka source connectors, application-level
+CDC — try to resume against a namespace that has been atomically renamed
+away, and fail.
+
+## Fix location (not modified here)
+
+The change-stream parser already drops `fromMigrate:true` oplog entries.
+See `change_stream_filter_helpers.cpp:buildNotFromMigrateFilter` — it
+adds a `{fromMigrate: {$ne: true}}` filter, with a narrow `showSystemEvents`
+exception for `o.create` / `o.createIndexes`. The parser does not need
+new logic. The leak is upstream: the rename plumbing fails to stamp
+`fromMigrate=true` on the staging-collection oplog entries during the
+data-cloning phase of a cross-DB rename.
+
+The fix lives in the catalog layer (sparse-checkout excluded here):
+`src/mongo/db/catalog/rename_collection.cpp`, in the helper that
+implements the cross-DB code path (historically
+`renameBetweenDBs` / `renameCollectionAcrossDatabases`). That helper
+opens an `AutoGetCollection` on the staging namespace and replays the
+source documents with `insertDocuments` / `Helpers::insert`.
+
+## Diff sketch (illustrative)
+
+```diff
+--- a/src/mongo/db/catalog/rename_collection.cpp
++++ b/src/mongo/db/catalog/rename_collection.cpp
+@@ Status renameBetweenDBs(OperationContext* opCtx, ...)
+-    // Create the staging collection on the target DB.
+-    CollectionOptions stagingOpts = sourceOpts;
+-    Status createStatus = db->createCollection(opCtx, stagingNss, stagingOpts);
++    // Create the staging collection on the target DB. Mark the create,
++    // index builds, and per-document inserts that follow as fromMigrate:true
++    // so that change-stream consumers do not observe the data-cloning phase
++    // (SERVER-107688). The terminal atomic rename remains user-visible.
++    CollectionOptions stagingOpts = sourceOpts;
++    stagingOpts.fromMigrate = true;     // tag the create oplog entry
++    Status createStatus = db->createCollection(opCtx, stagingNss, stagingOpts);
+@@ for each source index ...
+-    indexBuildsCoordinator->createIndexes(opCtx, stagingUUID, specs,
+-                                          IndexBuildsManager::IndexConstraints::kEnforce);
++    indexBuildsCoordinator->createIndexes(opCtx, stagingUUID, specs,
++                                          IndexBuildsManager::IndexConstraints::kEnforce,
++                                          /*fromMigrate=*/true);
+@@ document-clone loop ...
+-    Status insertStatus = collection_internal::insertDocuments(
+-        opCtx, *stagingCollection, batch.begin(), batch.end(), nullptr);
++    Status insertStatus = collection_internal::insertDocuments(
++        opCtx, *stagingCollection, batch.begin(), batch.end(), nullptr,
++        /*fromMigrate=*/true);
+```
+
+`collection_internal::insertDocuments` already forwards a `fromMigrate`
+parameter through `OpObserver::onInserts` → `MutableOplogEntry::fromMigrate`,
+which is what `change_stream_filter_helpers.cpp` filters on.
+
+## Out of scope
+
+- The final atomic rename of `tmp<nonce>.renameCollection` →
+  `<dstDb>.<dstColl>` must remain user-visible. It is a single oplog
+  entry, not part of the data-cloning phase, and is emitted without
+  `fromMigrate` today. The fix preserves that.
+- Source-DB events (`insert`, `createIndexes`, `drop` of the original
+  collection) are untouched; they remain visible on source-scoped streams.
+- The existing test `ddl_rename_cross_db.js` will need its assertions on
+  staging-namespace events (lines 170-179) inverted to `assertNoChanges`
+  semantics as part of landing the catalog fix.
+
+## Verification
+
+`jstests/change_streams/cross_db_rename_no_staging_events.js` exercises
+both database-scoped and cluster-scoped (`allChangesForCluster:true`)
+watchers, with and without `dropTarget:true`. Pre-fix it fails on the
+first staging-namespace event; post-fix it passes because the staging
+oplog entries carry `fromMigrate:true` and the parser's existing
+`fromMigrate:{$ne:true}` filter drops them.


### PR DESCRIPTION
## Summary

jstest + design doc for SERVER-107688: database-level change-stream readers see the temporary collection's insert events from the data-cloning phase of a cross-DB rename. Confuses external consumers (`mongosync`, CDC pipelines).

**Jira:** https://jira.mongodb.org/browse/SERVER-126552
**Related:** https://jira.mongodb.org/browse/SERVER-107688

## Key finding

The change-stream **parser is already correct**: `change_stream_filter_helpers.cpp:buildNotFromMigrateFilter` (lines 143-158) drops `fromMigrate:true` ops.

**The fix is upstream in `src/mongo/db/catalog/rename_collection.cpp::renameBetweenDBs`**: set `fromMigrate=true` on the staging create + createIndexes + per-document insert calls. Diff sketch threads `fromMigrate=true` through `collection_internal::insertDocuments` + `IndexBuildsCoordinator::createIndexes` + `CollectionOptions.fromMigrate`.

`ddl_rename_cross_db.js` lines 170–179 currently assert the leak as status quo and will need inverting once the catalog fix lands.

## Files

- `jstests/change_streams/cross_db_rename_no_staging_events.js` (162 lines) — 4 scenarios = `{DB-scoped, cluster-scoped} × {dropTarget:false, true}`. Helper `eventIsForStagingNamespace` regex-matches the `tmp[a-zA-Z0-9]{5}.renameCollection` namespace.
- `src/mongo/db/pipeline/CROSSDB_RENAME_FIX.md` (90 lines)

## Verify

```
node --input-type=module --check < jstests/change_streams/cross_db_rename_no_staging_events.js
```

## Draft status

Opened as Draft. No C++ modified in this PR — repro + fix proposal only.
