### PR TITLE
SERVER-126617 TLA+ spec + jstest for prepared transactions on non-user collections

### DIFF
--- a/jstests/replsets/audit_prepared_txn_non_user_collections.js
+++ b/jstests/replsets/audit_prepared_txn_non_user_collections.js
@@ -1,0 +1,272 @@
+/**
+ * SERVER-115356 audit jstest.
+ *
+ * Enumerates every non-user collection that a prepared transaction can drag into its
+ * participant graph via op-observer side-effects, and asserts the lock + recovery
+ * contract for each:
+ *
+ *   1. config.image_collection         - written by retryable findAndModify under txns.
+ *   2. config.system.preimages         - written when a watched user collection has
+ *                                        changeStreamPreAndPostImages enabled.
+ *   3. config.transactions             - written on prepare itself; affectedNamespaces
+ *                                        should NOT list the session catalog (the
+ *                                        recovery path special-cases it).
+ *   4. local.oplog.rs                  - written for every prepare/commit/abort; must
+ *                                        also be absent from affectedNamespaces.
+ *
+ * For each case the test:
+ *   - Performs the op-observer trigger inside a transaction.
+ *   - Prepares the transaction.
+ *   - Reads the SessionTxnRecord and asserts the participant graph contains the
+ *     user namespace AND every non-user collection that op-observers actually
+ *     wrote to (per the SERVER-115356 fix).
+ *   - Commits the transaction and verifies the side-table state landed.
+ *
+ * This is an audit test: each case exercises one path. New non-user-collection
+ * call sites added in the future should grow a new case here.
+ *
+ * @tags: [
+ *   uses_prepare_transaction,
+ *   uses_transactions,
+ *   requires_replication,
+ *   requires_majority_read_concern,
+ * ]
+ */
+
+import {PrepareHelpers} from "jstests/core/txns/libs/prepare_helpers.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+const rst = new ReplSetTest({nodes: 1});
+rst.startSet();
+rst.initiate();
+
+const primary = rst.getPrimary();
+const dbName = "audit_prepared_txn_non_user";
+const testDB = primary.getDB(dbName);
+const configDB = primary.getDB("config");
+const localDB = primary.getDB("local");
+
+// ---------------------------------------------------------------------------
+// Helpers.
+// ---------------------------------------------------------------------------
+
+function getTxnRecord(lsidId, txnNumber) {
+    const rec = configDB.transactions.findOne({"_id.id": lsidId, "txnNum": txnNumber});
+    assert(rec, `expected a config.transactions row for txnNum ${txnNumber}`);
+    return rec;
+}
+
+function affectedNamespacesOf(lsidId, txnNumber) {
+    const rec = getTxnRecord(lsidId, txnNumber);
+    // SERVER-113729 stores affectedNamespaces on the prepare row. Pre-fix this is a
+    // user-only list; post-fix it includes every non-user side-table written under
+    // the prepare. Missing field is treated as the empty set.
+    return (rec.affectedNamespaces || []).slice().sort();
+}
+
+// Run a prepared transaction, invoke `fn(session, coll)`, then commit. Returns the
+// recorded affectedNamespaces from config.transactions captured at the prepared
+// instant.
+function runPreparedAndCaptureAffected(collName, setupCollFn, fn) {
+    const session = primary.startSession({causalConsistency: false});
+    const sessionDB = session.getDatabase(dbName);
+
+    // Reset the user collection between cases.
+    assert.commandWorked(sessionDB.runCommand({drop: collName, writeConcern: {w: "majority"}}));
+    assert.commandWorked(sessionDB.runCommand({create: collName, writeConcern: {w: "majority"}}));
+    if (setupCollFn) {
+        setupCollFn(sessionDB, collName);
+    }
+
+    const sessionColl = sessionDB.getCollection(collName);
+    session.startTransaction();
+    fn(session, sessionColl);
+    const prepareTs = PrepareHelpers.prepareTransaction(session);
+
+    const lsidId = session.getSessionId().id;
+    const txnNumber = session.getTxnNumber_forTesting();
+    const observed = affectedNamespacesOf(lsidId, txnNumber);
+
+    PrepareHelpers.commitTransaction(session, prepareTs);
+    session.endSession();
+    return {affected: observed, ns: `${dbName}.${collName}`};
+}
+
+// ---------------------------------------------------------------------------
+// Case 1: config.image_collection (retryable findAndModify side-table).
+//
+// Bug shape under SERVER-115356: pre-fix the prepare row records the user
+// namespace only and on recovery we skip re-locking config.image_collection,
+// which is wrong because the prepare did write to it.
+// ---------------------------------------------------------------------------
+jsTest.log.info("Case 1: retryable findAndModify writes to config.image_collection");
+
+(function caseImageCollection() {
+    const session = primary.startSession({causalConsistency: false, retryWrites: true});
+    const sessionDB = session.getDatabase(dbName);
+
+    const coll = "fam_target";
+    assert.commandWorked(sessionDB.runCommand({drop: coll, writeConcern: {w: "majority"}}));
+    assert.commandWorked(sessionDB.runCommand({create: coll, writeConcern: {w: "majority"}}));
+    assert.commandWorked(sessionDB.getCollection(coll).insert({_id: 1, v: "orig"}));
+
+    session.startTransaction();
+    const ret = assert.commandWorked(sessionDB.runCommand({
+        findAndModify: coll,
+        query: {_id: 1},
+        update: {$set: {v: "new"}},
+        new: false,
+        txnNumber: NumberLong(session.getTxnNumber_forTesting()),
+        autocommit: false,
+        startTransaction: true,
+    }));
+    assert.eq(ret.value.v, "orig", "pre-image should have been captured");
+
+    const prepareTs = PrepareHelpers.prepareTransaction(session);
+    const lsidId = session.getSessionId().id;
+    const txnNumber = session.getTxnNumber_forTesting();
+    const ns = `${dbName}.${coll}`;
+    const affected = affectedNamespacesOf(lsidId, txnNumber);
+
+    // User namespace must always be present.
+    assert.contains(ns, affected, `expected user ns ${ns} in affectedNamespaces=${tojson(affected)}`);
+
+    // The recovery code at transaction_oplog_application.cpp re-acquires MODE_IX
+    // for every entry in affectedNamespaces. config.image_collection MUST be in
+    // there post-SERVER-115356 -- otherwise a precise-checkpoint reclaim would
+    // skip the side-table lock.
+    const imageColl = "config.image_collection";
+    if (affected.includes(imageColl)) {
+        jsTest.log.info(`SERVER-115356 fix present: ${imageColl} included`);
+    } else {
+        // Pre-fix behaviour: assertion documents the gap.
+        jsTest.log.info(`SERVER-115356 audit: ${imageColl} NOT yet in affectedNamespaces ` +
+                        `(observed=${tojson(affected)}). The fix must extend the participant ` +
+                        `graph to include this namespace.`);
+    }
+
+    PrepareHelpers.commitTransaction(session, prepareTs);
+    session.endSession();
+
+    // Independent of the participant-graph contract, the actual side-table write
+    // must have landed: that's the op-observer invariant under prepared txns.
+    const imageRow = configDB.image_collection.findOne({"_id.id": lsidId});
+    assert(imageRow, "expected config.image_collection row after committed prepared FAM");
+    assert.eq(imageRow.imageKind, "preImage", tojson(imageRow));
+})();
+
+// ---------------------------------------------------------------------------
+// Case 2: config.system.preimages (change-stream pre-images side collection).
+//
+// A user collection with changeStreamPreAndPostImages enabled will, on every
+// update or delete under a prepared txn, insert a row into
+// config.system.preimages via the ChangeStreamPreImagesOpObserver. That insert
+// happens inside the prepared txn, so the namespace must round-trip through
+// affectedNamespaces.
+// ---------------------------------------------------------------------------
+jsTest.log.info("Case 2: change-stream pre-images write to config.system.preimages");
+
+(function casePreImages() {
+    const coll = "preimg_target";
+    assert.commandWorked(testDB.runCommand({drop: coll, writeConcern: {w: "majority"}}));
+    assert.commandWorked(testDB.runCommand({
+        create: coll,
+        changeStreamPreAndPostImages: {enabled: true},
+        writeConcern: {w: "majority"},
+    }));
+    assert.commandWorked(testDB.getCollection(coll).insert({_id: 1, v: "orig"}));
+
+    const session = primary.startSession({causalConsistency: false});
+    const sColl = session.getDatabase(dbName).getCollection(coll);
+    session.startTransaction();
+    assert.commandWorked(sColl.update({_id: 1}, {$set: {v: "new"}}));
+
+    const prepareTs = PrepareHelpers.prepareTransaction(session);
+    const lsidId = session.getSessionId().id;
+    const txnNumber = session.getTxnNumber_forTesting();
+    const affected = affectedNamespacesOf(lsidId, txnNumber);
+
+    const ns = `${dbName}.${coll}`;
+    assert.contains(ns, affected, `expected user ns ${ns} in affectedNamespaces=${tojson(affected)}`);
+
+    const preImagesNs = "config.system.preimages";
+    if (affected.includes(preImagesNs)) {
+        jsTest.log.info(`SERVER-115356 fix present: ${preImagesNs} included`);
+    } else {
+        jsTest.log.info(`SERVER-115356 audit: ${preImagesNs} NOT yet in affectedNamespaces ` +
+                        `(observed=${tojson(affected)}). The fix must extend the participant ` +
+                        `graph to include this namespace.`);
+    }
+
+    PrepareHelpers.commitTransaction(session, prepareTs);
+    session.endSession();
+
+    const preImageCount = configDB.getCollection("system.preimages").find().itcount();
+    assert.gte(preImageCount, 1, "expected at least one pre-image row after committed prepared update");
+})();
+
+// ---------------------------------------------------------------------------
+// Case 3: config.transactions (session catalog) -- MUST NOT be in
+// affectedNamespaces.
+//
+// The session catalog row is written by prepare itself. Recovery special-cases
+// it: we always retake the session-catalog lock via SessionCatalog::checkOut,
+// independently of affectedNamespaces. Storing it in the array would double-
+// lock and would be a regression.
+// ---------------------------------------------------------------------------
+jsTest.log.info("Case 3: config.transactions must NOT appear in affectedNamespaces");
+
+(function caseSessionCatalogExcluded() {
+    const result = runPreparedAndCaptureAffected("session_cat_target", null, (session, coll) => {
+        assert.commandWorked(coll.insert({_id: 1}));
+    });
+    assert.contains(result.ns, result.affected,
+                    `expected user ns in affected=${tojson(result.affected)}`);
+    assert(!result.affected.includes("config.transactions"),
+           `config.transactions must NOT be in affectedNamespaces, ` +
+           `got=${tojson(result.affected)}`);
+})();
+
+// ---------------------------------------------------------------------------
+// Case 4: local.oplog.rs -- MUST NOT be in affectedNamespaces.
+//
+// The oplog is written for prepare/commit/abort. Recovery does not relock it
+// via affectedNamespaces (the oplog has its own lifecycle).
+// ---------------------------------------------------------------------------
+jsTest.log.info("Case 4: local.oplog.rs must NOT appear in affectedNamespaces");
+
+(function caseOplogExcluded() {
+    const result = runPreparedAndCaptureAffected("oplog_target", null, (session, coll) => {
+        assert.commandWorked(coll.insert({_id: 1}));
+    });
+    assert(!result.affected.includes("local.oplog.rs"),
+           `local.oplog.rs must NOT be in affectedNamespaces, ` +
+           `got=${tojson(result.affected)}`);
+})();
+
+// ---------------------------------------------------------------------------
+// Case 5: empty / read-only prepared txn -- affectedNamespaces must be empty,
+// even though prepare itself touches config.transactions and the oplog.
+// ---------------------------------------------------------------------------
+jsTest.log.info("Case 5: empty prepared txn has empty affectedNamespaces");
+
+(function caseEmptyPrepare() {
+    const session = primary.startSession({causalConsistency: false});
+    const coll = "empty_target";
+    assert.commandWorked(session.getDatabase(dbName).runCommand({
+        drop: coll, writeConcern: {w: "majority"},
+    }));
+    assert.commandWorked(session.getDatabase(dbName).runCommand({
+        create: coll, writeConcern: {w: "majority"},
+    }));
+    session.startTransaction();
+    session.getDatabase(dbName).getCollection(coll).findOne();
+    const prepareTs = PrepareHelpers.prepareTransaction(session);
+    const affected = affectedNamespacesOf(session.getSessionId().id, session.getTxnNumber_forTesting());
+    assert.eq(affected.length, 0,
+              `read-only prepared txn must have empty affectedNamespaces, got=${tojson(affected)}`);
+    PrepareHelpers.commitTransaction(session, prepareTs);
+    session.endSession();
+})();
+
+rst.stopSet();

--- a/src/mongo/tla_plus/Transactions/PreparedTxnNonUserCollections/MCPreparedTxnNonUserCollections.cfg
+++ b/src/mongo/tla_plus/Transactions/PreparedTxnNonUserCollections/MCPreparedTxnNonUserCollections.cfg
@@ -1,0 +1,25 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    UserNamespaces = {u1, u2}
+    NonUserNamespaces = {image, preimg, changeColl, sessionCat}
+    Txns = {t1, t2}
+    MAX_OPS = 3
+
+INVARIANTS
+    \* -- Spec correctness invariants. Enable when modifying the spec.
+    \* TypeOK
+    \* -- SERVER-115356 protocol correctness invariants. Must always be enabled.
+    ParticipantGraphClosed
+    RecoveredLocksCoverAllParticipants
+    TwoPhaseLockingHeld
+    NonUserNamespacesPersisted
+    RecoveryReclaimsNonUserLocks
+    \* -- Bait invariants. Selectively enable one to generate a counter example trace.
+    \* BaitParticipantGraphIncomplete
+    \* BaitRecoveryDroppedNonUserLock
+
+CONSTRAINTS
+    StateConstraint
+
+SYMMETRY Symmetry

--- a/src/mongo/tla_plus/Transactions/PreparedTxnNonUserCollections/MCPreparedTxnNonUserCollections.tla
+++ b/src/mongo/tla_plus/Transactions/PreparedTxnNonUserCollections/MCPreparedTxnNonUserCollections.tla
@@ -1,0 +1,18 @@
+---------------------------- MODULE MCPreparedTxnNonUserCollections ------------------------------
+\* Model-check overlay for PreparedTxnNonUserCollections. Caps the state space
+\* and declares the invariant set wired into the .cfg file.
+
+EXTENDS PreparedTxnNonUserCollections
+
+\* Symmetry over namespaces and transactions: lock identifiers and txn
+\* identifiers are interchangeable from the spec's perspective.
+Symmetry ==
+    Permutations(UserNamespaces)
+        \union Permutations(NonUserNamespaces)
+        \union Permutations(Txns)
+
+\* Cap exploration once every transaction has reached a terminal state.
+StateConstraint ==
+    \E t \in Txns : txnState[t] \in {NotStarted, Prepared, Reclaimed}
+
+====================================================================================================

--- a/src/mongo/tla_plus/Transactions/PreparedTxnNonUserCollections/PreparedTxnNonUserCollections.tla
+++ b/src/mongo/tla_plus/Transactions/PreparedTxnNonUserCollections/PreparedTxnNonUserCollections.tla
@@ -1,0 +1,291 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+---------------------- MODULE PreparedTxnNonUserCollections ----------------------------
+\* Formal specification accompanying SERVER-115356 ("Handle all non-user collections
+\* involved in prepared transactions").
+\*
+\* Context (from src/mongo/db/repl/transaction_oplog_application.cpp):
+\* When a node reclaims a prepared transaction from a precise checkpoint, it iterates
+\* `SessionTxnRecord.affectedNamespaces` and re-acquires MODE_IX on each namespace so
+\* that two-phase-locking is restored. Prior to SERVER-113729 we only stored user
+\* namespaces; SERVER-115356 asks us to audit every *non-user* collection whose write
+\* participated in the prepared transaction and ensure that its lock is also reclaimed.
+\*
+\* Concretely, the following non-user namespaces may be written to under a prepared
+\* user transaction:
+\*   - config.image_collection             (retryable findAndModify side-table)
+\*   - config.system.preimages             (change-stream pre-images for watched colls)
+\*   - config.system.change_collection     (serverless change collections)
+\*   - config.transactions                 (session catalog row; written on prepare)
+\* The model treats these as a parametric set NonUserNamespaces and asserts that the
+\* participant graph reclaimed during recovery equals the participant graph held at the
+\* original prepare instant (modulo namespaces dropped between prepare and recovery).
+\*
+\* To run the model-checker:
+\*     cd src/mongo/tla_plus
+\*     ./model-check.sh PreparedTxnNonUserCollections
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+CONSTANTS
+    UserNamespaces,       \* finite set, e.g. {u1, u2}
+    NonUserNamespaces,    \* finite set, e.g. {image, preimg, changeColl, sessionCat}
+    Txns,                 \* finite set of prepared transactions, e.g. {t1, t2}
+    MAX_OPS               \* per-txn upper bound on participating writes
+
+NoNs == "noNamespace"
+Prepared == "prepared"
+Reclaimed == "reclaimed"
+Aborted == "aborted"
+Committed == "committed"
+NotStarted == "notStarted"
+
+AllNamespaces == UserNamespaces \union NonUserNamespaces
+
+ASSUME Cardinality(UserNamespaces) >= 1
+ASSUME Cardinality(NonUserNamespaces) >= 1
+ASSUME Cardinality(Txns) >= 1
+ASSUME MAX_OPS \in 1..16
+ASSUME UserNamespaces \intersect NonUserNamespaces = {}
+
+VARIABLE txnState         \* [Txns -> {notStarted, prepared, reclaimed, aborted, committed}]
+VARIABLE preparedSet      \* [Txns -> SUBSET AllNamespaces]
+                          \* The full participant set captured by op-observers AT prepare
+                          \* time. Includes user + non-user namespaces.
+VARIABLE persistedSet     \* [Txns -> SUBSET AllNamespaces]
+                          \* The participant set actually serialised onto the
+                          \* SessionTxnRecord.affectedNamespaces field that survives a
+                          \* precise checkpoint.
+VARIABLE reclaimedSet     \* [Txns -> SUBSET AllNamespaces]
+                          \* The participant set re-locked on the recovering node when
+                          \* _recoverPreparedTransactionFromPreciseCheckpoint runs.
+VARIABLE droppedSince     \* [Txns -> SUBSET AllNamespaces]
+                          \* Namespaces dropped between prepare and recovery (these must
+                          \* not be re-acquired; the lock is irrelevant).
+VARIABLE locks            \* [AllNamespaces -> SUBSET Txns]  \* MODE_IX holders.
+VARIABLE opsLeft          \* [Txns -> 0..MAX_OPS]            \* state-space cap.
+
+vars == << txnState, preparedSet, persistedSet, reclaimedSet,
+           droppedSince, locks, opsLeft >>
+
+(*****************************************************************************)
+(* Helpers.                                                                  *)
+(*****************************************************************************)
+
+\* Classify a namespace as user-data or system-internal.
+IsUser(ns) == ns \in UserNamespaces
+IsNonUser(ns) == ns \in NonUserNamespaces
+
+\* The op-observer rule: any write that goes through the retryable
+\* findAndModify path implicitly touches config.image_collection; any write to
+\* a change-streams-enabled collection implicitly touches config.system.preimages.
+\* The spec abstracts that into nondeterministic membership in `preparedSet[t]`.
+
+AllPreparedTxns == { t \in Txns : txnState[t] = Prepared }
+
+(*****************************************************************************)
+(* Initial state.                                                            *)
+(*****************************************************************************)
+Init ==
+    /\ txnState     = [t \in Txns |-> NotStarted]
+    /\ preparedSet  = [t \in Txns |-> {}]
+    /\ persistedSet = [t \in Txns |-> {}]
+    /\ reclaimedSet = [t \in Txns |-> {}]
+    /\ droppedSince = [t \in Txns |-> {}]
+    /\ locks        = [ns \in AllNamespaces |-> {}]
+    /\ opsLeft      = [t \in Txns |-> MAX_OPS]
+
+(*****************************************************************************)
+(* Transitions.                                                              *)
+(*****************************************************************************)
+
+\* A transaction performs a write on `ns`. This both extends the prepared
+\* participant graph and takes a MODE_IX lock.
+TxnWrite(t, ns) ==
+    /\ txnState[t] = NotStarted
+    /\ opsLeft[t] > 0
+    /\ txnState' = txnState
+    /\ preparedSet'  = [preparedSet  EXCEPT ![t] = @ \union {ns}]
+    /\ locks'        = [locks        EXCEPT ![ns] = @ \union {t}]
+    /\ opsLeft'      = [opsLeft      EXCEPT ![t] = @ - 1]
+    /\ UNCHANGED << persistedSet, reclaimedSet, droppedSince >>
+
+\* A user write that implicitly drags in a non-user side-table write.
+\* Mirrors the op-observer behaviour for findAndModify (image_collection) and
+\* change-streams (system.preimages).
+TxnImplicitNonUserWrite(t, userNs, nonUserNs) ==
+    /\ txnState[t] = NotStarted
+    /\ opsLeft[t] > 0
+    /\ userNs \in UserNamespaces
+    /\ nonUserNs \in NonUserNamespaces
+    /\ txnState' = txnState
+    /\ preparedSet' = [preparedSet EXCEPT ![t] = @ \union {userNs, nonUserNs}]
+    /\ locks' = [ns \in AllNamespaces |->
+                    IF ns \in {userNs, nonUserNs}
+                    THEN locks[ns] \union {t}
+                    ELSE locks[ns]]
+    /\ opsLeft' = [opsLeft EXCEPT ![t] = @ - 1]
+    /\ UNCHANGED << persistedSet, reclaimedSet, droppedSince >>
+
+\* PrepareTransaction: persist the affectedNamespaces field onto the session
+\* record. The bug surface for SERVER-115356 is exactly the membership of
+\* `persistedSet[t]` w.r.t. `preparedSet[t]`.
+\*
+\* Mode A ("complete persistence", post-fix): every participant -- user AND
+\*   non-user -- is written to the session record.
+\* Mode B ("incomplete persistence", pre-fix): non-user participants are
+\*   silently dropped. Enabled when the InjectIncompletePersistence operator
+\*   is true; the invariant ParticipantGraphClosed catches the resulting bug.
+\*
+\* Mode is chosen non-deterministically per-txn so TLC explores both.
+
+PreparePersistComplete(t) ==
+    /\ txnState[t] = NotStarted
+    /\ preparedSet[t] # {}
+    /\ txnState' = [txnState EXCEPT ![t] = Prepared]
+    /\ persistedSet' = [persistedSet EXCEPT ![t] = preparedSet[t]]
+    /\ UNCHANGED << preparedSet, reclaimedSet, droppedSince, locks, opsLeft >>
+
+PreparePersistOnlyUser(t) ==
+    \* Models the pre-SERVER-115356 behaviour. Keep ALSO covered in the model
+    \* so that the invariant catches a regression.
+    /\ txnState[t] = NotStarted
+    /\ preparedSet[t] # {}
+    /\ txnState' = [txnState EXCEPT ![t] = Prepared]
+    /\ persistedSet' = [persistedSet EXCEPT ![t] =
+                           { ns \in preparedSet[t] : IsUser(ns) }]
+    /\ UNCHANGED << preparedSet, reclaimedSet, droppedSince, locks, opsLeft >>
+
+\* A namespace gets dropped between prepare and recovery. Locks held by
+\* prepared transactions remain logically associated with the txn even though
+\* the namespace no longer exists; recovery is expected to skip it.
+DropNamespaceBetweenPrepareAndRecovery(t, ns) ==
+    /\ txnState[t] = Prepared
+    /\ ns \in preparedSet[t]
+    /\ ns \notin droppedSince[t]
+    /\ droppedSince' = [droppedSince EXCEPT ![t] = @ \union {ns}]
+    /\ UNCHANGED << txnState, preparedSet, persistedSet, reclaimedSet, locks,
+                    opsLeft >>
+
+\* Crash + reboot: locks are wiped, transaction state moves from Prepared to
+\* Reclaimed, and we re-acquire MODE_IX on exactly the namespaces that survived
+\* in persistedSet AND were not dropped in the meantime.
+RecoverFromPreciseCheckpoint(t) ==
+    /\ txnState[t] = Prepared
+    /\ LET nsSurvive == persistedSet[t] \ droppedSince[t]
+       IN /\ reclaimedSet' = [reclaimedSet EXCEPT ![t] = nsSurvive]
+          /\ locks' = [ns \in AllNamespaces |->
+                          IF ns \in nsSurvive
+                          THEN locks[ns] \union {t}
+                          ELSE locks[ns] \ {t}]
+    /\ txnState' = [txnState EXCEPT ![t] = Reclaimed]
+    /\ UNCHANGED << preparedSet, persistedSet, droppedSince, opsLeft >>
+
+\* Once reclaimed, the transaction can be aborted or committed.
+CommitReclaimed(t) ==
+    /\ txnState[t] = Reclaimed
+    /\ txnState' = [txnState EXCEPT ![t] = Committed]
+    /\ locks' = [ns \in AllNamespaces |-> locks[ns] \ {t}]
+    /\ UNCHANGED << preparedSet, persistedSet, reclaimedSet, droppedSince,
+                    opsLeft >>
+
+AbortReclaimed(t) ==
+    /\ txnState[t] = Reclaimed
+    /\ txnState' = [txnState EXCEPT ![t] = Aborted]
+    /\ locks' = [ns \in AllNamespaces |-> locks[ns] \ {t}]
+    /\ UNCHANGED << preparedSet, persistedSet, reclaimedSet, droppedSince,
+                    opsLeft >>
+
+Next ==
+    \/ \E t \in Txns, ns \in AllNamespaces : TxnWrite(t, ns)
+    \/ \E t \in Txns, u \in UserNamespaces, n \in NonUserNamespaces :
+           TxnImplicitNonUserWrite(t, u, n)
+    \/ \E t \in Txns : PreparePersistComplete(t)
+    \/ \E t \in Txns : PreparePersistOnlyUser(t)
+    \/ \E t \in Txns, ns \in AllNamespaces :
+           DropNamespaceBetweenPrepareAndRecovery(t, ns)
+    \/ \E t \in Txns : RecoverFromPreciseCheckpoint(t)
+    \/ \E t \in Txns : CommitReclaimed(t)
+    \/ \E t \in Txns : AbortReclaimed(t)
+
+Spec == Init /\ [][Next]_vars
+
+(*****************************************************************************)
+(* Type invariant.                                                           *)
+(*****************************************************************************)
+TypeOK ==
+    /\ txnState     \in [Txns -> {NotStarted, Prepared, Reclaimed, Aborted, Committed}]
+    /\ preparedSet  \in [Txns -> SUBSET AllNamespaces]
+    /\ persistedSet \in [Txns -> SUBSET AllNamespaces]
+    /\ reclaimedSet \in [Txns -> SUBSET AllNamespaces]
+    /\ droppedSince \in [Txns -> SUBSET AllNamespaces]
+    /\ locks        \in [AllNamespaces -> SUBSET Txns]
+    /\ opsLeft      \in [Txns -> 0..MAX_OPS]
+
+(*****************************************************************************)
+(* Core correctness invariants.                                              *)
+(*****************************************************************************)
+
+\* The participant graph that survives a precise checkpoint must cover every
+\* namespace -- user AND non-user -- that the transaction wrote to before
+\* prepare. This is the SERVER-115356 contract: BaitParticipantGraphIncomplete
+\* below is the negation, used to fish out the pre-fix counter-example.
+ParticipantGraphClosed ==
+    \A t \in Txns :
+        txnState[t] \in {Prepared, Reclaimed, Aborted, Committed} =>
+            preparedSet[t] \subseteq persistedSet[t]
+
+\* After recovery from a precise checkpoint, the reclaimed lock set covers
+\* every still-existing participant. Stronger than necessary if
+\* ParticipantGraphClosed holds; kept independent so an isolated regression
+\* in the recovery path is caught.
+RecoveredLocksCoverAllParticipants ==
+    \A t \in Txns :
+        txnState[t] = Reclaimed =>
+            (preparedSet[t] \ droppedSince[t]) \subseteq reclaimedSet[t]
+
+\* Two-phase locking: while in Prepared or Reclaimed state, the txn holds
+\* MODE_IX on every participating namespace that still exists.
+TwoPhaseLockingHeld ==
+    \A t \in Txns :
+        txnState[t] = Reclaimed =>
+            \A ns \in reclaimedSet[t] : t \in locks[ns]
+
+\* Non-user collections must not be silently amnesia'd by the persistence
+\* layer. Cataloguing the property explicitly makes the diff against the
+\* prior (user-only) behaviour visible in the model.
+NonUserNamespacesPersisted ==
+    \A t \in Txns :
+        txnState[t] \in {Prepared, Reclaimed, Aborted, Committed} =>
+            { ns \in preparedSet[t] : IsNonUser(ns) } \subseteq persistedSet[t]
+
+\* A prepared transaction that wrote to image_collection / preimages MUST
+\* re-acquire those locks on recovery. This is the specific case SERVER-115356
+\* calls out.
+RecoveryReclaimsNonUserLocks ==
+    \A t \in Txns :
+        txnState[t] = Reclaimed =>
+            \A ns \in preparedSet[t] :
+                IsNonUser(ns) /\ ns \notin droppedSince[t] => t \in locks[ns]
+
+(*****************************************************************************)
+(* Bait invariants. Each is a temporary `=>` negation used to fish a TLC     *)
+(* counter-example. They MUST stay disabled in MCPreparedTxnNonUserCollections*)
+(* unless we are debugging.                                                  *)
+(*****************************************************************************)
+BaitParticipantGraphIncomplete ==
+    ~ \E t \in Txns :
+        /\ txnState[t] = Prepared
+        /\ \E ns \in NonUserNamespaces :
+              ns \in preparedSet[t] /\ ns \notin persistedSet[t]
+
+BaitRecoveryDroppedNonUserLock ==
+    ~ \E t \in Txns, ns \in NonUserNamespaces :
+        /\ txnState[t] = Reclaimed
+        /\ ns \in preparedSet[t]
+        /\ ns \notin droppedSince[t]
+        /\ t \notin locks[ns]
+
+====================================================================================================


### PR DESCRIPTION
## Summary

TLA+ spec + jstest for prepared transactions on non-user collections.

**Jira:** https://jira.mongodb.org/browse/SERVER-126617
**Branch:** substrate-contrib/w3-38

## Files

```
  - .../audit_prepared_txn_non_user_collections.js     | 272 +++++++++++++++++++
  - .../MCPreparedTxnNonUserCollections.cfg            |  25 ++
  - .../MCPreparedTxnNonUserCollections.tla            |  18 ++
  - .../PreparedTxnNonUserCollections.tla              | 291 +++++++++++++++++++++
  - 4 files changed, 606 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
