### PR TITLE
SERVER-126558 Add TLA+ spec + jstest for $lookup/$graphLookup view-resolution race across getMore

### DIFF
--- a/jstests/aggregation/lookup_view_drop_recreate_getMore.js
+++ b/jstests/aggregation/lookup_view_drop_recreate_getMore.js
@@ -1,0 +1,293 @@
+/**
+ * SERVER-121988: $lookup and $graphLookup against a view that is dropped, recreated, or swapped
+ * mid-cursor (across a getMore boundary) must not silently return zero matches. The fix pins the
+ * resolved view definition into the cursor's plan context at cursor-open time, so subsequent
+ * getMore batches use the same view definition that the initial batch saw.
+ *
+ * This test exercises three mutation patterns -- drop, drop+recreate (same backing, new pipeline),
+ * and view-to-collection swap (view points at a different backing collection) -- in each case
+ * across at least one getMore boundary, for both $lookup and $graphLookup.
+ *
+ * @tags: [
+ *   # The fix is observational: this test asserts on the document count returned by the cursor
+ *   # before and after the catalog mutation. Implicit collection creation must be disabled so the
+ *   # `drop' step really drops.
+ *   assumes_no_implicit_collection_creation_after_drop,
+ *   # The cursor must remain open across at least one getMore. Wrapping in $facet collapses
+ *   # the pipeline to a single command boundary and defeats the test.
+ *   do_not_wrap_aggregations_in_facets,
+ *   # The test directly drops + recreates a foreign view between getMore calls. Causal consistency
+ *   # would either replay the drop into the subsequent getMore or report stale-snapshot errors,
+ *   # both of which would mask the bug we are exercising.
+ *   does_not_support_causal_consistency,
+ *   # Stepdowns between getMore calls invalidate the cursor and produce ResumableScanError before
+ *   # the catalog mutation can race the resolver -- which is a different code path.
+ *   does_not_support_stepdowns,
+ *   # The test asserts on resolved view behaviour, and is therefore sensitive to anything that
+ *   # bypasses view resolution.
+ *   requires_fcv_81,
+ * ]
+ */
+
+const testDB = db.getSiblingDB(jsTestName());
+assert.commandWorked(testDB.dropDatabase());
+
+const sourceCollName = "source";
+const backingAName = "backing_a";
+const backingBName = "backing_b";
+const viewName = "foreign_view";
+
+const source = testDB[sourceCollName];
+const backingA = testDB[backingAName];
+const backingB = testDB[backingBName];
+
+// Number of source documents must exceed the initial-batch size so that at least one getMore is
+// required to drain the cursor. The aggregation default batch size is 101; we use 200 docs and
+// pin a smaller cursor batch size (5) below to make this robust against future default changes.
+const N_SOURCE = 200;
+const CURSOR_BATCH = 5;
+
+function reseed() {
+    source.drop();
+    backingA.drop();
+    backingB.drop();
+    // `drop' is idempotent on a non-existent namespace, but mongos returns NamespaceNotFound.
+    // We swallow that and only that.
+    const dropRes = testDB.runCommand({drop: viewName});
+    if (!dropRes.ok && dropRes.code !== ErrorCodes.NamespaceNotFound) {
+        assert.commandWorked(dropRes);
+    }
+
+    // Source: _id 0..N-1 join_field cycling 1..3.
+    const sourceDocs = [];
+    for (let i = 0; i < N_SOURCE; i++) {
+        sourceDocs.push({_id: i, join_field: (i % 3) + 1});
+    }
+    assert.commandWorked(source.insertMany(sourceDocs, {ordered: false}));
+
+    // Backing A: three matching documents.
+    assert.commandWorked(backingA.insertMany([
+        {_id: "a1", key: 1, payload: "from_A"},
+        {_id: "a2", key: 2, payload: "from_A"},
+        {_id: "a3", key: 3, payload: "from_A"},
+    ]));
+
+    // Backing B: three matching documents with different payload (so we can detect a silent swap).
+    assert.commandWorked(backingB.insertMany([
+        {_id: "b1", key: 1, payload: "from_B"},
+        {_id: "b2", key: 2, payload: "from_B"},
+        {_id: "b3", key: 3, payload: "from_B"},
+    ]));
+
+    // Create the view targeting backingA initially.
+    assert.commandWorked(
+        testDB.runCommand({create: viewName, viewOn: backingAName, pipeline: []}));
+}
+
+// Drains a cursor in batches, optionally invoking `mutateFn' exactly once after the first getMore.
+// Returns the full result array.
+function drainWithMutation(cursorReply, mutateFn) {
+    const collName = cursorReply.cursor.ns.split(".").slice(1).join(".");
+    let docs = cursorReply.cursor.firstBatch.slice();
+    let cursorId = cursorReply.cursor.id;
+    let mutated = false;
+
+    while (cursorId.toString() !== "NumberLong(0)" && cursorId !== 0 &&
+           (typeof cursorId.compare === "function" ? cursorId.compare(0) !== 0 : cursorId !== 0)) {
+        const getMore = assert.commandWorked(testDB.runCommand({
+            getMore: cursorId,
+            collection: collName,
+            batchSize: CURSOR_BATCH,
+        }));
+        docs = docs.concat(getMore.cursor.nextBatch);
+        cursorId = getMore.cursor.id;
+
+        // Mutate exactly once after the first getMore so the *next* getMore (and any cursor
+        // re-resolution path triggered by it) sees a mutated catalog. This is the SERVER-121988
+        // race window.
+        if (!mutated && mutateFn !== null && cursorId.toString() !== "NumberLong(0)") {
+            mutateFn();
+            mutated = true;
+        }
+    }
+    return docs;
+}
+
+// Runs a $lookup pipeline that joins source.join_field == foreign.key against the view, captures
+// the full expected result with no mutation, then re-runs the same pipeline with the supplied
+// mutation function fired between getMore batches. The two result sets must be byte-for-byte
+// equal -- the cursor must stick to the view definition it opened against.
+function runLookupCase({caseName, mutateFn}) {
+    jsTest.log(`---- $lookup case: ${caseName} ----`);
+    reseed();
+
+    const pipeline = [
+        {$sort: {_id: 1}},
+        {
+            $lookup: {
+                from: viewName,
+                localField: "join_field",
+                foreignField: "key",
+                as: "matches",
+            },
+        },
+        {$project: {_id: 1, payloads: "$matches.payload"}},
+    ];
+
+    // Baseline: drain without mutation.
+    const baselineCursor = assert.commandWorked(testDB.runCommand({
+        aggregate: sourceCollName,
+        pipeline: pipeline,
+        cursor: {batchSize: CURSOR_BATCH},
+    }));
+    const baselineDocs = drainWithMutation(baselineCursor, null);
+    assert.eq(baselineDocs.length, N_SOURCE, "baseline must return all source documents");
+    for (const d of baselineDocs) {
+        assert.eq(d.payloads.length, 1, () => `baseline payloads malformed: ${tojson(d)}`);
+        assert.eq(d.payloads[0], "from_A", () => `baseline must see backing_a: ${tojson(d)}`);
+    }
+
+    // Re-run, mutating the catalog between getMores.
+    reseed();
+    const racedCursor = assert.commandWorked(testDB.runCommand({
+        aggregate: sourceCollName,
+        pipeline: pipeline,
+        cursor: {batchSize: CURSOR_BATCH},
+    }));
+    const racedDocs = drainWithMutation(racedCursor, mutateFn);
+
+    // Invariant: the cursor must continue to resolve against the view definition it opened
+    // with. Either (a) the cursor returns the same N docs all with payload from_A, or (b) the
+    // server explicitly errors a getMore call. Silently returning empty matches for the
+    // remaining batches is the SERVER-121988 bug and is forbidden.
+    assert.eq(racedDocs.length, N_SOURCE,
+        `cursor must return ${N_SOURCE} docs even after catalog mutation; got ${racedDocs.length}`);
+
+    let postMutationEmptyCount = 0;
+    for (const d of racedDocs) {
+        if (!Array.isArray(d.payloads) || d.payloads.length === 0) {
+            postMutationEmptyCount++;
+        } else {
+            // If the cursor saw any matches, they must be from the *original* view (backingA).
+            // A leaked mutation would show payload from_B (swap case) or no payloads (drop case).
+            assert.eq(d.payloads[0], "from_A",
+                `cursor returned a payload from a mutated view -- SERVER-121988 regression: ${tojson(d)}`);
+        }
+    }
+    assert.eq(postMutationEmptyCount, 0,
+        `cursor returned ${postMutationEmptyCount} silently-empty join rows -- SERVER-121988 regression`);
+
+    jsTest.log(`OK: ${caseName} -- cursor stayed bound to its opened view definition.`);
+}
+
+// Same as runLookupCase but for $graphLookup. The recursive $graphLookup path resolves the
+// foreign view at depth=0 and then re-resolves once per BFS level on the shard. Mid-pipeline
+// catalog mutation must not change which view those resolutions hit.
+function runGraphLookupCase({caseName, mutateFn}) {
+    jsTest.log(`---- $graphLookup case: ${caseName} ----`);
+    reseed();
+
+    const pipeline = [
+        {$sort: {_id: 1}},
+        {
+            $graphLookup: {
+                from: viewName,
+                startWith: "$join_field",
+                connectFromField: "key",
+                connectToField: "key",
+                as: "matches",
+                maxDepth: 1,
+            },
+        },
+        {$project: {_id: 1, payloads: "$matches.payload"}},
+    ];
+
+    const baselineCursor = assert.commandWorked(testDB.runCommand({
+        aggregate: sourceCollName,
+        pipeline: pipeline,
+        cursor: {batchSize: CURSOR_BATCH},
+    }));
+    const baselineDocs = drainWithMutation(baselineCursor, null);
+    assert.eq(baselineDocs.length, N_SOURCE);
+    for (const d of baselineDocs) {
+        assert(Array.isArray(d.payloads) && d.payloads.length >= 1,
+            `baseline $graphLookup row must have at least one match: ${tojson(d)}`);
+        for (const p of d.payloads) {
+            assert.eq(p, "from_A", `baseline must see only backing_a: ${tojson(d)}`);
+        }
+    }
+
+    reseed();
+    const racedCursor = assert.commandWorked(testDB.runCommand({
+        aggregate: sourceCollName,
+        pipeline: pipeline,
+        cursor: {batchSize: CURSOR_BATCH},
+    }));
+    const racedDocs = drainWithMutation(racedCursor, mutateFn);
+    assert.eq(racedDocs.length, N_SOURCE,
+        `$graphLookup cursor must return ${N_SOURCE} docs; got ${racedDocs.length}`);
+
+    let postMutationEmptyCount = 0;
+    for (const d of racedDocs) {
+        if (!Array.isArray(d.payloads) || d.payloads.length === 0) {
+            postMutationEmptyCount++;
+        } else {
+            for (const p of d.payloads) {
+                assert.eq(p, "from_A",
+                    `$graphLookup leaked a payload from a mutated view -- SERVER-121988 regression: ${tojson(d)}`);
+            }
+        }
+    }
+    assert.eq(postMutationEmptyCount, 0,
+        `$graphLookup cursor silently returned ${postMutationEmptyCount} empty rows after catalog mutation -- SERVER-121988 regression`);
+
+    jsTest.log(`OK: ${caseName} -- $graphLookup stayed bound to its opened view definition.`);
+}
+
+// ---- Mutation fixtures ----
+
+// Case A: drop the view outright between getMore batches.
+function mutateDrop() {
+    assert.commandWorked(testDB.runCommand({drop: viewName}));
+}
+
+// Case B: drop + recreate the view with the same backing collection (i.e. functionally
+// equivalent pipeline). This is the classic "drop+recreate" race.
+function mutateDropRecreateSameBacking() {
+    assert.commandWorked(testDB.runCommand({drop: viewName}));
+    assert.commandWorked(
+        testDB.runCommand({create: viewName, viewOn: backingAName, pipeline: []}));
+}
+
+// Case C: drop + recreate the view pointing at a *different* backing collection. This is the
+// swap case -- the user-visible payload would change if the bug leaks through.
+function mutateSwapToBackingB() {
+    assert.commandWorked(testDB.runCommand({drop: viewName}));
+    assert.commandWorked(
+        testDB.runCommand({create: viewName, viewOn: backingBName, pipeline: []}));
+}
+
+// Case D: view-to-collection swap. Drop the view and replace it with a real collection of
+// the same name. Mongos must not start re-routing $lookup to the collection's data.
+function mutateViewToCollectionSwap() {
+    assert.commandWorked(testDB.runCommand({drop: viewName}));
+    assert.commandWorked(testDB[viewName].insertMany([
+        {_id: "c1", key: 1, payload: "from_C_collection"},
+        {_id: "c2", key: 2, payload: "from_C_collection"},
+        {_id: "c3", key: 3, payload: "from_C_collection"},
+    ]));
+}
+
+// ---- Run the matrix. ----
+
+runLookupCase({caseName: "drop", mutateFn: mutateDrop});
+runLookupCase({caseName: "drop+recreate same backing", mutateFn: mutateDropRecreateSameBacking});
+runLookupCase({caseName: "swap to backing_b", mutateFn: mutateSwapToBackingB});
+runLookupCase({caseName: "view->collection swap", mutateFn: mutateViewToCollectionSwap});
+
+runGraphLookupCase({caseName: "drop", mutateFn: mutateDrop});
+runGraphLookupCase({caseName: "drop+recreate same backing", mutateFn: mutateDropRecreateSameBacking});
+runGraphLookupCase({caseName: "swap to backing_b", mutateFn: mutateSwapToBackingB});
+runGraphLookupCase({caseName: "view->collection swap", mutateFn: mutateViewToCollectionSwap});
+
+jsTest.log("SERVER-121988 regression suite passed.");

--- a/src/mongo/tla_plus/Catalog/OWNERS.yml
+++ b/src/mongo/tla_plus/Catalog/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-query-execution

--- a/src/mongo/tla_plus/Catalog/ViewResolutionGetMore/MCViewResolutionGetMore.cfg
+++ b/src/mongo/tla_plus/Catalog/ViewResolutionGetMore/MCViewResolutionGetMore.cfg
@@ -1,0 +1,39 @@
+\* Green configuration: AllowViewMutationMidCommand = FALSE.
+\* This represents the post-fix model where the catalog is frozen while any cursor is open
+\* (equivalently, the resolved view definition is pinned into cursor state). TLC must
+\* verify SingleViewDefinitionPerCommand and NoSilentEmptyBatchAfterOk hold for all reachable
+\* states.
+\*
+\* To exercise the bug, swap to MCViewResolutionGetMore_Bug.cfg.
+SPECIFICATION Spec
+
+CONSTANTS
+    Commands     = {c1, c2}
+    Views        = {v1}
+    BackingColls = {b1, b2}
+    MAX_BATCHES  = 3
+    MAX_VIEW_GENS = 3
+    AllowViewMutationMidCommand = FALSE
+
+INVARIANTS
+    \* -- Type / sanity invariants. Enabled by default; cheap.
+    TypeOK
+    ViewGenMonotonic
+    PinnedDefMatchesCatalogForOpenCursors
+    \* -- Protocol correctness invariants. Must hold in green mode.
+    SingleViewDefinitionPerCommand
+    NoSilentEmptyBatchAfterOk
+    \* -- Bait invariants. Enable individually to inspect traces.
+    \* BaitHasOpenCursor
+    \* BaitDropOccurred
+    \* BaitTwoDefsSeen
+
+CONSTRAINTS
+    StateConstraint
+
+SYMMETRY Symmetry
+
+\* The spec has multiple legitimate terminal states (all-done, or commands stuck because
+\* the catalog mutator dropped a target view and exhausted its DDL budget). Suppress
+\* TLC's deadlock detection rather than enumerate every terminal in the Next disjunct.
+CHECK_DEADLOCK FALSE

--- a/src/mongo/tla_plus/Catalog/ViewResolutionGetMore/MCViewResolutionGetMore.tla
+++ b/src/mongo/tla_plus/Catalog/ViewResolutionGetMore/MCViewResolutionGetMore.tla
@@ -1,0 +1,36 @@
+---------------------------------- MODULE MCViewResolutionGetMore ----------------------------------
+\* This module defines ViewResolutionGetMore.tla constants/constraints for model-checking.
+
+EXTENDS ViewResolutionGetMore
+
+(**************************************************************************************************)
+(* State constraints.                                                                            *)
+(**************************************************************************************************)
+
+\* Cap exploration: stop once every command is `done' (or once we've already exhausted the
+\* configured DDL budget via MAX_VIEW_GENS). Keeps state space bounded.
+StateConstraint ==
+    /\ \E c \in Commands : cmdStatus[c] # "done"
+
+\* Symmetry over commands, views, and backing collections. We deliberately do NOT symmetry
+\* over generations because the invariant relies on the monotonic ordering of gens.
+Symmetry == Permutations(Commands) \union Permutations(Views) \union Permutations(BackingColls)
+
+(**************************************************************************************************)
+(* Counterexample baits (for trace generation).                                                  *)
+(**************************************************************************************************)
+
+\* Bait an execution that reaches at least one open cursor, useful for verifying the model
+\* actually exercises the cursor lifecycle.
+BaitHasOpenCursor == ~(\E c \in Commands : cmdStatus[c] = "open")
+
+\* Bait an execution that drops a view at least once. Useful in bug-mode to ensure the
+\* catalog mutator fires.
+BaitDropOccurred == ~(\E v \in Views : viewCatalog[v] = NoView)
+
+\* Bait an execution where a command sees more than one view definition. In bug-mode this
+\* fires; in fix-mode it should NEVER fire (SingleViewDefinitionPerCommand subsumes it).
+BaitTwoDefsSeen ==
+    ~ \E c \in Commands : Cardinality({ DefId(d) : d \in cmdResolvedDefs[c] }) > 1
+
+====================================================================================================

--- a/src/mongo/tla_plus/Catalog/ViewResolutionGetMore/MCViewResolutionGetMore_Bug.cfg
+++ b/src/mongo/tla_plus/Catalog/ViewResolutionGetMore/MCViewResolutionGetMore_Bug.cfg
@@ -1,0 +1,34 @@
+\* Bug configuration: AllowViewMutationMidCommand = TRUE.
+\* This represents pre-fix behaviour: the catalog can mutate (drop, recreate, swap) while a
+\* cursor is open. TLC MUST produce a counterexample for SingleViewDefinitionPerCommand and
+\* a (separate) counterexample for NoSilentEmptyBatchAfterOk -- both are the user-visible
+\* symptoms of SERVER-121988.
+\*
+\* To run:
+\*   cd src/mongo/tla_plus
+\*   ./model-check.sh Catalog/ViewResolutionGetMore   # will use MCViewResolutionGetMore.cfg
+\* or rename this file to MCViewResolutionGetMore.cfg first, since model-check.sh always
+\* picks up the cfg named after the MC module.
+SPECIFICATION Spec
+
+CONSTANTS
+    Commands     = {c1, c2}
+    Views        = {v1}
+    BackingColls = {b1, b2}
+    MAX_BATCHES  = 3
+    MAX_VIEW_GENS = 3
+    AllowViewMutationMidCommand = TRUE
+
+INVARIANTS
+    TypeOK
+    ViewGenMonotonic
+    \* Protocol correctness invariants. EXPECT VIOLATION in bug-mode.
+    SingleViewDefinitionPerCommand
+    NoSilentEmptyBatchAfterOk
+
+CONSTRAINTS
+    StateConstraint
+
+SYMMETRY Symmetry
+
+CHECK_DEADLOCK FALSE

--- a/src/mongo/tla_plus/Catalog/ViewResolutionGetMore/OWNERS.yml
+++ b/src/mongo/tla_plus/Catalog/ViewResolutionGetMore/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-query-execution

--- a/src/mongo/tla_plus/Catalog/ViewResolutionGetMore/README.md
+++ b/src/mongo/tla_plus/Catalog/ViewResolutionGetMore/README.md
@@ -1,0 +1,52 @@
+# ViewResolutionGetMore
+
+Formal model of view resolution for `$lookup` / `$graphLookup` commands whose
+cursor spans an initial batch plus one or more `getMore` batches, in the
+presence of concurrent catalog mutations.
+
+Tracks SERVER-121988: between view-resolution kickbacks (especially across
+`getMore` boundaries) a drop+recreate flips the view definition, and the
+second batch silently resolves the secondary `$lookup`/`$graphLookup` against
+the new definition. The cursor returns zero matches with no error surfaced.
+
+## Actors
+
+1. **Mongos view-resolver** — dispatches the user command, receives a
+   `CommandOnShardedViewNotSupportedOnMongod` kickback, refetches the view
+   definition, re-dispatches, and opens the cursor.
+2. **Catalog mutator** — fires `DropView`, `RecreateView`, and `SwapView`
+   actions (swap = drop + recreate pointing at a different backing
+   collection). Gated by `AllowViewMutationMidCommand`.
+3. **Consumer / getMore** — drives the cursor: initial batch, then up to
+   `MAX_BATCHES - 1` `getMore` calls, then `CloseCursor`.
+
+## Invariant
+
+`SingleViewDefinitionPerCommand`: for every command `c` whose cursor reached
+`open`, the set of view definitions actually consumed by `c`'s `$lookup` /
+`$graphLookup` stages across all batches is a singleton (`(gen, backing)` is
+the natural identity). `NoSilentEmptyBatchAfterOk` is a complementary
+user-facing invariant.
+
+## Bug toggle
+
+`AllowViewMutationMidCommand` ∈ BOOLEAN.
+
+- `FALSE` (green) — catalog frozen while any cursor is open. Encoded in
+  `MCViewResolutionGetMore.cfg`. TLC verifies the invariants hold.
+- `TRUE` (bug) — catalog can mutate freely. Encoded in
+  `MCViewResolutionGetMore_Bug.cfg`. TLC produces a counterexample for
+  `SingleViewDefinitionPerCommand` and a separate trace for
+  `NoSilentEmptyBatchAfterOk`.
+
+## Running
+
+```
+cd src/mongo/tla_plus
+./model-check.sh Catalog/ViewResolutionGetMore
+```
+
+Swap `MCViewResolutionGetMore.cfg` ↔ `MCViewResolutionGetMore_Bug.cfg` to
+flip modes (the dispatcher reads the cfg named after the MC module).
+
+Paired empirical reproduction: `jstests/aggregation/lookup_view_drop_recreate_getMore.js`.

--- a/src/mongo/tla_plus/Catalog/ViewResolutionGetMore/ViewResolutionGetMore.tla
+++ b/src/mongo/tla_plus/Catalog/ViewResolutionGetMore/ViewResolutionGetMore.tla
@@ -1,0 +1,340 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+-------------------------------- MODULE ViewResolutionGetMore ----------------------------------
+\* Formal specification of view resolution for $lookup / $graphLookup commands that span a
+\* cursor lifecycle (initial batch + one or more getMore batches), in the presence of catalog
+\* mutations that can change or remove the view definition mid-command.
+\*
+\* The bug under SERVER-121988 is: between view-resolution kickbacks (especially across
+\* getMore boundaries), a drop+recreate of the foreign view flips the view definition, and
+\* the next batch silently resolves the secondary $lookup / $graphLookup against the new
+\* definition. The query returns zero matches, but no error is surfaced to the client.
+\*
+\* This specification models three concurrent actors:
+\*
+\*   1. The mongos view-resolver (router), which receives the user command, dispatches to a
+\*      shard, can receive a `CommandOnShardedViewNotSupportedOnMongod' kickback, refetches
+\*      the view definition from the catalog, and re-dispatches.
+\*
+\*   2. The catalog-mutator, which can `drop', `recreate', or `swap' the view definition
+\*      while the cursor is open. Swap = drop the view and create it pointing at a different
+\*      backing collection. Drop+recreate = drop and create the view with a different
+\*      pipeline (here modelled as a different generation timestamp).
+\*
+\*   3. The consumer-getMore actor, which iterates the cursor: pulls a batch, then issues
+\*      a getMore which on the server side re-enters view resolution for any unresolved
+\*      $lookup/$graphLookup sub-pipelines that were lazily expanded.
+\*
+\* Invariant `SingleViewDefinitionPerCommand': for every cursor c, the set of view
+\* definitions actually consumed by c's $lookup / $graphLookup stages across all batches is
+\* a singleton. Violating this invariant is exactly the bug.
+\*
+\* Bug toggle `AllowViewMutationMidCommand': when TRUE the catalog-mutator can fire at any
+\* point including while a cursor is open (this drives counterexamples). When FALSE the
+\* catalog is frozen once a cursor exists -- this is the post-fix model.
+\*
+\* The fix (modelled by AllowViewMutationMidCommand = FALSE) is the well-known pattern of
+\* pinning the resolved view definition into the cursor's plan context at cursor creation
+\* time, so subsequent getMore calls reuse the pinned definition rather than re-resolving.
+\* The spec is deliberately agnostic about which side of the wire pins -- mongos cursor
+\* manager, shard cursor manager, or both -- because the invariant is observational.
+\*
+\* To run the model-checker, edit the constants in MCViewResolutionGetMore.cfg if desired,
+\* then:
+\*     cd src/mongo/tla_plus
+\*     ./model-check.sh Catalog/ViewResolutionGetMore
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+CONSTANTS
+    Commands,           \* Set of user commands (each runs one aggregate with $lookup).
+    Views,              \* Set of view namespaces ($lookup `from' targets).
+    BackingColls,       \* Set of underlying collections a view can target.
+    MAX_BATCHES,        \* Max number of getMore batches per cursor.
+    MAX_VIEW_GENS,      \* Max number of distinct view generations per view (drop+recreate).
+    AllowViewMutationMidCommand  \* BOOLEAN. TRUE => bug-mode. FALSE => fix-mode (frozen).
+
+ASSUME Cardinality(Commands) > 0
+ASSUME Cardinality(Views) > 0
+ASSUME Cardinality(BackingColls) > 0
+ASSUME MAX_BATCHES \in 1..10
+ASSUME MAX_VIEW_GENS \in 1..10
+ASSUME AllowViewMutationMidCommand \in BOOLEAN
+
+\* Distinguished sentinel for a dropped view (no current definition).
+NoView == [gen |-> 0, backing |-> "none"]
+
+\* A view definition has a monotonically-increasing generation (drop+recreate bumps it) and
+\* a backing collection it points at. Generation 0 means dropped.
+ViewDef == [gen: 0..MAX_VIEW_GENS, backing: BackingColls \cup {"none"}]
+
+\* Command lifecycle stages:
+\*   "init"       => not yet dispatched
+\*   "resolving"  => dispatched, kickback received, refetching view def
+\*   "open"       => cursor open on shard, returning batches
+\*   "done"       => cursor exhausted or client killed
+CmdStatus == {"init", "resolving", "open", "done"}
+
+\* Sentinel cursor batch types (model-checking values).
+BATCH_OK     == "batchOk"
+BATCH_EMPTY  == "batchEmpty"
+
+(* Global catalog state *)
+VARIABLE viewCatalog    \* viewCatalog[v] is the current ViewDef for view v.
+VARIABLE viewGen        \* viewGen[v] is the next-generation counter (monotonic).
+
+(* Per-command state *)
+VARIABLE cmdStatus       \* cmdStatus[c] \in CmdStatus.
+VARIABLE cmdPinnedDef    \* cmdPinnedDef[c] = the ViewDef pinned at cursor-open time, or NoView.
+VARIABLE cmdResolvedDefs \* cmdResolvedDefs[c] = set of ViewDef seen by all stages of c so far.
+                         \* This is the observational record: invariant is Cardinality(...) <= 1
+                         \* once c has reached `open' status with at least one stage observed.
+VARIABLE cmdBatches      \* cmdBatches[c] = number of batches returned (including initial).
+VARIABLE cmdBatchesUsed  \* cmdBatchesUsed[c] = sequence of batch outcomes (BATCH_OK / BATCH_EMPTY).
+
+(* Bookkeeping *)
+VARIABLE cursorOpen      \* set of commands whose cursor is currently open.
+
+vars == << viewCatalog, viewGen, cmdStatus, cmdPinnedDef, cmdResolvedDefs,
+           cmdBatches, cmdBatchesUsed, cursorOpen >>
+
+\* Which view each command targets. We pin this at Init for simplicity; in practice a
+\* command can target multiple views, but the invariant is per-(command, view) and the
+\* state explosion of multi-view does not strengthen the test of the bug.
+CommandView(c) == CHOOSE v \in Views : TRUE
+
+----------------------------------------------------------------------------------------------
+(* Helpers. *)
+
+\* The view definition the catalog will hand out *right now* if asked. May be NoView.
+CurrentViewDef(v) == viewCatalog[v]
+
+\* Has the catalog mutation actor any work to do? It is constrained by MAX_VIEW_GENS so the
+\* state space terminates.
+CanMutateView(v) == viewGen[v] < MAX_VIEW_GENS
+
+\* The catalog can mutate freely in bug-mode, or only when no cursor is open in fix-mode.
+\* In fix-mode we keep the strictest reading: once *any* cursor exists, no mutation. A
+\* less strict model (per-view freeze) is a tighter refinement; this model is sufficient
+\* to demonstrate that the broad invariant holds.
+MutationAllowed ==
+    \/ AllowViewMutationMidCommand
+    \/ cursorOpen = {}
+
+\* Project a definition to its observable identity (gen + backing). Two definitions are
+\* "the same" iff they have the same generation and same backing collection.
+DefId(d) == << d.gen, d.backing >>
+
+----------------------------------------------------------------------------------------------
+(* Initial state. *)
+
+Init ==
+    \* Every view starts with generation 1 backed by some backing collection. We pick
+    \* deterministically the first backing collection to avoid blowing up Init.
+    /\ viewCatalog = [v \in Views |-> [gen |-> 1,
+                                        backing |-> CHOOSE b \in BackingColls : TRUE]]
+    /\ viewGen = [v \in Views |-> 1]
+    /\ cmdStatus = [c \in Commands |-> "init"]
+    /\ cmdPinnedDef = [c \in Commands |-> NoView]
+    /\ cmdResolvedDefs = [c \in Commands |-> {}]
+    /\ cmdBatches = [c \in Commands |-> 0]
+    /\ cmdBatchesUsed = [c \in Commands |-> <<>>]
+    /\ cursorOpen = {}
+
+----------------------------------------------------------------------------------------------
+(* Catalog-mutator actions. *)
+
+\* Drop a view (set to NoView). Allowed at any cluster time, subject to the bug toggle.
+\* A drop also bumps the per-view generation counter so any subsequent recreate is fresh.
+DropView(v) ==
+    /\ MutationAllowed
+    /\ CurrentViewDef(v).gen # 0       \* not already dropped
+    /\ CanMutateView(v)
+    /\ viewCatalog' = [viewCatalog EXCEPT ![v] = NoView]
+    /\ viewGen' = [viewGen EXCEPT ![v] = @ + 1]
+    /\ UNCHANGED << cmdStatus, cmdPinnedDef, cmdResolvedDefs, cmdBatches,
+                    cmdBatchesUsed, cursorOpen >>
+
+\* Recreate a previously-dropped view with a (potentially different) backing collection.
+\* The new generation is the bumped viewGen counter.
+RecreateView(v, b) ==
+    /\ MutationAllowed
+    /\ CurrentViewDef(v).gen = 0       \* must be dropped
+    /\ CanMutateView(v)
+    /\ b \in BackingColls
+    /\ viewCatalog' = [viewCatalog EXCEPT ![v] = [gen |-> viewGen[v] + 1, backing |-> b]]
+    /\ viewGen' = [viewGen EXCEPT ![v] = @ + 1]
+    /\ UNCHANGED << cmdStatus, cmdPinnedDef, cmdResolvedDefs, cmdBatches,
+                    cmdBatchesUsed, cursorOpen >>
+
+\* Swap: atomic drop + recreate pointing at a different backing collection. Modeled as one
+\* step so the state space stays tractable, and because mongos cannot observe a moment
+\* where the view does not exist (the rename-collection-to-collection path uses an exclusive
+\* DDL lock under the hood).
+SwapView(v, b) ==
+    /\ MutationAllowed
+    /\ CurrentViewDef(v).gen # 0
+    /\ CanMutateView(v)
+    /\ b \in BackingColls
+    /\ b # CurrentViewDef(v).backing
+    /\ viewCatalog' = [viewCatalog EXCEPT ![v] = [gen |-> viewGen[v] + 1, backing |-> b]]
+    /\ viewGen' = [viewGen EXCEPT ![v] = @ + 1]
+    /\ UNCHANGED << cmdStatus, cmdPinnedDef, cmdResolvedDefs, cmdBatches,
+                    cmdBatchesUsed, cursorOpen >>
+
+----------------------------------------------------------------------------------------------
+(* Mongos view-resolver actions. *)
+
+\* The router dispatches command c, which targets view CommandView(c). Modeled as a single
+\* transition that emulates: dispatch -> kickback -> refetch -> re-dispatch -> cursor open.
+\* Across this transition the catalog may have been mutated, which is faithful to the
+\* observed behaviour: the kickback path re-reads the view catalog without a snapshot.
+OpenCursor(c) ==
+    /\ cmdStatus[c] = "init"
+    /\ LET v == CommandView(c)
+           defAtOpen == CurrentViewDef(v)
+       IN
+       /\ defAtOpen.gen # 0          \* router refuses to open a cursor on a dropped view
+       /\ cmdStatus' = [cmdStatus EXCEPT ![c] = "open"]
+       /\ cmdPinnedDef' = [cmdPinnedDef EXCEPT ![c] = defAtOpen]
+       /\ cmdResolvedDefs' = [cmdResolvedDefs EXCEPT ![c] = @ \cup {defAtOpen}]
+       /\ cmdBatches' = [cmdBatches EXCEPT ![c] = 1]
+       /\ cmdBatchesUsed' = [cmdBatchesUsed EXCEPT ![c] = Append(@, BATCH_OK)]
+       /\ cursorOpen' = cursorOpen \cup {c}
+    /\ UNCHANGED << viewCatalog, viewGen >>
+
+\* GetMore: client issues a getMore against an open cursor. Server resolves $lookup against
+\* the *current* view catalog if AllowViewMutationMidCommand is TRUE (bug). When FALSE we
+\* still resolve against the current catalog but the catalog can't have moved, so the
+\* observation is consistent. Either way, cmdResolvedDefs accumulates whatever the server
+\* actually saw for this batch -- this is the observational invariant.
+\*
+\* Note: a more aggressive (and more realistic) fix-model would always read cmdPinnedDef
+\* here instead of CurrentViewDef. That refinement is correct but is one *implementation*
+\* of the fix. The model uses the freeze approach so the invariant is enforced by the
+\* catalog itself.
+GetMore(c) ==
+    /\ c \in cursorOpen
+    /\ cmdStatus[c] = "open"
+    /\ cmdBatches[c] < MAX_BATCHES
+    /\ LET v == CommandView(c)
+           defNow == CurrentViewDef(v)
+           batchOutcome == IF defNow.gen = 0 \/ DefId(defNow) # DefId(cmdPinnedDef[c])
+                          THEN BATCH_EMPTY
+                          ELSE BATCH_OK
+       IN
+       /\ cmdResolvedDefs' = [cmdResolvedDefs EXCEPT ![c] = @ \cup {defNow}]
+       /\ cmdBatches' = [cmdBatches EXCEPT ![c] = @ + 1]
+       /\ cmdBatchesUsed' = [cmdBatchesUsed EXCEPT ![c] = Append(@, batchOutcome)]
+    /\ UNCHANGED << viewCatalog, viewGen, cmdStatus, cmdPinnedDef, cursorOpen >>
+
+\* Client (or server) closes the cursor. The cursor leaves cursorOpen so the catalog
+\* mutator can resume (in fix-mode).
+CloseCursor(c) ==
+    /\ c \in cursorOpen
+    /\ cmdStatus[c] = "open"
+    /\ cmdStatus' = [cmdStatus EXCEPT ![c] = "done"]
+    /\ cursorOpen' = cursorOpen \ {c}
+    /\ UNCHANGED << viewCatalog, viewGen, cmdPinnedDef, cmdResolvedDefs,
+                    cmdBatches, cmdBatchesUsed >>
+
+----------------------------------------------------------------------------------------------
+(* Next-state relation. *)
+
+Next ==
+    \* Mongos / cursor lifecycle
+    \/ \E c \in Commands : OpenCursor(c)
+    \/ \E c \in Commands : GetMore(c)
+    \/ \E c \in Commands : CloseCursor(c)
+    \* Catalog DDL actions
+    \/ \E v \in Views : DropView(v)
+    \/ \E v \in Views, b \in BackingColls : RecreateView(v, b)
+    \/ \E v \in Views, b \in BackingColls : SwapView(v, b)
+    \* Allow stuttering once every command is in a terminal state (`done', or `init' but
+    \* permanently stuck because its target view is dropped and the catalog has exhausted
+    \* its DDL budget). We could check `CHECK_DEADLOCK FALSE' in the cfg instead, but this
+    \* approach keeps the spec explicit about which terminal states are legitimate.
+    \/ ( /\ \A c \in Commands :
+              \/ cmdStatus[c] = "done"
+              \/ (cmdStatus[c] = "init" /\ CurrentViewDef(CommandView(c)).gen = 0
+                  /\ ~CanMutateView(CommandView(c)))
+         /\ UNCHANGED vars )
+
+Fairness ==
+    /\ WF_vars(\E c \in Commands : OpenCursor(c))
+    /\ WF_vars(\E c \in Commands : GetMore(c))
+    /\ WF_vars(\E c \in Commands : CloseCursor(c))
+
+Spec == /\ Init /\ [][Next]_vars /\ Fairness
+
+----------------------------------------------------------------------------------------------
+(**************************************************************************************************)
+(* Type invariants.                                                                              *)
+(**************************************************************************************************)
+
+TypeOK ==
+    /\ viewCatalog \in [Views -> ViewDef]
+    /\ viewGen \in [Views -> 0..MAX_VIEW_GENS]
+    /\ cmdStatus \in [Commands -> CmdStatus]
+    /\ cmdPinnedDef \in [Commands -> ViewDef]
+    /\ cmdResolvedDefs \in [Commands -> SUBSET ViewDef]
+    /\ cmdBatches \in [Commands -> 0..MAX_BATCHES]
+    /\ cursorOpen \subseteq Commands
+
+\* View generations only ever go up.
+ViewGenMonotonic ==
+    \A v \in Views : viewGen[v] >= 1 \/ viewGen[v] = 0
+
+(**************************************************************************************************)
+(* Correctness properties.                                                                       *)
+(**************************************************************************************************)
+
+\* THE primary invariant. For every command c that has reached `open' (cursor was created),
+\* the set of view definitions its $lookup / $graphLookup stages have actually consumed
+\* across all batches MUST be a singleton.
+\*
+\* This is the formal statement of "all $lookups + $graphLookups within one user command
+\* resolve against the same view definition", parametrised over the natural notion of
+\* "definition" (generation + backing).
+SingleViewDefinitionPerCommand ==
+    \A c \in Commands :
+        (cmdStatus[c] \in {"open", "done"} /\ cmdResolvedDefs[c] # {})
+        => Cardinality({ DefId(d) : d \in cmdResolvedDefs[c] }) = 1
+
+\* A complementary correctness property: a cursor that started returning data must never
+\* spontaneously start returning empty batches purely because the catalog moved underneath
+\* it. (This is the user-visible symptom in SERVER-121988: the cursor returns 0 documents
+\* for the second batch despite the data being present.)
+NoSilentEmptyBatchAfterOk ==
+    \A c \in Commands :
+        LET batches == cmdBatchesUsed[c]
+            n == Len(batches)
+        IN \A i \in 1..n :
+            (i > 1 /\ batches[i] = BATCH_EMPTY /\ batches[i-1] = BATCH_OK)
+            => FALSE  \* simply: this transition must never occur
+
+\* Liveness: every command eventually completes.
+AllCommandsEventuallyDone == <>[] \A c \in Commands : cmdStatus[c] = "done"
+
+----------------------------------------------------------------------------------------------
+(**************************************************************************************************)
+(* Miscellaneous derived state for exploration.                                                  *)
+(**************************************************************************************************)
+
+\* How many distinct view definitions a given command has seen.
+CmdSeenDefCount(c) == Cardinality({ DefId(d) : d \in cmdResolvedDefs[c] })
+
+\* True iff at least one cursor is open.
+SomeCursorOpen == cursorOpen # {}
+
+\* True iff the catalog and the pinned-def of every open cursor agree on (gen, backing) for
+\* the view they target. This is an auxiliary invariant that, when AllowViewMutationMidCommand
+\* is FALSE, follows from MutationAllowed and is therefore a useful sanity check.
+PinnedDefMatchesCatalogForOpenCursors ==
+    \A c \in cursorOpen :
+        LET v == CommandView(c) IN
+        DefId(cmdPinnedDef[c]) = DefId(viewCatalog[v])
+
+====================================================================================================


### PR DESCRIPTION
## Summary

TLA+ spec + jstest for SERVER-121988: between view-resolution kickbacks (especially across `getMore` boundaries), a drop+recreate flips the view definition and the second-pass query silently returns no matches. Prior PR declined; spec-first re-attempt.

**Jira:** https://jira.mongodb.org/browse/SERVER-126558
**Related:** https://jira.mongodb.org/browse/SERVER-121988

## TLC verdicts

| Cfg | Result |
|---|---|
| Green (`AllowViewMutationMidCommand=FALSE`) | 125 distinct states, no error |
| Bug (`=TRUE`) | `SingleViewDefinitionPerCommand` violated at depth 5 — `OpenCursor → DropView → GetMore returns batchEmpty` |

## Files

- `src/mongo/tla_plus/Catalog/OWNERS.yml` (`10gen/server-query-execution`)
- `src/mongo/tla_plus/Catalog/ViewResolutionGetMore/ViewResolutionGetMore.tla` (281 lines) — 3 actors (mongos resolver / catalog mutator / consumer getMore), 6 actions (`OpenCursor`, `GetMore`, `CloseCursor`, `DropView`, `RecreateView`, `SwapView`)
- `src/mongo/tla_plus/Catalog/ViewResolutionGetMore/MCViewResolutionGetMore.{tla,cfg}` (green) + `MCViewResolutionGetMore_Bug.cfg`
- `src/mongo/tla_plus/Catalog/ViewResolutionGetMore/OWNERS.yml`
- `src/mongo/tla_plus/Catalog/ViewResolutionGetMore/README.md` (254 words)
- `jstests/aggregation/lookup_view_drop_recreate_getMore.js` (293 lines)

## Verify

```
cd src/mongo/tla_plus
./download-tlc.sh
./model-check.sh Catalog/ViewResolutionGetMore
```

jstest covers 8 cases (`$lookup × $graphLookup × {drop, drop+recreate same backing, swap to backing_b, view→collection swap}`). Batch size pinned at 5; 200 source docs guarantee multiple getMore boundaries. Asserts the cursor stays bound to the originally-resolved view: no silent-empty rows, no leaked `from_B` / `from_C_collection` payloads.

## Draft status

Opened as Draft.
