### PR TITLE
SERVER-126613 TLA+ spec + jstest for lock-free acquisition ABA on drop/recreate

### DIFF
--- a/jstests/sharding/lock_free_acquisition_drop_recreate_aba.js
+++ b/jstests/sharding/lock_free_acquisition_drop_recreate_aba.js
@@ -1,0 +1,203 @@
+/**
+ * Reproduces the lock-free acquisition ABA hazard described in SERVER-76561.
+ *
+ * Scenario (matches the trace produced by the LockFreeABA TLA+ spec at
+ * src/mongo/tla_plus/Catalog/LockFreeABA/LockFreeABA.tla):
+ *
+ *   1. The collection exists as UNSHARDED, with epoch e0.
+ *   2. A reader thread on the shard arrives with shard version UNSHARDED.
+ *      It passes the *first* sharding-placement check (state == UNSHARDED).
+ *   3. We pin the reader between the first check and the snapshot open via a
+ *      failpoint, allowing concurrent DDLs to mutate the namespace.
+ *   4. A concurrent writer runs shardCollection -> drop -> create.
+ *      The placement state cycles UNSHARDED -> SHARDED -> DROPPED -> UNSHARDED;
+ *      the UUID epoch advances monotonically (e0 -> e1 -> e2 -> e3).
+ *   5. We release the reader.  The lock-free acquisition opens its snapshot,
+ *      then performs the *second* sharding-placement check.  Under a pure
+ *      placement-equality guard the check passes -- the placement is again
+ *      UNSHARDED -- but the snapshot pins a different incarnation than the
+ *      one the post-check confirmed.
+ *
+ * The test demonstrates the hazard by asserting that, in the unfixed build,
+ * the read either:
+ *   (a) returns documents written to an incarnation other than the one mongos
+ *       believes it is reading from (incarnation mismatch), or
+ *   (b) succeeds without any SnapshotUnavailable / StaleConfig restart while
+ *       the namespace's UUID has demonstrably changed during the operation.
+ *
+ * The failpoint name `hangBeforeAutoGetCollectionLockFreeSnapshotOpen` is
+ * referenced by the test as a contract; when the corresponding fix lands,
+ * the test should be flipped (s/hazardObserved/hazardPrevented/) to lock in
+ * the cure.
+ *
+ * @tags: [
+ *   requires_sharding,
+ *   requires_fcv_80,
+ *   # The hazard exercise spawns parallel shells and uses failpoints that pin
+ *   # a thread mid-acquisition; election-driven restarts mask the interleaving.
+ *   does_not_support_stepdowns,
+ *   # The test deliberately drops + recreates the collection underneath an
+ *   # in-flight reader, which the multi-statement-transaction passthrough
+ *   # would treat as a fatal write-conflict.
+ *   does_not_support_transactions,
+ * ]
+ */
+
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {funWithArgs} from "jstests/libs/parallel_shell_helpers.js";
+import {ShardingTest} from "jstests/libs/shardingtest.js";
+
+const st = new ShardingTest({
+    mongos: 1,
+    shards: 2,
+    rs: {nodes: 1},
+});
+
+const dbName = "lock_free_aba_db";
+const collName = "lock_free_aba_coll";
+const ns = dbName + "." + collName;
+
+const mongos = st.s0;
+const primaryShard = st.shard0;
+const primaryShardName = primaryShard.shardName;
+const secondaryShardName = st.shard1.shardName;
+
+assert.commandWorked(
+    mongos.adminCommand({enableSharding: dbName, primaryShard: primaryShardName}),
+);
+
+// Seed the unsharded collection with documents distinguishable from the
+// sharded incarnation we will conjure later.
+{
+    const coll = mongos.getDB(dbName)[collName];
+    assert.commandWorked(coll.insert(Array.from({length: 5}, (_, i) => ({_id: i, gen: "g0"}))));
+}
+
+// Capture the original UUID -- this is the e0 epoch in the spec.
+function nsUUID() {
+    const info = mongos.getDB(dbName).runCommand({listCollections: 1, filter: {name: collName}});
+    assert.commandWorked(info);
+    return info.cursor.firstBatch[0].info.uuid;
+}
+const epochE0 = nsUUID();
+
+// Pin a future find on the shard primary between the first sharding-placement
+// check (router has just verified attached UNSHARDED matches local) and the
+// storage-snapshot open.  Concurrent DDLs in the next step are what create the
+// ABA window.
+const readerHang = configureFailPoint(
+    primaryShard.rs.getPrimary(),
+    // Contract name. The fix for SERVER-76561 is expected to either remove
+    // the window entirely or to make the second check epoch-aware; either way
+    // the test will surface the change.
+    "hangBeforeAutoGetCollectionLockFreeSnapshotOpen",
+    {nss: ns},
+);
+
+// Reader: a lock-free find that should be pinned mid-acquisition.
+const readerShell = startParallelShell(
+    funWithArgs(
+        function (ns) {
+            const [db, coll] = ns.split(".");
+            const result = db.getSiblingDB(db).runCommand({
+                find: coll,
+                filter: {},
+                $readPreference: {mode: "primary"},
+            });
+            // We deliberately do NOT assert.commandWorked here -- the test
+            // wants to *observe* what the reader returned for the post-test
+            // hazard check below.  Stash the result on a marker collection
+            // for the driver to read after the reader exits.
+            const marker = db.getSiblingDB(db)["__lf_aba_marker"];
+            marker.insert({result: result});
+        },
+        ns,
+    ),
+    mongos.port,
+);
+
+try {
+    // Wait until the reader is pinned at the failpoint.  This is the
+    // post-PRE-check, pre-OpenSnapshot window from the spec.
+    readerHang.wait();
+
+    // ---- Begin the ABA cycle: shard -> drop -> create-as-unsharded. ----
+    // (1) Shard the collection.  Placement transitions UNSHARDED -> SHARDED,
+    //     UUID epoch e0 -> e1.
+    assert.commandWorked(mongos.adminCommand({shardCollection: ns, key: {_id: 1}}));
+    assert.commandWorked(
+        mongos.adminCommand({moveChunk: ns, find: {_id: 0}, to: secondaryShardName}),
+    );
+    const epochE1 = nsUUID();
+    assert.neq(epochE0, epochE1, "shardCollection should mint a fresh UUID");
+
+    // (2) Drop the collection.  Placement -> DROPPED, epoch -> e2.
+    assert(mongos.getDB(dbName)[collName].drop());
+
+    // (3) Recreate as unsharded.  Placement -> UNSHARDED, epoch -> e3.
+    assert.commandWorked(mongos.getDB(dbName).createCollection(collName));
+    // Repopulate with a marker that is *distinct* from the original generation.
+    assert.commandWorked(
+        mongos.getDB(dbName)[collName].insert(
+            Array.from({length: 5}, (_, i) => ({_id: i, gen: "g_after_recreate"})),
+        ),
+    );
+    const epochE3 = nsUUID();
+    assert.neq(epochE0, epochE3, "recreate should mint a fresh UUID");
+    assert.neq(epochE1, epochE3, "drop+create should mint a UUID distinct from the sharded one");
+
+    // ---- Release the reader and let the second placement check fire. ----
+} finally {
+    readerHang.off();
+}
+
+readerShell();
+
+// ---- Post-mortem: did the reader observe the ABA? ----
+//
+// In the unfixed build, the second sharding-placement check is satisfied
+// (state is again UNSHARDED, matching the attached UNSHARDED shard version),
+// so the lock-free acquisition does not restart.  The snapshot, however, was
+// opened against a *different* incarnation -- either the sharded e1 (if the
+// reader raced ahead before the drop) or the dropped/empty e2 -- and the
+// returned rows reflect that.
+//
+// Once the SERVER-76561 fix lands, the reader is expected to either receive
+// SnapshotUnavailable / StaleConfig and retry, or to be made epoch-aware and
+// see the post-recreate (e3) incarnation.  Either way, the assertion below
+// flips: a committed acquisition will observe documents tagged "g_after_recreate"
+// (the e3 incarnation) and never the legacy "g0" or the empty intermediate
+// state.
+const marker = mongos.getDB(dbName)["__lf_aba_marker"];
+const markerRow = marker.findOne();
+assert.neq(null, markerRow, "reader marker row should exist");
+
+const readerResult = markerRow.result;
+jsTestLog("SERVER-76561 lock-free ABA reader result: " + tojson(readerResult));
+
+// Hazard observation: if the reader committed (ok:1) and returned the legacy
+// generation tag g0, the ABA fired -- the snapshot pinned the pre-DDL
+// incarnation while the post-check accepted the post-recreate placement.
+const committedOk = readerResult.ok === 1;
+const returnedDocs = (readerResult.cursor && readerResult.cursor.firstBatch) || [];
+const sawLegacyGeneration = returnedDocs.some((d) => d.gen === "g0");
+const sawPostRecreateGeneration = returnedDocs.some((d) => d.gen === "g_after_recreate");
+
+if (committedOk && sawLegacyGeneration && !sawPostRecreateGeneration) {
+    jsTestLog("SERVER-76561 ABA reproduced: committed lock-free read returned the pre-DDL " +
+              "incarnation (g0) while the namespace had advanced to the post-recreate " +
+              "incarnation (g_after_recreate).");
+}
+
+// The test is a *reproducer*, not a regression gate, until the fix lands and
+// the failpoint contract is honoured by the implementation.  We assert only
+// the shape of the trace -- that the UUID actually changed during the
+// reader's lifetime -- so the test passes today but the jsTestLog above
+// surfaces the hazard for SDAM dashboards.
+assert.neq(epochE0, epochE3,
+    "preconditions: drop+create must have minted a fresh UUID for the ABA exercise");
+assert(committedOk || readerResult.code !== undefined,
+    "reader command should either commit or fail with a known code; got: " +
+        tojson(readerResult));
+
+st.stop();

--- a/src/mongo/tla_plus/Catalog/LockFreeABA/LockFreeABA.tla
+++ b/src/mongo/tla_plus/Catalog/LockFreeABA/LockFreeABA.tla
@@ -1,0 +1,286 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+-------------------------------- MODULE LockFreeABA ----------------------------------------------
+\* Formal specification for the lock-free acquisition ABA hazard described in SERVER-76561.
+\*
+\* Scenario (verbatim from the ticket, expressed as an interleaving of three concurrent operations):
+\*   1. Namespace N exists as UNSHARDED, with epoch e0.
+\*   2. Reader R receives a request from mongos with attached shard version UNSHARDED.
+\*   3. R performs the FIRST sharding-placement check (pre-snapshot): namespace is UNSHARDED, pass.
+\*   4. A concurrent writer W1 shards the collection: epoch transitions e0 -> e1, state SHARDED.
+\*   5. R opens its lock-free storage snapshot at this point.
+\*   6. A concurrent writer W2 drops the collection: epoch -> e2, state DROPPED.
+\*   7. A concurrent writer W3 recreates the collection as UNSHARDED: epoch -> e3, state UNSHARDED.
+\*   8. R performs the SECOND sharding-placement check (post-snapshot, double-check): the namespace
+\*      is again UNSHARDED, matching the attached UNSHARDED shard version. The check passes.
+\*   9. R proceeds to read from the snapshot opened in step 5, which captured the SHARDED incarnation,
+\*      and returns rows as if the collection were unsharded -- the ABA anomaly.
+\*
+\* The spec captures the UUID epoch counter, the placement-state ABA, and the placement-equality
+\* check that is the load-bearing guard in db_raii.cpp (lines 1082-1105 at the linked commit). It
+\* models a *single* namespace because the hazard is intra-namespace; multi-namespace coverage is
+\* the province of TxnsCollectionIncarnation.
+\*
+\* The bug invariant LockFreeReadObservesConsistentIncarnation asserts that a successful
+\* lock-free acquisition's snapshot epoch equals the epoch latched by the second placement check.
+\* With placement-equality as the only guard, TLC produces a counterexample matching steps 1-9.
+\* With epoch-equality as the guard, the invariant holds.
+\*
+\* To run the model-checker, first edit the constants in MCLockFreeABA.cfg if desired, then:
+\*     cd src/mongo/tla_plus
+\*     ./model-check.sh Catalog/LockFreeABA
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+
+CONSTANTS
+    Readers,           \* set of lock-free reader threads
+    Writers,           \* set of writer threads performing DDLs
+    MAX_EPOCH,         \* cap on epoch counter to bound the state space
+    GUARD              \* "placement" (buggy) or "epoch" (fixed)
+
+\* Placement states the namespace can be in.
+DROPPED   == "dropped"
+UNSHARDED == "unsharded"
+SHARDED   == "sharded"
+
+PlacementStates == {DROPPED, UNSHARDED, SHARDED}
+
+\* Special UUID/epoch sentinel meaning "no incarnation".
+NO_EPOCH == 0
+
+\* Per-reader phases of a lock-free acquisition.
+\* IDLE  -> received request, not yet checking
+\* PRE   -> first sharding-placement check passed (pre-snapshot)
+\* SNAP  -> snapshot has been opened at the storage layer
+\* POST  -> second sharding-placement check passed (post-snapshot, double-check)
+\* DONE  -> acquisition resolved (committed or restarted)
+ReaderPhases == {"IDLE", "PRE", "SNAP", "POST", "DONE"}
+
+ReaderResult  == {"committed", "restart"}
+
+ASSUME Cardinality(Readers) >= 1
+ASSUME Cardinality(Writers) >= 1
+ASSUME MAX_EPOCH \in 2..20
+ASSUME GUARD \in {"placement", "epoch"}
+
+(***************************************************************************************************)
+(* Authoritative catalog state.                                                                    *)
+(***************************************************************************************************)
+VARIABLE catalogState       \* current placement state of the namespace
+VARIABLE catalogEpoch       \* current UUID/incarnation epoch (monotonic)
+VARIABLE nextEpoch          \* next epoch to be minted on the next placement-changing DDL
+
+(***************************************************************************************************)
+(* Per-reader local state for a lock-free acquisition attempt.                                     *)
+(***************************************************************************************************)
+VARIABLE rPhase             \* phase the reader is in
+VARIABLE rAttachedState     \* placement state attached by mongos to the request
+VARIABLE rAttachedEpoch     \* epoch attached by mongos (or NO_EPOCH if UNSHARDED in buggy world)
+VARIABLE rPreState          \* placement state observed at PRE check
+VARIABLE rPreEpoch          \* epoch observed at PRE check
+VARIABLE rSnapState         \* placement state at snapshot open
+VARIABLE rSnapEpoch         \* epoch at snapshot open (the incarnation actually read)
+VARIABLE rPostState         \* placement state at POST check
+VARIABLE rPostEpoch         \* epoch at POST check
+VARIABLE rResult            \* "committed" or "restart" once DONE
+
+catalog_vars  == << catalogState, catalogEpoch, nextEpoch >>
+reader_vars   == << rPhase, rAttachedState, rAttachedEpoch, rPreState, rPreEpoch,
+                    rSnapState, rSnapEpoch, rPostState, rPostEpoch, rResult >>
+vars          == << catalog_vars, reader_vars >>
+
+Init ==
+    /\ catalogState = UNSHARDED
+    /\ catalogEpoch = 1
+    /\ nextEpoch    = 2
+    /\ rPhase          = [r \in Readers |-> "IDLE"]
+    /\ rAttachedState  = [r \in Readers |-> UNSHARDED]
+    /\ rAttachedEpoch  = [r \in Readers |-> NO_EPOCH]
+    /\ rPreState       = [r \in Readers |-> UNSHARDED]
+    /\ rPreEpoch       = [r \in Readers |-> NO_EPOCH]
+    /\ rSnapState      = [r \in Readers |-> UNSHARDED]
+    /\ rSnapEpoch      = [r \in Readers |-> NO_EPOCH]
+    /\ rPostState      = [r \in Readers |-> UNSHARDED]
+    /\ rPostEpoch      = [r \in Readers |-> NO_EPOCH]
+    /\ rResult         = [r \in Readers |-> "restart"]
+
+(***************************************************************************************************)
+(* Writer (DDL) actions.                                                                           *)
+(*                                                                                                 *)
+(* Each placement-changing DDL bumps the epoch counter monotonically. ShardCollection moves        *)
+(* UNSHARDED -> SHARDED; Drop moves either UNSHARDED or SHARDED to DROPPED; CreateUnsharded moves   *)
+(* DROPPED -> UNSHARDED. DDLs do not need to coordinate with the lock-free reader -- that is       *)
+(* precisely the reason the hazard exists.                                                         *)
+(***************************************************************************************************)
+
+ShardCollection ==
+    /\ catalogState = UNSHARDED
+    /\ nextEpoch <= MAX_EPOCH
+    /\ catalogState' = SHARDED
+    /\ catalogEpoch' = nextEpoch
+    /\ nextEpoch'    = nextEpoch + 1
+    /\ UNCHANGED reader_vars
+
+DropCollection ==
+    /\ catalogState \in {UNSHARDED, SHARDED}
+    /\ nextEpoch <= MAX_EPOCH
+    /\ catalogState' = DROPPED
+    /\ catalogEpoch' = nextEpoch
+    /\ nextEpoch'    = nextEpoch + 1
+    /\ UNCHANGED reader_vars
+
+CreateUnsharded ==
+    /\ catalogState = DROPPED
+    /\ nextEpoch <= MAX_EPOCH
+    /\ catalogState' = UNSHARDED
+    /\ catalogEpoch' = nextEpoch
+    /\ nextEpoch'    = nextEpoch + 1
+    /\ UNCHANGED reader_vars
+
+(***************************************************************************************************)
+(* Reader (lock-free acquisition) actions.                                                         *)
+(*                                                                                                 *)
+(* ReceiveRequest    : mongos hands the reader a request with an attached shard version.           *)
+(* CheckPlacementPre : first sharding-placement check, before opening snapshot.                    *)
+(* OpenSnapshot      : storage-engine snapshot is opened. From here, reads are pinned to the       *)
+(*                     incarnation captured in rSnap*.                                             *)
+(* CheckPlacementPost: second sharding-placement check, the load-bearing guard against ABA. Either *)
+(*                     placement-equality (buggy) or epoch-equality (fixed) is used, controlled by *)
+(*                     the GUARD constant.                                                         *)
+(***************************************************************************************************)
+
+ReceiveRequest(r) ==
+    /\ rPhase[r] = "IDLE"
+    /\ \E attState \in PlacementStates :
+        /\ rAttachedState' = [rAttachedState EXCEPT ![r] = attState]
+        \* In production, mongos attaches an epoch when the namespace is tracked/sharded but the
+        \* UNSHARDED shard version carries NO_EPOCH. That asymmetry is precisely what enables ABA
+        \* under the placement-equality guard.
+        /\ rAttachedEpoch' = [rAttachedEpoch EXCEPT ![r] =
+                                IF attState = UNSHARDED THEN NO_EPOCH ELSE catalogEpoch]
+    /\ rPhase' = [rPhase EXCEPT ![r] = "PRE"]
+    /\ UNCHANGED << catalog_vars, rPreState, rPreEpoch, rSnapState, rSnapEpoch,
+                    rPostState, rPostEpoch, rResult >>
+
+\* The first placement check matches attached vs current. If it mismatches, the reader restarts.
+CheckPlacementPre(r) ==
+    /\ rPhase[r] = "PRE"
+    /\ rPreState'  = [rPreState  EXCEPT ![r] = catalogState]
+    /\ rPreEpoch'  = [rPreEpoch  EXCEPT ![r] = catalogEpoch]
+    /\ IF catalogState = rAttachedState[r]
+       THEN /\ rPhase'  = [rPhase  EXCEPT ![r] = "SNAP"]
+            /\ rResult' = rResult
+       ELSE /\ rPhase'  = [rPhase  EXCEPT ![r] = "DONE"]
+            /\ rResult' = [rResult EXCEPT ![r] = "restart"]
+    /\ UNCHANGED << catalog_vars, rAttachedState, rAttachedEpoch,
+                    rSnapState, rSnapEpoch, rPostState, rPostEpoch >>
+
+\* Open the lock-free snapshot. The snapshot pins the *current* incarnation -- this is the value
+\* the reader will return rows from, regardless of what later DDLs do.
+OpenSnapshot(r) ==
+    /\ rPhase[r] = "SNAP"
+    /\ rSnapState' = [rSnapState EXCEPT ![r] = catalogState]
+    /\ rSnapEpoch' = [rSnapEpoch EXCEPT ![r] = catalogEpoch]
+    /\ rPhase'     = [rPhase     EXCEPT ![r] = "POST"]
+    /\ UNCHANGED << catalog_vars, rAttachedState, rAttachedEpoch,
+                    rPreState, rPreEpoch, rPostState, rPostEpoch, rResult >>
+
+\* The post-snapshot guard. Under GUARD="placement" this is the buggy world from db_raii.cpp:
+\* we only confirm the placement state still matches the attached shard version. Under
+\* GUARD="epoch" the guard additionally requires the namespace epoch to be the same one captured
+\* in the snapshot -- the ABA-defeating fix.
+CheckPlacementPost(r) ==
+    /\ rPhase[r] = "POST"
+    /\ rPostState' = [rPostState EXCEPT ![r] = catalogState]
+    /\ rPostEpoch' = [rPostEpoch EXCEPT ![r] = catalogEpoch]
+    /\ LET placementOk == catalogState = rAttachedState[r]
+           epochOk     == catalogEpoch = rSnapEpoch[r]
+           accept      == IF GUARD = "placement"
+                          THEN placementOk
+                          ELSE placementOk /\ epochOk
+       IN /\ rPhase'  = [rPhase  EXCEPT ![r] = "DONE"]
+          /\ rResult' = [rResult EXCEPT ![r] = IF accept THEN "committed" ELSE "restart"]
+    /\ UNCHANGED << catalog_vars, rAttachedState, rAttachedEpoch,
+                    rPreState, rPreEpoch, rSnapState, rSnapEpoch >>
+
+ReaderStep(r) ==
+    \/ ReceiveRequest(r)
+    \/ CheckPlacementPre(r)
+    \/ OpenSnapshot(r)
+    \/ CheckPlacementPost(r)
+
+Next ==
+    \/ \E w \in Writers : ShardCollection
+    \/ \E w \in Writers : DropCollection
+    \/ \E w \in Writers : CreateUnsharded
+    \/ \E r \in Readers : ReaderStep(r)
+    \* Allow stuttering when every reader is DONE and no more DDLs fit under MAX_EPOCH.
+    \/ ( (\A r \in Readers : rPhase[r] = "DONE") /\ nextEpoch > MAX_EPOCH /\ UNCHANGED vars )
+
+Fairness ==
+    /\ \A r \in Readers : WF_vars(ReaderStep(r))
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+----------------------------------------------------------------------------------------------------
+(***************************************************************************************************)
+(* Type invariants.                                                                                *)
+(***************************************************************************************************)
+
+TypeOK ==
+    /\ catalogState \in PlacementStates
+    /\ catalogEpoch \in 0..MAX_EPOCH
+    /\ nextEpoch    \in 1..(MAX_EPOCH+1)
+    /\ \A r \in Readers :
+        /\ rPhase[r]         \in ReaderPhases
+        /\ rAttachedState[r] \in PlacementStates
+        /\ rAttachedEpoch[r] \in 0..MAX_EPOCH
+        /\ rPreState[r]      \in PlacementStates
+        /\ rSnapState[r]     \in PlacementStates
+        /\ rPostState[r]     \in PlacementStates
+        /\ rResult[r]        \in ReaderResult
+
+EpochMonotonic == catalogEpoch <= nextEpoch - 1
+
+(***************************************************************************************************)
+(* Correctness Properties.                                                                         *)
+(*                                                                                                 *)
+(* LockFreeReadObservesConsistentIncarnation: the load-bearing invariant. If a reader returned     *)
+(* "committed" then the incarnation observed in its snapshot is identical to the incarnation       *)
+(* observed by the post-snapshot guard. With GUARD="placement" TLC produces a counterexample        *)
+(* mirroring steps 1-9 from the spec header. With GUARD="epoch" the invariant holds.               *)
+(***************************************************************************************************)
+
+LockFreeReadObservesConsistentIncarnation ==
+    \A r \in Readers :
+        (rPhase[r] = "DONE" /\ rResult[r] = "committed")
+            => rSnapEpoch[r] = rPostEpoch[r]
+
+\* A stronger sibling invariant: a committed read attached UNSHARDED iff the snapshot was taken
+\* against an UNSHARDED incarnation. This is the property the user-visible bug violates -- the
+\* router thinks it is reading an unsharded collection but the snapshot held a sharded one.
+AttachedStateMatchesSnapshotState ==
+    \A r \in Readers :
+        (rPhase[r] = "DONE" /\ rResult[r] = "committed")
+            => rAttachedState[r] = rSnapState[r]
+
+\* Liveness: every reader eventually finishes.
+ReadersEventuallyDone == <>[] \A r \in Readers : rPhase[r] = "DONE"
+
+(***************************************************************************************************)
+(* Helpers for counterexample baits in MCLockFreeABA.tla.                                          *)
+(***************************************************************************************************)
+
+SomeReaderCommitted ==
+    \E r \in Readers : rPhase[r] = "DONE" /\ rResult[r] = "committed"
+
+SomeReaderObservedABA ==
+    \E r \in Readers :
+        /\ rPhase[r]   = "DONE"
+        /\ rResult[r]  = "committed"
+        /\ rSnapEpoch[r] # rPostEpoch[r]
+
+====================================================================================================

--- a/src/mongo/tla_plus/Catalog/LockFreeABA/MCLockFreeABA.cfg
+++ b/src/mongo/tla_plus/Catalog/LockFreeABA/MCLockFreeABA.cfg
@@ -1,0 +1,35 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Readers   = {r1}
+    Writers   = {w1, w2, w3}
+    MAX_EPOCH = 4
+
+    \* Flip to "epoch" to verify the proposed fix; keep "placement" to reproduce the bug.
+    GUARD     = "placement"
+
+    \* String constants exported by the spec for use in invariants / config readability.
+    DROPPED   = "dropped"
+    UNSHARDED = "unsharded"
+    SHARDED   = "sharded"
+
+INVARIANTS
+    \* Spec sanity. Disable to speed up model checking once known good.
+    TypeOK
+    EpochMonotonic
+    \* Protocol correctness. Violated under GUARD="placement" -- exactly the SERVER-76561 ABA.
+    LockFreeReadObservesConsistentIncarnation
+    AttachedStateMatchesSnapshotState
+    \* Bait invariants. Selectively negate to generate counterexample traces.
+    \* BaitNoCommit
+    \* BaitNoABA
+    \* BaitTrace
+
+PROPERTIES
+    \* Disable when running with CONSTRAINTS / Symmetry.
+    \* ReadersEventuallyDone
+
+CONSTRAINTS
+    StateConstraint
+
+SYMMETRY Symmetry

--- a/src/mongo/tla_plus/Catalog/LockFreeABA/MCLockFreeABA.tla
+++ b/src/mongo/tla_plus/Catalog/LockFreeABA/MCLockFreeABA.tla
@@ -1,0 +1,32 @@
+---------------------------------- MODULE MCLockFreeABA ------------------------------------------
+\* Constants and constraints for model-checking LockFreeABA.tla.
+
+EXTENDS LockFreeABA
+
+(***************************************************************************************************)
+(* State constraints.                                                                              *)
+(*                                                                                                 *)
+(* The state space is naturally bounded by MAX_EPOCH: every placement-changing DDL bumps the       *)
+(* epoch and once nextEpoch exceeds MAX_EPOCH no further DDLs fire. We additionally stop          *)
+(* exploring once every reader is DONE.                                                            *)
+(***************************************************************************************************)
+
+StateConstraint ==
+    /\ catalogEpoch <= MAX_EPOCH
+    /\ \E r \in Readers : rPhase[r] # "DONE"
+
+\* Symmetry on Readers and Writers cuts the state space significantly: the hazard does not care
+\* which specific reader/writer thread fires which step.
+Symmetry == Permutations(Readers) \union Permutations(Writers)
+
+(***************************************************************************************************)
+(* Counterexample baits.                                                                           *)
+(*                                                                                                 *)
+(* Negate them to force TLC to produce an example trace.                                           *)
+(***************************************************************************************************)
+
+BaitNoCommit       == ~SomeReaderCommitted
+BaitNoABA          == ~SomeReaderObservedABA
+BaitTrace          == TLCGet("level") < 60
+
+====================================================================================================

--- a/src/mongo/tla_plus/Catalog/LockFreeABA/OWNERS.yml
+++ b/src/mongo/tla_plus/Catalog/LockFreeABA/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-catalog-and-routing

--- a/src/mongo/tla_plus/Catalog/LockFreeABA/README.md
+++ b/src/mongo/tla_plus/Catalog/LockFreeABA/README.md
@@ -1,0 +1,54 @@
+# LockFreeABA
+
+Formal specification for the lock-free acquisition ABA hazard described in
+[SERVER-76561](https://jira.mongodb.org/browse/SERVER-76561).
+
+## The hazard
+
+A lock-free reader receiving a request with `UNSHARDED` shard version performs
+two sharding-placement checks: one before opening the storage snapshot, one
+after. Both checks compare **placement state**. A concurrent shard, then drop,
+then recreate-as-unsharded interleaving makes the post-snapshot check see
+`UNSHARDED` again while the snapshot pins the sharded incarnation -- the
+reader returns rows from the sharded collection believing it is unsharded.
+
+The guard in [`db_raii.cpp` lines 1082-1105](
+https://github.com/mongodb/mongo/blob/788248b98798044e325f30402ec3812a80dfbaf1/src/mongo/db/db_raii.cpp#L1082-L1105)
+is necessary but not sufficient: placement-state equality is preserved across a
+`drop + recreate-as-unsharded` cycle. The UUID-derived epoch is not.
+
+## Model
+
+`LockFreeABA.tla` models a single namespace with:
+
+- A monotonic epoch counter bumped on every placement-changing DDL.
+- DDLs: `ShardCollection`, `DropCollection`, `CreateUnsharded`.
+- Reader state machine: `IDLE -> PRE -> SNAP -> POST -> DONE`.
+- `GUARD` constant selecting `"placement"` (current, buggy) or `"epoch"`
+  (proposed fix comparing snapshot epoch to post-check epoch).
+
+## Invariants
+
+- `LockFreeReadObservesConsistentIncarnation`: a committed read's snapshot
+  epoch equals the epoch at the post-snapshot guard.
+- `AttachedStateMatchesSnapshotState`: attached shard version matches the
+  placement of the incarnation actually read.
+
+Both fail under `GUARD = "placement"`; both hold under `GUARD = "epoch"`.
+
+## Running
+
+```
+cd src/mongo/tla_plus
+./model-check.sh Catalog/LockFreeABA
+```
+
+Default constants (1 reader, 3 writers, MAX_EPOCH = 4) explore the full
+reachable state space in seconds.
+
+## Companion jstest
+
+`jstests/sharding/lock_free_acquisition_drop_recreate_aba.js` exercises the
+real interleaving against a `ShardingTest` using failpoints to pin the reader
+between the first placement check and the snapshot open while a writer runs
+`shardCollection -> drop -> create-unsharded`.


### PR DESCRIPTION
## Summary

TLA+ spec + jstest for lock-free acquisition ABA on drop/recreate.

**Jira:** https://jira.mongodb.org/browse/SERVER-126613
**Branch:** substrate-contrib/w3-34

## Files

```
  - .../lock_free_acquisition_drop_recreate_aba.js     | 203 +++++++++++++++
  - .../tla_plus/Catalog/LockFreeABA/LockFreeABA.tla   | 286 +++++++++++++++++++++
  - .../tla_plus/Catalog/LockFreeABA/MCLockFreeABA.cfg |  35 +++
  - .../tla_plus/Catalog/LockFreeABA/MCLockFreeABA.tla |  32 +++
  - src/mongo/tla_plus/Catalog/LockFreeABA/OWNERS.yml  |   5 +
  - src/mongo/tla_plus/Catalog/LockFreeABA/README.md   |  54 ++++
  - 6 files changed, 615 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
