### PR TITLE
SERVER-126619 TLA+ spec + jstest for standby rollback of prepared-abort timestamp

### DIFF
--- a/jstests/replsets/standby_rollback_timestamp_on_prepared_abort.js
+++ b/jstests/replsets/standby_rollback_timestamp_on_prepared_abort.js
@@ -1,0 +1,133 @@
+/**
+ * SERVER-125802: When a standby applies the abort entry for a prepared
+ * transaction, it must advance its rollback timestamp to the abort's optime so
+ * that, after a step-up, any checkpoint that observes the abort's effects has
+ * a well-defined visibility relationship with the engine's rollback timestamp.
+ *
+ * Repro shape (without the fix):
+ *   1. Primary prepares a txn at prepareTs, then aborts at abortTs.
+ *   2. Standby replicates prepare + abort.  abortTs is NOT yet checkpointed.
+ *   3. Standby steps up.
+ *   4. New primary takes a checkpoint that captures the abort's effects.
+ *   5. Because the old standby never advanced rollbackTs at abort-apply, the
+ *      engine cannot determine whether the abort is visible in the checkpoint
+ *      -> inconsistent post-recovery state for any document the prepared txn
+ *      touched.
+ *
+ * With the fix: at step 2, the standby advances rollbackTs to abortTs, so the
+ * checkpoint at step 4 trivially knows the abort is visible.
+ *
+ * This jstest is the empirical companion to the TLA+ spec at
+ *   src/mongo/tla_plus/Replication/RollbackPreparedAbort/RollbackPreparedAbort.tla
+ *
+ * @tags: [
+ *   uses_prepare_transaction,
+ *   uses_transactions,
+ *   requires_persistence,
+ *   requires_majority_read_concern,
+ * ]
+ */
+import {PrepareHelpers} from "jstests/core/txns/libs/prepare_helpers.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+import {reconnect} from "jstests/replsets/rslib.js";
+
+const replTest = new ReplSetTest({nodes: 2});
+replTest.startSet();
+replTest.initiate();
+
+const dbName = "rollback_prepared_abort_db";
+const collName = "rollback_prepared_abort_coll";
+
+let primary = replTest.getPrimary();
+let secondary = replTest.getSecondary();
+
+assert.commandWorked(primary.getDB(dbName).runCommand({create: collName, writeConcern: {w: "majority"}}));
+const baseDoc = {_id: "base"};
+assert.commandWorked(
+    primary.getDB(dbName).getCollection(collName).insert(baseDoc, {writeConcern: {w: "majority"}}),
+);
+replTest.awaitReplication();
+
+jsTestLog("Starting transaction on primary and preparing it");
+const session = primary.startSession({causalConsistency: false});
+session.startTransaction({writeConcern: {w: "majority"}});
+const txnDoc = {_id: "txn-doc"};
+assert.commandWorked(session.getDatabase(dbName).getCollection(collName).insert(txnDoc));
+
+const prepareTimestamp = PrepareHelpers.prepareTransaction(session);
+jsTestLog("Prepared at ts=" + tojson(prepareTimestamp));
+replTest.awaitReplication();
+
+jsTestLog("Aborting the prepared transaction on the primary");
+assert.commandWorked(session.abortTransaction_forTesting());
+replTest.awaitReplication();
+
+// Capture the secondary's lastApplied optime; the standby's rollbackTimestamp
+// is expected to be at least the abort's optime after the abort is applied.
+const secondaryStatus = assert.commandWorked(secondary.adminCommand({replSetGetStatus: 1}));
+const secondaryLastApplied = secondaryStatus.optimes.appliedOpTime;
+jsTestLog("Secondary lastApplied after abort: " + tojson(secondaryLastApplied));
+
+// Read WT rollback timestamp via serverStatus; it must be at least the abort
+// optime to satisfy the SERVER-125802 contract.
+function getRollbackTimestamp(conn) {
+    const ss = assert.commandWorked(conn.adminCommand({serverStatus: 1}));
+    // Field path is wiredTiger.snapshot-window-settings or storageEngineStatus
+    // depending on build; consult both.
+    if (ss.storageEngine && ss.storageEngine.rollbackTimestamp) {
+        return ss.storageEngine.rollbackTimestamp;
+    }
+    if (ss.wiredTiger && ss.wiredTiger["snapshot-window-settings"]) {
+        const w = ss.wiredTiger["snapshot-window-settings"];
+        if (w["rollback timestamp"]) {
+            return w["rollback timestamp"];
+        }
+    }
+    return null;
+}
+
+const rbts = getRollbackTimestamp(secondary);
+jsTestLog("Secondary rollback timestamp: " + tojson(rbts));
+assert(rbts !== null, "Could not read rollback timestamp from serverStatus on secondary");
+
+// Core assertion: the standby's rollback timestamp is >= the abort optime.
+// Compare on the ts component since rollbackTimestamp is a BSON Timestamp.
+function tsAtLeast(a, b) {
+    if (a.t > b.t) return true;
+    if (a.t < b.t) return false;
+    return a.i >= b.i;
+}
+assert(
+    tsAtLeast(rbts, secondaryLastApplied.ts),
+    "Standby did not advance rollbackTimestamp on prepared-abort apply: " +
+        "rollbackTs=" +
+        tojson(rbts) +
+        " < abortOptime=" +
+        tojson(secondaryLastApplied.ts),
+);
+
+// Now step up the secondary and verify a checkpoint captures the abort's
+// effects without crashing the engine into an inconsistent state.
+jsTestLog("Stepping up the secondary");
+replTest.stepUp(secondary);
+reconnect(primary);
+primary = replTest.getPrimary();
+assert.eq(primary, secondary);
+
+jsTestLog("Forcing a checkpoint on the new primary");
+assert.commandWorked(primary.adminCommand({fsync: 1}));
+
+jsTestLog("Verifying the aborted txn's effects are NOT visible post-step-up");
+const visibleDocs = primary.getDB(dbName).getCollection(collName).find().toArray();
+assert.eq(1, visibleDocs.length, "Expected only the base doc after aborted prepare: " + tojson(visibleDocs));
+assert.docEq(baseDoc, visibleDocs[0]);
+
+jsTestLog("Verifying we can run a fresh txn on the new primary post-recovery");
+const newSession = primary.startSession({causalConsistency: false});
+newSession.startTransaction({writeConcern: {w: "majority"}});
+assert.commandWorked(
+    newSession.getDatabase(dbName).getCollection(collName).insert({_id: "post-step-up"}),
+);
+assert.commandWorked(newSession.commitTransaction_forTesting());
+
+replTest.stopSet();

--- a/src/mongo/tla_plus/Replication/RollbackPreparedAbort/MCRollbackPreparedAbort.cfg
+++ b/src/mongo/tla_plus/Replication/RollbackPreparedAbort/MCRollbackPreparedAbort.cfg
@@ -1,0 +1,19 @@
+\* Config file to run TLC on RollbackPreparedAbort.tla.
+\* See RollbackPreparedAbort.tla for instructions.
+
+\* Two servers is enough: one primary, one standby that will step up.
+CONSTANT Server = {n1, n2}
+
+\* Small ts space; this is a small-state spec by design.
+CONSTANT MaxTs = 3
+
+\* Bound the number of checkpoints per server to keep the state space finite.
+CONSTANT MaxCheckpoints = 2
+
+INVARIANT TypeOK
+INVARIANT AbortPinnedByRollbackTimestamp
+INVARIANT CheckpointVisibilityConsistent
+
+SYMMETRY ServerSymmetry
+CONSTRAINT StateConstraint
+SPECIFICATION Spec

--- a/src/mongo/tla_plus/Replication/RollbackPreparedAbort/MCRollbackPreparedAbort.tla
+++ b/src/mongo/tla_plus/Replication/RollbackPreparedAbort/MCRollbackPreparedAbort.tla
@@ -1,0 +1,13 @@
+---- MODULE MCRollbackPreparedAbort ----
+\* This module defines MCRollbackPreparedAbort.tla constants/constraints for
+\* model-checking the SERVER-125802 spec.
+
+EXTENDS RollbackPreparedAbort
+
+CONSTANTS MaxCheckpoints
+
+StateConstraint == \A s \in Server :
+                       Cardinality(checkpoints[s]) <= MaxCheckpoints
+
+ServerSymmetry == Permutations(Server)
+=============================================================================

--- a/src/mongo/tla_plus/Replication/RollbackPreparedAbort/OWNERS.yml
+++ b/src/mongo/tla_plus/Replication/RollbackPreparedAbort/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-replication-reviewers

--- a/src/mongo/tla_plus/Replication/RollbackPreparedAbort/RollbackPreparedAbort.tla
+++ b/src/mongo/tla_plus/Replication/RollbackPreparedAbort/RollbackPreparedAbort.tla
@@ -1,0 +1,176 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+--------------------------- MODULE RollbackPreparedAbort ---------------------------
+\* SERVER-125802: Standby should set rollback timestamp when applying aborts for
+\* prepared transactions.
+\*
+\* Motivation (from the ticket):
+\*   * Primary prepares a transaction at ts P and aborts at ts A, but A is not
+\*     yet checkpointed.
+\*   * Standby applies the abort but does NOT set a rollback timestamp at A.
+\*   * Standby steps up; the abort's effects are eventually checkpointed.
+\*   * Without a rollback timestamp pinning when the abort becomes visible in
+\*     a checkpoint, the engine has no way to know whether the abort should be
+\*     visible in any given checkpoint -> inconsistent state across the
+\*     prepared-document keys.
+\*
+\* This spec models the abort-apply path on a standby and pairs it with the
+\* WiredTiger rollback-timestamp advancement.  The invariant we want:
+\* whenever a standby has applied an abort for a prepared transaction at ts A,
+\* the standby's rollbackTimestamp is >= A on every later checkpoint that
+\* observes the abort's effects.
+\*
+\* To run the model-checker:
+\*     cd src/mongo/tla_plus
+\*     ./model-check.sh RollbackPreparedAbort
+
+EXTENDS Integers, FiniteSets, Sequences, TLC
+
+\* The set of server IDs.
+CONSTANT Server
+
+\* The maximum prepare/abort timestamp considered during model-checking.
+CONSTANT MaxTs
+
+\* Per-server state.
+\* prepared[s] : set of prepared transactions known to s (with their prepareTs).
+\* aborted[s]  : set of (txn, abortTs) the standby has applied an abort for.
+\* checkpoints[s] : set of {ts, visible} tuples; visible is the set of aborts
+\*                  whose effects are durable in that checkpoint.
+\* rollbackTs[s] : the WiredTiger rollback timestamp on s.  Aborts at ts >
+\*                 rollbackTs are NOT visible in checkpoints; aborts at ts <=
+\*                 rollbackTs ARE visible.
+\* role[s] : "Primary" or "Standby".
+VARIABLE prepared, aborted, checkpoints, rollbackTs, role
+
+vars == <<prepared, aborted, checkpoints, rollbackTs, role>>
+
+----
+\* Helpers.
+
+Txn == {"t1", "t2"}
+Timestamps == 1..MaxTs
+
+Max(a, b) == IF a >= b THEN a ELSE b
+
+\* Aborts that, at the time of checkpoint c, MUST be visible if pinned by
+\* rollbackTs.  The standby's contract: any aborted entry with abortTs <=
+\* checkpoint.ts AND abortTs <= rollbackTs is visible.
+ShouldBeVisible(s, c) ==
+    {a \in aborted[s] :
+        /\ a.abortTs <= c.ts
+        /\ a.abortTs <= rollbackTs[s]}
+
+----
+\* Initial values.
+
+Init ==
+    /\ prepared    = [s \in Server |-> {}]
+    /\ aborted     = [s \in Server |-> {}]
+    /\ checkpoints = [s \in Server |-> {}]
+    /\ rollbackTs  = [s \in Server |-> 0]
+    /\ role        = [s \in Server |-> "Standby"]
+
+----
+\* Actions.
+
+\* Primary prepares a transaction at ts.
+PrepareTxnOnPrimary(s, t, ts) ==
+    /\ role[s] = "Primary"
+    /\ ts \in Timestamps
+    /\ ~ \E p \in prepared[s] : p.txn = t
+    /\ prepared' = [prepared EXCEPT ![s] = prepared[s] \cup {[txn |-> t, prepareTs |-> ts]}]
+    /\ UNCHANGED <<aborted, checkpoints, rollbackTs, role>>
+
+\* Replicate prepare to standby (no rollbackTs side effect yet -- the abort is
+\* what carries the rollback-timestamp obligation in this ticket's scope).
+ReplicatePrepare(src, dst, t, ts) ==
+    /\ role[src] = "Primary"
+    /\ role[dst] = "Standby"
+    /\ [txn |-> t, prepareTs |-> ts] \in prepared[src]
+    /\ prepared' = [prepared EXCEPT ![dst] = prepared[dst] \cup {[txn |-> t, prepareTs |-> ts]}]
+    /\ UNCHANGED <<aborted, checkpoints, rollbackTs, role>>
+
+\* Standby applies an abort for a prepared transaction at ts.
+\* THIS IS THE FIX UNDER TEST: applying the abort must advance rollbackTs to
+\* at least ts so that future checkpoints know at what time the abort becomes
+\* visible.  Without this, ShouldBeVisible may return {} for an abort that the
+\* standby has actually applied, leading to the checkpoint inconsistency that
+\* SERVER-125802 describes.
+StandbyApplyAbort(s, t, ts) ==
+    /\ role[s] = "Standby"
+    /\ \E p \in prepared[s] : p.txn = t /\ p.prepareTs <= ts
+    /\ ~ \E a \in aborted[s] : a.txn = t
+    /\ aborted'    = [aborted EXCEPT ![s] = aborted[s] \cup {[txn |-> t, abortTs |-> ts]}]
+    \* The patch: rollbackTs advances on abort-apply.
+    /\ rollbackTs' = [rollbackTs EXCEPT ![s] = Max(rollbackTs[s], ts)]
+    /\ UNCHANGED <<prepared, checkpoints, role>>
+
+\* WiredTiger takes a checkpoint at ts on server s.  The set of aborts visible
+\* in this checkpoint is determined by ShouldBeVisible at checkpoint-time.
+TakeCheckpoint(s, ts) ==
+    /\ ts \in Timestamps
+    /\ ts >= rollbackTs[s]  \* checkpoint advances time forward
+    /\ LET c == [ts |-> ts, visible |-> {a \in aborted[s] : a.abortTs <= ts}]
+        IN checkpoints' = [checkpoints EXCEPT ![s] = checkpoints[s] \cup {c}]
+    /\ UNCHANGED <<prepared, aborted, rollbackTs, role>>
+
+\* Standby steps up to primary.
+StepUp(s) ==
+    /\ role[s] = "Standby"
+    /\ role' = [role EXCEPT ![s] = "Primary"]
+    /\ UNCHANGED <<prepared, aborted, checkpoints, rollbackTs>>
+
+\* Bootstrap one primary so the system can do anything.
+ElectInitialPrimary(s) ==
+    /\ \A x \in Server : role[x] = "Standby"
+    /\ role' = [role EXCEPT ![s] = "Primary"]
+    /\ UNCHANGED <<prepared, aborted, checkpoints, rollbackTs>>
+
+----
+
+Next ==
+    \/ \E s \in Server : ElectInitialPrimary(s)
+    \/ \E s \in Server, t \in Txn, ts \in Timestamps : PrepareTxnOnPrimary(s, t, ts)
+    \/ \E src, dst \in Server, t \in Txn, ts \in Timestamps : ReplicatePrepare(src, dst, t, ts)
+    \/ \E s \in Server, t \in Txn, ts \in Timestamps : StandbyApplyAbort(s, t, ts)
+    \/ \E s \in Server, ts \in Timestamps : TakeCheckpoint(s, ts)
+    \/ \E s \in Server : StepUp(s)
+
+Spec == Init /\ [][Next]_vars
+
+----
+\* Invariants.
+
+\* The headline safety property: every abort the standby has applied at ts A
+\* is pinned by rollbackTs >= A.  If this holds, then any subsequent
+\* checkpoint that observes the abort's effects has a well-defined visibility
+\* relationship with rollbackTs and the engine knows whether to show the
+\* abort.  Without the SERVER-125802 fix (advance rollbackTs on abort-apply
+\* in StandbyApplyAbort) this is violated trivially.
+AbortPinnedByRollbackTimestamp ==
+    \A s \in Server :
+        \A a \in aborted[s] :
+            rollbackTs[s] >= a.abortTs
+
+\* No checkpoint claims an abort as visible whose abortTs exceeds rollbackTs
+\* at the time of the checkpoint.  Together with AbortPinnedByRollbackTimestamp
+\* this gives the post-step-up consistency guarantee.
+CheckpointVisibilityConsistent ==
+    \A s \in Server :
+        \A c \in checkpoints[s] :
+            \A a \in c.visible :
+                a.abortTs <= rollbackTs[s]
+
+\* Liveness sanity: state shape.
+TypeOK ==
+    /\ prepared    \in [Server -> SUBSET [txn : Txn, prepareTs : Timestamps]]
+    /\ aborted     \in [Server -> SUBSET [txn : Txn, abortTs   : Timestamps]]
+    /\ rollbackTs  \in [Server -> 0..MaxTs]
+    /\ role        \in [Server -> {"Primary", "Standby"}]
+
+===============================================================================


### PR DESCRIPTION
## Summary

TLA+ spec + jstest for standby rollback of prepared-abort timestamp.

**Jira:** https://jira.mongodb.org/browse/SERVER-126619
**Branch:** substrate-contrib/w3-40

## Files

```
  - ...standby_rollback_timestamp_on_prepared_abort.js | 133 ++++++++++++++++
  - .../MCRollbackPreparedAbort.cfg                    |  19 +++
  - .../MCRollbackPreparedAbort.tla                    |  13 ++
  - .../Replication/RollbackPreparedAbort/OWNERS.yml   |   5 +
  - .../RollbackPreparedAbort.tla                      | 176 +++++++++++++++++++++
  - 5 files changed, 346 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
