### PR TITLE
SERVER-126610 TLA+ spec for default readConcern behavior under afterClusterTime

### DIFF
--- a/jstests/replsets/cluster_default_read_concern_with_after_cluster_time.js
+++ b/jstests/replsets/cluster_default_read_concern_with_after_cluster_time.js
@@ -1,0 +1,115 @@
+/**
+ * SERVER-126299: Cluster-wide default read concern is not honored when
+ * afterClusterTime is sent without an explicit level.
+ *
+ * Reproduces the bug as follows:
+ *   1. Set the cluster-wide default read concern to {level: "majority"} via
+ *      setDefaultRWConcern.
+ *   2. Pause replication on the secondary with the stopReplProducer failpoint
+ *      so subsequent writes cannot reach majority.
+ *   3. Run a {w: "majority", wtimeout: ...} write that the primary applies
+ *      locally but that times out waiting for replication. The write
+ *      advances the primary's optime / cluster time.
+ *   4. Start a causally-consistent session (which sends afterClusterTime
+ *      automatically with NO explicit level on subsequent reads).
+ *   5. Issue a read on the session.
+ *
+ * Expected post-fix behavior: the read inherits the cluster-wide default
+ * read concern "majority" and blocks (returning ExceededTimeLimit when
+ * capped via maxTimeMS) because the afterClusterTime is not yet
+ * majority-committed.
+ *
+ * Pre-fix bug: the read silently resolves to read concern "local" and
+ * returns the write that was never replicated, violating the operator's
+ * setDefaultRWConcern contract.
+ *
+ * @tags: [
+ *   requires_majority_read_concern,
+ *   requires_replication,
+ * ]
+ */
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+
+const rst = new ReplSetTest({nodes: 2});
+rst.startSet();
+rst.initiate();
+
+const primary = rst.getPrimary();
+const secondary = rst.getSecondary();
+const dbName = "test";
+const collName = jsTestName();
+
+const primaryDB = primary.getDB(dbName);
+const primaryColl = primaryDB.getCollection(collName);
+
+// Seed the collection and replicate so the secondary has a baseline.
+assert.commandWorked(primaryColl.insert({_id: 0, x: 1}, {writeConcern: {w: "majority"}}));
+
+// Step 1: set the cluster-wide default read concern to "majority".
+assert.commandWorked(
+    primary.adminCommand({
+        setDefaultRWConcern: 1,
+        defaultReadConcern: {level: "majority"},
+    }),
+);
+
+// Step 2: pause replication on the secondary so subsequent writes cannot
+// be majority-committed.
+const stopReplProducer = configureFailPoint(secondary, "stopReplProducer");
+
+// Step 3: issue a write that the primary applies locally but that cannot
+// be majority-acknowledged. We expect WriteConcernFailed / wtimeout.
+const writeRes = primaryDB.runCommand({
+    update: collName,
+    updates: [{q: {_id: 0}, u: {$inc: {x: 1}}}],
+    writeConcern: {w: "majority", wtimeout: 2000},
+});
+assert.commandWorkedIgnoringWriteConcernErrors(writeRes);
+assert(writeRes.writeConcernError,
+       "Expected w:majority write to time out while replication is paused: " + tojson(writeRes));
+
+// Step 4 + 5: start an explicit, causally-consistent session and issue a
+// read. The driver attaches afterClusterTime automatically with no
+// explicit level field. After the SERVER-126299 fix the server must
+// resolve this read's level to the cluster-wide default ("majority").
+const session = primary.startSession({causalConsistency: true});
+const sessionDB = session.getDatabase(dbName);
+const sessionColl = sessionDB.getCollection(collName);
+
+// First, perform a write inside the session so the session's clusterTime
+// advances to a point that is NOT yet majority-committed. This mirrors
+// the original Jira repro precisely.
+assert.commandWorked(sessionColl.update({_id: 0}, {$inc: {x: 1}}, {writeConcern: {w: 1}}));
+
+// A non-session read should still observe the primary's local state,
+// because no afterClusterTime is sent. This anchors the "control" half
+// of the experiment.
+const noSessionDoc = primaryColl.findOne({_id: 0});
+assert.neq(null,
+           noSessionDoc,
+           "Non-session read should always return the document on the primary.");
+
+// A causally-consistent session read MUST block until the
+// afterClusterTime entry is majority-committed. Replication is still
+// paused, so the read should time out. Pre-fix, the read instead
+// returned immediately with the local (uncommitted) document.
+const readRes = sessionDB.runCommand({
+    find: collName,
+    filter: {_id: 0},
+    maxTimeMS: 3000,
+});
+
+assert.commandFailedWithCode(
+    readRes,
+    ErrorCodes.MaxTimeMSExpired,
+    "Pre-SERVER-126299 fix: the causally-consistent read silently used " +
+        "readConcern:local and returned uncommitted data. After the fix it " +
+        "should time out waiting for the afterClusterTime to reach majority.",
+);
+
+// Cleanup: lift the failpoint so the consistency checks at stopSet time
+// can complete.
+stopReplProducer.off();
+session.endSession();
+rst.stopSet();

--- a/src/mongo/tla_plus/Replication/DefaultReadConcernAfterClusterTime/DefaultReadConcernAfterClusterTime.tla
+++ b/src/mongo/tla_plus/Replication/DefaultReadConcernAfterClusterTime/DefaultReadConcernAfterClusterTime.tla
@@ -1,0 +1,203 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+--------------------------- MODULE DefaultReadConcernAfterClusterTime ---------------------------
+\* SERVER-126299: Cluster-wide default read concern is not honored when
+\* afterClusterTime is sent without an explicit level.
+\*
+\* When a cluster has setDefaultRWConcern{ defaultReadConcern: {level: "majority"} },
+\* a client request of the shape { readConcern: { afterClusterTime: T } }
+\* (with "level" omitted, as a causally-consistent session does) must resolve
+\* the effective level to the cluster-wide default ("majority"), NOT to "local".
+\*
+\* If the level resolves to "local", the read can return a value at a cluster
+\* time T whose corresponding oplog entry has not yet been majority-committed,
+\* violating the contract the operator established with setDefaultRWConcern.
+\*
+\* This spec models the read-concern resolution as a pure function of:
+\*   (clientLevel, clientHasAfterClusterTime, clusterDefaultLevel)
+\* and an effective oplog-visibility function over the resolved level.
+\*
+\* To model-check:
+\*     cd src/mongo/tla_plus
+\*     ./model-check.sh Replication/DefaultReadConcernAfterClusterTime
+
+EXTENDS Integers, FiniteSets, Sequences, TLC
+
+\* "majority" or "local". The cluster-wide default read concern level.
+CONSTANT ClusterDefaultLevel
+
+\* TRUE  = patched (fixed) behavior: an afterClusterTime-only request
+\*         resolves its level from the cluster default.
+\* FALSE = buggy behavior (pre-SERVER-126299 fix): an afterClusterTime-only
+\*         request resolves to "local" regardless of the cluster default.
+CONSTANT ResolveLevelFromDefault
+
+\* Bound on the number of oplog entries the primary can issue.
+CONSTANT MaxOpTime
+
+----
+\* Levels and shapes used by the client.
+Levels == {"local", "majority"}
+
+\* What a client may send. A client either:
+\*   - omits readConcern entirely               (sends no level, no aCT)
+\*   - sends an explicit level only             (no aCT)
+\*   - sends afterClusterTime only              (level omitted)  <-- the bug case
+\*   - sends both an explicit level and aCT
+ClientShapes == {"none", "levelOnly", "actOnly", "levelAndAct"}
+
+----
+\* Variables describing the primary's view of the oplog.
+
+\* Sequence of oplog timestamps the primary has issued. Each entry is an Int
+\* (the cluster time of the write). Strictly increasing.
+VARIABLE oplog
+
+\* The largest cluster time that has been majority-acknowledged.
+\* committedClusterTime <= last entry in oplog.
+VARIABLE committedClusterTime
+
+\* The set of read requests issued so far. Each request is a record:
+\*   [ clientShape, clientLevel, afterClusterTime, resolvedLevel,
+\*     waited, observedClusterTime ]
+\* "waited" is TRUE iff the resolved level forced the server to block until
+\* the requested afterClusterTime was majority-committed.
+\* "observedClusterTime" is the cluster time of the entry returned to the
+\* client (or 0 for a "none" request reading from before any write).
+VARIABLE reads
+
+vars == <<oplog, committedClusterTime, reads>>
+
+----
+\* Helpers.
+
+\* The latest cluster time the primary has ever issued.
+LatestOpTime == IF Len(oplog) = 0 THEN 0 ELSE oplog[Len(oplog)]
+
+\* Read-concern resolution. Returns the effective level the server uses.
+\* The bug is exactly the "actOnly" arm.
+ResolveLevel(clientShape, clientLevel) ==
+    CASE clientShape = "none"        -> ClusterDefaultLevel
+      [] clientShape = "levelOnly"   -> clientLevel
+      [] clientShape = "actOnly"     -> IF ResolveLevelFromDefault
+                                        THEN ClusterDefaultLevel
+                                        ELSE "local"
+      [] clientShape = "levelAndAct" -> clientLevel
+
+\* Given a resolved level and an afterClusterTime (0 means "no aCT"), is
+\* cluster time t visible right now?
+\*   - level "local"    : any t in the primary oplog is visible.
+\*   - level "majority" : only t <= committedClusterTime is visible.
+\* aCT >0 additionally requires the server to wait until aCT is satisfied
+\* under the resolved level (i.e., aCT entry is visible under that level).
+LevelVisible(level, t) ==
+    \/ level = "local"     /\ t \in {oplog[i] : i \in 1..Len(oplog)} \cup {0}
+    \/ level = "majority"  /\ t <= committedClusterTime
+
+\* The server may only return an entry that is BOTH:
+\*   (a) visible under the resolved level, AND
+\*   (b) at least as recent as the requested afterClusterTime (when given).
+Returnable(level, aCT, t) ==
+    /\ t >= aCT
+    /\ LevelVisible(level, t)
+    /\ \/ aCT = 0
+       \/ LevelVisible(level, aCT)
+
+----
+\* Initial state.
+
+Init ==
+    /\ oplog = <<>>
+    /\ committedClusterTime = 0
+    /\ reads = {}
+
+----
+\* Actions.
+
+\* The primary issues a new write at the next cluster time.
+PrimaryWrite ==
+    /\ Len(oplog) < MaxOpTime
+    /\ oplog' = Append(oplog, LatestOpTime + 1)
+    /\ UNCHANGED <<committedClusterTime, reads>>
+
+\* A majority of secondaries replicate a previously-issued entry, advancing
+\* committedClusterTime. We allow the commit point to advance to any oplog
+\* entry already issued, monotonically.
+AdvanceCommitPoint ==
+    \E t \in {oplog[i] : i \in 1..Len(oplog)} :
+        /\ t > committedClusterTime
+        /\ committedClusterTime' = t
+        /\ UNCHANGED <<oplog, reads>>
+
+\* A client issues a read request and the server resolves + serves it.
+\* The "actOnly" case (afterClusterTime without level) is the one
+\* SERVER-126299 mishandles.
+ClientRead ==
+    \E shape \in ClientShapes,
+       lvl   \in Levels,
+       aCT   \in 0..LatestOpTime,
+       t     \in {oplog[i] : i \in 1..Len(oplog)} \cup {0} :
+        LET rlvl == ResolveLevel(shape, lvl) IN
+        /\ \* "actOnly" / "levelAndAct" must have aCT > 0; the level-only and
+           \* none shapes must not carry an aCT.
+           CASE shape = "none"        -> aCT = 0
+             [] shape = "levelOnly"   -> aCT = 0
+             [] shape = "actOnly"     -> aCT > 0
+             [] shape = "levelAndAct" -> aCT > 0
+        /\ Returnable(rlvl, aCT, t)
+        /\ reads' = reads \cup {[
+               clientShape         |-> shape,
+               clientLevel         |-> lvl,
+               afterClusterTime    |-> aCT,
+               resolvedLevel       |-> rlvl,
+               observedClusterTime |-> t
+           ]}
+        /\ UNCHANGED <<oplog, committedClusterTime>>
+
+Next ==
+    \/ PrimaryWrite
+    \/ AdvanceCommitPoint
+    \/ ClientRead
+
+Spec == Init /\ [][Next]_vars
+
+----
+\* Invariants.
+
+\* No two oplog entries share a cluster time, and timestamps are increasing.
+OplogStrictlyMonotonic ==
+    \A i, j \in 1..Len(oplog) : i < j => oplog[i] < oplog[j]
+
+\* committedClusterTime never exceeds the largest oplog entry.
+CommitPointBoundedByOplog == committedClusterTime <= LatestOpTime
+
+\* THE CORRECTNESS PROPERTY OF INTEREST.
+\* When the operator has set the cluster-wide default to "majority", any
+\* read that did NOT explicitly request a different level must observe
+\* only majority-committed data. Clients that explicitly send
+\* {level: "local"} (i.e. "levelOnly" or "levelAndAct" with level=local)
+\* have opted out of the default and are intentionally excluded.
+\*
+\* The "actOnly" shape (afterClusterTime, no level) is the bug case:
+\* on the pre-fix path it silently resolves to "local" even though the
+\* client never asked for "local".
+HonorClusterDefaultMajority ==
+    ClusterDefaultLevel = "majority" =>
+        \A r \in reads :
+            (r.clientShape \in {"none", "actOnly"}) =>
+                \/ r.observedClusterTime <= committedClusterTime
+                \/ r.observedClusterTime = 0
+
+\* A weaker witness predicate that names the buggy shape explicitly: under
+\* the fix, an aCT-only request must resolve to the cluster default level.
+ActOnlyResolvesToDefault ==
+    ResolveLevelFromDefault =>
+        \A r \in reads :
+            r.clientShape = "actOnly" =>
+                r.resolvedLevel = ClusterDefaultLevel
+
+=============================================================================

--- a/src/mongo/tla_plus/Replication/DefaultReadConcernAfterClusterTime/MCDefaultReadConcernAfterClusterTime.cfg
+++ b/src/mongo/tla_plus/Replication/DefaultReadConcernAfterClusterTime/MCDefaultReadConcernAfterClusterTime.cfg
@@ -1,0 +1,17 @@
+\* Green config: ResolveLevelFromDefault = TRUE models the SERVER-126299 fix.
+\* All invariants must hold.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    ClusterDefaultLevel = "majority"
+    ResolveLevelFromDefault = TRUE
+    MaxOpTime = 3
+    MaxReads = 3
+
+CONSTRAINT StateConstraint
+
+INVARIANT OplogStrictlyMonotonic
+INVARIANT CommitPointBoundedByOplog
+INVARIANT HonorClusterDefaultMajority
+INVARIANT ActOnlyResolvesToDefault

--- a/src/mongo/tla_plus/Replication/DefaultReadConcernAfterClusterTime/MCDefaultReadConcernAfterClusterTime.tla
+++ b/src/mongo/tla_plus/Replication/DefaultReadConcernAfterClusterTime/MCDefaultReadConcernAfterClusterTime.tla
@@ -1,0 +1,13 @@
+---- MODULE MCDefaultReadConcernAfterClusterTime ----
+\* Model-checking module for DefaultReadConcernAfterClusterTime.tla.
+\* See DefaultReadConcernAfterClusterTime.tla for instructions.
+
+EXTENDS DefaultReadConcernAfterClusterTime
+
+\* Bound the state space: at most MaxReads issued reads.
+CONSTANT MaxReads
+
+StateConstraint ==
+    /\ Len(oplog) <= MaxOpTime
+    /\ Cardinality(reads) <= MaxReads
+=============================================================================

--- a/src/mongo/tla_plus/Replication/DefaultReadConcernAfterClusterTime/MCDefaultReadConcernAfterClusterTime_bug.cfg
+++ b/src/mongo/tla_plus/Replication/DefaultReadConcernAfterClusterTime/MCDefaultReadConcernAfterClusterTime_bug.cfg
@@ -1,0 +1,18 @@
+\* Bug config: ResolveLevelFromDefault = FALSE models pre-fix behavior, where
+\* an afterClusterTime-only request silently resolves to read concern "local"
+\* and bypasses the cluster-wide default of "majority". TLC must produce a
+\* counterexample to HonorClusterDefaultMajority.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    ClusterDefaultLevel = "majority"
+    ResolveLevelFromDefault = FALSE
+    MaxOpTime = 3
+    MaxReads = 3
+
+CONSTRAINT StateConstraint
+
+INVARIANT OplogStrictlyMonotonic
+INVARIANT CommitPointBoundedByOplog
+INVARIANT HonorClusterDefaultMajority

--- a/src/mongo/tla_plus/Replication/DefaultReadConcernAfterClusterTime/OWNERS.yml
+++ b/src/mongo/tla_plus/Replication/DefaultReadConcernAfterClusterTime/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-replication-reviewers

--- a/src/mongo/tla_plus/Replication/DefaultReadConcernAfterClusterTime/README.md
+++ b/src/mongo/tla_plus/Replication/DefaultReadConcernAfterClusterTime/README.md
@@ -1,0 +1,50 @@
+# DefaultReadConcernAfterClusterTime
+
+Formal specification for SERVER-126299: the cluster-wide default read concern
+is not honored when an explicit-session client sends `afterClusterTime`
+without a `level` field.
+
+## What the spec models
+
+A primary maintains an oplog of strictly-increasing cluster timestamps and a
+single `committedClusterTime` that advances as a majority of secondaries
+replicate each entry. A client issues read requests in one of four shapes:
+
+- `none`        — no `readConcern` field at all
+- `levelOnly`   — `{readConcern: {level: "local"|"majority"}}`
+- `actOnly`     — `{readConcern: {afterClusterTime: T}}` (no `level`)
+- `levelAndAct` — both fields present
+
+The pure function `ResolveLevel(shape, level)` returns the effective level
+the server uses to satisfy the read. The flag `ResolveLevelFromDefault`
+distinguishes the two behaviors under test:
+
+- `TRUE`  — the fixed behavior: `actOnly` resolves to the cluster default.
+- `FALSE` — the buggy behavior: `actOnly` resolves to `"local"`, ignoring
+            `setDefaultRWConcern`.
+
+`HonorClusterDefaultMajority` requires that when the cluster default is
+`"majority"`, every successful read must have observed only data at or
+before `committedClusterTime`.
+
+## Configs
+
+- `MCDefaultReadConcernAfterClusterTime.cfg` — fixed behavior; all
+  invariants must hold.
+- `MCDefaultReadConcernAfterClusterTime_bug.cfg` — pre-fix behavior; TLC
+  must produce a counterexample to `HonorClusterDefaultMajority` showing
+  an `actOnly` read observing a cluster time strictly greater than
+  `committedClusterTime`.
+
+## Running
+
+```sh
+cd src/mongo/tla_plus
+./download-tlc.sh
+./model-check.sh Replication/DefaultReadConcernAfterClusterTime
+```
+
+To exercise the bug cfg, copy or rename
+`MCDefaultReadConcernAfterClusterTime_bug.cfg` to
+`MCDefaultReadConcernAfterClusterTime.cfg` (the model-check script reads
+the canonical filename).


### PR DESCRIPTION
## Summary

TLA+ spec for default readConcern behavior under afterClusterTime.

**Jira:** https://jira.mongodb.org/browse/SERVER-126610
**Branch:** substrate-contrib/w3-31

## Files

```
  - ...default_read_concern_with_after_cluster_time.js | 115 ++++++++++++
  - .../DefaultReadConcernAfterClusterTime.tla         | 203 +++++++++++++++++++++
  - .../MCDefaultReadConcernAfterClusterTime.cfg       |  17 ++
  - .../MCDefaultReadConcernAfterClusterTime.tla       |  13 ++
  - .../MCDefaultReadConcernAfterClusterTime_bug.cfg   |  18 ++
  - .../DefaultReadConcernAfterClusterTime/OWNERS.yml  |   5 +
  - .../DefaultReadConcernAfterClusterTime/README.md   |  50 +++++
  - 7 files changed, 421 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
