### PR TITLE
SERVER-126627 jstest + design for checkpoint oplog-volume knob

### DIFF
--- a/jstests/noPassthrough/wt_integration/checkpoint_oplog_volume.js
+++ b/jstests/noPassthrough/wt_integration/checkpoint_oplog_volume.js
@@ -1,0 +1,214 @@
+/**
+ * SERVER-120876: oplog-volume-triggered checkpoint cadence.
+ *
+ * Exercises the three new server parameters introduced by SERVER-120876:
+ *   - checkpointMinIntervalSecs
+ *   - checkpointMaxIntervalSecs
+ *   - checkpointOplogVolumeBytes
+ *
+ * Verifies the matrix:
+ *   (1) max-interval ceiling fires a checkpoint with zero oplog writes.
+ *   (2) volume gate fires a checkpoint before the max interval when enough
+ *       oplog data has accumulated.
+ *   (3) min-interval floor suppresses back-to-back checkpoints under burst.
+ *   (4) explicit syncdelay override (sentinel cleared) bypasses the volume gate.
+ *   (5) checkpointOplogVolumeBytes == 0 falls back to legacy cadence.
+ *   (6) min > max is rejected at parameter-set time.
+ *
+ * @tags: [
+ *   requires_persistence,
+ *   requires_replication,
+ *   requires_wiredtiger,
+ * ]
+ */
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+const minSecs = 2;
+const maxSecs = 10;
+const volumeBytes = 1 * 1024 * 1024; // 1 MiB — small to keep test wall time low.
+
+const rst = new ReplSetTest({
+    nodes: 1,
+    nodeOptions: {
+        setParameter: {
+            checkpointMinIntervalSecs: minSecs,
+            checkpointMaxIntervalSecs: maxSecs,
+            checkpointOplogVolumeBytes: volumeBytes,
+        },
+    },
+});
+rst.startSet();
+rst.initiate();
+
+const primary = rst.getPrimary();
+const adminDB = primary.getDB("admin");
+const testDB = primary.getDB("checkpoint_oplog_volume");
+const coll = testDB.c;
+
+function checkpointGeneration() {
+    const wt = adminDB.serverStatus().wiredTiger;
+    assert(wt, "wiredTiger section missing from serverStatus");
+    return wt.checkpoint.generation;
+}
+
+function waitForGenerationAdvance(prior, timeoutMs) {
+    let observed = prior;
+    assert.soon(
+        () => {
+            observed = checkpointGeneration();
+            return observed > prior;
+        },
+        () => `expected checkpoint generation to advance past ${prior}, still ${observed}`,
+        timeoutMs,
+        500);
+    return observed;
+}
+
+function insertBytes(targetBytes) {
+    // ~1 KiB payload per doc.
+    const payload = "x".repeat(1000);
+    const docsNeeded = Math.ceil(targetBytes / 1000) + 4;
+    const bulk = coll.initializeUnorderedBulkOp();
+    for (let i = 0; i < docsNeeded; ++i) {
+        bulk.insert({_id: new Date().getTime() + "_" + i, p: payload});
+    }
+    assert.commandWorked(bulk.execute());
+}
+
+// ------------------------------------------------------------------
+// Case 1: max-interval ceiling fires a checkpoint with no oplog writes.
+// ------------------------------------------------------------------
+jsTestLog("case 1: max-interval ceiling fires with no oplog writes");
+{
+    // Drain any pending generation tick.
+    sleep(minSecs * 1000);
+    const baseline = checkpointGeneration();
+    // No writes. Wait slightly past max-interval and assert we advanced.
+    const after = waitForGenerationAdvance(baseline, (maxSecs + minSecs + 5) * 1000);
+    jsTestLog(`case 1 ok: generation ${baseline} -> ${after}`);
+}
+
+// ------------------------------------------------------------------
+// Case 2: volume gate fires before max-interval.
+// ------------------------------------------------------------------
+jsTestLog("case 2: volume gate fires before max-interval");
+{
+    sleep(minSecs * 1000);
+    const baseline = checkpointGeneration();
+    const t0 = Date.now();
+    insertBytes(volumeBytes * 2); // safely above threshold
+    const after = waitForGenerationAdvance(baseline, (maxSecs - 1) * 1000);
+    const elapsed = Date.now() - t0;
+    assert.lt(elapsed,
+              maxSecs * 1000,
+              `volume-triggered checkpoint should have fired before max-interval; elapsed=${elapsed}ms`);
+    jsTestLog(`case 2 ok: generation ${baseline} -> ${after} in ${elapsed}ms`);
+}
+
+// ------------------------------------------------------------------
+// Case 3: min-interval floor suppresses back-to-back checkpoints.
+// ------------------------------------------------------------------
+jsTestLog("case 3: min-interval floor holds under burst");
+{
+    // Force a checkpoint as our reference point.
+    assert.commandWorked(adminDB.runCommand({fsync: 1}));
+    const baseline = checkpointGeneration();
+    // Drive several volume-thresholds back-to-back; min-interval should keep
+    // us to at most one additional checkpoint inside that window.
+    const burstStart = Date.now();
+    for (let i = 0; i < 4; ++i) {
+        insertBytes(volumeBytes * 2);
+    }
+    // Wait less than min-interval and confirm we have not exceeded baseline+1.
+    sleep(Math.floor(minSecs * 1000 * 0.5));
+    const mid = checkpointGeneration();
+    assert.lte(mid,
+               baseline + 1,
+               `inside min-interval window, expected at most one new checkpoint, saw ${mid - baseline}`);
+    jsTestLog(`case 3 ok: held to ${mid - baseline} new checkpoint(s) inside min-interval`);
+    // Drain so subsequent cases start from a steady state.
+    sleep((minSecs + 1) * 1000);
+}
+
+// ------------------------------------------------------------------
+// Case 4: explicit syncdelay override bypasses the volume gate.
+// ------------------------------------------------------------------
+jsTestLog("case 4: explicit syncdelay override bypasses volume gate");
+{
+    // Set syncdelay to a value larger than max-interval — if the override is
+    // honoured, the next checkpoint should follow syncdelay, not max-interval.
+    const overrideSyncdelay = maxSecs * 3;
+    assert.commandWorked(
+        adminDB.runCommand({setParameter: 1, syncdelay: overrideSyncdelay}));
+
+    // Force a clean reference checkpoint.
+    assert.commandWorked(adminDB.runCommand({fsync: 1}));
+    const baseline = checkpointGeneration();
+
+    // Drive volume past the gate.
+    insertBytes(volumeBytes * 2);
+
+    // Wait past max-interval but well under override syncdelay.
+    sleep((maxSecs + 2) * 1000);
+    const mid = checkpointGeneration();
+    assert.eq(mid,
+              baseline,
+              `volume gate must be bypassed when syncdelay override is set; saw ${mid - baseline} new checkpoints`);
+    jsTestLog(`case 4 ok: no checkpoint inside ${maxSecs + 2}s with syncdelay=${overrideSyncdelay}`);
+
+    // Restore default so case 5 starts clean.
+    assert.commandWorked(adminDB.runCommand({setParameter: 1, syncdelay: -1.0}));
+}
+
+// ------------------------------------------------------------------
+// Case 5: checkpointOplogVolumeBytes == 0 falls back to legacy cadence.
+// ------------------------------------------------------------------
+jsTestLog("case 5: volume=0 falls back to legacy interval-only cadence");
+{
+    assert.commandWorked(
+        adminDB.runCommand({setParameter: 1, checkpointOplogVolumeBytes: 0}));
+
+    assert.commandWorked(adminDB.runCommand({fsync: 1}));
+    const baseline = checkpointGeneration();
+
+    // Drive a write storm. With volume gate disabled, we should NOT see a
+    // sub-max-interval checkpoint.
+    insertBytes(volumeBytes * 4);
+    sleep((minSecs + 1) * 1000);
+    const mid = checkpointGeneration();
+    assert.eq(mid,
+              baseline,
+              `with volume=0, no volume-driven checkpoint expected; saw ${mid - baseline}`);
+
+    // But the max-interval ceiling must still trip eventually.
+    const after = waitForGenerationAdvance(baseline, (maxSecs + minSecs + 5) * 1000);
+    jsTestLog(`case 5 ok: legacy cadence held; eventual generation ${baseline} -> ${after}`);
+
+    // Restore default.
+    assert.commandWorked(
+        adminDB.runCommand({setParameter: 1, checkpointOplogVolumeBytes: volumeBytes}));
+}
+
+// ------------------------------------------------------------------
+// Case 6: validator rejects min > max at runtime.
+// ------------------------------------------------------------------
+jsTestLog("case 6: validator rejects min > max");
+{
+    // Bump max down toward min, then attempt to push min above it.
+    assert.commandWorked(
+        adminDB.runCommand({setParameter: 1, checkpointMaxIntervalSecs: minSecs + 1}));
+    const bad = adminDB.runCommand({
+        setParameter: 1,
+        checkpointMinIntervalSecs: minSecs + 5, // > max
+    });
+    assert.commandFailedWithCode(bad, ErrorCodes.BadValue);
+
+    // Restore sane state.
+    assert.commandWorked(
+        adminDB.runCommand({setParameter: 1, checkpointMaxIntervalSecs: maxSecs}));
+    assert.commandWorked(
+        adminDB.runCommand({setParameter: 1, checkpointMinIntervalSecs: minSecs}));
+    jsTestLog("case 6 ok: validator rejected min > max with BadValue");
+}
+
+rst.stopSet();

--- a/src/mongo/db/storage/CHECKPOINT_OPLOG_KNOB_DESIGN.md
+++ b/src/mongo/db/storage/CHECKPOINT_OPLOG_KNOB_DESIGN.md
@@ -1,0 +1,147 @@
+# Oplog-Volume-Triggered Checkpoint Cadence
+
+**Ticket:** [SERVER-120876](https://jira.mongodb.org/browse/SERVER-120876)
+**Status:** In Code Review
+**Authors:** Surya Dhoolam (impl), substrate-contrib (design doc + jstest)
+**Related:** [SERVER-114491](https://jira.mongodb.org/browse/SERVER-114491) (DSC checkpoint-write workaround to revert)
+
+## 1. Problem
+
+`Checkpointer::run()` sleeps for `storageGlobalParams.syncdelay` seconds, then
+unconditionally calls `StorageEngine::checkpoint()`. ASC defaults `syncdelay` to
+60s; DSC defaults to 5s. For low-throughput DSC workloads we have observed
+checkpoint-driven write amplification 75x larger than the underlying oplog
+write rate. Frequent checkpoints exist to bound recovery time on non-primary
+nodes; a quiet node does not need them.
+
+## 2. Goals
+
+- Decouple checkpoint cadence from a single fixed interval.
+- Cheap checkpoints when oplog has accumulated meaningful work
+  (`>= checkpointOplogVolumeBytes`, recommended default 16 MB).
+- Lower bound `checkpointMinIntervalSecs` (default 5s) — never thrash.
+- Upper bound `checkpointMaxIntervalSecs` (default 300s) — bound recovery RPO.
+- Preserve the existing `syncdelay` knob as an explicit override.
+- No new write path; only modulates wake cadence in the checkpoint thread.
+
+## 3. Non-goals
+
+- Changing the WiredTiger internal checkpoint contract.
+- Per-collection or per-namespace checkpoint cadence.
+- Eliminating shutdown / first-stable / triggered-checkpoint paths
+  (`triggerFirstStableCheckpoint`, `pauseCheckpointThread`).
+- Replication / oplog truncation logic.
+
+## 4. Knob surface (new server parameters)
+
+Added under the existing `storage_parameters.idl` `storage` group:
+
+| Parameter | Type | Default | Bounds | `set_at` |
+|---|---|---|---|---|
+| `checkpointMinIntervalSecs` | `AtomicWord<int32_t>` | 5 | `[1, 3600]` | startup, runtime |
+| `checkpointMaxIntervalSecs` | `AtomicWord<int32_t>` | 300 | `[1, 3600]` | startup, runtime |
+| `checkpointOplogVolumeBytes` | `AtomicWord<int64_t>` | 16 * 1024 * 1024 | `[0, 1 << 32]` | startup, runtime |
+
+Validators enforce `min <= max` at parameter-set time; mismatched values are
+rejected with `ErrorCodes::BadValue` so we never produce a degenerate window.
+`checkpointOplogVolumeBytes == 0` disables volume-based triggering and falls
+back to the pre-existing `syncdelay`-only behaviour (compat mode).
+
+Interaction with `syncdelay`: if the operator has set `syncdelay` to any value
+other than its sentinel `-1.0`, that value wins and the volume gate is bypassed.
+This is the explicit override contract — users with an existing tuned
+`syncdelay` see no behaviour change.
+
+## 5. Algorithm
+
+```
+loop in Checkpointer::run():
+  oplogBaselineBytes := storageEngine->oplogBytesWritten()
+  sleepBudget       := checkpointMaxIntervalSecs
+  pollInterval      := checkpointMinIntervalSecs
+
+  while sleepBudget > 0 and not shuttingDown and not triggered:
+    wait(pollInterval) on _sleepCV
+    sleepBudget -= pollInterval
+
+    delta := storageEngine->oplogBytesWritten() - oplogBaselineBytes
+    if delta >= checkpointOplogVolumeBytes:
+      break   // volume gate fired
+
+  storageEngine->checkpoint()
+```
+
+State stays on the stack; no new mutex. The condition variable wait already
+exists. `oplogBytesWritten()` is a cheap atomic counter we already maintain
+in the oplog truncate-marker code path (`OplogTruncateMarkers::_currBytes`).
+
+### 5.1 Why poll instead of "wake on oplog write"
+
+A signal-on-every-write path adds cost to the hot insert path. Polling at
+`checkpointMinIntervalSecs` (default 5s) keeps the existing decoupled-thread
+shape. The maximum extra checkpoint latency we incur is one poll interval.
+
+### 5.2 Interaction with explicit triggers
+
+`triggerFirstStableCheckpoint` and `_triggerCheckpoint` short-circuit the loop
+exactly as today. Shutdown still takes a final checkpoint. `pauseCheckpointThread`
+failpoint still works since the pause point is unchanged.
+
+## 6. Backout / revert plan
+
+`checkpointOplogVolumeBytes = 0` reverts to legacy behaviour at runtime, no
+restart required. The SERVER-114491 DSC-syncdelay workaround can be reverted
+in a follow-up once this knob has soaked one release with telemetry showing
+phylog/oplog write ratios in line with expectation (see grafana panel
+attached on the ticket).
+
+## 7. Risk analysis
+
+| Risk | Mitigation |
+|---|---|
+| Recovery window grows unbounded under quiet workload | `checkpointMaxIntervalSecs` upper bound (default 5min, matches old syncdelay ceiling). |
+| Volume threshold lets a write storm produce thrash | `checkpointMinIntervalSecs` floor; loop never re-enters checkpoint inside that window. |
+| `oplogBytesWritten()` counter wraps or is reset | Counter is monotonic per process; reset only on restart. After restart the baseline is the post-recovery counter value — first checkpoint will fire by max-interval, not by delta. |
+| Standalone (no oplog) | If `oplogBytesWritten()` returns 0 forever, volume gate never fires; checkpoint cadence collapses to `checkpointMaxIntervalSecs`. Acceptable — standalones have no replica recovery requirement. |
+| `syncdelay` explicit override is bypassed | Detected by sentinel check (`syncdelay != -1.0`); legacy path wins. |
+| Param set racing with thread wakeup | Both knobs are `AtomicWord`; read at top of each iteration. Worst case: one iteration uses the old value. |
+
+## 8. Test plan
+
+- **Unit:** `WiredTigerKVEngineTest` — covered by impl PR (not part of this commit).
+- **e2e jstest:** `jstests/noPassthrough/wt_integration/checkpoint_oplog_volume.js`
+  exercises the knob matrix:
+  1. Defaults take a checkpoint after at most `checkpointMaxIntervalSecs`
+     even with zero oplog writes.
+  2. Driving `> checkpointOplogVolumeBytes` of inserts fires a checkpoint
+     before `checkpointMaxIntervalSecs`.
+  3. `checkpointMinIntervalSecs` is honoured — a write burst inside that
+     window does not double-checkpoint.
+  4. Setting `syncdelay` explicitly (sentinel cleared) overrides volume gate.
+  5. Setting `checkpointOplogVolumeBytes = 0` falls back to legacy
+     `syncdelay`-only cadence.
+  6. Validator rejects `min > max` at runtime.
+- **Soak / perf:** sys-perf low-throughput-DSC variant (off this PR);
+  expect phylog/oplog ratio to converge near 1.0 over a day, matching the
+  grafana panel on the ticket.
+
+## 9. Observability
+
+`db.serverStatus().wiredTiger.checkpoint` already exposes
+`generation` / `most recent time` / `total time`. We add two scalar fields
+that the existing checkpoint stats reporter can pick up cheaply:
+
+- `oplogBytesAtLastCheckpoint` — value of `oplogBytesWritten()` at the
+  moment the most recent checkpoint started.
+- `triggerReason` — enum `{interval, volume, explicit, shutdown}`.
+
+These are not part of the wire-format contract; they are
+`serverStatus`-only diagnostic surfaces.
+
+## 10. Rollout
+
+1. Land knob with defaults set to `min=5`, `max=300`, `volume=16MB`.
+2. One release soak with telemetry.
+3. Revert SERVER-114491 workaround.
+4. Consider bumping DSC default `max` toward 300s formally (today the
+   override knob does it).


### PR DESCRIPTION
## Summary

jstest + design for checkpoint oplog-volume knob.

**Jira:** https://jira.mongodb.org/browse/SERVER-126627
**Branch:** substrate-contrib/w3-50

## Files

```
  - .../wt_integration/checkpoint_oplog_volume.js      | 214 +++++++++++++++++++++
  - .../db/storage/CHECKPOINT_OPLOG_KNOB_DESIGN.md     | 147 ++++++++++++++
  - 2 files changed, 361 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
