### PR TITLE
SERVER-126556 Add jstest matrix + parser-invariant spec for $diff field oplog misparse

### DIFF
--- a/jstests/replsets/oplog_update_reserved_field_names.js
+++ b/jstests/replsets/oplog_update_reserved_field_names.js
@@ -1,0 +1,154 @@
+/**
+ * SERVER-124369 regression — replacement-style update documents that carry
+ * reserved oplog-update field names (e.g. $diff, $set, $v) as ordinary
+ * keys must be applied LITERALLY on the secondary, not misparsed as a
+ * delta update.
+ *
+ * Background:
+ *   Replication classifies an update oplog entry by looking at the shape
+ *   of `o`. A v2 delta update has the form `{$v: 2, diff: {...}}` and is
+ *   routed through `write_ops::UpdateModification::parseFromOplogEntry`
+ *   (src/mongo/db/exec/agg/internal_apply_oplog_update_stage.cpp). A
+ *   replacement-style update is `o = <full new document>`, with NO
+ *   wrapping $v / diff. The bug class: when the user's *replacement*
+ *   payload happens to contain a top-level field literally named `$diff`
+ *   (or another reserved oplog token), the classifier latches onto the
+ *   reserved name and tries to apply the value as a delta — corrupting
+ *   the document or asserting on the secondary.
+ *
+ * This test pins the contract: for every reserved token T in the
+ * oplog-update vocabulary, a replacement `{T: <value>, ...}` issued on
+ * the primary must be visible on the secondary byte-for-byte, and the
+ * recorded oplog entry must be the replacement form (no $v: 2 wrapper).
+ *
+ * Do NOT promote any of these tokens to "interpreted" semantics without
+ * also bumping the oplog version sentinel — this test will fail loudly.
+ *
+ * @tags: [
+ *   requires_replication,
+ * ]
+ */
+
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+const replTest = new ReplSetTest({nodes: 2, oplogSize: 4});
+replTest.startSet();
+replTest.initiate();
+
+const primary = replTest.getPrimary();
+const secondary = replTest.getSecondary();
+const dbName = "server124369";
+const collName = "reserved_field_names";
+const primaryColl = primary.getDB(dbName)[collName];
+const secondaryColl = secondary.getDB(dbName)[collName];
+const oplog = primary.getDB("local").oplog.rs;
+
+// Reserved tokens that appear in v2-delta oplog entries or are otherwise
+// part of the update-modifier vocabulary. Each must round-trip as DATA
+// when it appears in a replacement update.
+const RESERVED_TOKENS = [
+    "$diff",   // v2 delta wrapper key (the SERVER-124369 trigger)
+    "$set",    // classic update modifier
+    "$unset",  // classic update modifier
+    "$v",      // oplog version sentinel
+    "$rename", // classic update modifier
+    "$inc",    // classic update modifier
+];
+
+// One representative value per token. We deliberately pick values that
+// would be syntactically valid as the right-hand side of the modifier,
+// so a buggy parser would happily try to apply them.
+const RESERVED_VALUES = {
+    "$diff": {u: {a: 99}, i: {b: "should-not-apply"}},
+    "$set": {a: 99},
+    "$unset": {a: ""},
+    "$v": 2,
+    "$rename": {a: "b"},
+    "$inc": {a: 1},
+};
+
+function getLastUpdateOplogEntry(ns) {
+    return oplog
+        .find({op: "u", ns: ns})
+        .sort({$natural: -1})
+        .limit(1)
+        .next();
+}
+
+function assertReplicated(doc, msg) {
+    replTest.awaitReplication();
+    const onSecondary = secondaryColl.findOne({_id: doc._id});
+    assert.docEq(doc, onSecondary,
+                 "secondary diverged from primary for " + msg);
+}
+
+function runOne(token, idx) {
+    const _id = "rf-" + idx;
+    const seed = {_id: _id, anchor: "before-replace"};
+    assert.commandWorked(primaryColl.insert(seed));
+    assertReplicated(seed, "seed-insert for " + token);
+
+    // Build a replacement document whose top-level fields include the
+    // reserved token. The replace() path issues a replacement-style
+    // update — NOT a $set / delta — so the oplog `o` should be the
+    // literal replacement body.
+    const replacement = {_id: _id, anchor: "after-replace", marker: token};
+    replacement[token] = RESERVED_VALUES[token];
+
+    const res = assert.commandWorked(primaryColl.replaceOne({_id: _id}, replacement));
+    assert.eq(res.modifiedCount, 1, "replaceOne did not modify for " + token);
+
+    // 1. Primary must reflect the replacement literally.
+    const onPrimary = primaryColl.findOne({_id: _id});
+    assert.docEq(replacement, onPrimary,
+                 "primary lost reserved field " + token);
+
+    // 2. The oplog entry must be the replacement shape, not v2 delta.
+    const entry = getLastUpdateOplogEntry(primaryColl.getFullName());
+    assert(entry, "no update oplog entry recorded for " + token);
+    assert(!entry.o.hasOwnProperty("$v") || entry.o.$v !== 2,
+           "expected replacement-style oplog entry for " + token +
+           " but got delta: " + tojson(entry));
+    assert.docEq(replacement, entry.o,
+                 "oplog `o` does not match replacement for " + token);
+
+    // 3. Secondary must converge bit-identically. This is the real
+    //    regression assertion — a misclassifying parser corrupts here.
+    assertReplicated(replacement, "post-replace for " + token);
+}
+
+RESERVED_TOKENS.forEach(runOne);
+
+// Nested coverage: the reserved token appears as a *value-side* key
+// inside a non-reserved field. This must also be preserved literally
+// — the classifier should only inspect top-level keys of `o`.
+const nestedId = "rf-nested";
+assert.commandWorked(primaryColl.insert({_id: nestedId, anchor: "before"}));
+const nestedReplacement = {
+    _id: nestedId,
+    anchor: "after",
+    payload: {"$diff": {u: {x: 1}}, "$v": 2, normal: "ok"},
+};
+assert.commandWorked(primaryColl.replaceOne({_id: nestedId}, nestedReplacement));
+assert.docEq(nestedReplacement, primaryColl.findOne({_id: nestedId}),
+             "primary lost nested reserved tokens");
+assertReplicated(nestedReplacement, "nested reserved tokens");
+
+// Combined coverage: a single replacement carrying every reserved token
+// at once. Future-proofs against any classifier that short-circuits on
+// the first reserved key seen.
+const allId = "rf-all";
+assert.commandWorked(primaryColl.insert({_id: allId, anchor: "before"}));
+const allReplacement = {_id: allId, anchor: "after"};
+RESERVED_TOKENS.forEach((t) => {
+    allReplacement[t] = RESERVED_VALUES[t];
+});
+assert.commandWorked(primaryColl.replaceOne({_id: allId}, allReplacement));
+assert.docEq(allReplacement, primaryColl.findOne({_id: allId}),
+             "primary lost combined reserved tokens");
+const allEntry = getLastUpdateOplogEntry(primaryColl.getFullName());
+assert(!allEntry.o.hasOwnProperty("$v") || allEntry.o.$v !== 2,
+       "combined replacement misclassified as delta: " + tojson(allEntry));
+assertReplicated(allReplacement, "combined reserved tokens");
+
+replTest.stopSet();

--- a/src/mongo/db/repl/UPDATE_FIELD_NAME_PARSER_INVARIANT.md
+++ b/src/mongo/db/repl/UPDATE_FIELD_NAME_PARSER_INVARIANT.md
@@ -1,0 +1,88 @@
+# Update Oplog Entry — Field-Name Parser Invariant
+
+> Companion spec for SERVER-124369. Pins the contract that the
+> replication oplog-update classifier MUST honour. Replication
+> correctness for replacement-style updates depends on it.
+
+## Statement of the invariant
+
+A replication oplog entry with `op: "u"` carries an update description
+in its `o` field. Two shapes are valid:
+
+| Shape | `o` form | Routed through |
+|-------|---------|----------------|
+| v2 delta | `{$v: 2, diff: {...}}` | `UpdateModification::parseFromOplogEntry` → diff applier |
+| replacement | full new document (no `$v: 2` wrapper) | replacement applier |
+
+**Invariant.** The classifier that picks between the two routes MUST
+discriminate by the *presence and value of the top-level `$v` sentinel*,
+NOT by the presence of any reserved-looking key (`$diff`, `$set`,
+`$unset`, `$rename`, `$inc`, etc.) inside `o`.
+
+Equivalently: when `o` is a replacement document, every top-level field
+of `o` — including any whose name happens to start with `$` — MUST be
+preserved literally as a data field on the secondary. The replacement
+applier MUST NOT inspect reserved names for modifier semantics.
+
+## Why it matters
+
+User documents may legally contain fields named `$diff`, `$set`, etc.
+(BSON allows `$`-prefixed names at non-top-level positions, and a number
+of drivers / pipeline stages produce them at the top level too). A
+classifier that latches onto a reserved name without first checking `$v`
+will:
+
+1. Treat the user's literal data as a delta operator.
+2. Apply that "delta" to whatever happens to live on the secondary.
+3. Silently corrupt the document, or crash the secondary on a malformed
+   delta payload — a hard data-divergence event.
+
+This bug class also recurs whenever the diff format adds new reserved
+names: any schema change that introduces a sentinel must update the
+classifier and add a regression row to the jstest matrix.
+
+## Parser site
+
+`src/mongo/db/exec/agg/internal_apply_oplog_update_stage.cpp` —
+`InternalApplyOplogUpdateStage::InternalApplyOplogUpdateStage`
+(constructor, ~line 64). It invokes
+`write_ops::UpdateModification::parseFromOplogEntry(oplogUpdate, ...)`,
+which is the single chokepoint that decides delta-vs-replacement. The
+classifier inside `parseFromOplogEntry` is the load-bearing function;
+it must read `$v` FIRST and refuse to interpret any other key on the
+replacement path.
+
+A secondary site is `src/mongo/db/repl/oplog.cpp` near the update
+applier dispatch — both sites must agree on the discriminator.
+
+## Regression-pinning unit test (proposed)
+
+A C++ unit test belongs alongside `UpdateModification::parseFromOplogEntry`
+(e.g. `src/mongo/db/ops/write_ops_parsers_test.cpp` or the nearest
+equivalent in this checkout). Shape:
+
+```cpp
+TEST(UpdateModificationParseFromOplog, ReplacementWithReservedKeysIsNotDelta) {
+    for (auto&& key : {"$diff", "$set", "$unset", "$v", "$rename", "$inc"}) {
+        BSONObj replacement = BSON("_id" << 1 << key << BSON("a" << 1));
+        auto mod = write_ops::UpdateModification::parseFromOplogEntry(
+            replacement, {true});
+        ASSERT(mod.type() ==
+               write_ops::UpdateModification::Type::kReplacement);
+        ASSERT_BSONOBJ_EQ(mod.getUpdateReplacement(), replacement);
+    }
+}
+```
+
+The matching end-to-end coverage lives at
+`jstests/replsets/oplog_update_reserved_field_names.js`. Both must be
+kept green together — the C++ test pins parser intent; the jstest pins
+that the replication pipeline composes the parser correctly.
+
+## When this invariant is amended
+
+If a future oplog version legitimately needs new reserved top-level
+keys, bump `$v` to a new sentinel value AND add the new key to the
+jstest matrix under that sentinel. The invariant text above must then
+specify: discrimination is by `$v` value, never by reserved-name
+presence under the replacement branch.


### PR DESCRIPTION
## Summary

jstest matrix + parser-invariant spec for SERVER-124369: replacement-style update documents containing a `$diff` field are misparsed as delta updates during oplog application. Same class of bug recurs on schema additions of reserved field names.

**Jira:** https://jira.mongodb.org/browse/SERVER-126556
**Related:** https://jira.mongodb.org/browse/SERVER-124369

## Files

- `jstests/replsets/oplog_update_reserved_field_names.js` (154 lines) — 2-node replset; for each token in `{$diff, $set, $unset, $v, $rename, $inc}` inserts a seed doc, issues `replaceOne()` with the token as a top-level field carrying a syntactically-valid modifier value. Asserts (1) primary preserves the field literally, (2) the recorded oplog entry has `op:"u"` with `o` matching the replacement byte-for-byte and lacks `$v: 2`, (3) secondary converges via `docEq`. Plus nested-token and all-tokens-combined cases.
- `src/mongo/db/repl/UPDATE_FIELD_NAME_PARSER_INVARIANT.md` (513 words) — states the invariant (discriminate by `$v` value, never by reserved-name presence on the replacement branch). Identifies parser site `internal_apply_oplog_update_stage.cpp:64` → `write_ops::UpdateModification::parseFromOplogEntry`, with secondary site in `oplog.cpp`.

## Cross-reference

v2 delta shape `{$v: 2, diff: {...}}` confirmed by `jstests/replsets/oplog_format.js` (line 46+); the invariant aligns with the established format.

## Verify

```
node --input-type=module --check < jstests/replsets/oplog_update_reserved_field_names.js
```

## Draft status

Opened as Draft.
