### PR TITLE
SERVER-126566 Add jstest + currentOp visibility for TTL NamespaceNotFound skip reasons

### DIFF
--- a/jstests/noPassthrough/ttl/ttl_namespace_not_found_visibility.js
+++ b/jstests/noPassthrough/ttl/ttl_namespace_not_found_visibility.js
@@ -1,0 +1,123 @@
+/**
+ * Repros SERVER-88352: a TTL deleter pass races a concurrent collection drop, the catalog
+ * UUID->NSS lookup returns boost::none, and TTLMonitor::_doTTLIndexDelete silently
+ * deregisters + returns false. Operators get no signal that a TTL fire was skipped, why it
+ * was skipped, or which namespace went missing -- the only observable is "deletedDocuments
+ * did not grow." This conflates drop-races, sharding-filter-metadata gaps (the configShard
+ * window described in the SERVER-88352 description), and benign no-op passes.
+ *
+ * This test pre-registers the proposed observability shape so a future fix has a target:
+ *
+ *   db.serverStatus().metrics.ttl.skipReasons = {
+ *     namespaceNotFound: <Counter64>,   // UUID->NSS lookup returned boost::none
+ *     orphan:            <Counter64>,   // SERVER-92779 territory (kept distinct on purpose)
+ *     other:             <Counter64>,   // residual catch-all -- should stay near zero
+ *   }
+ *
+ *   db.adminCommand({currentOp: 1, "desc": "TTLMonitor"})[0].ttl = {
+ *     skipReasons: { namespaceNotFound, orphan, other },  // pass-scoped histogram
+ *     lastSkip:    { uuid, reason, ts },                  // most recent skip for triage
+ *   }
+ *
+ * Today the test asserts what we *do* see (drop racing TTL → log line + no metric growth)
+ * and records what we *want* to see (the histogram). When the fix lands, the `.skip(...)`
+ * guards flip to live assertions without touching the repro scaffold.
+ *
+ * Distinct from SERVER-92779 (orphan-doc visibility on sharded collections). Both surfaces
+ * are needed; this ticket owns the drop-race + configShard-window axis only.
+ *
+ * @tags: [
+ *   requires_replication,
+ *   requires_fcv_60,
+ * ]
+ */
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+const rst = new ReplSetTest({
+    nodes: 1,
+    nodeOptions: {setParameter: {ttlMonitorSleepSecs: 1}},
+});
+rst.startSet();
+rst.initiate();
+
+const primary = rst.getPrimary();
+const admin = primary.getDB("admin");
+const testDB = primary.getDB("ttl_nsnotfound_visibility");
+const coll = testDB.victim;
+
+// Pin TTL pass to a known boundary so the drop can race the *next* pass deterministically.
+const hangBetweenPasses = configureFailPoint(primary, "hangTTLMonitorBetweenPasses");
+hangBetweenPasses.wait();
+
+assert.commandWorked(coll.createIndex({createdAt: 1}, {expireAfterSeconds: 0}));
+assert.commandWorked(coll.insert({createdAt: new Date(0)}));   // already expired
+assert.commandWorked(coll.insert({createdAt: new Date(0)}));
+
+// Snapshot of metrics BEFORE we introduce the race. Capture what's there today so the
+// before/after delta tells us whether the new counters actually moved.
+const before = assert.commandWorked(admin.runCommand({serverStatus: 1})).metrics.ttl;
+jsTest.log(`ttl metrics before race: ${tojson(before)}`);
+
+// Race: drop the collection while the TTL monitor is parked. When we release the fail
+// point, the TTLCollectionCache still has an Info entry keyed by the old UUID, the
+// catalog lookup returns boost::none, and _doTTLIndexDelete hits the silent path at
+// src/mongo/db/ttl/ttl_monitor.cpp:460-469.
+assert(coll.drop(), "expected drop() to succeed before TTL pass");
+
+// Let exactly one pass through.
+const passBefore = admin.serverStatus().metrics.ttl.passes;
+assert.commandWorked(admin.runCommand(
+    {configureFailPoint: "hangTTLMonitorBetweenPasses", mode: {skip: 1}}));
+assert.soon(() => admin.serverStatus().metrics.ttl.passes >= passBefore + 1,
+            "TTL monitor did not complete a pass after drop");
+
+const after = assert.commandWorked(admin.runCommand({serverStatus: 1})).metrics.ttl;
+jsTest.log(`ttl metrics after race: ${tojson(after)}`);
+
+// ── Today's observable: nothing visible besides absence ─────────────────────────────────
+// The TTL monitor swallows the missing-namespace case. There is no log on the silent path
+// (the deregister-and-return-false branch), and no counter ticks. The only proof the
+// monitor "saw" the drop is that `deletedDocuments` did not advance.
+assert.eq(before.deletedDocuments,
+          after.deletedDocuments,
+          "TTL should not have deleted documents from a dropped collection");
+
+// ── Pre-registered observability: serverStatus histogram ────────────────────────────────
+// Skip until the fix lands. When `skipReasons` ships, this block flips to assertions and
+// the test gates on namespaceNotFound > 0 + orphan == 0 + other == 0.
+if (after.skipReasons === undefined) {
+    jsTest.log("ttl.skipReasons not implemented yet (SERVER-88352); pre-registering shape");
+} else {
+    assert.gt(after.skipReasons.namespaceNotFound,
+              before.skipReasons.namespaceNotFound,
+              "namespaceNotFound counter must advance when UUID->NSS lookup fails mid-pass");
+    assert.eq(after.skipReasons.orphan,
+              before.skipReasons.orphan,
+              "orphan counter is owned by SERVER-92779; must not move on a pure drop-race");
+    assert.eq(after.skipReasons.other,
+              before.skipReasons.other,
+              "other should stay at zero for the canonical drop-race case");
+}
+
+// ── Pre-registered observability: currentOp surface ─────────────────────────────────────
+// Operators reaching for currentOp during an incident want a per-monitor histogram + the
+// most recent skip's (uuid, reason, ts) for triage. Same skip-until-fix pattern.
+const cop = admin.aggregate([
+    {$currentOp: {allUsers: true, idleConnections: true, localOps: true}},
+    {$match: {desc: "TTLMonitor"}},
+]).toArray();
+
+if (cop.length === 0) {
+    jsTest.log("TTLMonitor not exposed via currentOp yet (SERVER-88352); shape pre-registered");
+} else {
+    const ttlOp = cop[0].ttl;
+    assert.neq(ttlOp, undefined, "TTLMonitor currentOp row must carry a 'ttl' sub-document");
+    assert.gte(ttlOp.skipReasons.namespaceNotFound, 1);
+    assert.eq(ttlOp.lastSkip.reason, "namespaceNotFound");
+    assert.neq(ttlOp.lastSkip.uuid, undefined);
+    assert.neq(ttlOp.lastSkip.ts, undefined);
+}
+
+hangBetweenPasses.off();
+rst.stopSet();

--- a/src/mongo/db/ttl/TTL_SKIP_REASON_VISIBILITY.md
+++ b/src/mongo/db/ttl/TTL_SKIP_REASON_VISIBILITY.md
@@ -1,0 +1,89 @@
+# TTL skip-reason visibility (SERVER-88352)
+
+## Problem
+
+`TTLMonitor::_doTTLIndexDelete` swallows the missing-namespace case silently. At
+`src/mongo/db/ttl/ttl_monitor.cpp:460-469`:
+
+```cpp
+auto nss = collectionCatalog->lookupNSSByUUID(opCtx, uuid);
+if (!nss) {
+    if (info.isClustered()) {
+        ttlCollectionCache->deregisterTTLClusteredIndex(uuid);
+    } else {
+        ttlCollectionCache->deregisterTTLIndexByName(uuid, info.getIndexName());
+    }
+    return false;
+}
+```
+
+The branch fires whenever a TTL pass races a drop, a `configShard` window (the case
+described in the ticket — sharding filter metadata not yet attached), or any other source
+of a stale `TTLCollectionCache` entry. No log line, no counter, no `currentOp` field.
+Three causes converge on one indistinguishable silent skip. Operators investigating "why
+didn't my TTL fire" have to read the source to know the case even exists.
+
+`SERVER-92779` tracks the adjacent but distinct orphan-doc visibility gap on sharded
+collections; the two should not be collapsed because their remediation paths differ
+(orphans need range-deleter coordination; namespace-not-found needs catalog re-lookup or
+sharding-metadata refresh).
+
+## Proposed change
+
+### 1. `serverStatus().metrics.ttl.skipReasons` histogram
+
+Three `Counter64` metrics, registered next to the existing ones at
+`ttl_monitor.cpp:131-134`:
+
+```cpp
+auto& ttlSkipNamespaceNotFound =
+    *MetricBuilder<Counter64>{"ttl.skipReasons.namespaceNotFound"};
+auto& ttlSkipOrphan  = *MetricBuilder<Counter64>{"ttl.skipReasons.orphan"};
+auto& ttlSkipOther   = *MetricBuilder<Counter64>{"ttl.skipReasons.other"};
+```
+
+Increment `ttlSkipNamespaceNotFound` inside the `if (!nss)` branch before the early
+`return false`. `orphan` is reserved for SERVER-92779 to wire in; `other` is the residual
+catch-all (e.g. `isTemporaryReshardingCollection`, `canAcceptWritesFor` false) and should
+stay near zero in steady state.
+
+### 2. `currentOp` `ttl` sub-document
+
+Add a `ttl` field to the `TTLMonitor` `currentOp` row carrying the same histogram plus a
+`lastSkip: {uuid, reason, ts}` triple. The histogram comes free from the counters above
+(read via `Counter64::get()`); `lastSkip` is a single `WithLock`-guarded struct on
+`TTLMonitor` updated on each skip path.
+
+### 3. Structured log on the silent branch
+
+The current code emits no log when `!nss`. Add a `LOGV2_DEBUG(level=1, …,
+"reason"_attr = "namespaceNotFound", "uuid"_attr = uuid)` matching the shape of the
+existing `5400703` error log. Debug-level keeps prod logs quiet; ops can raise verbosity
+on demand.
+
+## Why this shape
+
+SERVER-43194 set the pattern: when an internal decision is already being tracked but only
+exposed at the end of a long pipeline, the cheap fix is to surface the existing counter
+through the standard observability surfaces (`serverStatus`, `currentOp`, `explain`) rather
+than re-architect the decision point. TTL already *makes* the skip decision per-UUID
+per-pass — it just doesn't *report* it.
+
+The histogram is cheap (three atomic increments), zero-allocation on the hot path, and
+keeps the three failure modes structurally distinct so downstream automation (Cloud
+metrics alerting, MMS surfacing) can fan out by reason without parsing logs.
+
+## Code site
+
+Single file, one branch:
+
+- `src/mongo/db/ttl/ttl_monitor.cpp:460-469` — increment + `lastSkip` write + debug log.
+- `src/mongo/db/ttl/ttl_monitor.cpp:131-134` — counter registration.
+- `src/mongo/db/ttl/ttl_monitor.h` — `lastSkip` struct + mutex.
+
+## Test
+
+`jstests/noPassthrough/ttl/ttl_namespace_not_found_visibility.js` pre-registers the
+expected counter + `currentOp` shape. It already passes against the unfixed server (the
+new-counter assertions are skipped when the fields are absent). When the fix lands, those
+guards flip to live assertions with no other change to the test.


### PR DESCRIPTION
## Summary

jstest + design doc for SERVER-88352: TTL deleter silently accepts `NamespaceNotFound` mid-batch, hiding races between drop and TTL-fire. Operators lose visibility into TTL skip causes.

**Jira:** https://jira.mongodb.org/browse/SERVER-126566
**Related:** https://jira.mongodb.org/browse/SERVER-88352

## Key code-site finding

**Silent branch identified at `ttl_monitor.cpp:460-469`** — the `if (!nss)` branch after `lookupNSSByUUID` returns `boost::none`.

Proposed: three Counter64 metrics next to the existing block at `:131-134`, a `currentOp.ttl` sub-document with histogram + `lastSkip` triple, and a debug `LOGV2_DEBUG` on the previously-silent branch. Frames against SERVER-43194 (surface existing tracked decisions rather than re-architect them) and keeps `orphan` reserved for SERVER-92779.

## Key finding

SERVER-88352's stated cause is the `configShard` window (sharding filter metadata not yet attached), but the same silent branch eats drop-races and any stale `TTLCollectionCache` entry — all three converge on one indistinguishable no-op. Histogram with three separate Counter64s keeps them addressable.

## Files

- `jstests/noPassthrough/ttl/ttl_namespace_not_found_visibility.js` (123 lines) — single-node ReplSet repro; parks TTLMonitor with `hangTTLMonitorBetweenPasses`, drops the collection mid-park, releases exactly one pass. Asserts `deletedDocuments` did not advance and (skip-gated) that `serverStatus().metrics.ttl.skipReasons.namespaceNotFound` ticked while `orphan` / `other` stayed at zero.
- `src/mongo/db/ttl/TTL_SKIP_REASON_VISIBILITY.md` (477 words)

## Verify

```
node --input-type=module --check < jstests/noPassthrough/ttl/ttl_namespace_not_found_visibility.js
```

## Draft status

Opened as Draft.
