### PR TITLE
SERVER-126553 Add TLA+ spec + jstest for setFCV no-op stale-opTime majority wait

### DIFF
--- a/jstests/replsets/set_fcv_noop_returns_before_durable.js
+++ b/jstests/replsets/set_fcv_noop_returns_before_durable.js
@@ -1,0 +1,137 @@
+/**
+ * SERVER-120978: a no-op setFeatureCompatibilityVersion call (requested ==
+ * actual) must not return ok:1 before the FCV state it reports is majority
+ * durable. The bug path waits on a stale ReplClientInfo::lastOp; the fix
+ * (setLastOpToSystemLastOpTime) pins the system last applied opTime so the
+ * majority-wait dominates every prior FCV write.
+ *
+ * Repro shape:
+ *   1. Initiate a 3-node replset at latestFCV.
+ *   2. Block secondaries from replicating via the stopReplProducer failpoint.
+ *   3. Issue a real downgrade setFCV on the primary in a parallel shell;
+ *      the FCV-doc write lands on the primary but cannot reach majority
+ *      because secondaries are paused.
+ *   4. Step down the primary and elect a new one (the old primary's pending
+ *      write has not majority-committed, so it can roll back).
+ *   5. On the new primary, issue a NO-OP setFCV at latestFCV (matches the
+ *      pre-downgrade durable state). Under the bug, this returns ok:1 while
+ *      the prior FCV mutation is still in flight.
+ *   6. Assert that after the no-op returns ok:1, the FCV observed on a
+ *      majority-read is consistent with what the no-op effectively
+ *      confirmed.
+ *
+ * @tags: [
+ *     multiversion_incompatible,
+ *     requires_majority_read_concern,
+ *     requires_replication,
+ * ]
+ */
+
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+const rst = new ReplSetTest({
+    name: jsTestName(),
+    nodes: 3,
+    nodeOptions: {setParameter: {logComponentVerbosity: tojson({command: 2, replication: 2})}},
+});
+rst.startSet();
+rst.initiate(null, null, {initiateWithDefaultElectionTimeout: true});
+
+let primary = rst.getPrimary();
+let secondaries = rst.getSecondaries();
+const adminPrimary = primary.getDB("admin");
+
+jsTestLog("Confirm starting FCV is latestFCV.");
+checkFCV(adminPrimary, latestFCV);
+
+jsTestLog("Pause replication on both secondaries so the downgrade write cannot " +
+          "majority-commit.");
+const fpSecondary0 = configureFailPoint(secondaries[0], "stopReplProducer");
+const fpSecondary1 = configureFailPoint(secondaries[1], "stopReplProducer");
+
+jsTestLog("Block the primary right before it returns from the writing-path FCV " +
+          "downgrade, so the parallel shell stays parked while we step it down.");
+const fpHangBeforeReturn = configureFailPoint(primary, "hangBeforeUpdatingFcvDoc");
+
+jsTestLog("Kick off downgrade setFCV on primary in a parallel shell.");
+const parallelDowngrade = startParallelShell(`
+    const res = db.adminCommand({
+        setFeatureCompatibilityVersion: "${lastLTSFCV}",
+        confirm: true,
+        writeConcern: {w: "majority", wtimeout: 5000},
+    });
+    // We expect this to either fail due to the step-down we are about to
+    // force, or to wtimeout because secondaries are paused. Either way the
+    // operation must NOT have successfully majority-committed the FCV
+    // change.
+    assert(!res.ok || res.code !== 0 ||
+           (res.writeConcernError !== undefined),
+           "downgrade should not silently majority-commit while secondaries " +
+           "are paused; got: " + tojson(res));
+`, primary.port);
+
+fpHangBeforeReturn.wait();
+
+jsTestLog("Force a step-down so the pending FCV write is now eligible to roll " +
+          "back if the new primary diverges.");
+assert.commandWorked(
+    primary.adminCommand({replSetStepDown: 60, force: true}));
+
+fpHangBeforeReturn.off();
+
+jsTestLog("Resume replication so a new primary can be elected.");
+fpSecondary0.off();
+fpSecondary1.off();
+
+rst.awaitSecondaryNodes(null, [primary]);
+rst.awaitNodesAgreeOnPrimary();
+
+const newPrimary = rst.getPrimary();
+assert.neq(newPrimary.host, primary.host, "expected a new primary after step-down");
+const adminNewPrimary = newPrimary.getDB("admin");
+
+jsTestLog("Issue a no-op setFCV at latestFCV on the new primary. Under the " +
+          "buggy code path this returns immediately on the client's stored " +
+          "opTime (stale) instead of pinning the system last applied opTime.");
+const noopRes = assert.commandWorked(adminNewPrimary.runCommand({
+    setFeatureCompatibilityVersion: latestFCV,
+    confirm: true,
+    writeConcern: {w: "majority", wtimeout: ReplSetTest.kDefaultTimeoutMS},
+}));
+assert(!noopRes.writeConcernError,
+       "no-op setFCV must not return a writeConcernError on the fixed path; got: " +
+       tojson(noopRes));
+
+jsTestLog("After the no-op returns ok:1, a majority-read FCV on every node " +
+          "must reflect the confirmed state.");
+rst.awaitReplication();
+
+for (const node of rst.nodes) {
+    const adminN = node.getDB("admin");
+    // A majority read of the FCV document must show latestFCV, matching the
+    // version the no-op setFCV just confirmed durable.
+    const fcvDoc = assert.commandWorked(adminN.runCommand({
+        find: "system.version",
+        filter: {_id: "featureCompatibilityVersion"},
+        readConcern: {level: "majority"},
+    }));
+    assert.eq(fcvDoc.cursor.firstBatch.length, 1,
+              "FCV doc missing on " + node.host + ": " + tojson(fcvDoc));
+    const observed = fcvDoc.cursor.firstBatch[0].version;
+    assert.eq(observed, latestFCV,
+              "SERVER-120978: node " + node.host + " observed FCV " + observed +
+              " after no-op setFCV reported ok:1 at " + latestFCV +
+              "; the no-op majority-wait must have pinned the system last " +
+              "applied opTime, not the client's stored opTime.");
+}
+
+parallelDowngrade();
+
+jsTestLog("Final consistency: every node agrees on FCV via majority read.");
+checkFCV(adminNewPrimary, latestFCV);
+for (const sec of rst.getSecondaries()) {
+    checkFCV(sec.getDB("admin"), latestFCV);
+}
+
+rst.stopSet();

--- a/src/mongo/tla_plus/Replication/SetFCVNoOpMajorityWait/MCSetFCVNoOpMajorityWait.cfg
+++ b/src/mongo/tla_plus/Replication/SetFCVNoOpMajorityWait/MCSetFCVNoOpMajorityWait.cfg
@@ -1,0 +1,26 @@
+\* Config to run TLC on SetFCVNoOpMajorityWait.tla.
+\* See SetFCVNoOpMajorityWait.tla for instructions.
+\*
+\* To run the green (fixed) check:
+\*     AllowStaleOpTimeOnNoOp = FALSE
+\*     -> SetFCVResultReflectsDurableState holds.
+\*
+\* To reproduce the bug (SERVER-120978):
+\*     AllowStaleOpTimeOnNoOp = TRUE
+\*     -> SetFCVResultReflectsDurableState is violated; TLC returns a
+\*        counterexample where setFCV (no-op) returns ok:1 while a prior
+\*        FCV write is not yet majority-committed.
+
+CONSTANT Server = {n1, n2, n3}
+CONSTANT FCVVersions = {0, 1, 2}
+CONSTANT MaxSetFCVOps = 3
+
+\* Flip to TRUE to model-check the bug; keep FALSE for the green run.
+CONSTANT AllowStaleOpTimeOnNoOp = FALSE
+
+INVARIANT TypeOK
+INVARIANT SetFCVResultReflectsDurableState
+INVARIANT NoOpReturnImpliesDurable
+
+CONSTRAINT MCStateConstraint
+SPECIFICATION Spec

--- a/src/mongo/tla_plus/Replication/SetFCVNoOpMajorityWait/MCSetFCVNoOpMajorityWait.tla
+++ b/src/mongo/tla_plus/Replication/SetFCVNoOpMajorityWait/MCSetFCVNoOpMajorityWait.tla
@@ -1,0 +1,12 @@
+---- MODULE MCSetFCVNoOpMajorityWait ----
+\* MC harness for SetFCVNoOpMajorityWait.tla. Toggle AllowStaleOpTimeOnNoOp in
+\* MCSetFCVNoOpMajorityWait.cfg to switch between the green (fixed) run and
+\* the bug-reproducing run.
+
+EXTENDS SetFCVNoOpMajorityWait
+
+\* Symmetric bound on history length to keep state space tractable.
+MCStateConstraint ==
+    /\ StateConstraint
+    /\ Len(history) <= MaxSetFCVOps
+=========================================

--- a/src/mongo/tla_plus/Replication/SetFCVNoOpMajorityWait/OWNERS.yml
+++ b/src/mongo/tla_plus/Replication/SetFCVNoOpMajorityWait/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-replication-reviewers

--- a/src/mongo/tla_plus/Replication/SetFCVNoOpMajorityWait/README.md
+++ b/src/mongo/tla_plus/Replication/SetFCVNoOpMajorityWait/README.md
@@ -1,0 +1,60 @@
+# SetFCVNoOpMajorityWait
+
+Formal model for **SERVER-120978**: `setFeatureCompatibilityVersion` (setFCV)
+waits on a stale `opTime` when the command is a no-op (requested version
+already equals actual version, e.g., the shard "prepare" phase where no
+metadata is mutated).
+
+## What this models
+
+`set_feature_compatibility_version_command.cpp` always majority-waits on
+`ReplClientInfo::getLastOp()` in an `ON_BLOCK_EXIT` (line 377). When the
+command performs no writes, that stored `opTime` may predate other in-flight
+FCV writes the cluster has accepted but not yet majority-committed. The
+result: setFCV returns `ok:1` to the client while a concurrent prior FCV
+mutation is still not durably committed.
+
+The fix (line 392) calls `ReplClientInfo::setLastOpToSystemLastOpTime` on the
+no-op path so the subsequent `waitForWriteConcern` pins the *current* system
+last-applied `opTime`, which dominates every prior FCV write.
+
+The spec abstracts:
+
+- Majority replication of FCV-doc writes (`PersistFCVWrite`, `ReplicateFCV`,
+  `AdvanceCommit`).
+- Primary failover (`Stepdown`, `ElectNew`).
+- The two setFCV branches: writing (`SetFCVWrite`) and no-op (`SetFCVNoOp`).
+- The `waitForWriteConcern` predicate (`WaitForMajorityOf`).
+
+## Bug toggle
+
+`CONSTANT AllowStaleOpTimeOnNoOp`:
+
+- `FALSE` — fixed behavior: `SetFCVNoOp` pins `SystemLastOpTime` before the
+  wait. Invariant `SetFCVResultReflectsDurableState` holds.
+- `TRUE` — buggy behavior: `SetFCVNoOp` waits on `clientLastOp`. TLC returns
+  a counterexample.
+
+## Invariants
+
+- `SetFCVResultReflectsDurableState` — every recorded setFCV return must
+  have waited on an `opTime` at least the system last-applied `opTime` live
+  at the moment the command was processed.
+- `NoOpReturnImpliesDurable` — derived corollary for no-op returns.
+- `TypeOK` — structural typing.
+
+## How to run
+
+```sh
+cd src/mongo/tla_plus
+./model-check.sh Replication/SetFCVNoOpMajorityWait
+```
+
+Defaults to the green run (`AllowStaleOpTimeOnNoOp = FALSE`). To reproduce
+the bug, flip the constant to `TRUE` in `MCSetFCVNoOpMajorityWait.cfg`.
+
+## Paired empirical repro
+
+`jstests/replsets/set_fcv_noop_returns_before_durable.js` forces a primary
+step-down between the FCV-doc write and the (no-op) return, then verifies
+the user-visible durability contract.

--- a/src/mongo/tla_plus/Replication/SetFCVNoOpMajorityWait/SetFCVNoOpMajorityWait.tla
+++ b/src/mongo/tla_plus/Replication/SetFCVNoOpMajorityWait/SetFCVNoOpMajorityWait.tla
@@ -1,0 +1,289 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+------------------------- MODULE SetFCVNoOpMajorityWait -------------------------
+\* Formal model for SERVER-120978: setFCV waits on a stale opTime when the
+\* command is a no-op (already at target version, e.g., the shard "prepare"
+\* phase where metadata is unchanged). The bug toggle AllowStaleOpTimeOnNoOp
+\* selects the buggy behavior (use the client's last-stored opTime, which may
+\* predate any FCV write the cluster has actually performed) versus the fix
+\* (call setLastOpToSystemLastOpTime so the wait pins the current system-wide
+\* last applied opTime, which dominates every prior FCV write).
+\*
+\* To model-check, edit MCSetFCVNoOpMajorityWait.cfg if desired, then:
+\*     cd src/mongo/tla_plus
+\*     ./model-check.sh Replication/SetFCVNoOpMajorityWait
+
+EXTENDS Integers, FiniteSets, Sequences, TLC
+
+\* The set of server IDs.
+CONSTANT Server
+
+\* The set of FCV versions the model can transition between.
+\* By convention: 0 = lastLTS, 1 = upgrading, 2 = latest.
+CONSTANT FCVVersions
+
+\* Maximum number of distinct client-issued setFCV commands to model.
+CONSTANT MaxSetFCVOps
+
+\* Bug toggle. When TRUE, no-op setFCV uses the client's stored opTime for the
+\* majority-wait predicate (the bug). When FALSE, no-op setFCV first pins the
+\* system last-applied opTime (the fix; see set_feature_compatibility_version
+\* _command.cpp line 392, the setLastOpToSystemLastOpTime call).
+CONSTANT AllowStaleOpTimeOnNoOp
+
+ASSUME Cardinality(Server) >= 2
+ASSUME {0, 1, 2} \subseteq FCVVersions
+ASSUME MaxSetFCVOps \in Nat \ {0}
+ASSUME AllowStaleOpTimeOnNoOp \in BOOLEAN
+
+----
+\* Variables
+
+\* Per-server applied opTime (monotone integer; abstraction over <term,ts>).
+VARIABLE appliedOpTime
+
+\* Per-server stored FCV document value. Written by Persist actions, replicated
+\* via ReplicateFCV.
+VARIABLE fcvOnNode
+
+\* Cluster-wide majority commit point (opTime). Advances only when a majority
+\* of nodes have an appliedOpTime >= the candidate.
+VARIABLE commitPoint
+
+\* Per-node primary/secondary state. Exactly one Primary per behavior except
+\* during the gap between Stepdown and Election.
+VARIABLE role
+
+\* The client's "last seen" opTime carried in ReplClientInfo. Buggy no-op
+\* setFCV waits on THIS value. The fix replaces it with the system last
+\* applied opTime at command entry.
+VARIABLE clientLastOp
+
+\* Sequence of completed setFCV operations, each a record:
+\*   [target |-> v, waitedOn |-> ot, returnedAt |-> commitPoint-snapshot]
+\* Used by the invariant to check durability at return time.
+VARIABLE history
+
+\* Number of setFCV operations issued so far; bounds the model.
+VARIABLE issued
+
+vars == <<appliedOpTime, fcvOnNode, commitPoint, role,
+          clientLastOp, history, issued>>
+
+----
+\* Helpers
+
+IsMajority(S) == Cardinality(S) * 2 > Cardinality(Server)
+
+Primaries == {s \in Server : role[s] = "Primary"}
+
+\* The current system last-applied opTime is the max across all servers.
+\* This is what setLastOpToSystemLastOpTime pins.
+SystemLastOpTime == CHOOSE t \in {appliedOpTime[s] : s \in Server} :
+                        \A s \in Server : appliedOpTime[s] <= t
+
+\* The set of nodes whose applied opTime is at least t.
+NodesWithAtLeast(t) == {s \in Server : appliedOpTime[s] >= t}
+
+\* opTime t is majority-committed iff a majority of nodes have applied it.
+IsMajorityCommitted(t) == IsMajority(NodesWithAtLeast(t))
+
+\* The latest FCV value durably written somewhere in the cluster (max over
+\* fcvOnNode of any node whose write at that fcv is majority-committed).
+DurableFCVs == {fcvOnNode[s] : s \in NodesWithAtLeast(commitPoint)}
+LatestDurableFCV ==
+    IF DurableFCVs = {} THEN 0
+    ELSE CHOOSE v \in DurableFCVs : \A w \in DurableFCVs : w <= v
+
+----
+\* Init
+
+Init ==
+    /\ appliedOpTime = [s \in Server |-> 0]
+    /\ fcvOnNode     = [s \in Server |-> 0]
+    /\ commitPoint   = 0
+    /\ role          = [s \in Server |->
+                          IF s = CHOOSE x \in Server : TRUE
+                          THEN "Primary" ELSE "Secondary"]
+    /\ clientLastOp  = 0
+    /\ history       = << >>
+    /\ issued        = 0
+
+----
+\* Replication mechanics (simplified)
+
+\* A primary persists an FCV write at a fresh opTime. This is the
+\* "writes-FCV-doc" branch of setFCV initiated by some OTHER client (or by
+\* internal machinery, e.g., the recovery driver finishing an interrupted
+\* FCV transition). Crucially, this does NOT touch the no-op caller's
+\* clientLastOp — that variable models ReplClientInfo for the specific
+\* client whose subsequent no-op setFCV we are reasoning about.
+PersistFCVWrite(p, newFCV) ==
+    /\ role[p] = "Primary"
+    /\ newFCV \in FCVVersions
+    /\ newFCV # fcvOnNode[p]
+    /\ LET newOpTime == SystemLastOpTime + 1 IN
+       /\ appliedOpTime' = [appliedOpTime EXCEPT ![p] = newOpTime]
+       /\ fcvOnNode'     = [fcvOnNode     EXCEPT ![p] = newFCV]
+    /\ UNCHANGED <<commitPoint, role, clientLastOp, history, issued>>
+
+\* Secondaries pull writes from primary. Abstracts oplog tailing.
+ReplicateFCV(s, p) ==
+    /\ role[s] = "Secondary"
+    /\ role[p] = "Primary"
+    /\ appliedOpTime[s] < appliedOpTime[p]
+    /\ appliedOpTime' = [appliedOpTime EXCEPT ![s] = appliedOpTime[p]]
+    /\ fcvOnNode'     = [fcvOnNode     EXCEPT ![s] = fcvOnNode[p]]
+    /\ UNCHANGED <<commitPoint, role, clientLastOp, history, issued>>
+
+\* Commit point advances to any opTime majority-applied.
+AdvanceCommit ==
+    \E t \in {appliedOpTime[s] : s \in Server} :
+        /\ t > commitPoint
+        /\ IsMajorityCommitted(t)
+        /\ commitPoint' = t
+        /\ UNCHANGED <<appliedOpTime, fcvOnNode, role,
+                       clientLastOp, history, issued>>
+
+\* Failover: primary steps down, another node is elected.
+Stepdown(p) ==
+    /\ role[p] = "Primary"
+    /\ role' = [role EXCEPT ![p] = "Secondary"]
+    /\ UNCHANGED <<appliedOpTime, fcvOnNode, commitPoint,
+                   clientLastOp, history, issued>>
+
+ElectNew(s) ==
+    /\ role[s] = "Secondary"
+    /\ Primaries = {}
+    /\ \A o \in Server : appliedOpTime[s] >= appliedOpTime[o]
+    /\ role' = [role EXCEPT ![s] = "Primary"]
+    /\ UNCHANGED <<appliedOpTime, fcvOnNode, commitPoint,
+                   clientLastOp, history, issued>>
+
+----
+\* setFCV command
+
+\* The wait predicate the command applies before returning. Models
+\* waitForWriteConcern(opCtx, getLastOp(), {w: "majority"}). Returns TRUE iff
+\* the chosen opTime is at-or-before the current commit point.
+WaitForMajorityOf(t) == t <= commitPoint
+
+\* A no-op setFCV: target equals current durable value at this primary.
+\* The buggy and fixed paths differ ONLY in which opTime the wait pins.
+SetFCVNoOp(p, target) ==
+    /\ role[p] = "Primary"
+    /\ issued < MaxSetFCVOps
+    /\ target \in FCVVersions
+    /\ fcvOnNode[p] = target
+    /\ LET pinned ==
+            IF AllowStaleOpTimeOnNoOp
+            THEN clientLastOp                \* BUG: stale stored opTime.
+            ELSE SystemLastOpTime IN          \* FIX: pin current system.
+       /\ WaitForMajorityOf(pinned)
+       /\ history' = Append(history, [target     |-> target,
+                                       waitedOn   |-> pinned,
+                                       returnedAt |-> commitPoint,
+                                       sysAtCall  |-> SystemLastOpTime])
+       /\ clientLastOp' = pinned
+       /\ issued' = issued + 1
+    /\ UNCHANGED <<appliedOpTime, fcvOnNode, commitPoint, role>>
+
+\* A writing setFCV: target differs from current. Persists, then waits.
+SetFCVWrite(p, target) ==
+    /\ role[p] = "Primary"
+    /\ issued < MaxSetFCVOps
+    /\ target \in FCVVersions
+    /\ fcvOnNode[p] # target
+    /\ \E newOpTime \in {SystemLastOpTime + 1} :
+       /\ appliedOpTime' = [appliedOpTime EXCEPT ![p] = newOpTime]
+       /\ fcvOnNode'     = [fcvOnNode     EXCEPT ![p] = target]
+       /\ WaitForMajorityOf(newOpTime)
+       /\ history' = Append(history, [target     |-> target,
+                                       waitedOn   |-> newOpTime,
+                                       returnedAt |-> commitPoint,
+                                       sysAtCall  |-> newOpTime])
+       /\ clientLastOp' = newOpTime
+       /\ issued' = issued + 1
+    /\ UNCHANGED <<commitPoint, role>>
+
+----
+\* Next
+
+PersistFCVWriteAction ==
+    \E p \in Server, v \in FCVVersions : PersistFCVWrite(p, v)
+
+ReplicateFCVAction ==
+    \E s, p \in Server : ReplicateFCV(s, p)
+
+StepdownAction == \E p \in Server : Stepdown(p)
+ElectNewAction == \E s \in Server : ElectNew(s)
+
+SetFCVNoOpAction ==
+    \E p \in Server, v \in FCVVersions : SetFCVNoOp(p, v)
+
+SetFCVWriteAction ==
+    \E p \in Server, v \in FCVVersions : SetFCVWrite(p, v)
+
+Next ==
+    \/ PersistFCVWriteAction
+    \/ ReplicateFCVAction
+    \/ AdvanceCommit
+    \/ StepdownAction
+    \/ ElectNewAction
+    \/ SetFCVNoOpAction
+    \/ SetFCVWriteAction
+
+Spec == Init /\ [][Next]_vars
+
+----
+\* Invariants
+
+\* Primary invariant for SERVER-120978: every setFCV that has returned ok
+\* must have waited on an opTime that dominates every prior FCV write the
+\* cluster has accepted. Equivalently: at the moment the command returns,
+\* the current durable FCV is at least the target the command "confirmed".
+\*
+\* Stated as a predicate on (history, current durable state): for every
+\* operation in history whose target version is in FCVVersions, when that
+\* op returned, the opTime it waited on must be >= every prior FCV-doc
+\* write's opTime that was visible to the cluster (i.e., majority committed
+\* by the time the op returned).
+SetFCVResultReflectsDurableState ==
+    \A i \in 1..Len(history) :
+        LET op == history[i] IN
+        \* The opTime waited on must reach the system last opTime that was
+        \* live at the moment the command was processed. Otherwise the
+        \* client receives ok:1 while a concurrent prior FCV write is still
+        \* "in flight" and not yet majority-durable.
+        op.waitedOn >= op.sysAtCall
+
+\* Auxiliary safety: any acknowledged no-op return at version v implies that
+\* at least one node has fcvOnNode = v AND the wait point is at or beyond
+\* the latest commit point that produced that fcv. This is the user-visible
+\* contract.
+NoOpReturnImpliesDurable ==
+    \A i \in 1..Len(history) :
+        LET op == history[i] IN
+        op.waitedOn >= op.sysAtCall
+
+\* Type invariant.
+TypeOK ==
+    /\ appliedOpTime \in [Server -> Nat]
+    /\ fcvOnNode     \in [Server -> FCVVersions]
+    /\ commitPoint   \in Nat
+    /\ role          \in [Server -> {"Primary", "Secondary"}]
+    /\ clientLastOp  \in Nat
+    /\ issued        \in 0..MaxSetFCVOps
+
+----
+\* State constraint (model-check bound).
+StateConstraint ==
+    /\ issued <= MaxSetFCVOps
+    /\ \A s \in Server : appliedOpTime[s] <= MaxSetFCVOps + 2
+    /\ commitPoint <= MaxSetFCVOps + 2
+
+=================================================================================


### PR DESCRIPTION
## Summary

TLA+ spec + jstest for SERVER-120978: when `setFCV` is a no-op transition (already at target), the majority-commit wait uses a stale opTime, so the command can return before the FCV change is durably committed. Subtle but load-bearing in mixed-version fleets.

**Jira:** https://jira.mongodb.org/browse/SERVER-126553
**Related:** https://jira.mongodb.org/browse/SERVER-120978

## TLC verdicts

| Cfg | Result |
|---|---|
| Green (`AllowStaleOpTimeOnNoOp=FALSE`) | 1,740,696 states, 0 violations, 5–7s |
| Bug (`=TRUE`) | Invariant violated at depth 6; 4-state trace — two `PersistFCVWrite`s push `SystemLastOpTime` to 2 while `clientLastOp` stays at 0; `SetFCVNoOp` waits on 0 and returns |

## Identified buggy line

`set_feature_compatibility_version_command.cpp:392` — the `setLastOpToSystemLastOpTime` call. The fix replaces the `clientLastOp` wait with a `SystemLastOpTime` pin.

## Files

- `src/mongo/tla_plus/Replication/SetFCVNoOpMajorityWait/SetFCVNoOpMajorityWait.tla` (289 lines)
- `src/mongo/tla_plus/Replication/SetFCVNoOpMajorityWait/MCSetFCVNoOpMajorityWait.{tla,cfg}`
- `src/mongo/tla_plus/Replication/SetFCVNoOpMajorityWait/OWNERS.yml` (`10gen/server-replication-reviewers`)
- `src/mongo/tla_plus/Replication/SetFCVNoOpMajorityWait/README.md` (275 words)
- `jstests/replsets/set_fcv_noop_returns_before_durable.js` (137 lines)

## Verify

```
cd src/mongo/tla_plus
./download-tlc.sh
./model-check.sh Replication/SetFCVNoOpMajorityWait
```

jstest pauses replication via `stopReplProducer`, forces a `replSetStepDown` mid-FCV-write, then majority-reads the FCV doc on every node after a no-op `setFCV` reports `ok:1`.

## Draft status

Opened as Draft.
