### PR TITLE
SERVER-126560 Add TLA+ spec + jstest for balancer round after balancerStop:1 returns OK

### DIFF
--- a/jstests/sharding/balancer_stop_no_round_after_return.js
+++ b/jstests/sharding/balancer_stop_no_round_after_return.js
@@ -1,0 +1,196 @@
+/**
+ * Reproduces SERVER-100155 (CAR-impact 5).
+ *
+ * Once `_configsvrBalancerStop` returns OK to the operator, no migration is permitted to commit.
+ * The bug lets a stepdown-interrupted balancer round mark itself complete (via `_endRound`) while
+ * a migration is still `commitInFlight` on the shard side, so `joinCurrentRound` returns OK but a
+ * later commit lands on disk -- breaking every operator workflow that runs `mongodump` or
+ * `mongosync` after stopping the balancer.
+ *
+ * The test:
+ *   1. Boots a 3-node CSRS with 2 shards.
+ *   2. Shards a collection and pre-splits it so the balancer has work.
+ *   3. Pins the donor at `hangBeforeSendingCommitDecision` so the migration is `commitInFlight`
+ *      from the recipient's point of view but cannot finalize.
+ *   4. Steps down the CSRS primary while the migration is pinned (mirrors the
+ *      `InterruptedDueToReplStateChange' path inside `Balancer::_mainThread`).
+ *   5. After the new primary is up, fires `balancerStop` and records the moment it returns OK.
+ *   6. Releases the pinned commit decision and asserts that no migration finalised after the
+ *      recorded OK timestamp. The buggy implementation lets the commit slip through; the fix
+ *      keeps the migration pending until the round actually drains.
+ *
+ * @tags: [
+ *   requires_fcv_80,
+ *   requires_sharding,
+ *   requires_replication,
+ *   does_not_support_stepdowns,
+ * ]
+ */
+
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {funWithArgs} from "jstests/libs/parallel_shell_helpers.js";
+import {ShardingTest} from "jstests/libs/shardingtest.js";
+import {findChunksUtil} from "jstests/sharding/libs/find_chunks_util.js";
+
+const st = new ShardingTest({
+    shards: 2,
+    config: 3,
+    other: {
+        enableBalancer: false,
+        configOptions: {
+            setParameter: {
+                // Speed up balancer rounds so the test is not blocked on default throttling.
+                balancerMigrationsThrottlingMs: 0,
+            },
+        },
+    },
+});
+
+const dbName = "test_server100155";
+const collName = "moveable";
+const ns = `${dbName}.${collName}`;
+
+assert.commandWorked(st.s.adminCommand({enableSharding: dbName, primaryShard: st.shard0.shardName}));
+assert.commandWorked(st.s.adminCommand({shardCollection: ns, key: {x: 1}}));
+
+// Pre-split so the balancer has imbalance to act on, with both halves currently on shard0.
+assert.commandWorked(st.s.adminCommand({split: ns, middle: {x: 0}}));
+
+const coll = st.s.getDB(dbName)[collName];
+const bulk = coll.initializeUnorderedBulkOp();
+for (let i = -50; i < 50; i++) {
+    bulk.insert({x: i, payload: "x".repeat(1024)});
+}
+assert.commandWorked(bulk.execute());
+
+// -------------------------------------------------------------------------------------------------
+// Pin the donor mid-commit. The recipient has already accepted the clone, so from its perspective
+// the migration is `commitInFlight'. The donor will sit at `hangBeforeSendingCommitDecision` until
+// we release it after balancerStop has returned.
+// -------------------------------------------------------------------------------------------------
+const donor = st.shard0;
+const hangCommit = configureFailPoint(donor, "hangBeforeSendingCommitDecision");
+
+// Issue the migration in a parallel shell so we can drive the rest of the scenario while it hangs.
+const moveRangeShell = startParallelShell(
+    funWithArgs(function (nss, toShard) {
+        // The command may fail with InterruptedDueToReplStateChange if the CSRS steps down while
+        // the commit is in flight. That outcome is fine; what matters for this test is the shard-
+        // side commit decision the donor has already prepared, not the success of this RPC.
+        const ret = db.getSiblingDB("admin").runCommand({
+            moveRange: nss,
+            min: {x: 0},
+            toShard: toShard,
+            secondaryThrottle: false,
+            waitForDelete: false,
+        });
+        jsTest.log("moveRange parallel shell returned: " + tojson(ret));
+    }, ns, st.shard1.shardName),
+    st.s.port,
+);
+
+hangCommit.wait();
+jsTest.log("Donor pinned at hangBeforeSendingCommitDecision; CSRS stepdown next.");
+
+// -------------------------------------------------------------------------------------------------
+// Step down the CSRS. `Balancer::onStepDown' fires `requestTermination', which marks the
+// balancer's `_threadOperationContext' killed -- mirroring the `InterruptedDueToReplStateChange'
+// path inside `_mainThread`. After step-up on a new primary, the balancer is `mode=full' again,
+// but the previous round's in-flight commit is still pinned on the donor.
+// -------------------------------------------------------------------------------------------------
+const oldPrimary = st.configRS.getPrimary();
+const newPrimary = st.configRS.getSecondaries()[0];
+jsTest.log(`Stepping down ${oldPrimary.host}; new primary will be ${newPrimary.host}.`);
+st.configRS.stepUp(newPrimary);
+st.configRS.awaitReplication();
+assert.eq(st.configRS.getPrimary().host, newPrimary.host, "stepUp did not promote the chosen node");
+
+// -------------------------------------------------------------------------------------------------
+// Issue balancerStop. With the fix in place, joinCurrentRound must NOT return OK until the
+// pinned commit is drained (committed or aborted). With the bug present, balancerStop will return
+// OK while the commit is still pinned on the donor; the failpoint release below then commits the
+// migration AFTER OK -- the violation we are pinning.
+// -------------------------------------------------------------------------------------------------
+let okTimestamp = null;
+const balancerStopShell = startParallelShell(
+    funWithArgs(function () {
+        const ret = assert.commandWorked(db.getSiblingDB("admin").runCommand({balancerStop: 1}));
+        // Stamp the moment OK was observed -- the operator's "the cluster is quiesced" point.
+        // The shell writes back via a sentinel collection that the parent reads after join.
+        assert.commandWorked(
+            db.getSiblingDB("test_server100155").server100155_sentinel.insert({
+                _id: "stop_ok_at",
+                clusterTime: new Date(),
+                response: ret,
+            }),
+        );
+    }),
+    st.s.port,
+);
+
+// Give balancerStop a beat to enter joinCurrentRound. If the bug is present, OK lands almost
+// immediately because `_inBalancerRound' was already cleared on the interrupt path. If the fix is
+// present, joinCurrentRound spins waiting for the round to drain -- the failpoint release below
+// is the only way out.
+sleep(2000);
+
+// -------------------------------------------------------------------------------------------------
+// Release the pinned commit. Any migration that finalises from this point onward must NOT
+// observe `stopReturnedOk = TRUE' (in spec terms). If it does, we have reproduced SERVER-100155.
+// -------------------------------------------------------------------------------------------------
+jsTest.log("Releasing hangBeforeSendingCommitDecision; recipient is now free to finalise commit.");
+hangCommit.off();
+
+moveRangeShell();
+balancerStopShell();
+
+const sentinel = st.s.getDB("test_server100155").server100155_sentinel.findOne({_id: "stop_ok_at"});
+assert.neq(sentinel, null, "balancerStop parallel shell never recorded its OK timestamp");
+const stopOkAt = sentinel.clusterTime;
+jsTest.log(`balancerStop returned OK at ${stopOkAt.toISOString()}.`);
+
+// -------------------------------------------------------------------------------------------------
+// THE LOAD-BEARING ASSERTION.
+//
+// Walk every chunk for the namespace. None of them may have been written to disk AFTER the
+// moment balancerStop returned OK. Chunks are stamped with `lastmod' / `lastmodEpoch'; the
+// `history' array on each chunk records every ownership transition with a `validAfter' timestamp.
+// We check both surfaces: any `validAfter' newer than `stopOkAt' is a SERVER-100155 violation.
+// -------------------------------------------------------------------------------------------------
+const configDB = st.s.getDB("config");
+const chunks = findChunksUtil.findChunksByNs(configDB, ns).toArray();
+assert.gt(chunks.length, 0, "expected at least one chunk for the test namespace");
+
+let violations = [];
+for (const chunk of chunks) {
+    if (!Array.isArray(chunk.history)) {
+        continue;
+    }
+    for (const entry of chunk.history) {
+        // `validAfter' is a Timestamp (clusterTime); compare against the JS Date we stamped.
+        const validAfterMs = entry.validAfter.getTime() * 1000;
+        if (validAfterMs > stopOkAt.getTime()) {
+            violations.push({
+                chunkId: chunk._id,
+                shard: entry.shard,
+                validAfter: entry.validAfter,
+                stopOkAt: stopOkAt,
+            });
+        }
+    }
+}
+
+assert.eq(
+    violations.length,
+    0,
+    "SERVER-100155: migration(s) finalised AFTER balancerStop returned OK: " + tojson(violations),
+);
+
+// Verify balancer is actually stopped now (post-condition).
+const status = assert.commandWorked(st.s.adminCommand({balancerStatus: 1}));
+assert.eq(status.mode, "off", "balancer mode should be off after balancerStop returned OK");
+assert.eq(status.inBalancerRound, false, "no balancer round should be in flight after balancerStop");
+
+jsTest.log("SERVER-100155 regression check passed: no migration committed after balancerStop OK.");
+
+st.stop();

--- a/src/mongo/tla_plus/Sharding/BalancerStopRace/BalancerStopRace.tla
+++ b/src/mongo/tla_plus/Sharding/BalancerStopRace/BalancerStopRace.tla
@@ -1,0 +1,306 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+------------------------------- MODULE BalancerStopRace -------------------------------------------
+\* This specification models the race between `_configsvrBalancerStop' (which calls
+\* `Balancer::joinCurrentRound') and the migration commit path on a config-server replica set
+\* that may step down mid-round. The bug being modelled is SERVER-100155 (CAR-impact 5):
+\*
+\*   The balancer thread is running a round and has dispatched a moveRange to a recipient shard.
+\*   The config server steps down. `onStepDown' calls `requestTermination', which marks the
+\*   balancer's thread operation context killed. The balancer round catches the
+\*   `InterruptedDueToReplStateChange' exception inside `_mainThread' and calls `_endRound', which
+\*   clears `_inBalancerRound' and increments `_numBalancerRounds'. A subsequent `balancerStop'
+\*   command observes `_inBalancerRound == false' and `joinCurrentRound' returns OK.
+\*
+\*   However, the migration command that was forked to the recipient shard was not durably
+\*   cancelled: the recipient may still commit the migration (via the migration coordinator
+\*   recovery code on the new primary, or via a retry from the command scheduler that survived the
+\*   step-down). The result: a migration finalizes AFTER `balancerStop' returned OK, which breaks
+\*   every operator workflow that runs `mongodump' / `mongosync' after stopping the balancer.
+\*
+\* The spec composes three actors:
+\*   * Balancer coordinator   -- `_mainThread' rounds, `_inBalancerRound', `_numBalancerRounds'
+\*   * Config-server stepdown -- `onStepDown' -> `requestTermination'
+\*   * Migration commit path  -- the shard-side commit, which is the surviving in-flight work
+\*
+\* Run the model-checker:
+\*     cd src/mongo/tla_plus
+\*     ./model-check.sh Sharding/BalancerStopRace
+\*
+\* The model-check config exposes a bug toggle, `AllowStepdownInterleave', that flips between the
+\* fixed implementation (the balancer waits for in-flight commits to drain before clearing
+\* `_inBalancerRound') and the buggy implementation (the round is marked complete as soon as the
+\* config-server thread is interrupted).
+\*
+\* Design choice: migration state is a fixed-arity function over `1..MaxMigrations' rather than a
+\* `Sequence', so TLC does not distinguish behaviours that differ only in the order migrations are
+\* dispatched. This keeps the state space tractable while preserving every interleaving relevant
+\* to the bug.
+
+EXTENDS Naturals, FiniteSets, TLC
+
+CONSTANTS
+    MaxMigrations,          \* Bound on migrations the balancer will attempt (>= 1).
+    MaxStopCalls,           \* Bound on operator balancerStop invocations (>= 1).
+    AllowStepdownInterleave \* TRUE enables the buggy interleaving; FALSE asserts the fix.
+
+ASSUME MaxMigrations \in 1..4
+ASSUME MaxStopCalls \in 1..2
+ASSUME AllowStepdownInterleave \in BOOLEAN
+
+\* Slot identifiers for the bounded migration table.
+MigrationSlots == 1..MaxMigrations
+
+\* Migration lifecycle states.
+\*   "unset"          -- slot has not been used by the balancer yet
+\*   "commitInFlight" -- the donor has prepared a commit decision but the shard-side commit has
+\*                       not been finalised. This is the state in which the race window opens.
+\*   "committed"      -- the migration is durably committed on the shard.
+\*   "aborted"        -- the migration was cancelled before commit.
+MigrationStateValues == {"unset", "commitInFlight", "committed", "aborted"}
+
+\* Balancer coordinator state ----------------------------------------------------------------------
+VARIABLE balancerMode       \* "full" | "off"   -- the persisted balancer setting.
+VARIABLE inBalancerRound    \* Whether the main thread is inside a round.
+VARIABLE numBalancerRounds  \* Monotonic counter, ticked at every `_endRound'.
+VARIABLE threadState        \* "running" | "terminating" | "terminated".
+VARIABLE threadInterrupted  \* TRUE iff `_threadOperationContext' was marked killed.
+
+\* Per-slot migration state ------------------------------------------------------------------------
+VARIABLE migrationState     \* [MigrationSlots -> MigrationStateValues]
+
+\* Operator-visible state --------------------------------------------------------------------------
+VARIABLE stopRequested      \* TRUE once an operator has invoked balancerStop.
+VARIABLE stopReturnedOk     \* TRUE once joinCurrentRound has returned OK to the operator.
+VARIABLE stopCallsIssued    \* Bound counter.
+
+\* History/observability ghost variables -----------------------------------------------------------
+VARIABLE commitsAfterStopOk \* Count of commits that finalised AFTER stopReturnedOk = TRUE.
+
+vars == <<balancerMode, inBalancerRound, numBalancerRounds, threadState, threadInterrupted,
+          migrationState, stopRequested, stopReturnedOk, stopCallsIssued, commitsAfterStopOk>>
+
+\* Helpers -----------------------------------------------------------------------------------------
+UnusedSlots       == {i \in MigrationSlots : migrationState[i] = "unset"}
+InFlightSlots     == {i \in MigrationSlots : migrationState[i] = "commitInFlight"}
+NoInFlight        == InFlightSlots = {}
+
+\* The fixed predicate that the balancer must observe before clearing `_inBalancerRound':
+\* drain every in-flight commit. With `AllowStepdownInterleave = TRUE' this drain is bypassed on
+\* the stepdown-interrupt path, reproducing the bug.
+SafeToEndRound == NoInFlight
+
+Init ==
+    /\ balancerMode = "full"
+    /\ inBalancerRound = FALSE
+    /\ numBalancerRounds = 0
+    /\ threadState = "running"
+    /\ threadInterrupted = FALSE
+    /\ migrationState = [i \in MigrationSlots |-> "unset"]
+    /\ stopRequested = FALSE
+    /\ stopReturnedOk = FALSE
+    /\ stopCallsIssued = 0
+    /\ commitsAfterStopOk = 0
+
+\* -------------------------------------------------------------------------------------------------
+\* Balancer round actions
+\* -------------------------------------------------------------------------------------------------
+
+\* Action: `_mainThread' begins a balancer round.
+BeginRound ==
+    /\ threadState = "running"
+    /\ ~threadInterrupted
+    /\ ~inBalancerRound
+    /\ balancerMode = "full"
+    /\ inBalancerRound' = TRUE
+    /\ UNCHANGED <<balancerMode, numBalancerRounds, threadState, threadInterrupted,
+                   migrationState, stopRequested, stopReturnedOk, stopCallsIssued,
+                   commitsAfterStopOk>>
+
+\* Action: the coordinator dispatches a moveRange. The recipient has accepted the clone, so from
+\* its perspective the migration is `commitInFlight'. The prepare/critical-section phases are
+\* collapsed because they do not change the race: the substantive race is between the
+\* coordinator's view of "round done" and the shard's view of "commit in flight".
+DispatchMigration ==
+    /\ threadState = "running"
+    /\ ~threadInterrupted
+    /\ inBalancerRound
+    /\ \E slot \in UnusedSlots :
+        migrationState' = [migrationState EXCEPT ![slot] = "commitInFlight"]
+    /\ UNCHANGED <<balancerMode, inBalancerRound, numBalancerRounds, threadState,
+                   threadInterrupted, stopRequested, stopReturnedOk, stopCallsIssued,
+                   commitsAfterStopOk>>
+
+\* Action: the recipient shard durably commits a migration. This can happen even while the
+\* coordinator's `OperationContext' has been killed -- the command scheduler's future-chain has
+\* already been forked to the shard. After a step-up on the new primary, the migration coordinator
+\* recovery code may also drive the commit forward; both interleavings collapse into this action.
+ShardCommitsMigration ==
+    /\ \E slot \in InFlightSlots :
+        /\ migrationState' = [migrationState EXCEPT ![slot] = "committed"]
+        /\ commitsAfterStopOk' =
+            IF stopReturnedOk
+                THEN commitsAfterStopOk + 1
+                ELSE commitsAfterStopOk
+    /\ UNCHANGED <<balancerMode, inBalancerRound, numBalancerRounds, threadState,
+                   threadInterrupted, stopRequested, stopReturnedOk, stopCallsIssued>>
+
+\* Action: a dispatched-but-not-yet-committed migration is cleanly aborted. This is the abort
+\* path that respects the balancerStop contract: it must complete BEFORE the coordinator clears
+\* `_inBalancerRound'.
+ShardAbortsMigration ==
+    /\ \E slot \in InFlightSlots :
+        migrationState' = [migrationState EXCEPT ![slot] = "aborted"]
+    /\ UNCHANGED <<balancerMode, inBalancerRound, numBalancerRounds, threadState,
+                   threadInterrupted, stopRequested, stopReturnedOk, stopCallsIssued,
+                   commitsAfterStopOk>>
+
+\* Action: clean round end. The coordinator drained every in-flight migration before clearing
+\* `_inBalancerRound' and ticking `_numBalancerRounds'. This is the correct behaviour.
+EndRoundClean ==
+    /\ inBalancerRound
+    /\ ~threadInterrupted
+    /\ SafeToEndRound
+    /\ inBalancerRound' = FALSE
+    /\ numBalancerRounds' = numBalancerRounds + 1
+    /\ UNCHANGED <<balancerMode, threadState, threadInterrupted, migrationState,
+                   stopRequested, stopReturnedOk, stopCallsIssued, commitsAfterStopOk>>
+
+\* Action: interrupted round end. The bug. With `AllowStepdownInterleave = TRUE', the coordinator
+\* clears `_inBalancerRound' as soon as the stepdown interrupts the thread, EVEN IF a migration
+\* is still `commitInFlight'. With the fix in place, the coordinator must still drain in-flight
+\* commits before declaring the round complete.
+EndRoundOnInterrupt ==
+    /\ inBalancerRound
+    /\ threadInterrupted
+    /\ \/ ~AllowStepdownInterleave /\ SafeToEndRound   \* fixed: drain first
+       \/ AllowStepdownInterleave                       \* bug: race past in-flight commits
+    /\ inBalancerRound' = FALSE
+    /\ numBalancerRounds' = numBalancerRounds + 1
+    /\ UNCHANGED <<balancerMode, threadState, threadInterrupted, migrationState,
+                   stopRequested, stopReturnedOk, stopCallsIssued, commitsAfterStopOk>>
+
+\* -------------------------------------------------------------------------------------------------
+\* Config-server stepdown actions
+\* -------------------------------------------------------------------------------------------------
+
+\* Action: `Balancer::onStepDown' -> `requestTermination'. Marks the thread's OperationContext
+\* killed and asks it to terminate. Does NOT wait for in-flight RPCs.
+StepDown ==
+    /\ threadState = "running"
+    /\ ~threadInterrupted
+    /\ threadInterrupted' = TRUE
+    /\ threadState' = "terminating"
+    /\ UNCHANGED <<balancerMode, inBalancerRound, numBalancerRounds, migrationState,
+                   stopRequested, stopReturnedOk, stopCallsIssued, commitsAfterStopOk>>
+
+\* Action: the balancer main thread observes the termination request, exits its loop and
+\* transitions to "terminated".
+ThreadTerminate ==
+    /\ threadState = "terminating"
+    /\ ~inBalancerRound
+    /\ threadState' = "terminated"
+    /\ UNCHANGED <<balancerMode, inBalancerRound, numBalancerRounds, threadInterrupted,
+                   migrationState, stopRequested, stopReturnedOk, stopCallsIssued,
+                   commitsAfterStopOk>>
+
+\* -------------------------------------------------------------------------------------------------
+\* Operator (balancerStop) actions
+\* -------------------------------------------------------------------------------------------------
+
+\* Action: an operator issues `balancerStop'. Persists `balancerMode = "off"' and enters
+\* `joinCurrentRound'.
+BalancerStopBegin ==
+    /\ stopCallsIssued < MaxStopCalls
+    /\ ~stopRequested
+    /\ stopRequested' = TRUE
+    /\ stopCallsIssued' = stopCallsIssued + 1
+    /\ balancerMode' = "off"
+    /\ UNCHANGED <<inBalancerRound, numBalancerRounds, threadState, threadInterrupted,
+                   migrationState, stopReturnedOk, commitsAfterStopOk>>
+
+\* Action: `joinCurrentRound' returns OK because the round has ended (or the thread terminated).
+\* This is the moment the operator is told "the balancer is stopped".
+BalancerStopReturnOk ==
+    /\ stopRequested
+    /\ ~stopReturnedOk
+    /\ \/ ~inBalancerRound                  \* round ended (clean or interrupted)
+       \/ threadState = "terminated"        \* thread fully drained
+    /\ stopReturnedOk' = TRUE
+    /\ UNCHANGED <<balancerMode, inBalancerRound, numBalancerRounds, threadState,
+                   threadInterrupted, migrationState, stopRequested, stopCallsIssued,
+                   commitsAfterStopOk>>
+
+\* -------------------------------------------------------------------------------------------------
+\* Spec
+\* -------------------------------------------------------------------------------------------------
+
+Next ==
+    \/ BeginRound
+    \/ DispatchMigration
+    \/ ShardCommitsMigration
+    \/ ShardAbortsMigration
+    \/ EndRoundClean
+    \/ EndRoundOnInterrupt
+    \/ StepDown
+    \/ ThreadTerminate
+    \/ BalancerStopBegin
+    \/ BalancerStopReturnOk
+
+\* Fairness: only what is needed to make the load-bearing liveness obligation meaningful when a
+\* PROPERTIES cfg enables it. The model is finite-state safe-check by default; liveness is
+\* optional and noted in the cfg.
+Fairness == WF_vars(BalancerStopReturnOk)
+
+Spec == /\ Init /\ [][Next]_vars /\ Fairness
+
+----------------------------------------------------------------------------------------------------
+(**************************************************************************************************)
+(* Type invariants                                                                                *)
+(**************************************************************************************************)
+
+TypeOK ==
+    /\ balancerMode \in {"full", "off"}
+    /\ inBalancerRound \in BOOLEAN
+    /\ numBalancerRounds \in Nat
+    /\ threadState \in {"running", "terminating", "terminated"}
+    /\ threadInterrupted \in BOOLEAN
+    /\ migrationState \in [MigrationSlots -> MigrationStateValues]
+    /\ stopRequested \in BOOLEAN
+    /\ stopReturnedOk \in BOOLEAN
+    /\ stopCallsIssued \in 0..MaxStopCalls
+    /\ commitsAfterStopOk \in Nat
+
+(**************************************************************************************************)
+(* Correctness invariants                                                                         *)
+(**************************************************************************************************)
+
+\* THE LOAD-BEARING INVARIANT (SERVER-100155).
+\*
+\* Once balancerStop has returned OK to the operator, no migration is allowed to transition into
+\* the `committed' state. This is the contract that `mongodump' / `mongosync' / backup procedures
+\* rely on: after balancerStop returns, the cluster's data distribution is stable.
+StopThenObserveStableState == commitsAfterStopOk = 0
+
+\* Monotonicity of the round counter.
+RoundCounterMonotonic == numBalancerRounds >= 0
+
+\* Once stop is observed OK, the mode is durably "off".
+StopImpliesModeOff == stopReturnedOk => balancerMode = "off"
+
+\* The thread cannot be both running and terminated.
+ThreadStateConsistent == (threadState = "terminated") => ~inBalancerRound
+
+(**************************************************************************************************)
+(* Liveness                                                                                       *)
+(**************************************************************************************************)
+
+\* If an operator calls balancerStop, they eventually get OK back.
+\* (Disabled in the default cfg to keep state-constraint + liveness clean -- see the cfg.)
+StopEventuallyReturns == stopRequested ~> stopReturnedOk
+
+====================================================================================================

--- a/src/mongo/tla_plus/Sharding/BalancerStopRace/MCBalancerStopRace.cfg
+++ b/src/mongo/tla_plus/Sharding/BalancerStopRace/MCBalancerStopRace.cfg
@@ -1,0 +1,33 @@
+\* Green configuration for BalancerStopRace.tla.
+\* `AllowStepdownInterleave = FALSE' asserts the fix: the balancer must drain in-flight migration
+\* commits before clearing `_inBalancerRound', even when the round was interrupted by a stepdown.
+\* Every safety invariant below must hold.
+
+SPECIFICATION Spec
+
+\* The spec has natural terminal states (operator has stopped the balancer; every migration
+\* dispatched has settled). Disable deadlock checking; the load-bearing safety invariant
+\* `StopThenObserveStableState' is the focus of this configuration.
+CHECK_DEADLOCK
+    FALSE
+
+CONSTANTS
+    MaxMigrations = 1
+    MaxStopCalls = 1
+    AllowStepdownInterleave = FALSE
+
+INVARIANT
+    TypeOK
+    StopThenObserveStableState
+    RoundCounterMonotonic
+    StopImpliesModeOff
+    ThreadStateConsistent
+
+\* Liveness is disabled in the default cfg to keep model-checking fast and to avoid the
+\* state-constraint-plus-liveness pitfall (see MoveRange/MCMoveRange.cfg for the same pattern).
+\* Re-enable by uncommenting the PROPERTIES section below.
+\* PROPERTIES
+\*     StopEventuallyReturns
+
+CONSTRAINT
+    StateConstraint

--- a/src/mongo/tla_plus/Sharding/BalancerStopRace/MCBalancerStopRace.tla
+++ b/src/mongo/tla_plus/Sharding/BalancerStopRace/MCBalancerStopRace.tla
@@ -1,0 +1,29 @@
+---------------------------- MODULE MCBalancerStopRace --------------------------------------------
+\* Model-checking harness for BalancerStopRace.tla.
+\*
+\* Two model configurations are provided:
+\*   * MCBalancerStopRace.cfg              -- green run; `AllowStepdownInterleave = FALSE'.
+\*                                            Invariants must hold.
+\*   * MCBalancerStopRace_Bug.cfg          -- bug repro; `AllowStepdownInterleave = TRUE'.
+\*                                            `StopThenObserveStableState' is violated and TLC
+\*                                            prints the counterexample trace.
+
+EXTENDS BalancerStopRace
+
+\* State constraint: keep the model finite. `numBalancerRounds' is a monotone counter that
+\* would let the model grow without bound otherwise; capping it to a small multiple of the
+\* migration / stop budgets is enough to cover every interleaving relevant to the bug. Once a
+\* commit has slipped past stop-OK we have the violation; one such witness is enough.
+MaxRounds == MaxMigrations + MaxStopCalls + 2
+
+StateConstraint ==
+    /\ numBalancerRounds <= MaxRounds
+    /\ commitsAfterStopOk <= 1
+
+\* Convenience baits for trace inspection (set as INVARIANT in a debug cfg).
+BaitMigrationDispatched == \A i \in MigrationSlots : migrationState[i] # "commitInFlight"
+BaitMigrationCommitted  == \A i \in MigrationSlots : migrationState[i] # "committed"
+BaitStepDownObserved    == ~threadInterrupted
+BaitStopReturnedOk      == ~stopReturnedOk
+
+====================================================================================================

--- a/src/mongo/tla_plus/Sharding/BalancerStopRace/MCBalancerStopRace_Bug.cfg
+++ b/src/mongo/tla_plus/Sharding/BalancerStopRace/MCBalancerStopRace_Bug.cfg
@@ -1,0 +1,32 @@
+\* Bug-reproduction configuration for BalancerStopRace.tla.
+\* `AllowStepdownInterleave = TRUE' flips the buggy path: the balancer's interrupted-round end
+\* clears `_inBalancerRound' without draining in-flight migration commits, modelling the master
+\* branch as of SERVER-100155.
+\*
+\* TLC is expected to FAIL the `StopThenObserveStableState' invariant and print a counterexample
+\* trace of the form:
+\*
+\*   BeginRound -> DispatchMigration -> StepDown -> EndRoundOnInterrupt
+\*   -> BalancerStopBegin -> BalancerStopReturnOk -> ShardCommitsMigration
+\*
+\* The final `ShardCommitsMigration' increments `commitsAfterStopOk', falsifying the invariant.
+
+SPECIFICATION Spec
+
+CHECK_DEADLOCK
+    FALSE
+
+CONSTANTS
+    MaxMigrations = 1
+    MaxStopCalls = 1
+    AllowStepdownInterleave = TRUE
+
+INVARIANT
+    TypeOK
+    StopThenObserveStableState
+    RoundCounterMonotonic
+    StopImpliesModeOff
+    ThreadStateConsistent
+
+CONSTRAINT
+    StateConstraint

--- a/src/mongo/tla_plus/Sharding/BalancerStopRace/OWNERS.yml
+++ b/src/mongo/tla_plus/Sharding/BalancerStopRace/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-sharding

--- a/src/mongo/tla_plus/Sharding/BalancerStopRace/README.md
+++ b/src/mongo/tla_plus/Sharding/BalancerStopRace/README.md
@@ -1,0 +1,54 @@
+# BalancerStopRace
+
+Formal model of the race between `_configsvrBalancerStop` and the migration commit path on a
+config-server replica set that may step down mid-round. Tracks [SERVER-100155][ticket]
+(CAR-impact 5).
+
+## The bug, in one paragraph
+
+`_configsvrBalancerStop` calls `Balancer::joinCurrentRound`, which waits for
+`!_inBalancerRound`. When a stepdown fires mid-round, `requestTermination` kills the balancer's
+`OperationContext`; the round-loop catches `InterruptedDueToReplStateChange` and runs
+`_endRound`, clearing `_inBalancerRound`. `joinCurrentRound` observes a "clean" state and
+returns OK -- but the migration command that was dispatched to the recipient shard before the
+interrupt was never durably cancelled. The recipient (or migration coordinator recovery on the
+new primary) may finalize the commit *after* `balancerStop` returned OK, breaking every
+operator workflow that runs `mongodump` / `mongosync` after stopping the balancer.
+
+## What this spec models
+
+Three composed actors:
+
+| Actor                  | Variables                                                                 |
+|------------------------|---------------------------------------------------------------------------|
+| Balancer coordinator   | `balancerMode`, `inBalancerRound`, `numBalancerRounds`, `threadState`, `threadInterrupted` |
+| Config-server stepdown | `StepDown`, `ThreadTerminate`                                             |
+| Migration commit path  | `migrationState` (fixed-arity over `1..MaxMigrations`)                    |
+| Operator               | `stopRequested`, `stopReturnedOk`, `stopCallsIssued`                      |
+
+Load-bearing invariant `StopThenObserveStableState`: once `balancerStop` has returned OK, no
+migration may transition into `committed`. Ghost counter `commitsAfterStopOk` ticks on every
+post-OK commit; the invariant pins it at zero.
+
+## Bug toggle
+
+`AllowStepdownInterleave \in BOOLEAN`. When `TRUE`, the interrupted-round end clears
+`_inBalancerRound` without draining in-flight commits -- master-branch behaviour as of the
+ticket. When `FALSE`, the coordinator must observe `NoInFlight` before declaring the round
+complete, even on the interrupt path.
+
+## Running
+
+```
+cd src/mongo/tla_plus
+./model-check.sh Sharding/BalancerStopRace
+```
+
+`MCBalancerStopRace.cfg` is the green run (`AllowStepdownInterleave = FALSE`): every safety
+invariant holds (197 distinct states, depth 15). To reproduce the bug, pass
+`-config MCBalancerStopRace_Bug.cfg` to TLC; the model-checker fails
+`StopThenObserveStableState` in 8 states and prints the
+`BeginRound -> DispatchMigration -> StepDown -> EndRoundOnInterrupt -> BalancerStopBegin ->
+BalancerStopReturnOk -> ShardCommitsMigration` counterexample.
+
+[ticket]: https://jira.mongodb.org/browse/SERVER-100155


### PR DESCRIPTION
## Summary

TLA+ spec + jstest for SERVER-100155 (CAR-impact 5): a stepdown-interleave lets a migration commit AFTER `balancerStop` returns OK. Breaks every operator workflow that runs `mongodump` / `mongosync` after stopping the balancer — including documented backup procedures.

**Jira:** https://jira.mongodb.org/browse/SERVER-126560
**Related:** https://jira.mongodb.org/browse/SERVER-100155

## TLC verdicts

| Cfg | Result |
|---|---|
| Green | 373 / 197 distinct, depth 15, no error |
| Bug (`AllowStepdownInterleave=TRUE`) | `StopThenObserveStableState` violated; 8-state counterexample `BeginRound → DispatchMigration → StepDown → EndRoundOnInterrupt → BalancerStopBegin → BalancerStopReturnOk → ShardCommitsMigration`; terminal `commitsAfterStopOk = 1` |

## Key insight surfaced by the spec

The bug isn't strictly that `joinCurrentRound` returns early — it's that `_endRound` clears `_inBalancerRound` on the `InterruptedDueToReplStateChange` catch path **without** draining migrations whose future-chain has already been forked to the shard. The spec-implied fix: `_endRound` on the interrupt branch must wait for in-flight migrations to reach a terminal `committed | aborted` state.

## Files

- `src/mongo/tla_plus/Sharding/BalancerStopRace/BalancerStopRace.tla` (306 lines) — migration table modelled as a fixed-arity function `[1..MaxMigrations -> {unset, commitInFlight, committed, aborted}]` rather than a sequence, to keep state space tractable.
- `src/mongo/tla_plus/Sharding/BalancerStopRace/MCBalancerStopRace.{tla,cfg}` (green) + `MCBalancerStopRace_Bug.cfg`
- `src/mongo/tla_plus/Sharding/BalancerStopRace/OWNERS.yml` (`10gen/server-sharding`)
- `src/mongo/tla_plus/Sharding/BalancerStopRace/README.md` (295 words)
- `jstests/sharding/balancer_stop_no_round_after_return.js` (196 lines)

## Verify

```
cd src/mongo/tla_plus
./download-tlc.sh
./model-check.sh Sharding/BalancerStopRace
```

jstest pins donor at `hangBeforeSendingCommitDecision`, fires `configRS.stepUp` mid-commit, runs `balancerStop` in a parallel shell that stamps the OK timestamp into a sentinel doc, releases the failpoint, then asserts every chunk's `history[].validAfter` predates that OK timestamp.

## Draft status

Opened as Draft.
