### PR TITLE
SERVER-126612 TLA+ spec + jstest for cross-DB rename writer fence

### DIFF
--- a/jstests/replsets/rename_across_dbs_concurrent_writes_not_lost.js
+++ b/jstests/replsets/rename_across_dbs_concurrent_writes_not_lost.js
@@ -1,0 +1,147 @@
+/**
+ * SERVER-101428: cross-database renameCollection can drop writes acked during the unlocked window
+ * between the clone phase (P1) and the rename/drop phase (P2/P3) of `renameCollectionAcrossDatabases`
+ * (src/mongo/db/shard_role/shard_catalog/rename_collection.cpp).
+ *
+ * Repro shape:
+ *   - Start a 1-node replica set.
+ *   - Seed a source collection with N pre-existing docs in db `srcDB`.
+ *   - Kick off a parallel shell that issues a steady stream of inserts targeting `srcDB.coll`
+ *     with `w: "majority", j: true` (writes are acked only after journaling -- if the write was
+ *     not durable, the parallel shell would surface the error to the assert).
+ *   - Concurrently drive a renameCollection moving `srcDB.coll` -> `dstDB.coll`.
+ *   - After both finish, count documents in `dstDB.coll` and compare against the count of
+ *     acknowledged inserts (preExisting + concurrently-acked). The two MUST be equal: every ack'd
+ *     write must be readable from the post-rename target collection.
+ *
+ * Under the buggy schedule (SERVER-101428), inserts that land in the unlocked window between P1
+ * and P3 are acked into the original `source` collection, then `source` is dropped in P3 -- those
+ * writes are neither in `dst.coll` (they never went through tmp) nor anywhere else. The
+ * post-rename count will be strictly less than the acked count.
+ *
+ * Under the fix (source MODE_S/MODE_X held for the full P1..P3 duration), the parallel-shell
+ * inserts either complete before the rename starts (and therefore appear in `dst.coll` via the
+ * clone), or they block until P3 has dropped `source` and observe NamespaceNotFound (which the
+ * parallel-shell handles by not counting them as acked). Either way: ack count == final count.
+ *
+ * @tags: [
+ *     requires_replication,
+ *     requires_majority_read_concern,
+ *     does_not_support_stepdowns,
+ * ]
+ */
+
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+import {funWithArgs} from "jstests/libs/parallel_shell_helpers.js";
+
+const replTest = new ReplSetTest({name: "rename_across_dbs_concurrent_writes_not_lost", nodes: 1});
+replTest.startSet();
+replTest.initiate();
+
+const primary = replTest.getPrimary();
+const srcDBName = "src_db_w3_33";
+const dstDBName = "dst_db_w3_33";
+const collName = "rename_concurrent";
+const srcNs = `${srcDBName}.${collName}`;
+const dstNs = `${dstDBName}.${collName}`;
+
+const srcDB = primary.getDB(srcDBName);
+const dstDB = primary.getDB(dstDBName);
+
+// Seed source with a known number of documents that get cloned to tmp in P1.
+const preExistingCount = 500;
+{
+    const bulk = srcDB[collName].initializeUnorderedBulkOp();
+    for (let i = 0; i < preExistingCount; ++i) {
+        bulk.insert({_id: `pre_${i}`, kind: "preExisting"});
+    }
+    assert.commandWorked(bulk.execute({w: "majority", j: true}));
+    assert.eq(preExistingCount, srcDB[collName].countDocuments({}));
+}
+
+// Launch a parallel shell that hammers the source namespace with single-doc inserts at majority
+// write concern. The shell returns the number of inserts whose getLastError-equivalent succeeded
+// (the only ones the client is allowed to assume durably landed).
+//
+// The shell stops when it sees NamespaceNotFound (the rename has committed and `source` was
+// dropped), which is the expected terminal state on the source side.
+const writerShell = startParallelShell(
+    funWithArgs(function (srcNsArg, ackedCountField) {
+        const [srcDBName, collName] = srcNsArg.split(".");
+        const writerDB = db.getSiblingDB(srcDBName);
+        const accounting = db.getSiblingDB("admin")[ackedCountField];
+        // Drop any prior accounting state from a previous run, just in case.
+        accounting.drop();
+        accounting.insertOne({_id: "acked", n: 0});
+
+        const deadline = Date.now() + 30 * 1000; // hard cap so the test cannot hang.
+        let i = 0;
+        while (Date.now() < deadline) {
+            const doc = {_id: `race_${i}`, kind: "racing"};
+            const res = writerDB.runCommand({
+                insert: collName,
+                documents: [doc],
+                writeConcern: {w: "majority", j: true},
+            });
+            // Per-doc batched insert returns n: number of inserts that succeeded. If the namespace
+            // is gone we stop. If we got a write error, do not count it.
+            if (!res.ok || res.code === ErrorCodes.NamespaceNotFound) {
+                break;
+            }
+            if (res.writeErrors && res.writeErrors.length > 0) {
+                const we = res.writeErrors[0];
+                if (we.code === ErrorCodes.NamespaceNotFound) {
+                    break;
+                }
+                // Any other write error: do not count, continue.
+            } else if (res.n === 1) {
+                accounting.updateOne({_id: "acked"}, {$inc: {n: 1}});
+            }
+            i++;
+        }
+    }, srcNs, "ackedAccounting_w3_33"),
+    primary.port,
+);
+
+// Give the writer a brief head start so the rename hits a non-empty stream.
+sleep(250);
+
+// Drive the cross-DB rename.
+const renameRes = primary.adminCommand({
+    renameCollection: srcNs,
+    to: dstNs,
+    dropTarget: false,
+});
+assert.commandWorked(renameRes, () => `renameCollection failed: ${tojson(renameRes)}`);
+
+// Wait for the writer to finish (either it observed NamespaceNotFound or hit the 30s deadline).
+writerShell();
+
+// Read the acked count durably journaled by the parallel shell.
+const acked = primary.getDB("admin").ackedAccounting_w3_33.findOne({_id: "acked"});
+assert(acked, "parallel-shell accounting record missing");
+const ackedRacingCount = acked.n;
+
+// Verify the target namespace exists and the source is gone.
+assert(dstDB[collName].exists(), `expected ${dstNs} to exist after rename`);
+assert(!srcDB[collName].exists(), `expected ${srcNs} to be dropped after rename`);
+
+const finalCount = dstDB[collName].countDocuments({});
+const expectedCount = preExistingCount + ackedRacingCount;
+
+jsTestLog(
+    `[SERVER-101428] preExisting=${preExistingCount} ackedConcurrent=${ackedRacingCount} ` +
+        `finalCount=${finalCount} expected=${expectedCount}`,
+);
+
+// The headline assertion. Under the bug this fails when at least one concurrent insert was acked
+// in the P1->P3 unlocked window. Under the fix this holds for every interleaving.
+assert.eq(
+    expectedCount,
+    finalCount,
+    `Lost write detected (SERVER-101428): expected ${expectedCount} docs in ${dstNs} ` +
+        `(${preExistingCount} pre-existing + ${ackedRacingCount} concurrently acked), ` +
+        `found ${finalCount}. Missing ${expectedCount - finalCount} write(s).`,
+);
+
+replTest.stopSet();

--- a/src/mongo/tla_plus/Catalog/CrossDBRenameWriterFence/CrossDBRenameWriterFence.tla
+++ b/src/mongo/tla_plus/Catalog/CrossDBRenameWriterFence/CrossDBRenameWriterFence.tla
@@ -1,0 +1,267 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+------------------------- MODULE CrossDBRenameWriterFence -----------------------------------------
+\* This specification models the locking schedule of a cross-database renameCollection on a replica
+\* set (SERVER-101428). Renaming a collection across databases is implemented in three sequential
+\* phases on a single node:
+\*
+\*  P1 (clone):  acquire MODE_S on `source` and MODE_X on a temporary collection `tmp` in the target
+\*               database; copy every document from `source` to `tmp`; release both locks.
+\*  P2 (rename): rename `tmp` to `target` under MODE_X.
+\*  P3 (drop):   drop `source` under MODE_X.
+\*
+\* The bug: in the production code path (src/mongo/db/shard_role/shard_catalog/rename_collection.cpp
+\* ~line 991), the MODE_S lock on `source` is released at the end of P1, *before* P2/P3 execute.
+\* During the unlocked window between P1 and P3 a writer can take MODE_IX on `source` and insert a
+\* document. That insert hits the original source collection, which P3 then drops -- the write is
+\* neither in the renamed (target) collection nor in any surviving collection. It is lost.
+\*
+\* This spec models the lock schedule, a single writer racing the rename, and the resulting document
+\* set. The correctness invariant `NoWriteLost' asserts that every write that the client observed as
+\* acknowledged is readable from *some* collection after the rename completes.
+\*
+\* Two CONSTANTS toggle the bug vs. the fix:
+\*  - HoldSourceLockUntilRename = FALSE  -> models the buggy production schedule
+\*  - HoldSourceLockUntilRename = TRUE   -> models the proposed fix (keep MODE_S/MODE_X on source
+\*                                          until after P3)
+\*
+\* To run the model-checker:
+\*     cd src/mongo/tla_plus
+\*     ./model-check.sh Catalog/CrossDBRenameWriterFence              \* uses MC*.cfg (bug cfg)
+\*
+\* See MCCrossDBRenameWriterFence_green.cfg for the fixed-schedule verification run.
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+
+CONSTANTS
+    Writes,                          \* Finite set of writes the racing writer may attempt, e.g. {w1,w2}.
+    HoldSourceLockUntilRename        \* BOOLEAN. TRUE => fix; FALSE => SERVER-101428 schedule.
+
+ASSUME Cardinality(Writes) >= 1
+ASSUME HoldSourceLockUntilRename \in BOOLEAN
+
+\* Lock modes we care about. MODE_S blocks IX; MODE_X blocks everything; MODE_NONE blocks nothing.
+LockNone == "NONE"
+LockS    == "S"
+LockIX   == "IX"
+LockX    == "X"
+
+\* Phases of the cross-DB rename.
+RenameIdle    == "idle"
+RenameClone   == "clone"     \* P1: holding S on source, X on tmp, copying docs.
+RenameUnlocked== "unlocked"  \* Buggy window: source S lock released, rename not yet executed.
+RenameRename  == "rename"    \* P2: rename tmp -> target under X on tmp/target.
+RenameDrop    == "drop"      \* P3: drop source under X on source.
+RenameDone    == "done"
+
+(* ----- State variables -------------------------------------------------------------------------- *)
+VARIABLE renamePhase           \* Current phase of the rename coordinator.
+VARIABLE sourceLock            \* Lock currently held on the `source' namespace by the renamer.
+VARIABLE writerPhase           \* For each w in Writes: "pending" | "acked_source" | "blocked" | "rejected".
+VARIABLE sourceDocs            \* Set of writes durably present in the `source' collection.
+VARIABLE tmpDocs               \* Set of writes durably present in the `tmp' collection.
+VARIABLE targetDocs            \* Set of writes durably present in the `target' collection after rename.
+VARIABLE sourceDropped         \* TRUE once P3 has dropped the original `source' collection.
+VARIABLE clientAcked           \* Writes the client received OK for. Every one of these MUST be
+                               \* readable from some surviving collection at the end of the run.
+
+vars == << renamePhase, sourceLock, writerPhase, sourceDocs, tmpDocs, targetDocs,
+           sourceDropped, clientAcked >>
+
+WriterPhases == {"pending", "acked_source", "blocked", "rejected"}
+
+(* ----- Initial state ---------------------------------------------------------------------------- *)
+Init ==
+    /\ renamePhase   = RenameIdle
+    /\ sourceLock    = LockNone
+    /\ writerPhase   = [w \in Writes |-> "pending"]
+    /\ sourceDocs    = {}     \* Source starts empty for clarity; the lost-write bug is independent
+                              \* of pre-existing content.
+    /\ tmpDocs       = {}
+    /\ targetDocs    = {}
+    /\ sourceDropped = FALSE
+    /\ clientAcked   = {}
+
+(* ----- Rename coordinator transitions ----------------------------------------------------------- *)
+
+\* P1 begin: acquire MODE_S on source, MODE_X on tmp, start cloning.
+\* Cannot start while a writer holds IX on source.
+RenameStartClone ==
+    /\ renamePhase = RenameIdle
+    /\ sourceLock \in {LockNone}
+    /\ renamePhase' = RenameClone
+    /\ sourceLock'  = LockS
+    /\ tmpDocs'     = sourceDocs              \* Clone copies the current docs into tmp.
+    /\ UNCHANGED << writerPhase, sourceDocs, targetDocs, sourceDropped, clientAcked >>
+
+\* End of P1: release source lock if running the buggy schedule, else hold it.
+\*
+\* In the buggy schedule the source MODE_S lock is released *here* (line 991 of
+\* rename_collection.cpp) before P2/P3. In the fixed schedule we keep the source locked (escalated to
+\* MODE_X in preparation for the drop) for the duration of P2+P3.
+RenameFinishClone ==
+    /\ renamePhase = RenameClone
+    /\ IF HoldSourceLockUntilRename
+        THEN /\ renamePhase' = RenameRename
+             /\ sourceLock'  = LockX           \* Escalate to MODE_X; writers stay blocked.
+        ELSE /\ renamePhase' = RenameUnlocked  \* Buggy window: source momentarily lockless.
+             /\ sourceLock'  = LockNone
+    /\ UNCHANGED << writerPhase, sourceDocs, tmpDocs, targetDocs, sourceDropped, clientAcked >>
+
+\* Acquire the cross-namespace X lock needed to execute the rename. From the unlocked window the
+\* renamer must re-acquire source/tmp/target locks.
+RenameAcquireForRename ==
+    /\ renamePhase = RenameUnlocked
+    /\ sourceLock = LockNone                  \* No writer currently holds IX (writer either finished
+                                              \* or hasn't started); modelled as a serial step.
+    /\ renamePhase' = RenameRename
+    /\ sourceLock'  = LockX
+    /\ UNCHANGED << writerPhase, sourceDocs, tmpDocs, targetDocs, sourceDropped, clientAcked >>
+
+\* P2: rename tmp -> target. The tmp collection's contents become target.
+RenameDoRename ==
+    /\ renamePhase = RenameRename
+    /\ renamePhase' = RenameDrop
+    /\ targetDocs'  = tmpDocs
+    /\ tmpDocs'     = {}
+    /\ UNCHANGED << sourceLock, writerPhase, sourceDocs, sourceDropped, clientAcked >>
+
+\* P3: drop the original `source` collection. Any docs still in source are now unreachable.
+RenameDoDrop ==
+    /\ renamePhase = RenameDrop
+    /\ renamePhase' = RenameDone
+    /\ sourceLock'  = LockNone
+    /\ sourceDocs'  = {}
+    /\ sourceDropped' = TRUE
+    /\ UNCHANGED << writerPhase, tmpDocs, targetDocs, clientAcked >>
+
+(* ----- Writer transitions ----------------------------------------------------------------------- *)
+
+\* A writer wants MODE_IX on source. It can proceed only if:
+\*   - source is not under MODE_S or MODE_X from the renamer, AND
+\*   - source has not been dropped (otherwise the namespace would be NamespaceNotFound).
+\*
+\* If source is under S or X, we model the writer as blocked (waiting); for the purposes of the
+\* lost-write bug, we let the renamer drive forward and the writer eventually retries. To keep the
+\* state space finite, a blocked writer simply cannot acknowledge until it acquires the lock.
+\*
+\* If source has been dropped, the insert returns NamespaceNotFound; the client knows the write was
+\* not accepted, so it is NOT added to clientAcked (no contract violation).
+WriterTryInsert(w) ==
+    /\ writerPhase[w] = "pending"
+    /\ \/ /\ sourceLock \in {LockS, LockX}
+          /\ writerPhase' = [writerPhase EXCEPT ![w] = "blocked"]
+          /\ UNCHANGED << renamePhase, sourceLock, sourceDocs, tmpDocs, targetDocs,
+                          sourceDropped, clientAcked >>
+       \/ /\ sourceLock = LockNone
+          /\ sourceDropped
+          \* Source dropped: the insert is rejected (NamespaceNotFound). No ack, no doc.
+          /\ writerPhase' = [writerPhase EXCEPT ![w] = "rejected"]
+          /\ UNCHANGED << renamePhase, sourceLock, sourceDocs, tmpDocs, targetDocs,
+                          sourceDropped, clientAcked >>
+       \/ /\ sourceLock = LockNone
+          /\ ~sourceDropped
+          \* Source unlocked and alive: writer takes IX, inserts, gets acked.
+          /\ writerPhase' = [writerPhase EXCEPT ![w] = "acked_source"]
+          /\ sourceDocs' = sourceDocs \cup {w}
+          /\ clientAcked' = clientAcked \cup {w}
+          /\ UNCHANGED << renamePhase, sourceLock, tmpDocs, targetDocs, sourceDropped >>
+
+\* A blocked writer retries once the lock clears. We collapse the retry into a single step that
+\* re-runs WriterTryInsert by flipping back to "pending"; this keeps the spec tractable.
+WriterRetry(w) ==
+    /\ writerPhase[w] = "blocked"
+    /\ sourceLock = LockNone
+    /\ writerPhase' = [writerPhase EXCEPT ![w] = "pending"]
+    /\ UNCHANGED << renamePhase, sourceLock, sourceDocs, tmpDocs, targetDocs, sourceDropped,
+                    clientAcked >>
+
+(* ----- Terminal stutter to keep TLC happy with a finite state space ----------------------------- *)
+
+\* When the rename has completed and every writer has reached a terminal phase, the spec
+\* deliberately stops doing useful work. Without an explicit stutter step TLC would flag this as a
+\* spurious deadlock; this action allows the system to remain in its terminal state.
+TerminalStutter ==
+    /\ renamePhase = RenameDone
+    /\ \A w \in Writes : writerPhase[w] \in {"acked_source", "rejected"}
+    /\ UNCHANGED vars
+
+(* ----- Next-state relation ---------------------------------------------------------------------- *)
+
+Next ==
+    \/ RenameStartClone
+    \/ RenameFinishClone
+    \/ RenameAcquireForRename
+    \/ RenameDoRename
+    \/ RenameDoDrop
+    \/ \E w \in Writes : WriterTryInsert(w)
+    \/ \E w \in Writes : WriterRetry(w)
+    \/ TerminalStutter
+
+Fairness ==
+    /\ WF_vars(RenameStartClone)
+    /\ WF_vars(RenameFinishClone)
+    /\ WF_vars(RenameAcquireForRename)
+    /\ WF_vars(RenameDoRename)
+    /\ WF_vars(RenameDoDrop)
+    /\ \A w \in Writes : WF_vars(WriterTryInsert(w))
+    /\ \A w \in Writes : WF_vars(WriterRetry(w))
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+(* ----- Type invariants -------------------------------------------------------------------------- *)
+
+RenamePhases == {RenameIdle, RenameClone, RenameUnlocked, RenameRename, RenameDrop, RenameDone}
+LockModes    == {LockNone, LockS, LockIX, LockX}
+
+TypeOK ==
+    /\ renamePhase   \in RenamePhases
+    /\ sourceLock    \in LockModes
+    /\ writerPhase   \in [Writes -> WriterPhases]
+    /\ sourceDocs    \subseteq Writes
+    /\ tmpDocs       \subseteq Writes
+    /\ targetDocs    \subseteq Writes
+    /\ sourceDropped \in BOOLEAN
+    /\ clientAcked   \subseteq Writes
+
+(* ----- Correctness properties ------------------------------------------------------------------- *)
+
+\* Lock exclusivity: while the renamer holds MODE_S or MODE_X on source, no writer is mid-insert.
+\* (Trivially true in this spec by construction, but documents the lock semantics.)
+LockExclusivity ==
+    sourceLock \in {LockS, LockX} =>
+        \A w \in Writes : writerPhase[w] # "acked_source" \/ w \in sourceDocs
+
+\* Headline invariant. Every write the client observed as acknowledged must, at every step,
+\* be readable from some collection in the system. A write disappears iff it landed in `source`
+\* during the unlocked P1->P2 window and then P3 dropped `source`.
+NoWriteLost ==
+    \A w \in clientAcked :
+        \/ w \in sourceDocs
+        \/ w \in tmpDocs
+        \/ w \in targetDocs
+
+\* Stronger end-state form: once the rename completes, every acked write is in `target` or still
+\* in `source` (the latter only possible if the writer raced *after* P3, which cannot happen since
+\* source is dropped). This is the form that fails dramatically under the bug.
+NoWriteLostAtEnd ==
+    renamePhase = RenameDone =>
+        \A w \in clientAcked :
+            \/ w \in targetDocs
+            \/ w \in sourceDocs
+
+(* ----- Liveness --------------------------------------------------------------------------------- *)
+
+\* Eventually every writer either gets acked or is rejected by NamespaceNotFound (post-drop). No
+\* writer is stuck forever in the "blocked" state.
+WriterMakesProgress ==
+    \A w \in Writes :
+        <>(writerPhase[w] \in {"acked_source", "rejected"})
+
+\* The rename eventually completes.
+RenameTerminates == <>(renamePhase = RenameDone)
+====================================================================================================

--- a/src/mongo/tla_plus/Catalog/CrossDBRenameWriterFence/MCCrossDBRenameWriterFence.cfg
+++ b/src/mongo/tla_plus/Catalog/CrossDBRenameWriterFence/MCCrossDBRenameWriterFence.cfg
@@ -1,0 +1,27 @@
+\* BUG configuration for SERVER-101428.
+\*
+\* HoldSourceLockUntilRename = FALSE models the production schedule that releases the source MODE_S
+\* lock between P1 (clone) and P2 (rename), creating the unlocked window in which a racing writer
+\* can ack an insert into the original `source' collection, only for P3 to drop the entire
+\* collection -- losing the write.
+\*
+\* Expected outcome: TLC reports `NoWriteLost' / `NoWriteLostAtEnd' violated and emits a
+\* counterexample trace exhibiting the lost write.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    Writes = {w1, w2}
+    HoldSourceLockUntilRename = FALSE
+
+INVARIANT
+    TypeOK
+    LockExclusivity
+    NoWriteLost
+    NoWriteLostAtEnd
+
+PROPERTY
+    WriterMakesProgress
+    RenameTerminates
+
+SYMMETRY Symmetry

--- a/src/mongo/tla_plus/Catalog/CrossDBRenameWriterFence/MCCrossDBRenameWriterFence.tla
+++ b/src/mongo/tla_plus/Catalog/CrossDBRenameWriterFence/MCCrossDBRenameWriterFence.tla
@@ -1,0 +1,32 @@
+------------------------- MODULE MCCrossDBRenameWriterFence ---------------------------------------
+\* Model-checking module for CrossDBRenameWriterFence.
+\*
+\* Two .cfg files share this module:
+\*   - MCCrossDBRenameWriterFence.cfg         (BUG schedule: HoldSourceLockUntilRename = FALSE)
+\*   - MCCrossDBRenameWriterFence_green.cfg   (FIX schedule: HoldSourceLockUntilRename = TRUE)
+\*
+\* The bug cfg expects NoWriteLost / NoWriteLostAtEnd to fail with a counterexample showing a write
+\* acked by the source between the unlocked-P1 and P3-drop window, which then vanishes when source
+\* is dropped. The green cfg expects the same invariants to hold across the full state space.
+
+EXTENDS CrossDBRenameWriterFence
+
+(* ----- Symmetry --------------------------------------------------------------------------------- *)
+
+\* All writes are interchangeable from the lost-write perspective; permuting them shouldn't grow
+\* the state space.
+Symmetry == Permutations(Writes)
+
+(* ----- Bait predicates (counterexample search) -------------------------------------------------- *)
+
+\* A write reaches the source collection while the rename is mid-flight.
+BaitWriteRacedRename ==
+    \A w \in Writes :
+        writerPhase[w] # "acked_source" \/ renamePhase \in {RenameIdle, RenameDone}
+
+\* A write was acked but is nowhere readable after the rename completes.
+BaitLostWrite ==
+    renamePhase # RenameDone \/
+    \A w \in clientAcked : w \in targetDocs \/ w \in sourceDocs
+
+====================================================================================================

--- a/src/mongo/tla_plus/Catalog/CrossDBRenameWriterFence/MCCrossDBRenameWriterFence_green.cfg
+++ b/src/mongo/tla_plus/Catalog/CrossDBRenameWriterFence/MCCrossDBRenameWriterFence_green.cfg
@@ -1,0 +1,28 @@
+\* GREEN configuration for SERVER-101428: the proposed fix.
+\*
+\* HoldSourceLockUntilRename = TRUE models the corrected schedule that keeps a blocking lock on
+\* `source' (MODE_S, escalated to MODE_X) for the full duration P1..P3. Concurrent writers
+\* targeting `source' either complete before P1 begins, or are blocked until P3 has acquired X
+\* and dropped the namespace -- in which case they observe NamespaceNotFound and the client never
+\* gets a misleading OK.
+\*
+\* Expected outcome: TLC reports `No errors found'. All invariants hold across the full reachable
+\* state space and both liveness properties are satisfied.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    Writes = {w1, w2}
+    HoldSourceLockUntilRename = TRUE
+
+INVARIANT
+    TypeOK
+    LockExclusivity
+    NoWriteLost
+    NoWriteLostAtEnd
+
+PROPERTY
+    WriterMakesProgress
+    RenameTerminates
+
+SYMMETRY Symmetry


### PR DESCRIPTION
## Summary

TLA+ spec + jstest for cross-DB rename writer fence.

**Jira:** https://jira.mongodb.org/browse/SERVER-126612
**Branch:** substrate-contrib/w3-33

## Files

```
  - ...rename_across_dbs_concurrent_writes_not_lost.js | 147 ++++++++++++
  - .../CrossDBRenameWriterFence.tla                   | 267 +++++++++++++++++++++
  - .../MCCrossDBRenameWriterFence.cfg                 |  27 +++
  - .../MCCrossDBRenameWriterFence.tla                 |  32 +++
  - .../MCCrossDBRenameWriterFence_green.cfg           |  28 +++
  - 5 files changed, 501 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
