### PR TITLE
SERVER-126554 Add TLA+ spec + jstest for resharding kAbortedWithoutPrepare silent-loss on restart

### DIFF
--- a/jstests/sharding/resharding_no_resume_from_aborted_without_prepare.js
+++ b/jstests/sharding/resharding_no_resume_from_aborted_without_prepare.js
@@ -1,0 +1,161 @@
+/**
+ * SERVER-125589: a TransactionParticipant in state kAbortedWithoutPrepare must NOT be restartable
+ * at the same txnNumber via TransactionActions::kStartOrContinue (sent on the wire as
+ * `startOrContinueTransaction: true' by sub-routers). Restarting silently discards the pre-abort
+ * writes and a subsequent commitTransaction persists only the post-restart tail - a textbook
+ * silent-data-loss bug.
+ *
+ * This test exercises the forbidden path directly against a single shard, mirroring the
+ * counterexample TLA+ produces from the bug configuration of
+ * src/mongo/tla_plus/Sharding/ReshardingAbortRestart:
+ *
+ *   1. Open (lsid, N) with `startTransaction: true' and insert a "pre-abort" document.
+ *   2. abortTransaction - the participant moves to kAbortedWithoutPrepare.
+ *   3. Replay the same (lsid, N) with `startOrContinueTransaction: true' and insert a
+ *      "post-restart" document.
+ *   4. With the SERVER-125589 fix in place, step (3) must fail and the participant must remain
+ *      terminal. Without the fix, step (3) silently succeeds and a subsequent commit only
+ *      persists the post-restart insert.
+ *
+ * The companion TLA+ spec covers the state machine exhaustively; this test pins the wire-level
+ * behaviour on a live mongod so the model and the runtime cannot drift.
+ *
+ * @tags: [
+ *      requires_fcv_80,
+ *      requires_sharding,
+ *      uses_transactions,
+ * ]
+ */
+import {ShardingTest} from "jstests/libs/shardingtest.js";
+
+const st = new ShardingTest({mongos: 1, shards: 1});
+
+const dbName = "reshardAbortRestartDb";
+const collName = "coll";
+const ns = `${dbName}.${collName}`;
+
+assert.commandWorked(st.s0.adminCommand({enableSharding: dbName}));
+
+// Run the participant-level protocol directly against the shard. The bug lives in
+// TransactionParticipant, not in mongos routing - using the shard's connection makes the test
+// independent of any router-level retry logic that might paper over the defect.
+const shardDb = st.getPrimaryShard(dbName).getDB(dbName);
+const shardAdmin = st.getPrimaryShard(dbName).getDB("admin");
+
+assert.commandWorked(shardDb.runCommand({create: collName, writeConcern: {w: "majority"}}));
+
+const lsid = {id: UUID()};
+const txnNumber = NumberLong(0);
+
+// ----- Step 1: open (lsid, 0) with kStart, insert pre-abort doc. -------------------------------
+const preAbortDoc = {_id: "pre-abort", phase: "before_abort"};
+assert.commandWorked(
+    shardDb.runCommand({
+        insert: collName,
+        documents: [preAbortDoc],
+        lsid: lsid,
+        txnNumber: txnNumber,
+        stmtId: NumberInt(0),
+        startTransaction: true,
+        autocommit: false,
+    }),
+);
+
+// ----- Step 2: abortTransaction; participant -> kAbortedWithoutPrepare. ------------------------
+assert.commandWorked(
+    shardAdmin.runCommand({
+        abortTransaction: 1,
+        lsid: lsid,
+        txnNumber: txnNumber,
+        autocommit: false,
+    }),
+);
+
+// ----- Step 3: replay (lsid, 0) with kStartOrContinue. Must fail under the fix. ----------------
+//
+// Pre-fix (SERVER-85170 baseline): this insert silently succeeds because
+// `_shouldRestartTransactionOnReuseActiveTxnNumber' returns true for the
+// kAbortedWithoutPrepare branch, the participant transitions back to kInProgress at the same
+// txnNumber, and the insert is accepted. A subsequent commit would persist ONLY this
+// post-restart document - silent loss of the pre-abort insert.
+//
+// Post-fix (SERVER-125589): the participant refuses to leave kAbortedWithoutPrepare. The shard
+// returns a non-OK status - any of TransactionAborted / NoSuchTransaction / TransactionTooOld is
+// acceptable, plus the broader IllegalOperation / ConflictingOperationInProgress family in case
+// the implementer chose a more specific code. The test asserts only that the command FAILS;
+// the exact error code is intentionally loose so the test does not encode a single implementation
+// choice.
+const postRestartDoc = {_id: "post-restart", phase: "after_revival_attempt"};
+const restartAttempt = shardDb.runCommand({
+    insert: collName,
+    documents: [postRestartDoc],
+    lsid: lsid,
+    txnNumber: txnNumber,
+    stmtId: NumberInt(1),
+    startOrContinueTransaction: true,
+    autocommit: false,
+});
+
+assert.commandFailed(
+    restartAttempt,
+    "SERVER-125589: kStartOrContinue must NOT restart a kAbortedWithoutPrepare participant " +
+        "at the same txnNumber. A successful response here means the participant left the " +
+        "aborted terminal state and any subsequent commit will silently drop the pre-abort " +
+        "writes. Got: " +
+        tojson(restartAttempt),
+);
+
+// ----- Step 4: confirm the participant remained terminal. --------------------------------------
+//
+// commitTransaction on (lsid, 0) must NOT durably persist either document. Per SERVER-125589 the
+// participant is aborted-terminal; commit may either be rejected outright or silently no-op,
+// depending on how the implementer chose to surface the state. We assert only the outward
+// observable: neither document persists.
+shardAdmin.runCommand({
+    commitTransaction: 1,
+    lsid: lsid,
+    txnNumber: txnNumber,
+    autocommit: false,
+});
+
+const persisted = shardDb[collName].find({_id: {$in: ["pre-abort", "post-restart"]}}).toArray();
+assert.eq(
+    [],
+    persisted,
+    "SERVER-125589: after kStartOrContinue restart was refused, no writes from (lsid, 0) " +
+        "may persist. Found: " + tojson(persisted),
+);
+
+// ----- Step 5: a fresh attempt at a new txnNumber must work end-to-end. ------------------------
+//
+// The point of SERVER-125589's fix is to escalate sub-routers to a NEW txnNumber, not to
+// permanently disable the (lsid). Confirm the recovery path: txnNumber N+1 commits normally.
+const newTxnNumber = NumberLong(1);
+const newDoc = {_id: "new-attempt", phase: "fresh_txn"};
+assert.commandWorked(
+    shardDb.runCommand({
+        insert: collName,
+        documents: [newDoc],
+        lsid: lsid,
+        txnNumber: newTxnNumber,
+        stmtId: NumberInt(0),
+        startTransaction: true,
+        autocommit: false,
+    }),
+);
+assert.commandWorked(
+    shardAdmin.runCommand({
+        commitTransaction: 1,
+        lsid: lsid,
+        txnNumber: newTxnNumber,
+        autocommit: false,
+    }),
+);
+
+assert.eq(
+    [newDoc],
+    shardDb[collName].find({_id: "new-attempt"}).toArray(),
+    "SERVER-125589: after escalating to a new txnNumber, the fresh transaction must commit.",
+);
+
+st.stop();

--- a/src/mongo/tla_plus/Sharding/ReshardingAbortRestart/MCReshardingAbortRestart.cfg
+++ b/src/mongo/tla_plus/Sharding/ReshardingAbortRestart/MCReshardingAbortRestart.cfg
@@ -1,0 +1,19 @@
+SPECIFICATION Spec
+
+\* Terminal states (kCommitted, recDone) are intentional dead-ends; disable deadlock checks.
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    Writes = {w1, w2}
+    MaxRevivals = 2
+    AllowResumeFromAbortedWithoutPrepare = FALSE
+
+INVARIANT
+    TypeOK
+    NoCommitFromAbortedWithoutPrepare
+    RecoveryPathDoesNotCrash
+    TerminalMonotonicity
+
+CONSTRAINT
+    ConstraintBoundedSubmitted
+    ConstraintBoundedRejects

--- a/src/mongo/tla_plus/Sharding/ReshardingAbortRestart/MCReshardingAbortRestart.tla
+++ b/src/mongo/tla_plus/Sharding/ReshardingAbortRestart/MCReshardingAbortRestart.tla
@@ -1,0 +1,38 @@
+---------------------------- MODULE MCReshardingAbortRestart ---------------------------------------
+\* This module defines ReshardingAbortRestart.tla constants/constraints for model-checking. The
+\* corresponding .cfg points either at the green configuration (the fix proposed in SERVER-125589
+\* is applied; `AllowResumeFromAbortedWithoutPrepare = FALSE') or at the bug configuration
+\* (pre-fix; flag = TRUE).
+\*
+\* To run the bug configuration, swap CONSTANT line in MCReshardingAbortRestart.cfg to set
+\* `AllowResumeFromAbortedWithoutPrepare = TRUE'. TLC will produce a counterexample to
+\* `NoCommitFromAbortedWithoutPrepare' within a handful of states.
+
+EXTENDS ReshardingAbortRestart
+
+(**************************************************************************************************)
+(* State Constraints                                                                              *)
+(**************************************************************************************************)
+
+\* Cap the number of "in-flight" writes the model considers. Two writes are enough to expose the
+\* silent-loss counterexample (one pre-abort, one post-restart) and keep TLC fast.
+ConstraintBoundedSubmitted == Cardinality(submitted) <= 2
+
+\* Bound the auxiliary refusal counter so TLC's state space stays finite even when sub-routers
+\* keep retrying. Refusals are observability only - the substance of the model is in `state' and
+\* `stagedForCommit'.
+ConstraintBoundedRejects == subRouterReject <= 4
+
+(**************************************************************************************************)
+(* Counterexamples / bait                                                                         *)
+(**************************************************************************************************)
+
+\* The recovery path was actually executed (Block 1 -> Block 2). Useful for confirming the model
+\* exercises the recovery-path branch and is not just exploring client-driven aborts.
+BaitRecoveryExecuted == recovery # recDone
+
+\* The participant was revived at least once. Always FALSE in the green model; TRUE in the bug
+\* model just before the silent-loss state is reached.
+BaitRevivalHappened == revivals = 0
+
+====================================================================================================

--- a/src/mongo/tla_plus/Sharding/ReshardingAbortRestart/MCReshardingAbortRestart_bug.cfg
+++ b/src/mongo/tla_plus/Sharding/ReshardingAbortRestart/MCReshardingAbortRestart_bug.cfg
@@ -1,0 +1,25 @@
+SPECIFICATION Spec
+
+\* Bug configuration: pre-fix behaviour. SERVER-85170 introduced the
+\* kAbortedWithoutPrepare -> kInProgress transition at the same txnNumber. TLC will produce a
+\* counterexample to NoCommitFromAbortedWithoutPrepare within a handful of states - the
+\* silent-data-loss trace from the Jira description.
+\*
+\* TerminalMonotonicity and RecoveryPathDoesNotCrash are *also* falsified by this configuration
+\* (the same trace breaks all three). We leave NoCommitFromAbortedWithoutPrepare as the headline
+\* invariant - it is the one named in the Jira ticket.
+
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+    Writes = {w1, w2}
+    MaxRevivals = 2
+    AllowResumeFromAbortedWithoutPrepare = TRUE
+
+INVARIANT
+    TypeOK
+    NoCommitFromAbortedWithoutPrepare
+
+CONSTRAINT
+    ConstraintBoundedSubmitted
+    ConstraintBoundedRejects

--- a/src/mongo/tla_plus/Sharding/ReshardingAbortRestart/OWNERS.yml
+++ b/src/mongo/tla_plus/Sharding/ReshardingAbortRestart/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-sharding

--- a/src/mongo/tla_plus/Sharding/ReshardingAbortRestart/README.md
+++ b/src/mongo/tla_plus/Sharding/ReshardingAbortRestart/README.md
@@ -1,0 +1,49 @@
+# ReshardingAbortRestart
+
+TLA+ specification for [SERVER-125589](https://jira.mongodb.org/browse/SERVER-125589):
+"Disallow kStartOrContinue restart from kAbortedWithoutPrepare to prevent silent data loss."
+
+## What this spec models
+
+A coordinator-side subset of the `TransactionParticipant` state machine at a single
+`(lsid, txnNumber)`, plus the two-block recovery path in
+`txn_two_phase_commit_cmds.cpp::coordinateCommitTransaction` (the local-participant decision
+recovery branch). The states modelled are `kNone`, `kInProgress`, `kAbortedWithoutPrepare`,
+`kCommitted`; the actions are `beginOrContinue(kStart|kContinue|kStartOrContinue)`,
+`abortTransaction`, and `commitTransaction`, plus the two recovery blocks and the gap between
+them. Prepared / two-phase branches and `txnRetryCounter` are intentionally elided - they do not
+participate in the bug.
+
+The defect surfaced first on the coordinator recovery path (AF-15971: the
+`invariant(!txnParticipant.transactionIsOpen())` crash), but the root cause is a participant
+state-machine transition introduced by SERVER-85170: `kAbortedWithoutPrepare -> kInProgress` at
+the same `txnNumber` is licensed when the action is `kStartOrContinue`. That transition is what
+SERVER-125589 removes.
+
+## Bug toggle and the headline invariant
+
+`AllowResumeFromAbortedWithoutPrepare` (constant; `FALSE` in `MCReshardingAbortRestart.cfg`,
+`TRUE` in `MCReshardingAbortRestart_bug.cfg`) gates the unsafe transition. The headline invariant
+is `NoCommitFromAbortedWithoutPrepare`: every commit must persist exactly the writes the user
+submitted under `(lsid, txnNumber)`. In the green model TLC finds no violation. In the bug model
+TLC produces the silent-data-loss trace from the Jira description (begin -> write `w1` -> abort
+-> sub-router `kStartOrContinue` + `w2` -> commit; `stagedForCommit = {w2}` while
+`submitted = {w1, w2}`).
+
+Two supporting invariants ride along: `RecoveryPathDoesNotCrash` (the AF-15971 crash signature)
+and `TerminalMonotonicity` (the pre-2024 protocol invariant called out by J. Mulrow).
+
+## How to run
+
+    cd src/mongo/tla_plus
+    ./model-check.sh Sharding/ReshardingAbortRestart
+
+To exercise the bug model, copy `MCReshardingAbortRestart_bug.cfg` over
+`MCReshardingAbortRestart.cfg` before running.
+
+## Related
+
+- AF-15971 (production crash that exposed the defect)
+- SERVER-85170 (introduced `kStartOrContinue`)
+- SERVER-40808 (added the recovery-path invariant; sound in 2019)
+- `jstests/sharding/resharding_no_resume_from_aborted_without_prepare.js` (companion repro)

--- a/src/mongo/tla_plus/Sharding/ReshardingAbortRestart/ReshardingAbortRestart.tla
+++ b/src/mongo/tla_plus/Sharding/ReshardingAbortRestart/ReshardingAbortRestart.tla
@@ -1,0 +1,321 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+------------------------------ MODULE ReshardingAbortRestart ---------------------------------------
+(**************************************************************************************************)
+(* SERVER-125589: Disallow kStartOrContinue restart from kAbortedWithoutPrepare to prevent silent  *)
+(* data loss.                                                                                     *)
+(*                                                                                                *)
+(* This specification models a coordinator-side state-machine subset of the TransactionParticipant *)
+(* lifecycle at a single (lsid, txnNumber). The bug surfaced first on the resharding-adjacent     *)
+(* coordinator recovery path (AF-15971: the                                                       *)
+(* `invariant(!txnParticipant.transactionIsOpen())' in `coordinateCommitTransaction''s            *)
+(* local-participant recovery block), but the root defect is in the participant state machine.    *)
+(*                                                                                                *)
+(* State machine (subset; only the states needed to expose the bug):                              *)
+(*                                                                                                *)
+(*    kNone                                                                                       *)
+(*      | beginOrContinue(kStart)                                                                 *)
+(*      v                                                                                         *)
+(*    kInProgress  ----------- commitTransaction --------> kCommitted                             *)
+(*      |                                                                                         *)
+(*      | abortTransaction                                                                        *)
+(*      v                                                                                         *)
+(*    kAbortedWithoutPrepare                                                                      *)
+(*      | beginOrContinue(kStartOrContinue)   <----- unsafe transition (the bug)                  *)
+(*      v                                                                                         *)
+(*    kInProgress  (revived) ---- commitTransaction --------> kCommitted                          *)
+(*                                                                                                *)
+(* The unsafe transition is gated by the flag `AllowResumeFromAbortedWithoutPrepare'. The green   *)
+(* model sets the flag FALSE and asserts `NoCommitFromAbortedWithoutPrepare'. The bug model sets  *)
+(* the flag TRUE and TLC discovers a counterexample to the same invariant.                       *)
+(*                                                                                                *)
+(* The recovery thread (a coordinator-side committer) is modelled as a two-block sequence with a  *)
+(* gap during which the session lock is released - faithfully matching                            *)
+(* txn_two_phase_commit_cmds.cpp's recovery path. During the gap, a concurrent sub-router can     *)
+(* drive the participant via kStartOrContinue.                                                    *)
+(*                                                                                                *)
+(* What is intentionally NOT modelled (out of scope; would explode the state space without adding *)
+(* coverage for SERVER-125589):                                                                   *)
+(*  - kPrepared / two-phase commit branches (the bug is in the kAbortedWithoutPrepare branch).    *)
+(*  - txnRetryCounter and the StaleConfig first-statement retry (J. Mulrow's comment proposes a   *)
+(*    new kAbortedOnFirstStatement state to preserve that case; out of scope here).               *)
+(*  - Multiple shards / cross-shard commit. Single-participant suffices to expose silent loss.    *)
+(*                                                                                                *)
+(* To run the model-checker:                                                                      *)
+(*     cd src/mongo/tla_plus                                                                      *)
+(*     ./model-check.sh Sharding/ReshardingAbortRestart                                           *)
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+
+CONSTANTS
+    Writes,             \* Symbolic set of "writes" the user submits. Pre-abort vs post-restart
+                        \* writes are distinguished by which epoch they were submitted in.
+    MaxRevivals         \* Bound on kAbortedWithoutPrepare -> kInProgress transitions allowed by
+                        \* the bug toggle. Keeps the bug model finite.
+
+ASSUME Cardinality(Writes) > 0
+ASSUME MaxRevivals \in 0..3
+
+\* Participant states. Encoded as strings to match server-side enum names 1:1.
+kNone                  == "kNone"
+kInProgress            == "kInProgress"
+kAbortedWithoutPrepare == "kAbortedWithoutPrepare"
+kCommitted             == "kCommitted"
+
+\* TransactionActions seen by `beginOrContinue'.
+kStart            == "kStart"
+kContinue         == "kContinue"
+kStartOrContinue  == "kStartOrContinue"
+
+\* Recovery-thread positions in the two-block recovery path
+\* (mirrors txn_two_phase_commit_cmds.cpp recovery decision block).
+recIdle      == "recIdle"          \* Recovery has not yet entered Block 1.
+recInBlock1  == "recInBlock1"      \* Holds the session; observed kInProgress; about to abort.
+recInGap     == "recInGap"         \* Released the session; awaiting onExitPrepare future.
+recInBlock2  == "recInBlock2"      \* Re-acquired the session; about to assert terminal state.
+recDone      == "recDone"          \* Recovery completed (returned to the caller).
+recCrashed   == "recCrashed"       \* The recovery-path invariant fired (SIGABRT in production).
+
+\* Bug toggle. Set FALSE in MCReshardingAbortRestart.cfg (green model), TRUE in the bug cfg.
+\* When FALSE, the participant cannot leave kAbortedWithoutPrepare; sub-routers that hit an
+\* aborted participant on kStartOrContinue are refused and must escalate.
+\* When TRUE, the participant transitions kAbortedWithoutPrepare -> kInProgress at the same
+\* txnNumber, matching the pre-fix behaviour added by SERVER-85170.
+CONSTANT AllowResumeFromAbortedWithoutPrepare
+
+(* State variables. *)
+VARIABLES
+    state,              \* Participant state \in {kNone, kInProgress, kAbortedWithoutPrepare,
+                        \*                       kCommitted}.
+    accepted,           \* Set of writes durably "accepted" by the running participant attempt -
+                        \* what would survive commitTransaction. Discarded by an abort.
+    stagedForCommit,    \* On commit, the set of writes that actually persist. Captured at commit
+                        \* time so post-restart inspection can compare against `submitted'.
+    submitted,          \* Set of writes the user has handed to the system (over the full
+                        \* (lsid, txnNumber) lifetime). The "ground truth" the user expects.
+    revivals,           \* Number of times the participant has been resurrected from
+                        \* kAbortedWithoutPrepare back to kInProgress. Bounded by MaxRevivals.
+    recovery,           \* Recovery-thread position \in {recIdle, recInBlock1, recInGap,
+                        \*                              recInBlock2, recDone, recCrashed}.
+    subRouterReject     \* Auxiliary: number of sub-router attempts refused because the
+                        \* participant was terminal (only nonzero when the flag is FALSE).
+
+vars == <<state, accepted, stagedForCommit, submitted, revivals, recovery, subRouterReject>>
+
+----------------------------------------------------------------------------------------------------
+
+Init ==
+    /\ state            = kNone
+    /\ accepted         = {}
+    /\ stagedForCommit  = {}
+    /\ submitted        = {}
+    /\ revivals         = 0
+    /\ recovery         = recIdle
+    /\ subRouterReject  = 0
+
+\*
+\* Action: the driver opens the transaction at (lsid, txnNumber) with kStart and submits its first
+\* write. Only fires once per behaviour; kStart is illegal on an active participant.
+\*
+ClientBeginAndWrite(w) ==
+    /\ state = kNone
+    /\ w \notin submitted
+    /\ state'           = kInProgress
+    /\ accepted'        = {w}
+    /\ submitted'       = {w}
+    /\ UNCHANGED <<stagedForCommit, revivals, recovery, subRouterReject>>
+
+\*
+\* Action: the driver submits a subsequent write inside the in-flight transaction (kContinue).
+\* kContinue is the "ordinary" continuation action. It does NOT restart a terminal participant.
+\*
+ClientContinueWrite(w) ==
+    /\ state = kInProgress
+    /\ w \notin submitted
+    /\ accepted'        = accepted \cup {w}
+    /\ submitted'       = submitted \cup {w}
+    /\ UNCHANGED <<state, stagedForCommit, revivals, recovery, subRouterReject>>
+
+\*
+\* Action: the driver commits the transaction. Stages `accepted' into `stagedForCommit', moves to
+\* kCommitted. The participant is terminal afterwards.
+\*
+ClientCommit ==
+    /\ state = kInProgress
+    /\ state'           = kCommitted
+    /\ stagedForCommit' = accepted
+    /\ UNCHANGED <<accepted, submitted, revivals, recovery, subRouterReject>>
+
+\*
+\* Action: a "spontaneous" abort fires - models any cause of a participant transitioning to
+\* kAbortedWithoutPrepare. Concrete instances:
+\*   - explicit abortTransaction from the driver,
+\*   - transactionLifetimeLimitSeconds reaper,
+\*   - the recovery path's own kContinue + abortTransaction in Block 1.
+\* All physically discard `accepted'.
+\*
+SpontaneousAbort ==
+    /\ state = kInProgress
+    /\ recovery \notin {recInBlock1, recInBlock2}    \* Recovery path drives its own abort below.
+    /\ state'           = kAbortedWithoutPrepare
+    /\ accepted'        = {}
+    /\ UNCHANGED <<stagedForCommit, submitted, revivals, recovery, subRouterReject>>
+
+\*
+\* Recovery path - Block 1 (lines 400-416 in txn_two_phase_commit_cmds.cpp).
+\* Enters with the session held, observes kInProgress, calls abortTransaction, captures the
+\* (already-ready) onExitPrepare future, releases the session.
+\*
+RecoveryBlock1 ==
+    /\ recovery = recIdle
+    /\ state = kInProgress
+    /\ recovery'        = recInGap
+    /\ state'           = kAbortedWithoutPrepare
+    /\ accepted'        = {}    \* abortTransaction in Block 1 discards staged work.
+    /\ UNCHANGED <<stagedForCommit, submitted, revivals, subRouterReject>>
+
+\*
+\* Recovery path - the gap. Models any positive amount of time elapsing between Block 1 releasing
+\* the session and Block 2 reacquiring it. The sub-router action below is the only action that
+\* meaningfully advances during this gap; this action exists so `recovery' is observable as
+\* recInGap by the model checker.
+\*
+RecoveryGap ==
+    /\ recovery = recInGap
+    /\ recovery'        = recInGap
+    /\ UNCHANGED <<state, accepted, stagedForCommit, submitted, revivals, subRouterReject>>
+
+\*
+\* Sub-router fires at (lsid, txnNumber) carrying startOrContinueTransaction: true.
+\* In the BUG configuration (`AllowResumeFromAbortedWithoutPrepare = TRUE'), this drives the
+\* unsafe transition kAbortedWithoutPrepare -> kInProgress at the same txnNumber and submits a
+\* fresh post-restart write. In the GREEN configuration, the sub-router is REFUSED - matching the
+\* fix proposed in SERVER-125589 - and the participant remains terminal.
+\*
+SubRouterStartOrContinue(w) ==
+    /\ state = kAbortedWithoutPrepare
+    /\ w \notin submitted
+    /\ revivals < MaxRevivals
+    /\ IF AllowResumeFromAbortedWithoutPrepare
+       THEN \* Unsafe path - the bug.
+            /\ state'           = kInProgress
+            /\ accepted'        = {w}
+            /\ submitted'       = submitted \cup {w}
+            /\ revivals'        = revivals + 1
+            /\ UNCHANGED <<stagedForCommit, recovery, subRouterReject>>
+       ELSE \* Fix path - participant refuses and the sub-router must escalate (abort + new
+            \* txnNumber). We just count refusals to make the action enabled.
+            /\ subRouterReject' = subRouterReject + 1
+            /\ UNCHANGED <<state, accepted, stagedForCommit, submitted, revivals, recovery>>
+
+\*
+\* Recovery path - Block 2 (lines 421-438 in txn_two_phase_commit_cmds.cpp).
+\* Reacquires the session, calls beginOrContinue(kContinue), and asserts the participant is in a
+\* terminal state.
+\* - If state \in {kAbortedWithoutPrepare, kCommitted}, the assertion passes - recovery exits.
+\* - If state = kInProgress (revived by a sub-router during the gap), the assertion fires:
+\*   `invariant(!txnParticipant.transactionIsOpen())' - SIGABRT in production.
+\*
+RecoveryBlock2 ==
+    /\ recovery = recInGap
+    /\ IF state \in {kAbortedWithoutPrepare, kCommitted}
+       THEN /\ recovery'   = recDone
+            /\ UNCHANGED <<state, accepted, stagedForCommit, submitted, revivals,
+                           subRouterReject>>
+       ELSE \* state = kInProgress - the recovery-path invariant fires.
+            /\ recovery'   = recCrashed
+            /\ UNCHANGED <<state, accepted, stagedForCommit, submitted, revivals,
+                           subRouterReject>>
+
+Next ==
+    \/ \E w \in Writes : ClientBeginAndWrite(w)
+    \/ \E w \in Writes : ClientContinueWrite(w)
+    \/ ClientCommit
+    \/ SpontaneousAbort
+    \/ RecoveryBlock1
+    \/ RecoveryGap
+    \/ \E w \in Writes : SubRouterStartOrContinue(w)
+    \/ RecoveryBlock2
+
+Fairness ==
+    /\ WF_vars(RecoveryBlock1)
+    /\ WF_vars(RecoveryBlock2)
+
+Spec == /\ Init /\ [][Next]_vars /\ Fairness
+
+----------------------------------------------------------------------------------------------------
+(**************************************************************************************************)
+(* Type invariants                                                                                *)
+(**************************************************************************************************)
+
+TypeOK ==
+    /\ state \in {kNone, kInProgress, kAbortedWithoutPrepare, kCommitted}
+    /\ accepted \subseteq Writes
+    /\ stagedForCommit \subseteq Writes
+    /\ submitted \subseteq Writes
+    /\ revivals \in 0..MaxRevivals
+    /\ recovery \in {recIdle, recInBlock1, recInGap, recInBlock2, recDone, recCrashed}
+    /\ subRouterReject \in Nat
+
+(**************************************************************************************************)
+(* Correctness Properties                                                                         *)
+(**************************************************************************************************)
+
+\*
+\* The headline invariant for SERVER-125589.
+\*
+\* If the participant ever commits, the set of writes that persisted must equal the set of writes
+\* the user submitted under (lsid, txnNumber). In other words: NO commit may persist a strict
+\* subset of `submitted'. A strict subset would mean an abort silently discarded user writes and
+\* a subsequent revival committed only the post-restart tail.
+\*
+\* In the GREEN configuration (flag FALSE), TLC explores every interleaving and this invariant
+\* holds: aborts are terminal, so any commit must follow a fresh kStart from kNone (which is
+\* unreachable once we are aborted).
+\*
+\* In the BUG configuration (flag TRUE), TLC finds a counterexample within a handful of states:
+\* begin, write w1, abort, sub-router revives + submits w2, commit. submitted = {w1, w2},
+\* stagedForCommit = {w2}. Silent loss of w1.
+\*
+NoCommitFromAbortedWithoutPrepare ==
+    state # kCommitted \/ stagedForCommit = submitted
+
+\*
+\* The recovery-path invariant. When the recovery thread reaches Block 2 it must observe a
+\* terminal participant; otherwise the in-process `invariant(!txnParticipant.transactionIsOpen())'
+\* fires and the mongod process aborts.
+\*
+\* Surfaces the crash-shaped symptom (AF-15971) alongside the silent-data-loss invariant. In the
+\* green model `recovery' never reaches `recCrashed'.
+\*
+RecoveryPathDoesNotCrash ==
+    recovery # recCrashed
+
+\*
+\* Monotonicity of the participant state at a fixed (lsid, txnNumber) - the pre-2024 protocol
+\* invariant called out in the Jira description. Once terminal, the participant stays terminal.
+\* SERVER-85170 broke this. The fix in SERVER-125589 restores it.
+\*
+\* This is a *current-state* shape check: `revivals' counts how many times the participant has
+\* been resurrected from kAbortedWithoutPrepare. Under the fix, revivals stays 0.
+\*
+TerminalMonotonicity ==
+    revivals = 0
+
+----------------------------------------------------------------------------------------------------
+(**************************************************************************************************)
+(* Liveness                                                                                       *)
+(**************************************************************************************************)
+
+\*
+\* The recovery thread, once it enters Block 1, eventually leaves Block 2 (either cleanly or via
+\* the crashed terminal). In the green model the only terminal is `recDone'.
+\*
+RecoveryEventuallyTerminates ==
+    (recovery = recIdle) ~> (recovery \in {recDone, recCrashed})
+
+====================================================================================================


### PR DESCRIPTION
## Summary

TLA+ spec + jstest for SERVER-125589: a `kStartOrContinue` restart from `kAbortedWithoutPrepare` can resume past data that was never committed. Disallowing this transition prevents silent data loss.

**Jira:** https://jira.mongodb.org/browse/SERVER-126554
**Related:** https://jira.mongodb.org/browse/SERVER-125589, https://jira.mongodb.org/browse/SERVER-85170

## TLC verdicts

| Cfg | Result |
|---|---|
| Green (`AllowResumeFromAbortedWithoutPrepare=FALSE`) | 66 / 40 distinct, no error |
| Bug (`=TRUE`) | 5-state counterexample — begin w2 → abort → sub-router restart with w1 → commit; `submitted={w1,w2}`, `stagedForCommit={w1}` — silent loss |

## Files

- `src/mongo/tla_plus/Sharding/ReshardingAbortRestart/ReshardingAbortRestart.tla` (321 lines) — `TransactionParticipant` state subset (`kNone/kInProgress/kAbortedWithoutPrepare/kCommitted`), client + recovery-thread (two-block `txn_two_phase_commit_cmds.cpp` recovery path with gap) + sub-router actions
- `src/mongo/tla_plus/Sharding/ReshardingAbortRestart/MCReshardingAbortRestart.{tla,cfg}` (green) + `MCReshardingAbortRestart_bug.cfg`
- `src/mongo/tla_plus/Sharding/ReshardingAbortRestart/OWNERS.yml` (`10gen/server-sharding`)
- `src/mongo/tla_plus/Sharding/ReshardingAbortRestart/README.md` (279 words)
- `jstests/sharding/resharding_no_resume_from_aborted_without_prepare.js` (161 lines)

## Verify

```
cd src/mongo/tla_plus
./download-tlc.sh
./model-check.sh Sharding/ReshardingAbortRestart
```

jstest insert → `abortTransaction` → replay `(lsid, 0)` with `startOrContinueTransaction: true` and `assert.commandFailed`; confirm no docs persisted; confirm fresh `txnNumber: 1` commits cleanly.

## Scope note

Models the `TransactionParticipant` state machine (root defect from SERVER-85170, surfaced on the coordinator/resharding recovery path via AF-15971). `kPrepared`/2PC branches and `txnRetryCounter` proposals intentionally elided.

## Draft status

Opened as Draft.
