### PR TITLE
SERVER-126555 Add TLA+ spec + jstest for stepdown x PDIB deadlock-freedom

### DIFF
--- a/jstests/replsets/stepdown_during_pdib_no_deadlock.js
+++ b/jstests/replsets/stepdown_during_pdib_no_deadlock.js
@@ -1,0 +1,148 @@
+/**
+ * SERVER-126266: stepdown must not deadlock with an in-flight primary-driven
+ * index build (PDIB).
+ *
+ * Bug shape: the stepdown thread enqueues an X waiter on the RSTL. BgSync
+ * then parks behind the X waiter (RSTL is fair), so commit-quorum vote
+ * oplog entries from secondaries cannot be applied on the primary. The
+ * PDIB coordinator, still holding its IX intent, blocks awaiting those
+ * votes, which closes the wait-for cycle. Stepdown's tryToStepDown()
+ * retry loop never observes the secondaries catching up.
+ *
+ * This test pauses PDIB in its commit-quorum wait via a failpoint,
+ * issues a non-force stepdown, and asserts that stepdown completes
+ * within a bounded interval. The matching TLA+ model
+ * src/mongo/tla_plus/IndexBuilds/StepdownPDIBDeadlock/ proves the same
+ * scenario at the lock-graph level.
+ *
+ * @tags: [
+ *   requires_replication,
+ *   requires_persistence,
+ *   requires_fcv_90,
+ *   resumable_primary_driven_index_builds_incompatible,
+ * ]
+ */
+
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {FeatureFlagUtil} from "jstests/libs/feature_flag_util.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+import {IndexBuildTest} from "jstests/noPassthrough/libs/index_builds/index_build.js";
+
+const dbName = jsTestName();
+const collName = "coll";
+const indexName = "a_1";
+const indexSpec = {a: 1};
+
+// Three-node set: one arbiter so the stepdown target has only one voting
+// secondary whose vote must be applied on the (stepping-down) primary
+// for the commit quorum to advance. This is the smallest topology that
+// surfaces the SERVER-126266 wait-for cycle.
+const rst = new ReplSetTest({
+    nodes: [
+        {},
+        {rsConfig: {priority: 0}},
+        {arbiter: true},
+    ],
+});
+rst.startSet();
+rst.initiate(null, null, {initiateWithDefaultElectionTimeout: true});
+
+let primary = rst.getPrimary();
+const secondary = rst.getSecondary();
+
+// Skip on builds without the PDIB feature flag.
+if (!FeatureFlagUtil.isPresentAndEnabled(primary.getDB(dbName), "PrimaryDrivenIndexBuilds")) {
+    jsTest.log.info("Skipping: featureFlagPrimaryDrivenIndexBuilds is disabled");
+    rst.stopSet();
+    quit();
+}
+
+jsTest.log.info("1. Seed data so the index build has work to do.");
+assert.commandWorked(primary.getDB(dbName).createCollection(collName));
+const bulk = primary.getDB(dbName).getCollection(collName).initializeUnorderedBulkOp();
+for (let i = 0; i < 200; i++) {
+    bulk.insert({_id: i, a: i});
+}
+assert.commandWorked(bulk.execute({w: "majority"}));
+rst.awaitReplication();
+
+const ns = primary.getDB(dbName).getCollection(collName).getFullName();
+
+jsTest.log.info("2. Pause PDIB on the primary at the commit-quorum signal.");
+// hangIndexBuildBeforeSignalPrimaryForCommitReadiness is the canonical
+// PDIB pause point: the build coordinator has finished its scan and is
+// about to read the votes pushed in by secondaries' OpObserver.
+const pdibFp = configureFailPoint(primary, "hangIndexBuildBeforeSignalPrimaryForCommitReadiness");
+
+jsTest.log.info("3. Kick off the index build on the primary.");
+const awaitIndexBuild = IndexBuildTest.startIndexBuild(
+    primary,
+    ns,
+    indexSpec,
+    {name: indexName},
+    [ErrorCodes.InterruptedDueToReplStateChange, ErrorCodes.IndexBuildAborted],
+);
+
+jsTest.log.info("4. Wait for PDIB to park at the failpoint.");
+pdibFp.wait();
+
+jsTest.log.info("5. Issue a non-force stepdown with a short stepDownSecs.");
+// The bug surfaces on non-force stepdown: force=true bypasses the
+// secondary-catch-up wait that the deadlock hinges on. A non-force
+// stepdown must (a) wait for secondaries to catch up to optime, then
+// (b) acquire the RSTL in X. With the fix in place, PDIB observes the
+// stepdown signal, releases its RSTL IX intent, BgSync drains the
+// vote-bearing oplog entries on secondaries, and stepdown completes.
+const stepDownDeadlineMs = 60 * 1000;
+const stepDownStart = Date.now();
+
+let stepDownErr = null;
+try {
+    assert.commandWorked(
+        primary.adminCommand({
+            replSetStepDown: 30,
+            secondaryCatchUpPeriodSecs: 25,
+            force: false,
+        }),
+    );
+} catch (e) {
+    // The stepDown response is by convention a network error because the
+    // RSTL flip closes the user-connection. Either a clean OK or a
+    // recognisable HostUnreachable-style error is acceptable; what we
+    // are testing for is timely completion, not the response shape.
+    stepDownErr = e;
+}
+
+const elapsed = Date.now() - stepDownStart;
+jsTest.log.info(`6. Stepdown returned after ${elapsed}ms (err=${stepDownErr})`);
+assert.lt(
+    elapsed,
+    stepDownDeadlineMs,
+    `Stepdown took >= ${stepDownDeadlineMs}ms; SERVER-126266 deadlock regressed`,
+);
+
+jsTest.log.info("7. Release the PDIB failpoint so the build can unwind.");
+// With the fix, PDIB has already been aborted via the stepdown
+// callback and the build is no longer parked; turning the failpoint off
+// is a no-op-or-cleanup. Keep the off() call so the test is robust to
+// the build still being on the failpoint at this instant.
+pdibFp.off();
+
+jsTest.log.info("8. The former primary is now SECONDARY.");
+rst.awaitSecondaryNodes(null, [primary]);
+
+jsTest.log.info("9. Index-build shell exits with an expected failure code.");
+awaitIndexBuild({checkExitSuccess: false});
+
+jsTest.log.info("10. A new primary takes over and resumes the workload.");
+rst.awaitNodesAgreeOnPrimary();
+const newPrimary = rst.getPrimary();
+assert.neq(newPrimary.host, primary.host, "Stepdown target is still primary");
+
+// Smoke: write a doc on the new primary to confirm the replica set is
+// not wedged.
+assert.commandWorked(
+    newPrimary.getDB(dbName).getCollection(collName).insert({_id: "post-stepdown", a: 999}, {writeConcern: {w: 1}}),
+);
+
+rst.stopSet();

--- a/src/mongo/tla_plus/IndexBuilds/StepdownPDIBDeadlock/MCStepdownPDIBDeadlock.cfg
+++ b/src/mongo/tla_plus/IndexBuilds/StepdownPDIBDeadlock/MCStepdownPDIBDeadlock.cfg
@@ -1,0 +1,22 @@
+\* TLC config: GREEN run.  Model-checks the patched behaviour
+\* (AllowPDIBHoldDuringStepdown = FALSE).  TLC should report no
+\* invariant violations and the liveness property should pass.
+\*
+\* Deadlock checking is enabled (no CHECK_DEADLOCK directive disables
+\* it); TLC's built-in deadlock detector is the most direct way to
+\* observe the cyclic wait we're testing for.
+
+CONSTANTS
+    PDIB     = PDIB
+    Stepdown = Stepdown
+    BgSync   = BgSync
+    AllowPDIBHoldDuringStepdown = FALSE
+    MaxQuorum = 2
+
+SPECIFICATION FairSpec
+
+INVARIANT TypeOK
+INVARIANT RSTLWellFormed
+INVARIANT DeadlockFreedom
+
+PROPERTY EveryStepdownCompletes

--- a/src/mongo/tla_plus/IndexBuilds/StepdownPDIBDeadlock/MCStepdownPDIBDeadlock.tla
+++ b/src/mongo/tla_plus/IndexBuilds/StepdownPDIBDeadlock/MCStepdownPDIBDeadlock.tla
@@ -1,0 +1,25 @@
+---- MODULE MCStepdownPDIBDeadlock ----
+\* Model-checking harness for StepdownPDIBDeadlock.tla.
+\*
+\* By default this harness model-checks the GREEN (patched) configuration:
+\* AllowPDIBHoldDuringStepdown = FALSE.  See MCStepdownPDIBDeadlock.cfg
+\* for that run.
+\*
+\* The accompanying file MCStepdownPDIBDeadlock_bug.cfg flips the bug
+\* toggle so TLC can produce a counterexample trace of the original
+\* SERVER-126266 deadlock.
+
+EXTENDS StepdownPDIBDeadlock
+
+\* No additional state-space bound beyond the bounded variables defined
+\* in the base spec.  The model is finite by construction:
+\*   - rstlQueue is bounded by |Threads| = 3 because no thread enqueues
+\*     itself twice (enforced in BgSyncEnqueue and PDIBStart guards).
+\*   - commitQuorumVotes is a subset of 1..MaxQuorum.
+\*   - All other variables range over finite domains.
+\*
+\* The "natural" symmetry of secondaries justifies a SYMMETRY clause in
+\* the cfg.  Provide it here as an operator over the secondary id set.
+QuorumSymmetry == Permutations(1..MaxQuorum)
+
+================================================================================

--- a/src/mongo/tla_plus/IndexBuilds/StepdownPDIBDeadlock/MCStepdownPDIBDeadlock_bug.cfg
+++ b/src/mongo/tla_plus/IndexBuilds/StepdownPDIBDeadlock/MCStepdownPDIBDeadlock_bug.cfg
@@ -1,0 +1,25 @@
+\* TLC config: BUG run.  Model-checks the production behaviour
+\* (AllowPDIBHoldDuringStepdown = TRUE).  TLC is expected to surface
+\* (a) the DeadlockFreedom invariant being violated and (b) the
+\* EveryStepdownCompletes liveness property failing.  Either outcome
+\* is the SERVER-126266 counterexample trace.
+\*
+\* Run with:
+\*     cd src/mongo/tla_plus/IndexBuilds/StepdownPDIBDeadlock
+\*     ../../../../tla2tools.jar tlc2.TLC \
+\*         -config MCStepdownPDIBDeadlock_bug.cfg MCStepdownPDIBDeadlock.tla
+
+CONSTANTS
+    PDIB     = PDIB
+    Stepdown = Stepdown
+    BgSync   = BgSync
+    AllowPDIBHoldDuringStepdown = TRUE
+    MaxQuorum = 2
+
+SPECIFICATION FairSpec
+
+INVARIANT TypeOK
+INVARIANT RSTLWellFormed
+INVARIANT DeadlockFreedom
+
+PROPERTY EveryStepdownCompletes

--- a/src/mongo/tla_plus/IndexBuilds/StepdownPDIBDeadlock/OWNERS.yml
+++ b/src/mongo/tla_plus/IndexBuilds/StepdownPDIBDeadlock/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-replication-reviewers

--- a/src/mongo/tla_plus/IndexBuilds/StepdownPDIBDeadlock/README.md
+++ b/src/mongo/tla_plus/IndexBuilds/StepdownPDIBDeadlock/README.md
@@ -1,0 +1,63 @@
+# StepdownPDIBDeadlock
+
+TLA+ model of the SERVER-126266 deadlock between stepdown and the
+primary-driven index build (PDIB) coordinator. Load-bearing for the 9.0
+PDIB release.
+
+## The bug
+
+A primary running an in-flight PDIB receives `replSetStepDown`. Stepdown
+enqueues an X-mode waiter on the RSTL. RSTL is approximately fair, so any
+subsequent IX request parks behind the X waiter. BackgroundSync needs IX
+to apply incoming oplog entries — including the commit-quorum vote
+entries the PDIB coordinator is waiting on. PDIB itself keeps holding its
+own IX intent through the `voting` phase. The wait-for graph closes:
+
+```
+stepdown(X)  --waits-for-->  pdib(IX)         (RSTL queue, fair)
+pdib(IX)     --waits-for-->  bgsync(IX-vote)  (commit-quorum starvation)
+bgsync(IX)   --waits-for-->  stepdown(X)      (RSTL queue, fair)
+```
+
+`tryToStepDown()` then loops forever because secondaries can never catch
+up to the primary's optime.
+
+## Model layout
+
+Three abstract threads contend on one RSTL: `PDIB`, `Stepdown`, `BgSync`.
+PDIB walks a small phase machine (`idle` -> `scanning` -> `voting` ->
+`committing` -> `done`, plus `aborted`). Stepdown walks (`none` ->
+`enqueued` -> `holding` -> `completed`). The commit quorum is modelled
+as a finite set of secondary votes that can only arrive while BgSync is
+making progress.
+
+## Bug toggle
+
+`AllowPDIBHoldDuringStepdown` switches between configurations:
+
+- `TRUE`  -- production behaviour; the deadlock is reachable.
+- `FALSE` -- patched behaviour; PDIB observes the stepdown signal and
+  releases IX via `PDIBAbortOnStepdown`. No cycle.
+
+## Invariants and properties
+
+- `TypeOK` -- variable domains.
+- `RSTLWellFormed` -- X is exclusive; X and IX never coexist.
+- `DeadlockFreedom` -- no cycle in the wait-for graph at any reachable
+  state.
+- `EveryStepdownCompletes` -- every enqueued stepdown eventually reaches
+  `completed`.
+
+## Run
+
+```
+cd src/mongo/tla_plus
+./model-check.sh IndexBuilds/StepdownPDIBDeadlock   # green
+java -cp tla2tools.jar tlc2.TLC -config \
+  IndexBuilds/StepdownPDIBDeadlock/MCStepdownPDIBDeadlock_bug.cfg \
+  IndexBuilds/StepdownPDIBDeadlock/MCStepdownPDIBDeadlock.tla   # bug
+```
+
+`DeadlockFreedom` and `EveryStepdownCompletes` each independently flag
+the bug. `jstests/replsets/stepdown_during_pdib_no_deadlock.js`
+exercises the same scenario against a real `mongod`.

--- a/src/mongo/tla_plus/IndexBuilds/StepdownPDIBDeadlock/StepdownPDIBDeadlock.tla
+++ b/src/mongo/tla_plus/IndexBuilds/StepdownPDIBDeadlock/StepdownPDIBDeadlock.tla
@@ -1,0 +1,382 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+------------------------- MODULE StepdownPDIBDeadlock -------------------------
+\* Formal specification of the SERVER-126266 deadlock between the stepdown
+\* coordinator thread and the primary-driven index build (PDIB) coordinator.
+\*
+\* The bug:  on a steady-state primary running a PDIB, a stepdown is issued.
+\* Stepdown enqueues an X-mode waiter on the Replication State Transition
+\* Lock (RSTL).  Once the X-waiter is enqueued, BackgroundSync, which needs
+\* to apply incoming oplog entries (including PDIB votes from other nodes)
+\* under an IX intent on the RSTL, blocks behind the waiter.  Meanwhile the
+\* PDIB coordinator is awaiting commit-quorum votes that will arrive only
+\* through BackgroundSync, while continuing to hold its own IX intent on the
+\* RSTL.  The wait-for graph is:
+\*
+\*     stepdown(X)  --waits-for-->  pdib(IX)         (RSTL queue)
+\*     pdib(IX)     --waits-for-->  bgsync(IX-vote)  (commit quorum)
+\*     bgsync(IX)   --waits-for-->  stepdown(X)      (RSTL queue, fair)
+\*
+\* The cycle is closed.  Stepdown's wait-loop never sees the secondaries
+\* catch up; on each iteration tryToStepDown() fails, the RSTL X waiter is
+\* re-enqueued, and the cycle restarts.
+\*
+\* The model has three actors (Stepdown, PDIB, BgSync) racing on one RSTL
+\* and one shared PDIB state machine.  We check (a) no cycle ever appears in
+\* the wait-for graph (DeadlockFreedom) and (b) every initiated stepdown
+\* eventually completes (EveryStepdownCompletes).  The bug toggle
+\* AllowPDIBHoldDuringStepdown selects the buggy vs the fixed behaviour:
+\* when TRUE, the PDIB coordinator may keep its RSTL IX intent across an
+\* enqueued stepdown X waiter, which is what the production code does today.
+\* When FALSE, PDIB observes the stepdown signal and drops its IX intent
+\* (the patch direction).
+\*
+\* To run the model-checker:
+\*     cd src/mongo/tla_plus
+\*     ./model-check.sh IndexBuilds/StepdownPDIBDeadlock
+
+EXTENDS Integers, FiniteSets, Sequences, TLC
+
+\* The PDIB coordinator's distinguished thread id.
+CONSTANT PDIB
+\* The stepdown coordinator's distinguished thread id.
+CONSTANT Stepdown
+\* The BackgroundSync thread id.
+CONSTANT BgSync
+
+\* The set of thread ids contending on the RSTL.
+Threads == {PDIB, Stepdown, BgSync}
+
+\* Bug toggle.  TRUE = production behaviour (deadlock-prone).
+\* FALSE = patched behaviour (PDIB releases IX on stepdown signal).
+CONSTANT AllowPDIBHoldDuringStepdown
+
+\* Number of secondaries whose votes are required for commit-quorum.  Two
+\* in MaxQuorum suffices to surface the bug; bumping it just grows the
+\* state space without changing reachability.
+CONSTANT MaxQuorum
+
+----
+\* PDIB coordinator phase.  See src/mongo/db/index_builds/primary_driven/.
+\*  - "idle"       : no PDIB in flight.
+\*  - "scanning"   : collection scan; IX RSTL held.
+\*  - "voting"     : awaiting commit-quorum votes; IX RSTL held.
+\*  - "committing" : commitIndexBuild written; IX RSTL held.
+\*  - "aborted"    : PDIB aborted; IX RSTL released.
+\*  - "done"       : committed; IX RSTL released.
+VARIABLE pdibPhase
+
+\* The set of secondaries that have voted in the commit quorum.  Models
+\* the OpObserver path on the primary observing replicated votes.
+VARIABLE commitQuorumVotes
+
+\* RSTL holder.  Holders is a function thread -> {"none","IX","X"}.
+VARIABLE rstlMode
+
+\* The FIFO RSTL waiter queue.  Sequence of <<thread, requestedMode>>.
+\* MongoDB's RSTL is approximately fair: an X waiter parks IX requesters
+\* enqueued behind it (see auto_get_rstl_for_stepup_stepdown.h).
+VARIABLE rstlQueue
+
+\* Stepdown control: phases per stepdown call.
+\*  - "none"     : no stepdown in flight.
+\*  - "enqueued" : X waiter on RSTL, awaiting acquisition.
+\*  - "holding"  : X acquired; running post-acquisition logic.
+\*  - "completed": stepDown() returned.
+VARIABLE stepdownPhase
+
+\* Whether PDIB has observed the stepdown signal (the fixed code path
+\* asynchronously cancels PDIB on a stepdown-initiated callback).
+VARIABLE pdibObservedStepdown
+
+vars == << pdibPhase, commitQuorumVotes, rstlMode, rstlQueue,
+           stepdownPhase, pdibObservedStepdown >>
+
+----
+\* Helpers.
+
+\* Set of threads holding the RSTL in any mode.
+Holders == { t \in Threads : rstlMode[t] \in {"IX","X"} }
+
+\* Does any thread hold the RSTL in X mode?
+XHeld == \E t \in Threads : rstlMode[t] = "X"
+
+\* The set of threads parked behind an X waiter.  This is the "fair queue"
+\* behaviour: once an X is enqueued, no further IX may be granted ahead of
+\* it.  Returns TRUE if there is at least one X already enqueued or held.
+XPendingOrHeld ==
+    \/ XHeld
+    \/ \E i \in 1..Len(rstlQueue) : rstlQueue[i][2] = "X"
+
+\* "thread t holds RSTL in mode m" predicate
+HoldsRSTL(t, m) == rstlMode[t] = m
+
+\* The first waiter in the queue.
+QueueHead == IF Len(rstlQueue) > 0 THEN rstlQueue[1] ELSE <<"none","none">>
+
+\* IsMajority over MaxQuorum secondaries  (primary's own vote is implicit).
+\* The primary's vote is added in CommitQuorumReached so this just counts
+\* observed secondary votes plus the primary's implicit one.
+IsMajority(votes) == (Cardinality(votes) + 1) * 2 > (MaxQuorum + 1)
+
+----
+\* Wait-for graph.  Edge (t1, t2) means "t1 is waiting for t2 to release
+\* some resource".  Two edge sources:
+\*   1. RSTL queue: t1 enqueued, t2 holds an incompatible mode.
+\*   2. CommitQuorum: PDIB in "voting" waits for BgSync to apply votes if
+\*      BgSync is itself parked on the RSTL.
+WaitsForRSTL(t1, t2) ==
+    /\ t1 # t2
+    /\ \E i \in 1..Len(rstlQueue) : rstlQueue[i][1] = t1
+    /\ rstlMode[t2] \in {"IX","X"}
+    /\ \* incompatibility
+       \/ rstlMode[t2] = "X"
+       \/ /\ rstlMode[t2] = "IX"
+          /\ \E j \in 1..Len(rstlQueue) :
+                 /\ rstlQueue[j][1] = t1
+                 /\ rstlQueue[j][2] = "X"
+
+WaitsForQuorum(t1, t2) ==
+    /\ t1 = PDIB
+    /\ t2 = BgSync
+    /\ pdibPhase = "voting"
+    /\ ~IsMajority(commitQuorumVotes)
+    /\ \* BgSync cannot apply oplog entries because it's parked on the RSTL.
+       \E i \in 1..Len(rstlQueue) : rstlQueue[i][1] = BgSync
+
+WaitsFor(t1, t2) == WaitsForRSTL(t1, t2) \/ WaitsForQuorum(t1, t2)
+
+\* TLA+ has no built-in transitive closure.  For three threads we can
+\* enumerate cycles of length 2 and 3 directly.
+HasCycle ==
+    \/ \E t1, t2 \in Threads :
+           /\ t1 # t2
+           /\ WaitsFor(t1, t2)
+           /\ WaitsFor(t2, t1)
+    \/ \E t1, t2, t3 \in Threads :
+           /\ t1 # t2 /\ t2 # t3 /\ t1 # t3
+           /\ WaitsFor(t1, t2)
+           /\ WaitsFor(t2, t3)
+           /\ WaitsFor(t3, t1)
+
+----
+\* Initial state.
+
+Init ==
+    /\ pdibPhase = "idle"
+    /\ commitQuorumVotes = {}
+    /\ rstlMode = [ t \in Threads |-> "none" ]
+    /\ rstlQueue = << >>
+    /\ stepdownPhase = "none"
+    /\ pdibObservedStepdown = FALSE
+
+----
+\* Actions.
+
+\* PDIB coordinator starts an index build.  Acquires IX RSTL if no X is
+\* pending.  If an X waiter is already enqueued, PDIB queues behind it.
+PDIBStart ==
+    /\ pdibPhase = "idle"
+    /\ stepdownPhase \in {"none","enqueued"}
+    /\ IF XPendingOrHeld
+         THEN /\ rstlQueue' = Append(rstlQueue, <<PDIB, "IX">>)
+              /\ UNCHANGED rstlMode
+         ELSE /\ rstlMode' = [rstlMode EXCEPT ![PDIB] = "IX"]
+              /\ UNCHANGED rstlQueue
+    /\ pdibPhase' = "scanning"
+    /\ UNCHANGED << commitQuorumVotes, stepdownPhase, pdibObservedStepdown >>
+
+PDIBFinishScan ==
+    /\ pdibPhase = "scanning"
+    /\ HoldsRSTL(PDIB, "IX")
+    /\ pdibPhase' = "voting"
+    /\ UNCHANGED << commitQuorumVotes, rstlMode, rstlQueue,
+                    stepdownPhase, pdibObservedStepdown >>
+
+\* A secondary's vote becomes observable on the primary, but ONLY if
+\* BgSync has been able to apply the entry.  We model BgSync's progress
+\* by gating vote arrival on BgSync's RSTL state: BgSync must hold IX
+\* (or no thread holds X and the queue head is BgSync) to apply.
+PDIBReceiveVote(s) ==
+    /\ pdibPhase = "voting"
+    /\ s \notin commitQuorumVotes
+    /\ Cardinality(commitQuorumVotes) < MaxQuorum
+    /\ \* BgSync can apply oplog entries.
+       \/ HoldsRSTL(BgSync, "IX")
+       \/ /\ ~XHeld
+          /\ rstlQueue = << >>
+    /\ commitQuorumVotes' = commitQuorumVotes \cup {s}
+    /\ UNCHANGED << pdibPhase, rstlMode, rstlQueue,
+                    stepdownPhase, pdibObservedStepdown >>
+
+\* PDIB sees commit quorum.  Transitions voting -> committing.
+PDIBCommitQuorumReached ==
+    /\ pdibPhase = "voting"
+    /\ IsMajority(commitQuorumVotes)
+    /\ HoldsRSTL(PDIB, "IX")
+    /\ pdibPhase' = "committing"
+    /\ UNCHANGED << commitQuorumVotes, rstlMode, rstlQueue,
+                    stepdownPhase, pdibObservedStepdown >>
+
+PDIBFinishCommit ==
+    /\ pdibPhase = "committing"
+    /\ HoldsRSTL(PDIB, "IX")
+    /\ rstlMode' = [rstlMode EXCEPT ![PDIB] = "none"]
+    /\ pdibPhase' = "done"
+    /\ UNCHANGED << commitQuorumVotes, rstlQueue,
+                    stepdownPhase, pdibObservedStepdown >>
+
+\* PDIB abort path.  On the patched code (AllowPDIBHoldDuringStepdown =
+\* FALSE), the stepdown callback marks pdibObservedStepdown = TRUE and the
+\* coordinator must release IX and transition to "aborted".  On the buggy
+\* path this action is disabled while in "voting" --- mirroring the
+\* observed live behaviour.
+PDIBAbortOnStepdown ==
+    /\ ~AllowPDIBHoldDuringStepdown
+    /\ pdibPhase \in {"scanning","voting","committing"}
+    /\ pdibObservedStepdown
+    /\ HoldsRSTL(PDIB, "IX")
+    /\ rstlMode' = [rstlMode EXCEPT ![PDIB] = "none"]
+    /\ pdibPhase' = "aborted"
+    /\ UNCHANGED << commitQuorumVotes, rstlQueue,
+                    stepdownPhase, pdibObservedStepdown >>
+
+\* Stepdown begins.  Enqueues X on RSTL.
+StepdownStart ==
+    /\ stepdownPhase = "none"
+    /\ ~XHeld
+    /\ stepdownPhase' = "enqueued"
+    /\ rstlQueue' = Append(rstlQueue, <<Stepdown, "X">>)
+    /\ pdibObservedStepdown' = ~AllowPDIBHoldDuringStepdown
+    /\ UNCHANGED << pdibPhase, commitQuorumVotes, rstlMode >>
+
+\* Stepdown promotes from queue to holder once no IX is held.  In the
+\* production code, the X waiter blocks until all IX holders drain.
+StepdownAcquireX ==
+    /\ stepdownPhase = "enqueued"
+    /\ Len(rstlQueue) > 0
+    /\ rstlQueue[1] = <<Stepdown, "X">>
+    /\ \A t \in Threads : rstlMode[t] = "none"
+    /\ rstlMode' = [rstlMode EXCEPT ![Stepdown] = "X"]
+    /\ rstlQueue' = Tail(rstlQueue)
+    /\ stepdownPhase' = "holding"
+    /\ UNCHANGED << pdibPhase, commitQuorumVotes, pdibObservedStepdown >>
+
+\* Stepdown completes and releases X.
+StepdownComplete ==
+    /\ stepdownPhase = "holding"
+    /\ HoldsRSTL(Stepdown, "X")
+    /\ rstlMode' = [rstlMode EXCEPT ![Stepdown] = "none"]
+    /\ stepdownPhase' = "completed"
+    /\ UNCHANGED << pdibPhase, commitQuorumVotes, rstlQueue,
+                    pdibObservedStepdown >>
+
+\* BgSync acquires IX so it can apply oplog entries (the vote-carrying
+\* entries the PDIB coordinator is awaiting).  Blocked by any pending X.
+BgSyncAcquire ==
+    /\ ~HoldsRSTL(BgSync, "IX")
+    /\ ~XPendingOrHeld
+    /\ rstlMode' = [rstlMode EXCEPT ![BgSync] = "IX"]
+    /\ UNCHANGED << pdibPhase, commitQuorumVotes, rstlQueue,
+                    stepdownPhase, pdibObservedStepdown >>
+
+\* BgSync queues if an X is pending.
+BgSyncEnqueue ==
+    /\ ~HoldsRSTL(BgSync, "IX")
+    /\ XPendingOrHeld
+    /\ ~ \E i \in 1..Len(rstlQueue) : rstlQueue[i][1] = BgSync
+    /\ rstlQueue' = Append(rstlQueue, <<BgSync, "IX">>)
+    /\ UNCHANGED << pdibPhase, commitQuorumVotes, rstlMode,
+                    stepdownPhase, pdibObservedStepdown >>
+
+\* BgSync drains from queue once X holder releases and queue head is its
+\* request (or no X is pending).  Approximates the lock manager's grant
+\* loop on RSTL release.
+BgSyncGrant ==
+    /\ \E i \in 1..Len(rstlQueue) : rstlQueue[i][1] = BgSync
+    /\ ~XHeld
+    /\ \* No earlier X waiter ahead of BgSync.
+       LET myIdx == CHOOSE i \in 1..Len(rstlQueue) : rstlQueue[i][1] = BgSync
+        IN \A j \in 1..(myIdx - 1) : rstlQueue[j][2] # "X"
+    /\ LET myIdx == CHOOSE i \in 1..Len(rstlQueue) : rstlQueue[i][1] = BgSync
+        IN rstlQueue' =
+             [ k \in 1..(Len(rstlQueue) - 1) |->
+                  IF k < myIdx THEN rstlQueue[k] ELSE rstlQueue[k+1] ]
+    /\ rstlMode' = [rstlMode EXCEPT ![BgSync] = "IX"]
+    /\ UNCHANGED << pdibPhase, commitQuorumVotes,
+                    stepdownPhase, pdibObservedStepdown >>
+
+\* BgSync releases IX (for example when it goes idle between batches).
+BgSyncRelease ==
+    /\ HoldsRSTL(BgSync, "IX")
+    /\ rstlMode' = [rstlMode EXCEPT ![BgSync] = "none"]
+    /\ UNCHANGED << pdibPhase, commitQuorumVotes, rstlQueue,
+                    stepdownPhase, pdibObservedStepdown >>
+
+----
+\* Next state relation.
+
+Next ==
+    \/ PDIBStart
+    \/ PDIBFinishScan
+    \/ \E s \in 1..MaxQuorum : PDIBReceiveVote(s)
+    \/ PDIBCommitQuorumReached
+    \/ PDIBFinishCommit
+    \/ PDIBAbortOnStepdown
+    \/ StepdownStart
+    \/ StepdownAcquireX
+    \/ StepdownComplete
+    \/ BgSyncAcquire
+    \/ BgSyncEnqueue
+    \/ BgSyncGrant
+    \/ BgSyncRelease
+
+Spec == Init /\ [][Next]_vars
+
+\* Fairness for the liveness check.  Without these, TLC could let
+\* StepdownAcquireX never fire even though it's enabled.  BgSyncRelease
+\* gets strong fairness so the modelled background sync can yield its IX
+\* intent between oplog batches when a stepdown X waiter is parked behind
+\* it, which is how production BgSync behaves.
+Liveness ==
+    /\ WF_vars(StepdownAcquireX)
+    /\ WF_vars(StepdownComplete)
+    /\ WF_vars(BgSyncGrant)
+    /\ WF_vars(BgSyncAcquire)
+    /\ SF_vars(BgSyncRelease)
+    /\ WF_vars(PDIBAbortOnStepdown)
+    /\ WF_vars(PDIBFinishCommit)
+    /\ \A s \in 1..MaxQuorum : WF_vars(PDIBReceiveVote(s))
+
+FairSpec == Spec /\ Liveness
+
+----
+\* Invariants and properties.
+
+\* SAFETY: the wait-for graph never closes a cycle.
+DeadlockFreedom == ~HasCycle
+
+\* SAFETY: RSTL is held in X by at most one thread, and X is incompatible
+\* with any IX hold.
+RSTLWellFormed ==
+    /\ Cardinality({ t \in Threads : rstlMode[t] = "X" }) <= 1
+    /\ \/ ~XHeld
+       \/ \A t \in Threads : rstlMode[t] # "IX"
+
+\* TYPE invariant.
+TypeOK ==
+    /\ pdibPhase \in {"idle","scanning","voting","committing","aborted","done"}
+    /\ commitQuorumVotes \subseteq 1..MaxQuorum
+    /\ rstlMode \in [Threads -> {"none","IX","X"}]
+    /\ stepdownPhase \in {"none","enqueued","holding","completed"}
+    /\ pdibObservedStepdown \in BOOLEAN
+
+\* LIVENESS: every issued stepdown eventually completes.
+EveryStepdownCompletes ==
+    [](stepdownPhase = "enqueued" ~> stepdownPhase = "completed")
+
+==============================================================================


### PR DESCRIPTION
## Summary

TLA+ spec + jstest for SERVER-126266 — possible deadlock between stepdown and primary-driven index build (PDIB). Load-bearing for the 9.0 PDIB release.

**Jira:** https://jira.mongodb.org/browse/SERVER-126555
**Related:** https://jira.mongodb.org/browse/SERVER-126266

## TLC verdicts (deadlock check enabled)

| Cfg | Result |
|---|---|
| Green | 268 / 133 distinct, depth 12, no error |
| Bug | `Error: Deadlock reached.` at depth 5; counterexample `PDIBStart → StepdownStart → PDIBFinishScan → BgSyncEnqueue` matching the wait-for cycle |

## Files

- `src/mongo/tla_plus/IndexBuilds/StepdownPDIBDeadlock/StepdownPDIBDeadlock.tla` (378 lines) — three threads (PDIB, Stepdown, BgSync) contend on one RSTL + commit-quorum vote set. `WaitsFor` + `HasCycle` enumerates length-2 and length-3 cycles directly.
- `src/mongo/tla_plus/IndexBuilds/StepdownPDIBDeadlock/MCStepdownPDIBDeadlock.{tla,cfg}` (green) + `MCStepdownPDIBDeadlock_bug.cfg`
- `src/mongo/tla_plus/IndexBuilds/StepdownPDIBDeadlock/OWNERS.yml` (`10gen/server-replication-reviewers`)
- `src/mongo/tla_plus/IndexBuilds/StepdownPDIBDeadlock/README.md` (298 words)
- `jstests/replsets/stepdown_during_pdib_no_deadlock.js` (148 lines)

## Verify

```
cd src/mongo/tla_plus
./download-tlc.sh
./model-check.sh IndexBuilds/StepdownPDIBDeadlock
```

jstest uses `hangIndexBuildBeforeSignalPrimaryForCommitReadiness` to park PDIB, fires non-force `replSetStepDown`, asserts completion under 60s.

## Draft status

Opened as Draft.
