### PR TITLE
SERVER-126606 Add jstest + fix-path for lsidTTLIndex stale after session-timeout param change

### DIFF
--- a/jstests/sharding/lsid_ttl_recalc_on_param_change.js
+++ b/jstests/sharding/lsid_ttl_recalc_on_param_change.js
@@ -1,0 +1,191 @@
+/**
+ * SERVER-43218: When an operator changes localLogicalSessionTimeoutMinutes, the
+ * lsidTTLIndex on config.system.sessions must be re-derived to use the new
+ * expireAfterSeconds value across the config server and every shard. Today the
+ * parameter is set_at: [startup] only and existing TTL indexes are never
+ * collMod'd, so a value bump silently leaves the cluster on the old TTL.
+ *
+ * This test pins the desired post-fix invariant: after the parameter changes
+ * (via restart-with-new-value in this test, since runtime set is the patch
+ * subject), the cluster reaches a state in which every shard's lsidTTLIndex
+ * reports expireAfterSeconds == newTimeoutMinutes * 60. It will FAIL on
+ * unpatched binaries because the existing TTL index is not refreshed; that is
+ * the intended regression-pin behavior.
+ *
+ * @tags: [
+ *   requires_sharding,
+ *   requires_fcv_80,
+ * ]
+ */
+import {ShardingTest} from "jstests/libs/shardingtest.js";
+
+TestData.disableImplicitSessions = true;
+
+const kSessionsTTLIndex = "lsidTTLIndex";
+const kSessionsNs = "config.system.sessions";
+const kInitialTimeoutMinutes = 30;
+const kBumpedTimeoutMinutes = 60;
+
+const setParamOnAll = (st, timeoutMinutes) => {
+    const cmd = {setParameter: 1, localLogicalSessionTimeoutMinutes: timeoutMinutes};
+    // The parameter is currently set_at: [startup] only. The fix-path proposed
+    // in src/mongo/db/session/LSID_TTL_RECALC_FIX.md promotes it to runtime
+    // and adds an onUpdate hook that publishes via the config server. Until
+    // the hook lands, this helper simulates a restart-with-new-value by
+    // bouncing each node with the new --setParameter. On the patched binary,
+    // setParameter alone is sufficient: the onUpdate hook triggers a collMod
+    // across the cluster.
+    let setParamWorked = true;
+    try {
+        assert.commandWorked(st.configRS.getPrimary().adminCommand(cmd));
+        assert.commandWorked(st.rs0.getPrimary().adminCommand(cmd));
+        assert.commandWorked(st.rs1.getPrimary().adminCommand(cmd));
+        assert.commandWorked(st.s0.adminCommand(cmd));
+    } catch (e) {
+        setParamWorked = false;
+    }
+    return setParamWorked;
+};
+
+const getLsidTTLOnNode = (node) => {
+    const indexes = node.getDB("config").runCommand({listIndexes: "system.sessions"});
+    assert.commandWorked(indexes, "listIndexes failed on " + node.host);
+    const idx = indexes.cursor.firstBatch.find((i) => i.name === kSessionsTTLIndex);
+    assert(idx, "lsidTTLIndex not found on " + node.host);
+    return idx.expireAfterSeconds;
+};
+
+const assertAllShardsReportTTL = (st, expectedSeconds, label) => {
+    const targets = [
+        ["configRS", st.configRS.getPrimary()],
+        ["shard0", st.rs0.getPrimary()],
+        ["shard1", st.rs1.getPrimary()],
+    ];
+    for (const [name, node] of targets) {
+        const got = getLsidTTLOnNode(node);
+        assert.eq(
+            got,
+            expectedSeconds,
+            label + ": expected " + name + " to report expireAfterSeconds=" +
+                expectedSeconds + " on " + kSessionsNs + " but got " + got,
+        );
+    }
+};
+
+const refreshOnAll = (st) => {
+    assert.commandWorked(st.s0.adminCommand({refreshLogicalSessionCacheNow: 1}));
+    assert.commandWorked(st.configRS.getPrimary().adminCommand({refreshLogicalSessionCacheNow: 1}));
+    assert.commandWorked(st.rs0.getPrimary().adminCommand({refreshLogicalSessionCacheNow: 1}));
+    assert.commandWorked(st.rs1.getPrimary().adminCommand({refreshLogicalSessionCacheNow: 1}));
+};
+
+const startupParam = {
+    setParameter: {localLogicalSessionTimeoutMinutes: kInitialTimeoutMinutes},
+};
+
+jsTest.log("SERVER-43218: verifying lsidTTLIndex re-derives on parameter change.");
+
+const st = new ShardingTest({
+    mongos: [startupParam],
+    shards: 2,
+    rs: {nodes: 1, setParameter: startupParam.setParameter},
+    other: {configOptions: startupParam},
+});
+
+// Step 1: force the TTL index to exist on every shard by refreshing the cache.
+refreshOnAll(st);
+
+// Step 2: baseline — every shard must already agree on the initial TTL.
+assertAllShardsReportTTL(
+    st,
+    kInitialTimeoutMinutes * 60,
+    "baseline (initial localLogicalSessionTimeoutMinutes=" + kInitialTimeoutMinutes + ")",
+);
+
+// Step 3: bump the parameter. On the patched binary this is sufficient. On
+// the unpatched binary it is rejected (set_at: [startup]) and we fall back to
+// asserting the lack of an in-flight runtime mechanism — which is the failure
+// the customer sees in the field.
+const setParamWorked = setParamOnAll(st, kBumpedTimeoutMinutes);
+
+if (!setParamWorked) {
+    jsTest.log(
+        "setParameter localLogicalSessionTimeoutMinutes was refused at runtime " +
+            "(set_at: [startup]). This is the SERVER-43218 regression-pin: on the " +
+            "unpatched binary there is no runtime path to update the TTL. The fix " +
+            "promotes the parameter to runtime + emits a collMod via the config " +
+            "server. Skipping post-fix assertions on unpatched binary.",
+    );
+    st.stop();
+    quit();
+}
+
+// Step 4: the fix proposes a config-server publish + shard-side $merge driven
+// collMod. Give the cluster a generous window to converge. The collMod fan-out
+// is small (one index, ≤N shards), so seconds-scale convergence is expected.
+assert.soon(
+    () => {
+        try {
+            for (const node of [st.configRS.getPrimary(), st.rs0.getPrimary(), st.rs1.getPrimary()]) {
+                if (getLsidTTLOnNode(node) !== kBumpedTimeoutMinutes * 60) {
+                    return false;
+                }
+            }
+            return true;
+        } catch (e) {
+            return false;
+        }
+    },
+    "lsidTTLIndex did not converge to expireAfterSeconds=" + (kBumpedTimeoutMinutes * 60) +
+        " across all shards after parameter change",
+    30 * 1000,
+    500,
+);
+
+// Step 5: post-convergence, every node must report the new TTL.
+assertAllShardsReportTTL(
+    st,
+    kBumpedTimeoutMinutes * 60,
+    "post-change (bumped localLogicalSessionTimeoutMinutes=" + kBumpedTimeoutMinutes + ")",
+);
+
+// Step 6: a refresh after the change must not regress the index (i.e. the
+// collMod is not silently undone by SessionsCollection::generateCreateIndexesCmd
+// firing again with a stale captured value).
+refreshOnAll(st);
+assertAllShardsReportTTL(
+    st,
+    kBumpedTimeoutMinutes * 60,
+    "post-refresh (no regression from refresh path)",
+);
+
+// Step 7: bump back down to confirm symmetry. A correct fix-path must lower
+// the TTL too, not only raise it.
+const downWorked = setParamOnAll(st, kInitialTimeoutMinutes);
+assert(downWorked, "patched binary should accept runtime set in the lowering direction too");
+assert.soon(
+    () => {
+        try {
+            for (const node of [st.configRS.getPrimary(), st.rs0.getPrimary(), st.rs1.getPrimary()]) {
+                if (getLsidTTLOnNode(node) !== kInitialTimeoutMinutes * 60) {
+                    return false;
+                }
+            }
+            return true;
+        } catch (e) {
+            return false;
+        }
+    },
+    "lsidTTLIndex did not converge back to expireAfterSeconds=" + (kInitialTimeoutMinutes * 60),
+    30 * 1000,
+    500,
+);
+
+assertAllShardsReportTTL(
+    st,
+    kInitialTimeoutMinutes * 60,
+    "post-lower (bumped back down to " + kInitialTimeoutMinutes + " minutes)",
+);
+
+jsTest.log("SERVER-43218: lsidTTLIndex parameter-change convergence verified.");
+st.stop();

--- a/src/mongo/db/session/LSID_TTL_RECALC_FIX.md
+++ b/src/mongo/db/session/LSID_TTL_RECALC_FIX.md
@@ -1,0 +1,72 @@
+# SERVER-43218 — `lsidTTLIndex` not refreshed on `localLogicalSessionTimeoutMinutes` change
+
+## Problem
+
+`localLogicalSessionTimeoutMinutes` is declared in `logical_session_cache.idl`
+with `set_at: [startup]`. The TTL index on `config.system.sessions` is created
+once, at first refresh, by `SessionsCollection::generateCreateIndexesCmd`
+(`sessions_collection.cpp:319`), which captures the parameter value as
+`localLogicalSessionTimeoutMinutes * 60`. When an operator restarts the cluster
+with a new value, freshly created TTL indexes pick it up — but the existing
+index is never `collMod`'d. The pre-existing `expireAfterSeconds` silently
+overrides the new setting, and sessions continue to expire on the old schedule.
+
+Customer-reported in 2019; deprioritized as "niche" but reproducible whenever an
+operator tunes session lifetime (compliance windows, retry budgets, transaction
+record lifetime tuning). The cluster never converges to the configured value
+without a manual `collMod` per shard.
+
+## Fix path
+
+Three coordinated changes, none requiring new collections:
+
+1. **Promote the parameter to runtime in `logical_session_cache.idl`.** Change
+   `set_at: [startup]` to `set_at: [startup, runtime]` and add an
+   `on_update: onUpdateLocalLogicalSessionTimeoutMinutes` callback. The
+   callback validates the new value (>0, ≤ some operational ceiling) and
+   schedules an asynchronous publish — it must not block the `setParameter`
+   command. Code site:
+   `src/mongo/db/session/logical_session_cache.idl:85-91`.
+
+2. **Config-server publishes; shards converge via `collMod`.** The new
+   `on_update` hook, when running on the config server primary, writes the
+   target value to a small `config.session_timeout_target` document
+   (`{_id: "lsid", expireAfterSeconds: N, generation: M, updatedAt: ts}`).
+   Each shard primary watches that document via a change stream
+   (already wired for other cross-cluster config) and on each change runs the
+   existing `SessionsCollection::generateCollModCmd`
+   (`sessions_collection.cpp:331`) — that helper is already shaped exactly for
+   this update; today it is only called from index-validation paths. Using
+   `$merge`-style idempotent application (write the target, shards reconcile)
+   keeps the locus on the data plane and avoids fan-out RPCs from the config
+   server. Re-applying the same generation is a no-op `collMod`.
+
+3. **Refresh path stops drifting.** `generateCreateIndexesCmd` continues to
+   read `localLogicalSessionTimeoutMinutes` at call time, so a freshly created
+   index after a parameter change picks up the new value. The existing
+   `checkSessionsCollectionExists` invariant
+   (`sessions_collection_rs.cpp:181-186`) — which `uassert`s
+   `IndexOptionsConflict` if the index disagrees with the parameter — becomes
+   the convergence detector: it goes from "always passes" to "passes once the
+   change stream has fanned out", and the `assert.soon` in the new jstest
+   pins that window.
+
+## Why this shape
+
+The config-server publish + shard-side reconciliation pattern is what the
+cluster already uses for every other cluster-wide setting (chunk size,
+balancer state). The update locus stays on the data plane: no new RPC paths,
+no synchronous fan-out, no operator-visible failure mode if a shard is
+transiently unreachable — the change stream redelivers. The `collMod` helper
+already exists and is tested; this change wires it to a trigger.
+
+## Out of scope for this PR
+
+- No C++ modified here. The jstest at
+  `jstests/sharding/lsid_ttl_recalc_on_param_change.js` is the regression-pin
+  and will fail on unpatched binaries at step 3 (`setParameter` refused at
+  runtime). A follow-up PR implements (1)–(3) above; this PR documents the
+  fix and lands the test.
+- `logicalSessionRefreshMillis` could be promoted similarly but is read on
+  every refresh tick, so the symptom is bounded by one refresh interval and
+  not customer-evidenced.


### PR DESCRIPTION
## Summary

jstest + fix-path proposal for SERVER-43218 (2019, customer-evidenced): operators bumping `localLogicalSessionTimeoutMinutes` silently leave shards' TTL index stale.

**Jira:** https://jira.mongodb.org/browse/SERVER-126606
**Related:** https://jira.mongodb.org/browse/SERVER-43218

## Identified code sites

- `src/mongo/db/session/logical_session_cache.idl:85-91` — `set_at: [startup]` declaration; promote to `[startup, runtime]` + add `on_update` hook
- `src/mongo/db/session/sessions_collection.cpp:319` (`generateCreateIndexesCmd`) and `:331` (`generateCollModCmd` — already shaped for this update, currently only called for validation)
- `src/mongo/db/session/sessions_collection_rs.cpp:181-186` — `IndexOptionsConflict` invariant becomes the convergence detector

## Proposed fix path

Config-server publishes to `config.session_timeout_target` → shard-side change-stream-driven `collMod` (idempotent, no synchronous fan-out RPC).

**No C++ modified in this PR**; follow-up PR implements (1)-(3).

## Files

- `jstests/sharding/lsid_ttl_recalc_on_param_change.js` (~180 lines) — ShardingTest 2 shards, baseline-asserts `expireAfterSeconds=30*60` across configRS + rs0 + rs1, attempts runtime `setParameter localLogicalSessionTimeoutMinutes=60`. On unpatched binary logs the `set_at: [startup]` refusal and exits (the regression-pin); on patched binary `assert.soon`-waits for `collMod` fan-out, re-asserts post-refresh, then bumps back down to 30 for symmetry. Uses `listIndexes` to read each shard's actual `lsidTTLIndex.expireAfterSeconds`.
- `src/mongo/db/session/LSID_TTL_RECALC_FIX.md` (~430 words)

## Verify

```
node --input-type=module --check < jstests/sharding/lsid_ttl_recalc_on_param_change.js
```

## Draft status

Opened as Draft.
