### PR TITLE
SERVER-126618 TLA+ spec + jstest for prepared-txn startup recovery under repeated restart

### DIFF
--- a/jstests/replsets/recover_prepared_transactions_startup_repeated_restart.js
+++ b/jstests/replsets/recover_prepared_transactions_startup_repeated_restart.js
@@ -1,0 +1,180 @@
+/**
+ * SERVER-115355: Recover prepared transactions at startup.
+ *
+ * SERVER-113729 added recovery of prepared transactions from a precise checkpoint, but only
+ * after the node transitioned to PRIMARY. SERVER-115355 moves that recovery into startup
+ * itself. This test exercises the new path by performing two back-to-back clean restarts of a
+ * single-node replica set while two prepared transactions are outstanding, verifying after
+ * each restart that:
+ *   - the prepared state is re-established before the node accepts client traffic,
+ *   - prepared documents are not visible and a conflicting write hits a write conflict,
+ *   - additional operations on the prepared transaction are rejected with
+ *     PreparedTransactionInProgress,
+ *   - the transactions can subsequently be deterministically committed or aborted.
+ *
+ * The double-restart is the load-bearing piece: the second restart must recover prepared
+ * state that was itself written by the first startup recovery cycle, exercising the new
+ * STARTUP-time path twice without ever depending on a PRIMARY transition to re-prepare.
+ *
+ * @tags: [requires_persistence, uses_transactions, uses_prepare_transaction]
+ */
+
+import {PrepareHelpers} from "jstests/core/txns/libs/prepare_helpers.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+const replTest = new ReplSetTest({nodes: 1});
+replTest.startSet();
+replTest.initiate();
+
+let primary = replTest.getPrimary();
+// Default WC is majority; disableSnapshotting prevents satisfying that, forcing the
+// prepared entries to live past the stable checkpoint and exercise startup recovery.
+assert.commandWorked(
+    primary.adminCommand({
+        setDefaultRWConcern: 1,
+        defaultWriteConcern: {w: 1},
+        writeConcern: {w: "majority"},
+    }),
+);
+
+const dbName = "test";
+const collName = "recover_prepared_transactions_startup_repeated_restart";
+let testDB = primary.getDB(dbName);
+const testColl = testDB.getCollection(collName);
+
+testDB.runCommand({drop: collName});
+assert.commandWorked(testDB.runCommand({create: collName}));
+
+let session = primary.startSession({causalConsistency: false});
+let sessionDB = session.getDatabase(dbName);
+const sessionColl = sessionDB.getCollection(collName);
+
+let session2 = primary.startSession({causalConsistency: false});
+let sessionDB2 = session2.getDatabase(dbName);
+const sessionColl2 = sessionDB2.getCollection(collName);
+
+assert.commandWorked(sessionColl.insert({_id: 1}));
+assert.commandWorked(sessionColl2.insert({_id: 2}));
+
+jsTestLog("Disable snapshotting so prepared entries live past the stable checkpoint");
+assert.commandWorked(
+    primary.adminCommand({configureFailPoint: "disableSnapshotting", mode: "alwaysOn"}),
+);
+
+session.startTransaction();
+assert.commandWorked(sessionColl.update({_id: 1}, {_id: 1, a: 1}));
+let prepareTimestamp = PrepareHelpers.prepareTransaction(session, {w: 1});
+
+session2.startTransaction();
+assert.commandWorked(sessionColl2.update({_id: 2}, {_id: 2, a: 1}));
+const prepareTimestamp2 = PrepareHelpers.prepareTransaction(session2, {w: 1});
+
+const lsid = session.getSessionId();
+const txnNumber = session.getTxnNumber_forTesting();
+const lsid2 = session2.getSessionId();
+const txnNumber2 = session2.getTxnNumber_forTesting();
+
+function rebindSessionsAfterRestart() {
+    primary = replTest.getPrimary();
+    testDB = primary.getDB(dbName);
+    session = primary.startSession({causalConsistency: false});
+    sessionDB = session.getDatabase(dbName);
+    session2 = primary.startSession({causalConsistency: false});
+    sessionDB2 = session2.getDatabase(dbName);
+    // Force both sessions to reuse their pre-restart identifiers so we are operating on the
+    // same prepared transactions that startup recovery just rebuilt.
+    session._serverSession.handle.getId = () => lsid;
+    session.setTxnNumber_forTesting(txnNumber);
+    session2._serverSession.handle.getId = () => lsid2;
+    session2.setTxnNumber_forTesting(txnNumber2);
+}
+
+function assertBothTxnsRecovered() {
+    // Prepared writes must not be visible.
+    assert.eq(testDB[collName].find({_id: 1}).toArray(), [{_id: 1}]);
+    assert.eq(testDB[collName].find({_id: 2}).toArray(), [{_id: 2}]);
+
+    // A conflicting write against a prepared document must time out.
+    assert.commandFailedWithCode(
+        testDB.runCommand({
+            update: collName,
+            updates: [{q: {_id: 1}, u: {$set: {a: 2}}}],
+            maxTimeMS: 5 * 1000,
+        }),
+        ErrorCodes.MaxTimeMSExpired,
+    );
+    assert.commandFailedWithCode(
+        testDB.runCommand({
+            update: collName,
+            updates: [{q: {_id: 2}, u: {$set: {a: 2}}}],
+            maxTimeMS: 5 * 1000,
+        }),
+        ErrorCodes.MaxTimeMSExpired,
+    );
+
+    // Adding statements to either prepared transaction must be rejected.
+    assert.commandFailedWithCode(
+        sessionDB.runCommand({
+            insert: collName,
+            documents: [{_id: 3}],
+            txnNumber: NumberLong(txnNumber),
+            stmtId: NumberInt(2),
+            autocommit: false,
+        }),
+        ErrorCodes.PreparedTransactionInProgress,
+    );
+    assert.commandFailedWithCode(
+        sessionDB2.runCommand({
+            insert: collName,
+            documents: [{_id: 4}],
+            txnNumber: NumberLong(txnNumber2),
+            stmtId: NumberInt(2),
+            autocommit: false,
+        }),
+        ErrorCodes.PreparedTransactionInProgress,
+    );
+}
+
+jsTestLog("First restart: both transactions should be rebuilt by startup recovery");
+replTest.stop(primary, undefined, {skipValidation: true});
+replTest.start(primary, {}, true);
+rebindSessionsAfterRestart();
+assertBothTxnsRecovered();
+
+jsTestLog("Second restart: prepared state from the first recovery must survive a second cycle");
+replTest.stop(primary, undefined, {skipValidation: true});
+replTest.start(primary, {}, true);
+rebindSessionsAfterRestart();
+assertBothTxnsRecovered();
+
+jsTestLog("Committing the first transaction after two recovery cycles");
+PrepareHelpers.awaitMajorityCommitted(replTest, prepareTimestamp);
+const commitTimestamp = Timestamp(prepareTimestamp.getTime(), prepareTimestamp.getInc() + 1);
+assert.commandWorked(
+    sessionDB.adminCommand({
+        commitTransaction: 1,
+        commitTimestamp: commitTimestamp,
+        txnNumber: NumberLong(txnNumber),
+        autocommit: false,
+    }),
+);
+assert.eq(testDB[collName].findOne({_id: 1}), {_id: 1, a: 1});
+
+jsTestLog("Aborting the second transaction after two recovery cycles");
+assert.commandWorked(
+    sessionDB2.adminCommand({
+        abortTransaction: 1,
+        txnNumber: NumberLong(txnNumber2),
+        autocommit: false,
+    }),
+);
+assert.eq(testDB[collName].findOne({_id: 2}), {_id: 2});
+
+jsTestLog("Running a fresh conflicting transaction to ensure no stale prepare state lingers");
+session.startTransaction();
+assert.commandWorked(sessionDB[collName].update({_id: 1}, {_id: 1, a: 3}));
+prepareTimestamp = PrepareHelpers.prepareTransaction(session);
+assert.commandWorked(PrepareHelpers.commitTransaction(session, prepareTimestamp));
+assert.eq(testDB[collName].findOne({_id: 1}), {_id: 1, a: 3});
+
+replTest.stopSet();

--- a/src/mongo/tla_plus/Transactions/PreparedTxnStartupRecovery/MCPreparedTxnStartupRecovery.cfg
+++ b/src/mongo/tla_plus/Transactions/PreparedTxnStartupRecovery/MCPreparedTxnStartupRecovery.cfg
@@ -1,0 +1,18 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Txns = {t1, t2}
+    MaxRestarts = 2
+    MaxOplogTail = 4
+
+CONSTRAINTS
+    OplogLenBound
+
+INVARIANT
+    TypeOK
+    CheckpointInOplog
+    NoResurrection
+    RecoveryReconstructsPreparedState
+    PreparedStateMatchesOplog
+    PreparedTxnsNeverLost
+    ResolvedMatchesOplog

--- a/src/mongo/tla_plus/Transactions/PreparedTxnStartupRecovery/MCPreparedTxnStartupRecovery.tla
+++ b/src/mongo/tla_plus/Transactions/PreparedTxnStartupRecovery/MCPreparedTxnStartupRecovery.tla
@@ -1,0 +1,13 @@
+------------------------ MODULE MCPreparedTxnStartupRecovery -----------------------------------
+\* Model-checking module for PreparedTxnStartupRecovery (SERVER-115355).
+
+EXTENDS PreparedTxnStartupRecovery
+
+(**************************************************************************************************)
+(* State constraints to keep the model finite.                                                    *)
+(**************************************************************************************************)
+
+\* Bound the total oplog length so TLC does not chase unbounded append sequences.
+OplogLenBound == Len(oplog) <= 8
+
+================================================================================================

--- a/src/mongo/tla_plus/Transactions/PreparedTxnStartupRecovery/OWNERS.yml
+++ b/src/mongo/tla_plus/Transactions/PreparedTxnStartupRecovery/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-repl

--- a/src/mongo/tla_plus/Transactions/PreparedTxnStartupRecovery/PreparedTxnStartupRecovery.tla
+++ b/src/mongo/tla_plus/Transactions/PreparedTxnStartupRecovery/PreparedTxnStartupRecovery.tla
@@ -1,0 +1,223 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+------------------------------- MODULE PreparedTxnStartupRecovery ------------------------------
+\* SERVER-115355: Recover prepared transactions at startup.
+\*
+\* SERVER-113729 made it possible to recover prepared transactions from a precise checkpoint,
+\* but only after the node had transitioned to PRIMARY (to work around WT-15051 / WT-16600).
+\* This spec models the new path: a node discovers and re-prepares its in-progress prepared
+\* transactions during startup recovery, before any state transition, then replays the tail of
+\* the oplog beyond the stable checkpoint. A subsequent commit or abort entry in the oplog tail
+\* (or issued by a client once the node is steady-state) must deterministically resolve the
+\* prepared transaction.
+\*
+\* The spec abstracts a single replica-set node across a sequence of crash/restart cycles. A
+\* transaction's lifecycle is: NotStarted -> InProgress -> Prepared -> {Committed, Aborted}.
+\* The "stable checkpoint" is the snapshot the node persists before each crash; the "oplog
+\* tail" is the suffix of the oplog beyond that checkpoint that startup recovery must replay.
+\*
+\* To run the model-checker:
+\*     cd src/mongo/tla_plus
+\*     ./model-check.sh Transactions/PreparedTxnStartupRecovery
+
+EXTENDS Integers, FiniteSets, Sequences, TLC
+
+CONSTANTS Txns,            \* Set of transaction identifiers.
+          MaxRestarts,     \* Bound on the number of crash/restart cycles.
+          MaxOplogTail     \* Bound on the length of oplog beyond the stable checkpoint.
+
+\* Transaction states.
+NotStarted == "NotStarted"
+InProgress == "InProgress"
+Prepared   == "Prepared"
+Committed  == "Committed"
+Aborted    == "Aborted"
+
+States == {NotStarted, InProgress, Prepared, Committed, Aborted}
+
+\* Oplog entry kinds we model.
+OpInsert  == "insert"
+OpPrepare == "prepare"
+OpCommit  == "commit"
+OpAbort   == "abort"
+
+OpKinds == {OpInsert, OpPrepare, OpCommit, OpAbort}
+
+VARIABLES
+    \* In-memory transaction state, keyed by txn id.
+    txnState,
+    \* Oplog: a sequence of records [txn |-> t, kind |-> k]. Append-only between restarts.
+    oplog,
+    \* Index into oplog of the last entry included in the stable checkpoint. Entries with
+    \* index > stableIdx are the "oplog tail" that startup recovery must replay.
+    stableIdx,
+    \* The persisted state of each transaction as of the stable checkpoint. This is what
+    \* startup recovery rebuilds in-memory state from before replaying the tail.
+    checkpointState,
+    \* Number of crash/restart cycles that have occurred.
+    restartCount,
+    \* TRUE iff the node is currently recovering (between crash and end of tail replay).
+    recovering,
+    \* History of resolved (committed or aborted) txns, used by invariants.
+    resolved
+
+vars == <<txnState, oplog, stableIdx, checkpointState,
+          restartCount, recovering, resolved>>
+
+----
+\* Helpers.
+
+EmptyState == [t \in Txns |-> NotStarted]
+
+\* Replay one oplog entry against an in-memory state map.
+ApplyEntry(stateMap, entry) ==
+    LET t == entry.txn IN
+    CASE entry.kind = OpInsert  -> [stateMap EXCEPT ![t] = InProgress]
+      [] entry.kind = OpPrepare -> [stateMap EXCEPT ![t] = Prepared]
+      [] entry.kind = OpCommit  -> [stateMap EXCEPT ![t] = Committed]
+      [] entry.kind = OpAbort   -> [stateMap EXCEPT ![t] = Aborted]
+
+\* Recursive replay of a sub-sequence of the oplog starting from stateMap.
+RECURSIVE Replay(_, _, _, _)
+Replay(stateMap, log, from, to) ==
+    IF from > to THEN stateMap
+    ELSE Replay(ApplyEntry(stateMap, log[from]), log, from + 1, to)
+
+\* The transactions that are prepared as of the stable checkpoint. Startup recovery is
+\* responsible for re-establishing the in-memory prepared state for every such txn before
+\* the node accepts new client traffic or transitions out of STARTUP.
+PreparedAtCheckpoint == {t \in Txns : checkpointState[t] = Prepared}
+
+\* Final state we expect after replaying the entire oplog from EmptyState.
+ExpectedState == Replay(EmptyState, oplog, 1, Len(oplog))
+
+CanAppend(t, kind) ==
+    CASE kind = OpInsert  -> txnState[t] = NotStarted
+      [] kind = OpPrepare -> txnState[t] = InProgress
+      [] kind = OpCommit  -> txnState[t] = Prepared
+      [] kind = OpAbort   -> txnState[t] \in {InProgress, Prepared}
+
+OplogTailLen == Len(oplog) - stableIdx
+
+----
+\* Initial state: empty oplog, empty checkpoint, no restarts yet, not recovering.
+Init ==
+    /\ txnState        = EmptyState
+    /\ oplog           = << >>
+    /\ stableIdx       = 0
+    /\ checkpointState = EmptyState
+    /\ restartCount    = 0
+    /\ recovering      = FALSE
+    /\ resolved        = {}
+
+----
+\* Actions.
+
+\* Append a new oplog entry while the node is steady-state. Models client writes,
+\* prepareTransaction, commitTransaction, abortTransaction.
+AppendEntry(t, kind) ==
+    /\ ~recovering
+    /\ kind \in OpKinds
+    /\ OplogTailLen < MaxOplogTail
+    /\ CanAppend(t, kind)
+    /\ oplog' = Append(oplog, [txn |-> t, kind |-> kind])
+    /\ txnState' = ApplyEntry(txnState, [txn |-> t, kind |-> kind])
+    /\ resolved' = IF kind \in {OpCommit, OpAbort} THEN resolved \union {t} ELSE resolved
+    /\ UNCHANGED <<stableIdx, checkpointState, restartCount, recovering>>
+
+\* Take a stable checkpoint of the current state. Advances stableIdx to the current oplog
+\* length and snapshots txnState into checkpointState.
+TakeStableCheckpoint ==
+    /\ ~recovering
+    /\ stableIdx < Len(oplog)
+    /\ stableIdx' = Len(oplog)
+    /\ checkpointState' = txnState
+    /\ UNCHANGED <<txnState, oplog, restartCount, recovering, resolved>>
+
+\* Crash: discard volatile in-memory state. Oplog and stable checkpoint persist; the oplog
+\* tail beyond the checkpoint also persists on disk and will be replayed by recovery.
+Crash ==
+    /\ ~recovering
+    /\ restartCount < MaxRestarts
+    /\ recovering' = TRUE
+    /\ txnState' = EmptyState
+    /\ restartCount' = restartCount + 1
+    /\ UNCHANGED <<oplog, stableIdx, checkpointState, resolved>>
+
+\* SERVER-115355 core action: during STARTUP, rebuild in-memory state from the stable
+\* checkpoint and replay the oplog tail. This must re-establish the Prepared state for
+\* every transaction that was Prepared at the checkpoint and not subsequently resolved in
+\* the tail. Before SERVER-115355 this work could only be done after PRIMARY transition;
+\* after the change it happens during startup.
+StartupRecover ==
+    /\ recovering
+    /\ txnState' = Replay(checkpointState, oplog, stableIdx + 1, Len(oplog))
+    /\ recovering' = FALSE
+    /\ UNCHANGED <<oplog, stableIdx, checkpointState, restartCount, resolved>>
+
+Next ==
+    \/ \E t \in Txns, k \in OpKinds : AppendEntry(t, k)
+    \/ TakeStableCheckpoint
+    \/ Crash
+    \/ StartupRecover
+
+Spec ==
+    /\ Init
+    /\ [][Next]_vars
+    /\ WF_vars(StartupRecover)
+
+----
+\* Invariants.
+
+TypeOK ==
+    /\ txnState        \in [Txns -> States]
+    /\ checkpointState \in [Txns -> States]
+    /\ stableIdx \in 0..Len(oplog)
+    /\ restartCount \in 0..MaxRestarts
+    /\ recovering \in BOOLEAN
+    /\ resolved \subseteq Txns
+    /\ \A i \in 1..Len(oplog) :
+        /\ oplog[i].txn  \in Txns
+        /\ oplog[i].kind \in OpKinds
+
+\* The checkpoint can never reference an oplog index beyond the oplog itself.
+CheckpointInOplog == stableIdx <= Len(oplog)
+
+\* Once a transaction has been committed, it cannot move back to any earlier state.
+\* Once aborted, likewise. (Modeled at the oplog level: replay is monotonic past commit/abort.)
+NoResurrection ==
+    \A t \in Txns :
+        (t \in resolved) =>
+            (ExpectedState[t] = Committed \/ ExpectedState[t] = Aborted)
+
+\* The headline correctness property for SERVER-115355: once startup recovery completes
+\* (recovering = FALSE), the in-memory state must match what you would get by replaying
+\* the entire oplog from scratch. In particular, every prepared-at-checkpoint txn that was
+\* not resolved in the tail is back in the Prepared state in memory.
+RecoveryReconstructsPreparedState ==
+    (~recovering) => (txnState = ExpectedState)
+
+\* During steady state, a transaction is Prepared in memory iff the oplog says so.
+PreparedStateMatchesOplog ==
+    (~recovering) =>
+        \A t \in Txns :
+            (txnState[t] = Prepared) <=> (ExpectedState[t] = Prepared)
+
+\* Every txn that was Prepared at the checkpoint is either still Prepared after recovery,
+\* or has been explicitly resolved by an entry in the oplog tail. There is no third option
+\* like "silently lost" or "rolled back to InProgress".
+PreparedTxnsNeverLost ==
+    (~recovering) =>
+        \A t \in PreparedAtCheckpoint :
+            txnState[t] \in {Prepared, Committed, Aborted}
+
+\* The set of resolved txns matches exactly those that reached Committed or Aborted in the
+\* oplog. This pins down idempotent replay: replaying twice doesn't fabricate a resolution.
+ResolvedMatchesOplog ==
+    resolved = {t \in Txns : ExpectedState[t] \in {Committed, Aborted}}
+
+================================================================================================


### PR DESCRIPTION
## Summary

TLA+ spec + jstest for prepared-txn startup recovery under repeated restart.

**Jira:** https://jira.mongodb.org/browse/SERVER-126618
**Branch:** substrate-contrib/w3-39

## Files

```
  - ...epared_transactions_startup_repeated_restart.js | 180 +++++++++++++++++
  - .../MCPreparedTxnStartupRecovery.cfg               |  18 ++
  - .../MCPreparedTxnStartupRecovery.tla               |  13 ++
  - .../PreparedTxnStartupRecovery/OWNERS.yml          |   5 +
  - .../PreparedTxnStartupRecovery.tla                 | 223 +++++++++++++++++++++
  - 5 files changed, 439 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
