### PR TITLE
SERVER-126621 jstests for standby cold restart / invalid start LSN / segment-drain reconnect

### DIFF
--- a/jstests/replsets/standby_cold_restart_after_sealing.js
+++ b/jstests/replsets/standby_cold_restart_after_sealing.js
@@ -1,0 +1,42 @@
+/**
+ * SERVER-126531: Verifies a standby survives a cold restart when the first log server it
+ * connects to hosts a sealed segment. Cold startup seeds state from the checkpoint of that
+ * server (_lastMajorityCommittedLSN = 0); segment scan must pick the segment using the larger
+ * of the standby's committed LSN and the WT stable timestamp, so a stale checkpoint start does
+ * not trigger restream-from-beginning and a 4017301 fassert.
+ *
+ * @tags: [
+ *   requires_persistence,
+ *   featureFlagDisaggregatedStorage,
+ * ]
+ */
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+const testName = "standby_cold_restart_after_sealing";
+const rst = new ReplSetTest({name: testName, nodes: [{}, {rsConfig: {priority: 0, votes: 0}}]});
+rst.startSet();
+rst.initiate(null, null, {initiateWithDefaultElectionTimeout: true});
+
+const primary = rst.getPrimary();
+const standby = rst.getSecondaries()[0];
+const primaryDb = primary.getDB("test");
+
+assert.commandWorked(primaryDb.coll.insert([{_id: 0}, {_id: 1}, {_id: 2}]));
+rst.awaitReplication();
+
+// Force a segment seal on the log server, then drive new writes so the sealed segment is the
+// one a fresh standby will pick from the checkpoint.
+assert.commandWorked(primary.adminCommand({_logSegmentSeal: 1}));
+assert.commandWorked(primaryDb.coll.insert([{_id: 3}, {_id: 4}]));
+rst.awaitReplication();
+
+const standbyId = rst.getNodeId(standby);
+rst.stop(standbyId);
+// Cold restart: _lastMajorityCommittedLSN = 0 on bootstrap.
+rst.restart(standbyId, {startClean: false});
+rst.awaitSecondaryNodes(null, [standby]);
+
+// Pre-fix this fasserts 4017301 during catchup. Post-fix the standby reconciles via WT stable
+// ts and does not restream redelivered entries.
+assert.eq(5, standby.getDB("test").coll.find().itcount());
+rst.stopSet();

--- a/jstests/replsets/standby_invalid_start_lsn_topology_refresh.js
+++ b/jstests/replsets/standby_invalid_start_lsn_topology_refresh.js
@@ -1,0 +1,47 @@
+/**
+ * SERVER-126531: When every log server rejects the requested LSN with INVALID_START_LSN or
+ * START_LSN_TRUNCATED, the standby must refresh topology from CMS and retry instead of
+ * fatalling. Also covers mid-seal restart: kill the standby while it is requesting a new
+ * segment, restart, and verify the topology-refresh path completes.
+ *
+ * Pre-fix: fatal exit when no log server accepts the LSN.
+ * Post-fix: standby refreshes topology, picks a new log server, and rejoins.
+ *
+ * @tags: [
+ *   requires_persistence,
+ *   featureFlagDisaggregatedStorage,
+ * ]
+ */
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+const testName = "standby_invalid_start_lsn_topology_refresh";
+const rst = new ReplSetTest({name: testName, nodes: [{}, {rsConfig: {priority: 0, votes: 0}}]});
+rst.startSet();
+rst.initiate(null, null, {initiateWithDefaultElectionTimeout: true});
+
+const primary = rst.getPrimary();
+const standby = rst.getSecondaries()[0];
+const primaryDb = primary.getDB("test");
+
+assert.commandWorked(primaryDb.coll.insert([{_id: 0}, {_id: 1}]));
+rst.awaitReplication();
+
+// Force every log server to reject the standby's requested LSN.
+const rejectFp = configureFailPoint(standby, "logServerRejectAllStartLsn", {
+    reason: "INVALID_START_LSN",
+});
+
+// Mid-seal restart: kill the standby while it is mid-request for a new segment.
+const standbyId = rst.getNodeId(standby);
+rst.stop(standbyId, 9 /* SIGKILL */);
+rst.restart(standbyId, {startClean: false});
+
+// Post-fix the standby refreshes topology from CMS and retries; pre-fix it fatals here.
+rst.awaitSecondaryNodes(null, [rst.nodes[standbyId]]);
+rejectFp.off();
+
+assert.commandWorked(primaryDb.coll.insert([{_id: 2}]));
+rst.awaitReplication();
+assert.eq(3, rst.nodes[standbyId].getDB("test").coll.find().itcount());
+rst.stopSet();

--- a/jstests/replsets/standby_reconnect_after_segment_drain.js
+++ b/jstests/replsets/standby_reconnect_after_segment_drain.js
@@ -1,0 +1,47 @@
+/**
+ * SERVER-126531: After draining a segment and reconnecting, the standby must not call
+ * clearLogServers() in a way that clears prevSegmentID and triggers restream-from-beginning.
+ * Restream should only happen when both the old and new segment IDs are known AND differ.
+ *
+ * Pre-fix: reconnect redelivers entries older than what's on disk, fassert 4017301 fires when
+ * the standby applies a redelivered oplog/checkpoint entry it has already applied (== check).
+ * Post-fix: standby skips redelivered entries via <= comparison and survives the reconnect.
+ *
+ * @tags: [
+ *   requires_persistence,
+ *   featureFlagDisaggregatedStorage,
+ * ]
+ */
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+const testName = "standby_reconnect_after_segment_drain";
+const rst = new ReplSetTest({name: testName, nodes: [{}, {rsConfig: {priority: 0, votes: 0}}]});
+rst.startSet();
+rst.initiate(null, null, {initiateWithDefaultElectionTimeout: true});
+
+const primary = rst.getPrimary();
+const standby = rst.getSecondaries()[0];
+const primaryDb = primary.getDB("test");
+
+assert.commandWorked(primaryDb.coll.insert([{_id: 0}, {_id: 1}]));
+rst.awaitReplication();
+
+// Drain the active segment on the standby, then drop the log-server connection so it
+// reconnects with the prevSegmentID populated.
+assert.commandWorked(standby.adminCommand({_logSegmentSeal: 1}));
+const dropFp = configureFailPoint(standby, "dropLogServerConnection");
+assert.commandWorked(primaryDb.coll.insert([{_id: 2}, {_id: 3}]));
+rst.awaitReplication();
+dropFp.off();
+
+// Force one more sealed segment so the reconnect picks up a fresh segment header. The standby
+// must compare old vs new segment IDs and NOT restream if they are equal.
+assert.commandWorked(primary.adminCommand({_logSegmentSeal: 1}));
+assert.commandWorked(primaryDb.coll.insert([{_id: 4}]));
+rst.awaitReplication();
+
+assert.eq(5, standby.getDB("test").coll.find().itcount());
+// fassert 4017301 must not have fired during reconnect-redelivery.
+assert(standby.adminCommand({hello: 1}).ok);
+rst.stopSet();


### PR DESCRIPTION
## Summary

jstests for standby cold restart / invalid start LSN / segment-drain reconnect.

**Jira:** https://jira.mongodb.org/browse/SERVER-126621
**Branch:** substrate-contrib/w3-42

## Files

```
  - .../replsets/standby_cold_restart_after_sealing.js | 42 +++++++++++++++++++
  - .../standby_invalid_start_lsn_topology_refresh.js  | 47 ++++++++++++++++++++++
  - .../standby_reconnect_after_segment_drain.js       | 47 ++++++++++++++++++++++
  - 3 files changed, 136 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
