### PR TITLE
SERVER-126623 TLA+ spec + jstest for sync-source selection edge cases

### DIFF
--- a/jstests/replsets/should_change_sync_source_edge_cases.js
+++ b/jstests/replsets/should_change_sync_source_edge_cases.js
@@ -1,0 +1,171 @@
+/**
+ * SERVER-126246 — companion matrix test for the
+ * ReplicationCoordinatorImpl::shouldChangeSyncSource edge-case fix.
+ *
+ * The fix narrows the previously-unconditional return of
+ *   ChangeSyncSourceAction::kStopSyncingAndEnqueueLastBatch
+ * into a guarded return: when topology requests a source change but the
+ * buffered last batch cannot be safely applied on a new sync source (the
+ * scenario observed in BF-43158, where the commit timestamp of the last
+ * batch precedes the new source's stable timestamp), the action must be
+ * downgraded to kStopSyncingAndDropLastBatchIfPresent.
+ *
+ * This matrix exercises three rows of the decision FSM modelled in
+ * src/mongo/tla_plus/Replication/SyncSourceSelection/SyncSourceSelection.tla:
+ *
+ *   row | entry point                     | topology | batch safe | expected
+ *   ----+---------------------------------+----------+------------+----------
+ *    1  | shouldChangeSyncSource          | wants    | yes        | enqueue
+ *    2  | shouldChangeSyncSource          | wants    | no         | drop
+ *    3  | shouldChangeSyncSourceOnError   | wants    | n/a        | drop
+ *
+ * Rows 4-6 (topology does not want change; ping-time wants change; both
+ * decline → continue) are covered by existing tests in
+ * jstests/replsets/sync_source_changes.js and the unit suite in
+ * src/mongo/db/repl/replication_coordinator_impl_test.cpp.
+ *
+ * @tags: [
+ *   requires_replication,
+ * ]
+ */
+
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+import {assertSyncSourceChangesTo} from "jstests/replsets/libs/sync_source.js";
+import {reconfig} from "jstests/replsets/rslib.js";
+
+// Replication verbosity 2 surfaces "Choosing new sync source" and the
+// action-code log lines we assert on.
+TestData["setParameters"]["logComponentVerbosity"]["replication"]["verbosity"] = 2;
+
+const rst = new ReplSetTest({
+    name: "should_change_sync_source_edge_cases",
+    nodes: [
+        {},
+        {rsConfig: {priority: 0, votes: 0}},
+        {rsConfig: {priority: 0, votes: 0}},
+    ],
+});
+rst.startSet();
+rst.initiate();
+rst.awaitReplication();
+
+const [primary, secondary, tertiary] = rst.nodes;
+
+// Helper: scan log for a single occurrence of one of the action codes
+// emitted by ReplicationCoordinatorImpl::shouldChangeSyncSource (verbosity
+// 2 prints them).  Returns the action code observed, or null.
+function lastSyncSourceActionFrom(conn) {
+    const log = assert.commandWorked(conn.adminCommand({getLog: "global"})).log;
+    let last = null;
+    for (let i = log.length - 1; i >= 0; --i) {
+        const line = log[i];
+        if (line.indexOf("kStopSyncingAndEnqueueLastBatch") >= 0) {
+            last = "kStopSyncingAndEnqueueLastBatch";
+            break;
+        }
+        if (line.indexOf("kStopSyncingAndDropLastBatchIfPresent") >= 0) {
+            last = "kStopSyncingAndDropLastBatchIfPresent";
+            break;
+        }
+        if (line.indexOf("kContinueSyncing") >= 0) {
+            last = "kContinueSyncing";
+            break;
+        }
+    }
+    return last;
+}
+
+// ---------------------------------------------------------------------------
+// Row 1 — heartbeat path, batch safe ⇒ kStopSyncingAndEnqueueLastBatch.
+// ---------------------------------------------------------------------------
+jsTestLog("Row 1: enqueue-when-safe");
+// Force the tertiary onto the secondary so we have a non-primary sync source
+// we can disqualify cleanly.
+{
+    const sec = TestData.usePriorityPorts ? secondary.priorityHost : secondary.host;
+    assert.commandWorked(tertiary.adminCommand({replSetSyncFrom: sec}));
+}
+assertSyncSourceChangesTo(rst, tertiary, secondary);
+// Now reconfigure secondary to non-voter — this makes it ineligible.  The
+// tertiary's buffered batch is safe (no timestamp pathology), so the
+// expected action is enqueue.
+{
+    let cfg = rst.getReplSetConfigFromNode();
+    cfg.members[1].votes = 0;
+    cfg.members[1].priority = 0;
+    reconfig(rst, cfg);
+}
+assertSyncSourceChangesTo(rst, tertiary, primary);
+{
+    const action = lastSyncSourceActionFrom(tertiary);
+    assert.eq(
+        action,
+        "kStopSyncingAndEnqueueLastBatch",
+        "row 1 expected enqueue when batch safe, observed: " + action,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Row 2 — heartbeat path, batch UNSAFE ⇒ kStopSyncingAndDropLastBatchIfPresent.
+// We simulate the BF-43158 condition with the dedicated failpoint that the
+// fix introduces: shouldChangeSyncSourceMarkLastBatchUnsafe causes the
+// coordinator to treat the buffered batch as unsafe to enqueue.
+// ---------------------------------------------------------------------------
+jsTestLog("Row 2: drop-when-unsafe");
+const markUnsafe = configureFailPoint(tertiary, "shouldChangeSyncSourceMarkLastBatchUnsafe");
+{
+    // Trigger a topology-wants-change event by reconfiguring the primary as
+    // non-voter (forces the tertiary to switch).  We need a voting candidate
+    // present, so flip secondary's votes back to 1 first.
+    let cfg = rst.getReplSetConfigFromNode();
+    cfg.members[1].votes = 1;
+    cfg.members[1].priority = 1;
+    reconfig(rst, cfg);
+    rst.stepUp(secondary);
+    cfg = rst.getReplSetConfigFromNode();
+    cfg.members[0].votes = 0;
+    cfg.members[0].priority = 0;
+    reconfig(rst, cfg);
+}
+assertSyncSourceChangesTo(rst, tertiary, secondary);
+{
+    const action = lastSyncSourceActionFrom(tertiary);
+    assert.eq(
+        action,
+        "kStopSyncingAndDropLastBatchIfPresent",
+        "row 2 expected drop when batch unsafe (BF-43158), observed: " + action,
+    );
+}
+markUnsafe.off();
+
+// ---------------------------------------------------------------------------
+// Row 3 — error path ⇒ kStopSyncingAndDropLastBatchIfPresent (never enqueue).
+// shouldChangeSyncSourceOnError must never return enqueue; this is the
+// ErrorPathNeverEnqueues invariant in the TLA+ spec.
+// ---------------------------------------------------------------------------
+jsTestLog("Row 3: error-path-never-enqueues");
+// Force a fetcher error to drive the on-error code path.
+const failFetcher = configureFailPoint(tertiary, "failfirstOplogEntryFetcherCallback");
+{
+    const newPrimary = rst.getPrimary();
+    const newPrimaryHost = TestData.usePriorityPorts ? newPrimary.priorityHost : newPrimary.host;
+    assert.commandWorked(tertiary.adminCommand({replSetSyncFrom: newPrimaryHost}));
+}
+failFetcher.wait();
+// Allow the on-error decision to be logged.
+assert.soon(() => {
+    const action = lastSyncSourceActionFrom(tertiary);
+    return action !== null && action !== "kStopSyncingAndEnqueueLastBatch";
+}, "error path must not return enqueue (SERVER-126246)");
+{
+    const action = lastSyncSourceActionFrom(tertiary);
+    assert.neq(
+        action,
+        "kStopSyncingAndEnqueueLastBatch",
+        "row 3 error path must never enqueue, observed: " + action,
+    );
+}
+failFetcher.off();
+
+rst.stopSet();

--- a/src/mongo/tla_plus/Replication/SyncSourceSelection/MCSyncSourceSelection.cfg
+++ b/src/mongo/tla_plus/Replication/SyncSourceSelection/MCSyncSourceSelection.cfg
@@ -1,0 +1,24 @@
+\* Config file to run the TLC model-checker on SyncSourceSelection.tla.
+\* See SyncSourceSelection.tla for instructions.
+
+\* The set of replica-set member IDs.  Three is enough to exercise the FSM
+\* since the decision is per-invocation and does not depend on quorum.
+CONSTANT Server = {s1, s2, s3}
+
+\* Upper bound on number of decision invocations modelled in one behaviour.
+CONSTANT MaxDecisions = 4
+
+\* Sentinel host used when the current sync source is not in this node's
+\* replica-set config (production: findMemberIndexByHostAndPort returns -1).
+CONSTANT NotInConfig = oob
+
+INVARIANT TypeOK
+INVARIANT NeverEnqueueUnsafeBatch
+INVARIANT ErrorPathNeverEnqueues
+INVARIANT ShortCircuitMeansContinue
+INVARIANT EnqueueOnlyWhenSafe
+
+PROPERTY EventuallyMakesDecisions
+
+CONSTRAINT StateConstraint
+SPECIFICATION Spec

--- a/src/mongo/tla_plus/Replication/SyncSourceSelection/MCSyncSourceSelection.tla
+++ b/src/mongo/tla_plus/Replication/SyncSourceSelection/MCSyncSourceSelection.tla
@@ -1,0 +1,10 @@
+---- MODULE MCSyncSourceSelection ----
+\* MC harness for SyncSourceSelection.tla — provides StateConstraint to bound
+\* the model checker, and a small concrete Server set.
+\* See SyncSourceSelection.tla for instructions.
+
+EXTENDS SyncSourceSelection
+
+StateConstraint ==
+    Len(history) <= MaxDecisions
+=============================================================================

--- a/src/mongo/tla_plus/Replication/SyncSourceSelection/OWNERS.yml
+++ b/src/mongo/tla_plus/Replication/SyncSourceSelection/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-replication-reviewers

--- a/src/mongo/tla_plus/Replication/SyncSourceSelection/SyncSourceSelection.tla
+++ b/src/mongo/tla_plus/Replication/SyncSourceSelection/SyncSourceSelection.tla
@@ -1,0 +1,196 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+------------------------- MODULE SyncSourceSelection -------------------------
+\* Formal model of ReplicationCoordinatorImpl::shouldChangeSyncSource and the
+\* paired shouldChangeSyncSourceOnError entry point.
+\*
+\* Background (SERVER-126246): the production code in
+\* src/mongo/db/repl/replication_coordinator_impl.cpp returns
+\*   - kStopSyncingAndEnqueueLastBatch    when topology says "change source"
+\*   - kStopSyncingAndDropLastBatchIfPresent when ping-time says "closer node"
+\*   - kContinueSyncing                   otherwise
+\* The bug observed in BF-43158 is that the "enqueue last batch" branch is
+\* taken unconditionally even when applying the buffered batch would violate
+\* a stable-timestamp / commit-point invariant on the new sync source.  In
+\* that case the buffered batch must be DROPPED, not enqueued, because the
+\* batch's commit timestamp would precede the new source's stable timestamp.
+\*
+\* This spec encodes:
+\*   1) the three-action decision FSM,
+\*   2) the predicates the topology coordinator consults
+\*      (topologyWantsChange, pingTimeWantsChange, lastBatchEnqueueable),
+\*   3) the proposed fix: kStopSyncingAndEnqueueLastBatch may be returned only
+\*      when lastBatchEnqueueable holds; otherwise we downgrade to
+\*      kStopSyncingAndDropLastBatchIfPresent.
+\*
+\* To run the model-checker, edit MCSyncSourceSelection.cfg if desired, then:
+\*     cd src/mongo/tla_plus
+\*     ./model-check.sh Replication/SyncSourceSelection/SyncSourceSelection
+
+EXTENDS Integers, FiniteSets, Sequences, TLC
+
+\* The set of replica-set member IDs.
+CONSTANT Server
+
+\* The maximum number of decision invocations we model in a single behaviour.
+\* Bound keeps the state space finite.
+CONSTANT MaxDecisions
+
+\* The set of HostAndPort identifiers we treat as "in config" candidates.
+\* A sync source observed at runtime can also be NotInConfig.
+CONSTANT NotInConfig
+
+\* The three actions defined by ChangeSyncSourceAction in
+\* src/mongo/db/repl/sync_source_selector.h.
+Actions == {"kContinueSyncing",
+            "kStopSyncingAndDropLastBatchIfPresent",
+            "kStopSyncingAndEnqueueLastBatch"}
+
+\* The two entry points: the heartbeat-driven path (with metadata) and the
+\* error-driven path (no metadata, restricted check set).
+EntryPoints == {"shouldChangeSyncSource", "shouldChangeSyncSourceOnError"}
+
+----
+\* Per-decision state observed by each invocation.  Each invocation is a
+\* tuple capturing the inputs and the action chosen.  We accumulate them in
+\* a sequence so model-checker can express temporal invariants like
+\* "no behaviour ever returns enqueueLastBatch when lastBatch is unsafe".
+
+\* The history of decisions produced so far.  Each element:
+\*   [ entry           |-> EntryPoints,
+\*     currentSource   |-> Server \cup {NotInConfig},
+\*     topologyWants   |-> BOOLEAN,
+\*     pingTimeWants   |-> BOOLEAN,
+\*     forceCleared    |-> BOOLEAN,  \* unsupportedSyncSource forced
+\*     selfInConfig    |-> BOOLEAN,
+\*     lastBatchExists |-> BOOLEAN,
+\*     batchSafe       |-> BOOLEAN,  \* batch may be safely enqueued
+\*     action          |-> Actions ]
+VARIABLE history
+
+vars == << history >>
+
+----
+\* Helpers / predicates.
+
+InConfigSources == Server
+
+ValidSources == InConfigSources \cup {NotInConfig}
+
+\* Initial-checks short-circuit: the production code returns "do not change"
+\* in two cases before consulting topology:
+\*   - we are not in the config
+\*   - unsupportedSyncSource has been forced via setParameter
+NoChangeShortCircuit(d) ==
+    \/ ~d.selfInConfig
+    \/ d.forceCleared
+
+\* Production code returns the enqueue action when topology requested a change
+\* AND the entry point provides metadata (shouldChangeSyncSource, not
+\* shouldChangeSyncSourceOnError).
+\*
+\* The PROPOSED FIX (SERVER-126246): downgrade enqueue to drop when the
+\* buffered batch cannot be applied safely on a new sync source.
+DecideAction(d) ==
+    IF NoChangeShortCircuit(d)
+    THEN "kContinueSyncing"
+    ELSE IF d.entry = "shouldChangeSyncSource" /\ d.topologyWants
+         THEN IF d.lastBatchExists /\ ~d.batchSafe
+              THEN "kStopSyncingAndDropLastBatchIfPresent"
+              ELSE "kStopSyncingAndEnqueueLastBatch"
+         ELSE IF d.entry = "shouldChangeSyncSourceOnError" /\ d.topologyWants
+              THEN "kStopSyncingAndDropLastBatchIfPresent"
+              ELSE IF d.pingTimeWants
+                   THEN "kStopSyncingAndDropLastBatchIfPresent"
+                   ELSE "kContinueSyncing"
+
+----
+Init == history = << >>
+
+\* ACTION
+\* A new shouldChangeSyncSource invocation arrives with non-deterministic
+\* inputs drawn from the observable state.  Each invocation appends one
+\* decision record to history.  The action is computed by DecideAction.
+Decide ==
+    /\ Len(history) < MaxDecisions
+    /\ \E entry          \in EntryPoints,
+          currentSource  \in ValidSources,
+          topologyWants  \in BOOLEAN,
+          pingTimeWants  \in BOOLEAN,
+          forceCleared   \in BOOLEAN,
+          selfInConfig   \in BOOLEAN,
+          lastBatchExists\in BOOLEAN,
+          batchSafe      \in BOOLEAN :
+        LET d == [ entry           |-> entry,
+                   currentSource   |-> currentSource,
+                   topologyWants   |-> topologyWants,
+                   pingTimeWants   |-> pingTimeWants,
+                   forceCleared    |-> forceCleared,
+                   selfInConfig    |-> selfInConfig,
+                   lastBatchExists |-> lastBatchExists,
+                   batchSafe       |-> batchSafe,
+                   action          |-> "kContinueSyncing" ]
+            withAction == [ d EXCEPT !.action = DecideAction(d) ]
+        IN history' = Append(history, withAction)
+
+Next == Decide
+
+Spec == Init /\ [][Next]_vars /\ WF_vars(Decide)
+
+----
+\* Properties (invariants).
+
+\* TypeOK: every recorded decision is well-formed.
+TypeOK ==
+    \A i \in DOMAIN history :
+        /\ history[i].entry  \in EntryPoints
+        /\ history[i].action \in Actions
+        /\ history[i].currentSource \in ValidSources
+
+\* SAFETY 1 — the edge case targeted by SERVER-126246.
+\* If a buffered last batch exists and is NOT safe to enqueue (e.g. its
+\* commit timestamp would precede the new sync source's stable timestamp,
+\* per BF-43158), the decision must never be kStopSyncingAndEnqueueLastBatch.
+NeverEnqueueUnsafeBatch ==
+    \A i \in DOMAIN history :
+        ~(  history[i].lastBatchExists
+         /\ ~history[i].batchSafe
+         /\ history[i].action = "kStopSyncingAndEnqueueLastBatch")
+
+\* SAFETY 2 — the error path is documented to be a strict subset of the
+\* heartbeat path: shouldChangeSyncSourceOnError must never return the
+\* enqueue action.  This codifies the comment in sync_source_selector.h.
+ErrorPathNeverEnqueues ==
+    \A i \in DOMAIN history :
+        ~(  history[i].entry = "shouldChangeSyncSourceOnError"
+         /\ history[i].action = "kStopSyncingAndEnqueueLastBatch")
+
+\* SAFETY 3 — short-circuit invariant: when we are not in the config or
+\* the unsupportedSyncSource override is set, the action must be
+\* kContinueSyncing (no sync-source change is initiated by this node).
+ShortCircuitMeansContinue ==
+    \A i \in DOMAIN history :
+        NoChangeShortCircuit(history[i]) =>
+            history[i].action = "kContinueSyncing"
+
+\* SAFETY 4 — pre-fix invariant that we EXPECT to violate, used as a
+\* counter-example generator.  If you flip DecideAction back to the
+\* pre-fix policy (always return enqueue when topology wants change),
+\* TLC will report a violation here.  Kept as documentation; not in cfg.
+EnqueueOnlyWhenSafe ==
+    \A i \in DOMAIN history :
+        history[i].action = "kStopSyncingAndEnqueueLastBatch" =>
+            (   ~history[i].lastBatchExists
+             \/ history[i].batchSafe)
+
+\* LIVENESS — under fair scheduling we eventually observe MaxDecisions
+\* recorded decisions.  Bounds the simulation so liveness checking is
+\* well-defined alongside StateConstraint.
+EventuallyMakesDecisions ==
+    <>(Len(history) = MaxDecisions)
+
+=============================================================================


### PR DESCRIPTION
## Summary

TLA+ spec + jstest for sync-source selection edge cases.

**Jira:** https://jira.mongodb.org/browse/SERVER-126623
**Branch:** substrate-contrib/w3-45

## Files

```
  - .../should_change_sync_source_edge_cases.js        | 171 ++++++++++++++++++
  - .../SyncSourceSelection/MCSyncSourceSelection.cfg  |  24 +++
  - .../SyncSourceSelection/MCSyncSourceSelection.tla  |  10 ++
  - .../Replication/SyncSourceSelection/OWNERS.yml     |   5 +
  - .../SyncSourceSelection/SyncSourceSelection.tla    | 196 +++++++++++++++++++++
  - 5 files changed, 406 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
