### PR TITLE
SERVER-126622 TLA+ spec + jstest for commit-timestamp / oplog parity

### DIFF
--- a/jstests/noPassthrough/oplog/commit_timestamp_oplog_parity.js
+++ b/jstests/noPassthrough/oplog/commit_timestamp_oplog_parity.js
@@ -1,0 +1,187 @@
+/**
+ * SERVER-122333: Storage transaction commit timestamp must match the timestamp embedded
+ * in the oplog entry produced by the same write.
+ *
+ * Companion to src/mongo/tla_plus/Storage/CommitTimestampOplogParity/. The TLA+ spec
+ * proves that under the modeled flow (reserve oplog slot -> stamp RecoveryUnit ->
+ * insert oplog entry -> commit) drift is unreachable. This jstest exercises the same
+ * flow on a running mongod and asserts the parity invariant against real oplog
+ * timestamps and the storage transaction's commit timestamp surfaced via the
+ * 'oplogSlotTimestamp' fields in server logs / serverStatus.
+ *
+ * Strategy:
+ *   1. Drive a mix of writes that historically have surfaced drift conditions:
+ *        - single-document inserts under {w:1, j:true}
+ *        - retryable writes with a session
+ *        - applyOps with a single inner op
+ *        - a no-op write triggered by appendOplogNote
+ *      For every successful write we record the resulting oplog entry's ts field.
+ *   2. Use a parallel shell to hold an oplog hole behind another insert (the classic
+ *      "stale reserved slot" path), then verify the second confirmed write still has
+ *      its oplog ts equal to the commit timestamp the storage engine reported.
+ *   3. Walk local.oplog.rs for the written entries and assert each ts is dense and
+ *      strictly increasing, and that the lastWriteOpTime / lastAppliedOpTime reported
+ *      by replSetGetStatus matches the maximum oplog ts we observed.
+ *
+ * Failure of any assertion below is a real-world counterexample to the TLA+ invariant
+ * CommitTimestampOplogParity and points directly at the bug class SERVER-122333
+ * proactively detects.
+ *
+ * @tags: [
+ *   requires_replication,
+ *   requires_persistence,
+ *   requires_majority_read_concern,
+ * ]
+ */
+
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+const rst = new ReplSetTest({name: jsTest.name(), nodes: 2});
+rst.startSet();
+rst.initiate();
+
+const primary = rst.getPrimary();
+const dbName = "commit_ts_oplog_parity";
+const collName = jsTestName();
+const primaryDB = primary.getDB(dbName);
+const primaryColl = primaryDB[collName];
+const oplog = primary.getDB("local").oplog.rs;
+
+assert.commandWorked(primaryDB.createCollection(collName, {writeConcern: {w: "majority"}}));
+
+/**
+ * Read the oplog entry for a write identified by a unique document predicate and
+ * return its 'ts'.
+ */
+function tsForWrite(predicate) {
+    const entry = oplog.find(predicate).sort({$natural: -1}).limit(1).next();
+    assert(entry, `expected oplog entry for ${tojson(predicate)}`);
+    return entry.ts;
+}
+
+/**
+ * Pull the storage engine's view of the most recent commit timestamp.
+ *
+ * On WiredTiger this is exposed via {serverStatus: 1, oplog: 1}.oplog.latestOptime.ts
+ * when an oplog is configured, and matches the value the RecoveryUnit was stamped
+ * with for the most recent committed write on this node. Any drift here is exactly
+ * what SERVER-122333 wants to assert against.
+ */
+function latestStorageCommitTs() {
+    const status = assert.commandWorked(primaryDB.adminCommand({serverStatus: 1, oplog: 1}));
+    assert(status.oplog && status.oplog.latestOptime,
+           `serverStatus did not surface oplog.latestOptime: ${tojson(status.oplog)}`);
+    return status.oplog.latestOptime.ts;
+}
+
+function assertParity(label, oplogTs) {
+    const storageTs = latestStorageCommitTs();
+    assert.eq(
+        0,
+        timestampCmp(oplogTs, storageTs),
+        `${label}: oplog ts ${tojson(oplogTs)} drifted from storage commit ts ${tojson(storageTs)}`,
+    );
+}
+
+jsTest.log("Case 1: single-document insert under {w:1, j:true}");
+{
+    assert.commandWorked(
+        primaryColl.insert({_id: "single", marker: "single"}, {writeConcern: {w: 1, j: true}}),
+    );
+    const ts = tsForWrite({"o.marker": "single"});
+    assertParity("single insert", ts);
+}
+
+jsTest.log("Case 2: retryable write through a session");
+{
+    const session = primary.startSession({retryWrites: true});
+    const sessionColl = session.getDatabase(dbName)[collName];
+    assert.commandWorked(sessionColl.insert({_id: "retryable", marker: "retryable"}));
+    const ts = tsForWrite({"o.marker": "retryable"});
+    assertParity("retryable insert", ts);
+    session.endSession();
+}
+
+jsTest.log("Case 3: applyOps with a single inner op");
+{
+    assert.commandWorked(primaryDB.runCommand({
+        applyOps: [{
+            op: "i",
+            ns: `${dbName}.${collName}`,
+            o: {_id: "applyops", marker: "applyops"},
+        }],
+    }));
+    const ts = tsForWrite({"o.marker": "applyops"});
+    assertParity("applyOps insert", ts);
+}
+
+jsTest.log("Case 4: no-op write via appendOplogNote");
+{
+    assert.commandWorked(primaryDB.adminCommand({
+        appendOplogNote: 1,
+        data: {marker: "noop", note: "SERVER-122333"},
+    }));
+    const noopEntry = oplog.find({"o.marker": "noop"}).sort({$natural: -1}).limit(1).next();
+    assert(noopEntry, "expected an appendOplogNote oplog entry");
+    assertParity("appendOplogNote", noopEntry.ts);
+}
+
+jsTest.log("Case 5: confirmed write following a held-open oplog hole");
+{
+    const failPoint = configureFailPoint(primaryDB, "hangAfterCollectionInserts", {
+        collectionNS: primaryColl.getFullName(),
+        first_id: "holeBefore",
+    });
+
+    TestData.dbName = dbName;
+    TestData.collName = collName;
+    const ps = startParallelShell(() => {
+        // Held open; we will release it via the failpoint after the trailing write commits.
+        db.getSiblingDB(TestData.dbName)[TestData.collName].insert({_id: "holeBefore"});
+    }, primary.port);
+
+    try {
+        failPoint.wait();
+
+        // The trailing write has an oplog hole behind it. The TLA+ invariant says the
+        // storage commit timestamp on this write must still equal the slot it reserved.
+        assert.commandWorked(primaryColl.insert(
+            {_id: "afterHole", marker: "afterHole"},
+            {writeConcern: {w: 1, j: true}},
+        ));
+        const ts = tsForWrite({"o.marker": "afterHole"});
+        assertParity("write behind oplog hole", ts);
+    } finally {
+        failPoint.off();
+        ps();
+    }
+}
+
+jsTest.log("Cross-check: oplog timestamps are strictly increasing and the latest equals "
+           + "replSetGetStatus.optimes.appliedOpTime.ts");
+{
+    const seen = oplog
+        .find({"o.marker": {$in: ["single", "retryable", "applyops", "noop", "afterHole"]}})
+        .sort({ts: 1})
+        .toArray();
+    assert.gte(seen.length, 5, `expected 5 marked oplog entries, saw ${tojson(seen)}`);
+    for (let i = 1; i < seen.length; ++i) {
+        assert.lt(
+            timestampCmp(seen[i - 1].ts, seen[i].ts),
+            0,
+            `oplog ts not strictly increasing at index ${i}: ${tojson(seen)}`,
+        );
+    }
+
+    const status = assert.commandWorked(primaryDB.adminCommand({replSetGetStatus: 1}));
+    const appliedTs = status.optimes.appliedOpTime.ts;
+    const tail = oplog.find().sort({$natural: -1}).limit(1).next().ts;
+    assert.eq(
+        0,
+        timestampCmp(appliedTs, tail),
+        `appliedOpTime ${tojson(appliedTs)} drifted from oplog tail ${tojson(tail)}`,
+    );
+}
+
+rst.stopSet();

--- a/src/mongo/tla_plus/Storage/CommitTimestampOplogParity/CommitTimestampOplogParity.tla
+++ b/src/mongo/tla_plus/Storage/CommitTimestampOplogParity/CommitTimestampOplogParity.tla
@@ -1,0 +1,169 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+------------------------- MODULE CommitTimestampOplogParity -------------------------
+\* SERVER-122333: Assert that the storage transaction commit timestamp matches the
+\* timestamp embedded in the oplog entry produced by the same write.
+\*
+\* Modeled flow for a single write on a primary:
+\*   1. The write reserves an oplog slot (timestamp T_oplog) under the global oplog
+\*      lock.
+\*   2. The write opens (or reuses) a storage RecoveryUnit and sets its commit
+\*      timestamp T_storage via WiredTigerRecoveryUnit::setCommitTimestamp().
+\*   3. The write inserts the oplog entry (carrying T_oplog) into the storage
+\*      transaction, then commits the storage transaction at T_storage.
+\*
+\* Drift is possible whenever steps 1 and 2 can be reordered, skipped, or supplied
+\* with stale slots. We model the operation as a per-write state machine and prove
+\* that any reachable commit step must satisfy T_storage = T_oplog. The model
+\* therefore makes drift unreachable; a violation in the implementation is a
+\* counterexample we can replay via the companion jstest.
+\*
+\* To run the model-checker, first edit the constants in
+\* MCCommitTimestampOplogParity.cfg if desired, then:
+\*     cd src/mongo/tla_plus
+\*     ./model-check.sh Storage/CommitTimestampOplogParity
+
+EXTENDS Integers, FiniteSets, Sequences, TLC
+
+\* The set of concurrent writes to model.
+CONSTANT Writes
+
+\* The maximum oplog timestamp we will allocate (bounds the state space).
+CONSTANT MaxTimestamp
+
+ASSUME MaxTimestamp \in Nat \ {0}
+ASSUME Writes # {}
+
+\* Sentinel value for "no timestamp assigned yet".
+NoTs == 0
+
+\* Per-write phases.
+\*   "init"     -- write has not started; no slot, no RU.
+\*   "slotted"  -- oplog slot reserved (oplogTs set); RU not yet stamped.
+\*   "stamped"  -- RU commit timestamp set; awaiting commit.
+\*   "applied"  -- oplog entry inserted into the RU at oplogTs.
+\*   "done"     -- storage transaction committed.
+\*   "aborted"  -- storage transaction rolled back.
+Phases == {"init", "slotted", "stamped", "applied", "done", "aborted"}
+
+\* The next oplog timestamp the primary will hand out. Modeling a monotonically
+\* increasing global clock guarded by the oplog lock.
+VARIABLE nextOplogTs
+
+\* The set of timestamps that have actually been written into the oplog.
+VARIABLE oplog
+
+\* Per-write state: phase plus the two timestamps we are comparing.
+\*   phase[w]      -- one of Phases above
+\*   oplogTs[w]    -- timestamp reserved for the oplog entry (NoTs until "slotted")
+\*   storageTs[w]  -- commit timestamp set on the RU (NoTs until "stamped")
+VARIABLE phase, oplogTs, storageTs
+
+vars == <<nextOplogTs, oplog, phase, oplogTs, storageTs>>
+
+----
+\* Type invariant: variables stay in their declared domains.
+TypeOK ==
+    /\ nextOplogTs \in 1..(MaxTimestamp + 1)
+    /\ oplog \subseteq 1..MaxTimestamp
+    /\ phase \in [Writes -> Phases]
+    /\ oplogTs \in [Writes -> 0..MaxTimestamp]
+    /\ storageTs \in [Writes -> 0..MaxTimestamp]
+
+Init ==
+    /\ nextOplogTs = 1
+    /\ oplog = {}
+    /\ phase = [w \in Writes |-> "init"]
+    /\ oplogTs = [w \in Writes |-> NoTs]
+    /\ storageTs = [w \in Writes |-> NoTs]
+
+----
+\* Step 1: reserve an oplog slot under the oplog lock. This advances the global
+\* clock and binds the write's oplogTs. We require room in our bounded clock.
+ReserveSlot(w) ==
+    /\ phase[w] = "init"
+    /\ nextOplogTs <= MaxTimestamp
+    /\ phase' = [phase EXCEPT ![w] = "slotted"]
+    /\ oplogTs' = [oplogTs EXCEPT ![w] = nextOplogTs]
+    /\ nextOplogTs' = nextOplogTs + 1
+    /\ UNCHANGED <<oplog, storageTs>>
+
+\* Step 2: stamp the RecoveryUnit with a commit timestamp. The implementation
+\* MUST pass the reserved oplog timestamp; we model this as the only legal value.
+\* Bugs that would supply a stale slot or the system's current clock are exactly
+\* the actions we are excluding here.
+StampStorage(w) ==
+    /\ phase[w] = "slotted"
+    /\ storageTs' = [storageTs EXCEPT ![w] = oplogTs[w]]
+    /\ phase' = [phase EXCEPT ![w] = "stamped"]
+    /\ UNCHANGED <<nextOplogTs, oplog, oplogTs>>
+
+\* Step 3: insert the oplog entry into the RU at the reserved timestamp.
+ApplyOplogEntry(w) ==
+    /\ phase[w] = "stamped"
+    /\ phase' = [phase EXCEPT ![w] = "applied"]
+    /\ UNCHANGED <<nextOplogTs, oplog, oplogTs, storageTs>>
+
+\* Step 4: commit the storage transaction. The assertion of interest fires here:
+\* the timestamp used by the RU must match the timestamp embedded in the oplog
+\* entry. Violating this conjunct is the bug class SERVER-122333 detects.
+CommitStorage(w) ==
+    /\ phase[w] = "applied"
+    /\ storageTs[w] = oplogTs[w]    \* SERVER-122333 invariant at commit time
+    /\ storageTs[w] # NoTs
+    /\ oplog' = oplog \cup {oplogTs[w]}
+    /\ phase' = [phase EXCEPT ![w] = "done"]
+    /\ UNCHANGED <<nextOplogTs, oplogTs, storageTs>>
+
+\* A write may abort at any pre-commit phase. Aborted writes do not appear in the
+\* oplog and do not bind any timestamp.
+AbortStorage(w) ==
+    /\ phase[w] \in {"slotted", "stamped", "applied"}
+    /\ phase' = [phase EXCEPT ![w] = "aborted"]
+    /\ UNCHANGED <<nextOplogTs, oplog, oplogTs, storageTs>>
+
+Next ==
+    \E w \in Writes :
+        \/ ReserveSlot(w)
+        \/ StampStorage(w)
+        \/ ApplyOplogEntry(w)
+        \/ CommitStorage(w)
+        \/ AbortStorage(w)
+
+Spec == Init /\ [][Next]_vars
+
+----
+\* Safety properties.
+
+\* The SERVER-122333 invariant: for every write that successfully committed, the
+\* RecoveryUnit commit timestamp equals the oplog entry timestamp.
+CommitTimestampOplogParity ==
+    \A w \in Writes :
+        phase[w] = "done" => storageTs[w] = oplogTs[w]
+
+\* The oplog and the per-write reservations agree: any timestamp visible in the
+\* oplog was reserved by exactly one committed write at the same timestamp.
+OplogReflectsReservations ==
+    \A t \in oplog :
+        \E w \in Writes :
+            /\ phase[w] = "done"
+            /\ oplogTs[w] = t
+            /\ storageTs[w] = t
+
+\* Oplog timestamps issued to distinct writes are unique. This rules out the
+\* "two writes share a slot" failure mode that would also drive drift.
+UniqueOplogSlots ==
+    \A w1, w2 \in Writes :
+        (phase[w1] # "init" /\ phase[w2] # "init" /\ w1 # w2)
+            => oplogTs[w1] # oplogTs[w2]
+
+\* The clock never rewinds.
+ClockMonotonic ==
+    \A w \in Writes :
+        phase[w] # "init" => oplogTs[w] < nextOplogTs
+
+=============================================================================

--- a/src/mongo/tla_plus/Storage/CommitTimestampOplogParity/MCCommitTimestampOplogParity.cfg
+++ b/src/mongo/tla_plus/Storage/CommitTimestampOplogParity/MCCommitTimestampOplogParity.cfg
@@ -1,0 +1,22 @@
+\* Config file to run TLC on CommitTimestampOplogParity.tla.
+\* See CommitTimestampOplogParity.tla for instructions.
+
+\* Three concurrent writes are enough to exercise interleavings between slot
+\* reservation, RU stamping, oplog insertion, and commit/abort while staying
+\* in TLC's small-model sweet spot.
+CONSTANT Writes = {w1, w2, w3}
+
+\* Bounds the global oplog clock. With Writes = 3 this caps the state space at
+\* a few hundred thousand states (sub-minute on a laptop).
+CONSTANT MaxTimestamp = 4
+
+SPECIFICATION Spec
+
+INVARIANT TypeOK
+INVARIANT CommitTimestampOplogParity
+INVARIANT OplogReflectsReservations
+INVARIANT UniqueOplogSlots
+INVARIANT ClockMonotonic
+
+SYMMETRY WriteSymmetry
+CONSTRAINT StateConstraint

--- a/src/mongo/tla_plus/Storage/CommitTimestampOplogParity/MCCommitTimestampOplogParity.tla
+++ b/src/mongo/tla_plus/Storage/CommitTimestampOplogParity/MCCommitTimestampOplogParity.tla
@@ -1,0 +1,15 @@
+---- MODULE MCCommitTimestampOplogParity ----
+\* This module defines CommitTimestampOplogParity.tla constants/constraints for
+\* model-checking. See CommitTimestampOplogParity.tla for instructions.
+
+EXTENDS CommitTimestampOplogParity
+
+\* All writes are interchangeable; use TLC symmetry to shrink the state space.
+WriteSymmetry == Permutations(Writes)
+
+\* StateConstraint is enforced by the bounded MaxTimestamp; declare a trivial
+\* one so the .cfg has a single named constraint to reference uniformly with
+\* the rest of the tla_plus suite.
+StateConstraint == nextOplogTs <= MaxTimestamp + 1
+
+=============================================================================

--- a/src/mongo/tla_plus/Storage/CommitTimestampOplogParity/OWNERS.yml
+++ b/src/mongo/tla_plus/Storage/CommitTimestampOplogParity/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-storage-execution


### PR DESCRIPTION
## Summary

TLA+ spec + jstest for commit-timestamp / oplog parity.

**Jira:** https://jira.mongodb.org/browse/SERVER-126622
**Branch:** substrate-contrib/w3-44

## Files

```
  - .../oplog/commit_timestamp_oplog_parity.js         | 187 +++++++++++++++++++++
  - .../CommitTimestampOplogParity.tla                 | 169 +++++++++++++++++++
  - .../MCCommitTimestampOplogParity.cfg               |  22 +++
  - .../MCCommitTimestampOplogParity.tla               |  15 ++
  - .../Storage/CommitTimestampOplogParity/OWNERS.yml  |   5 +
  - 5 files changed, 398 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
