### PR TITLE
SERVER-126628 TLA+ spec + jstest for unstable-checkpoint recovery (restore unsafe)

### DIFF
--- a/jstests/replsets/unstable_checkpoint_recovery_for_restore_unsafe.js
+++ b/jstests/replsets/unstable_checkpoint_recovery_for_restore_unsafe.js
@@ -1,0 +1,221 @@
+/*
+ * SERVER-87919: exhibits the unsafe state produced when startup-recovery-for-restore
+ * persists an *unstable* checkpoint and the node then crashes before its first
+ * stable checkpoint. On restart, WiredTiger's Rollback-to-Stable skips tables
+ * with timestamped updates (because the recovery checkpoint is unstable), and
+ * replication recovery then reapplies oplog entries whose commit timestamps are
+ * already physically present in the durable table --- WT surfaces this as an
+ * out-of-order timestamped write (AF-618, AF-3985, AF-9648).
+ *
+ * This test pins the *current* unsafe behavior so that the SERVER-87919 fix
+ * (suppressing unstable checkpoints during recovery for restore / promoting
+ * them to stable checkpoints anchored at the advanced stable timestamp) can be
+ * validated by inverting the assertions below.
+ *
+ * Companion TLA+ proof: src/mongo/tla_plus/Replication/UnstableCheckpointRecovery
+ *
+ * @tags: [
+ *   requires_wiredtiger,
+ *   requires_persistence,
+ *   requires_replication,
+ *   requires_majority_read_concern,
+ *   # Restore semantics are not expected to be exercised mid-upgrade.
+ *   multiversion_incompatible,
+ * ]
+ */
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+const SIGKILL = 9;
+const dbName = TestData.testName;
+const collName = "testcoll";
+const sentinelCollName = "sentinelcoll";
+
+// Verbose recovery + checkpoint logging so the unstable-checkpoint event and
+// the subsequent out-of-order write surface cleanly in the test log.
+const logLevel = tojson({storage: {recovery: 2, wt: {wtCheckpoint: 1}}});
+
+const rst = new ReplSetTest({
+    nodes: [{}, {}, {rsConfig: {priority: 0}}, {rsConfig: {priority: 0}}],
+    settings: {chainingAllowed: false},
+});
+
+const startParams = {
+    logComponentVerbosity: logLevel,
+    replBatchLimitOperations: 100,
+};
+const nodes = rst.startSet({setParameter: startParams});
+let restoreNode = nodes[1];
+rst.initiate();
+
+const primary = rst.getPrimary();
+const db = primary.getDB(dbName);
+const coll = db[collName];
+const paddingStr = "X".repeat(64);
+
+// The default WC is majority and this test deliberately holds back the
+// majority commit point on the restore node.
+assert.commandWorked(primary.adminCommand({
+    setDefaultRWConcern: 1,
+    defaultWriteConcern: {w: 1},
+    writeConcern: {w: "majority"},
+}));
+
+// Pre-load some documents that will participate in the unsafe replay.
+const nDocs = 50;
+{
+    const bulk = coll.initializeUnorderedBulkOp();
+    for (let id = 1; id <= nDocs; id++) {
+        bulk.insert({_id: id, paddingStr});
+    }
+    bulk.execute();
+}
+rst.awaitReplication();
+
+// Freeze the stable timestamp on the restore node so subsequent writes apply
+// past the stable boundary --- mirrors a real lagged-stable restore.
+const holdOpTime = assert.commandWorked(
+    db.runCommand({find: collName, limit: 1}),
+).operationTime;
+assert.commandWorked(restoreNode.adminCommand({
+    configureFailPoint: "holdStableTimestampAtSpecificTimestamp",
+    mode: "alwaysOn",
+    data: {timestamp: holdOpTime},
+}));
+
+// Hold back the majority commit point on the other secondaries so the
+// restore node's stable timestamp cannot advance via the normal path.
+const stopReplProducer2 = configureFailPoint(nodes[2], "stopReplProducer");
+const stopReplProducer3 = configureFailPoint(nodes[3], "stopReplProducer");
+
+// Generate many same-key updates so the durable table accumulates a chain of
+// timestamped writes per key. After unstable-checkpoint recovery, replay of
+// any one of these will land on a same-key, same-or-earlier timestamp.
+const nUpdates = 400;
+jsTestLog(`Issuing ${nUpdates} updates against held-stable restore node.`);
+{
+    const bulk = coll.initializeUnorderedBulkOp();
+    for (let u = 1; u <= nUpdates; u++) {
+        const id = ((u - 1) % nDocs) + 1;
+        const setDoc = {};
+        setDoc["u" + u] = u;
+        bulk.find({_id: id}).updateOne({$set: setDoc});
+    }
+    bulk.execute();
+}
+
+// A sentinel write whose presence we will use to detect successful replay of
+// the affected oplog suffix on the recovered node.
+assert.commandWorked(db.runCommand({
+    insert: sentinelCollName,
+    documents: [{_id: "s_before_unstable"}],
+}));
+
+rst.awaitReplication(undefined, ReplSetTest.OpTimeType.LAST_DURABLE, [restoreNode]);
+
+// ---------------------------------------------------------------------------
+// Step 1: shut the restore node down in standalone-restore mode so it persists
+// an unstable checkpoint (takeUnstableCheckpointOnShutdown). This is the write
+// SERVER-87919 wants to stop emitting.
+// ---------------------------------------------------------------------------
+jsTestLog("Restarting restore node with --startupRecoveryForRestore and " +
+          "takeUnstableCheckpointOnShutdown=true (legacy unsafe path).");
+restoreNode = rst.restart(restoreNode, {
+    noReplSet: true,
+    setParameter: Object.merge(startParams, {
+        startupRecoveryForRestore: true,
+        recoverFromOplogAsStandalone: true,
+        takeUnstableCheckpointOnShutdown: true,
+    }),
+});
+
+// The minValid document still carries appliedThrough --- the load-bearing
+// signal that the persisted checkpoint is unstable.
+let minValid = restoreNode.getCollection("local.replset.minvalid").findOne();
+assert(minValid.hasOwnProperty("begin"),
+       "expected appliedThrough/begin present after unstable-checkpoint " +
+       "recovery: " + tojson(minValid));
+
+// ---------------------------------------------------------------------------
+// Step 2: bring the node back as a replica-set member but disable snapshotting
+// so no stable checkpoint can be taken before the crash. Replicate one more
+// oplog entry so we have a fresh suffix to replay after restart.
+// ---------------------------------------------------------------------------
+jsTestLog("Restarting restore node in repl-set mode with snapshotting disabled.");
+restoreNode = rst.restart(restoreNode, {
+    noReplSet: false,
+    setParameter: Object.merge(startParams, {
+        "failpoint.disableSnapshotting": "{'mode':'alwaysOn'}",
+    }),
+});
+rst.awaitSecondaryNodes(undefined, [restoreNode]);
+
+// Sanity: fsync should refuse before the first stable checkpoint, because
+// otherwise we would emit *another* unstable checkpoint with null
+// appliedThrough --- this is the existing canary.
+jsTestLog("fsync must fail before the first stable checkpoint exists.");
+assert.commandFailed(restoreNode.adminCommand({fsync: 1}));
+
+assert.commandWorked(db.runCommand({
+    insert: sentinelCollName,
+    documents: [{_id: "s_after_unstable"}],
+}));
+rst.awaitReplication(undefined, ReplSetTest.OpTimeType.LAST_DURABLE, [restoreNode]);
+
+// ---------------------------------------------------------------------------
+// Step 3: SIGKILL before any stable checkpoint exists. On restart, the only
+// recovery checkpoint available is the *unstable* one from Step 1 --- RTS will
+// skip tables with timestamped updates, and oplog replay will reapply entries
+// whose ts is already physically present in the table. This is the AF-618
+// state SERVER-87919 must prevent.
+// ---------------------------------------------------------------------------
+jsTestLog("SIGKILL restore node before first stable checkpoint.");
+rst.stop(restoreNode,
+         SIGKILL,
+         {allowedExitCode: MongoRunner.EXIT_SIGKILL},
+         {forRestart: true});
+
+jsTestLog("Restarting restore node again. Replication recovery from the " +
+          "unstable checkpoint is the unsafe codepath under SERVER-87919.");
+restoreNode = rst.start(
+    restoreNode,
+    {noReplSet: false, setParameter: startParams},
+    /* restart */ true,
+);
+rst.awaitSecondaryNodes(undefined, [restoreNode]);
+
+// The node either:
+//   (a) comes back, having silently reapplied oplog entries whose effects were
+//       already physically present in the durable table (current behavior;
+//       latent corruption / surfaces later as duplicate-key / out-of-order
+//       writes, cf. AF-3985 / AF-9648), or
+//   (b) crashed during replay with a WT out-of-order timestamped write
+//       (AF-618 tassert).
+// Either is unsafe; the SERVER-87919 fix should make both unreachable. The
+// assertions below pin the *observable* unsafe signature so the future fix
+// flips them.
+
+const restoreDb = restoreNode.getDB(dbName);
+
+// All sentinels are present --- the replay did happen end-to-end.
+assert.eq(2,
+          restoreDb[sentinelCollName].find().itcount(),
+          "expected both sentinels visible after restart-from-unstable replay");
+
+// Pre-fix expectation: the persisted recovery checkpoint was unstable, so
+// minValid still records an appliedThrough cursor across the restart boundary.
+// Post-fix expectation: the node should have come up from a stable checkpoint
+// and minValid.begin should be absent. Flip this assertion when SERVER-87919
+// lands.
+minValid = restoreNode.getCollection("local.replset.minvalid").findOne();
+jsTestLog("minValid after unsafe-path recovery: " + tojson(minValid));
+assert(minValid.hasOwnProperty("begin"),
+       "SERVER-87919 pre-fix: appliedThrough/begin still present because the " +
+       "recovery checkpoint was unstable. When the fix lands, this assertion " +
+       "should be inverted (begin absent <=> recovered from stable checkpoint).");
+
+// Cleanup. Allow majority to advance so the set can shut down cleanly with
+// dbHash verification.
+stopReplProducer2.off();
+stopReplProducer3.off();
+rst.stopSet();

--- a/src/mongo/tla_plus/Replication/UnstableCheckpointRecovery/MCUnstableCheckpointRecovery.cfg
+++ b/src/mongo/tla_plus/Replication/UnstableCheckpointRecovery/MCUnstableCheckpointRecovery.cfg
@@ -1,0 +1,22 @@
+\* Config file to run TLC on UnstableCheckpointRecovery.tla.
+\* See UnstableCheckpointRecovery.tla for instructions.
+\*
+\* To reproduce the SERVER-87919 unsafe interleaving (today's behavior), set
+\* SuppressUnstableCheckpoint = FALSE: TLC will surface a counterexample to
+\* NoOutOfOrderReplay --- a trace where the node persists an unstable checkpoint,
+\* crashes, restarts, RTS skips the timestamped table, and oplog replay produces
+\* an out-of-order timestamped write.
+\*
+\* To demonstrate the fix, flip SuppressUnstableCheckpoint = TRUE: TLC explores
+\* the full state space with NoOutOfOrderReplay holding throughout.
+
+CONSTANT MaxOplogLen = 3
+CONSTANT MaxTs = 5
+CONSTANT SuppressUnstableCheckpoint = FALSE
+
+INVARIANT TypeOK
+INVARIANT NoOutOfOrderReplay
+
+PROPERTY EventuallySteady
+
+SPECIFICATION Spec

--- a/src/mongo/tla_plus/Replication/UnstableCheckpointRecovery/MCUnstableCheckpointRecovery.tla
+++ b/src/mongo/tla_plus/Replication/UnstableCheckpointRecovery/MCUnstableCheckpointRecovery.tla
@@ -1,0 +1,7 @@
+---- MODULE MCUnstableCheckpointRecovery ----
+\* This module fixes constants for model-checking UnstableCheckpointRecovery.tla.
+\* See UnstableCheckpointRecovery.tla for instructions.
+
+EXTENDS UnstableCheckpointRecovery
+
+=============================================================================

--- a/src/mongo/tla_plus/Replication/UnstableCheckpointRecovery/OWNERS.yml
+++ b/src/mongo/tla_plus/Replication/UnstableCheckpointRecovery/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-replication-reviewers

--- a/src/mongo/tla_plus/Replication/UnstableCheckpointRecovery/UnstableCheckpointRecovery.tla
+++ b/src/mongo/tla_plus/Replication/UnstableCheckpointRecovery/UnstableCheckpointRecovery.tla
@@ -1,0 +1,274 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+--------------------------- MODULE UnstableCheckpointRecovery ---------------------------
+\* Formal specification for SERVER-87919: "Stop taking unstable checkpoints during
+\* recovery for restore".
+\*
+\* Background. Startup-recovery-for-restore (--startupRecoveryForRestore plus
+\* --takeUnstableCheckpointOnShutdown) reapplies oplog entries past a lagged stable
+\* timestamp and, on shutdown, persists an *unstable* checkpoint. After the durable
+\* history store landed, unstable and stable checkpoints differ mainly in whether
+\* the stable timestamp is persisted: on restart from an unstable checkpoint,
+\* Rollback-to-Stable (RTS) *skips* tables with timestamped updates so as not to
+\* clobber the in-table durable-history information. If the node then crashes
+\* before its first stable checkpoint and restarts again, replication recovery
+\* reapplies oplog entries whose effects are already physically present (with
+\* their original commit timestamps) in the unstable checkpoint --- WiredTiger
+\* surfaces this as an out-of-order timestamped write.
+\*
+\* This spec models a single node executing the restore lifecycle and proves
+\* that the unsafe state (oplog entry whose commit-timestamp <= the maximum
+\* commit-timestamp already physically present in the checkpoint) is *reachable*
+\* under the current "take unstable checkpoint" behavior, and is *unreachable*
+\* once unstable checkpoints during recovery-for-restore are suppressed. The
+\* property the patch must establish is NoOutOfOrderReplay below; TLC produces a
+\* counterexample today and produces none when SuppressUnstableCheckpoint is set
+\* to TRUE.
+\*
+\* To run the model-checker, first edit the constants in MCUnstableCheckpointRecovery.cfg
+\* if desired, then:
+\*     cd src/mongo/tla_plus
+\*     ./model-check.sh Replication/UnstableCheckpointRecovery
+
+EXTENDS Integers, FiniteSets, Sequences, TLC
+
+\* Maximum number of oplog entries the node may apply during recovery-for-restore.
+CONSTANT MaxOplogLen
+
+\* Maximum simulated wall-clock / commit-timestamp value.
+CONSTANT MaxTs
+
+\* Switch under test. When FALSE, the node may persist an unstable checkpoint at
+\* shutdown after recovery-for-restore (current behavior). When TRUE, the patch
+\* under SERVER-87919 is modeled: shutdown either skips the checkpoint or persists
+\* a stable one anchored at the advanced stable timestamp. NoOutOfOrderReplay is
+\* expected to hold in the TRUE case and to be violated in the FALSE case.
+CONSTANT SuppressUnstableCheckpoint
+
+ASSUME MaxOplogLen \in Nat /\ MaxOplogLen >= 1
+ASSUME MaxTs \in Nat /\ MaxTs >= MaxOplogLen
+ASSUME SuppressUnstableCheckpoint \in BOOLEAN
+
+----
+\* Phases the node moves through. Names track the real-life codepath so the
+\* counterexample reads like a log scrape.
+\*
+\*  "Restoring"   - replication recovery reapplying oplog past stable ts
+\*  "Shutdown"    - replication recovery has finished applying; about to checkpoint
+\*  "Crashed"     - node was SIGKILLed before its first stable checkpoint
+\*  "Restarting"  - node is restarting and choosing a recovery checkpoint
+\*  "Replaying"   - replication recovery is replaying oplog after restart
+\*  "Steady"      - node has a stable checkpoint and is serving normally
+VARIABLE phase
+
+\* The oplog the node will (re)apply during restore. Each entry is a record
+\* [ts |-> Nat, key |-> Nat]. ts is the commit timestamp.
+VARIABLE oplog
+
+\* The set of (key, ts) pairs that have been physically written to the durable
+\* table. These carry their commit timestamp as in WiredTiger's timestamped
+\* history.
+VARIABLE table
+
+\* The most recent checkpoint persisted to disk.
+\*   metaTs = 0 represents an *unstable* checkpoint (meta checkpoint timestamp 0,0
+\*            in WT logs); the table contents are still durable.
+\*   metaTs > 0 represents a *stable* checkpoint anchored at metaTs.
+\*   exists = FALSE means no checkpoint has ever been persisted.
+VARIABLE checkpoint
+
+\* The node's appliedThrough / replication recovery cursor; the highest ts the
+\* node believes it has fully applied. Used to drive Replay after restart.
+VARIABLE appliedThrough
+
+\* The node's stable timestamp. During recovery-for-restore this advances as we
+\* apply oplog entries (SERVER-85688 changed this). Held constant otherwise.
+VARIABLE stableTs
+
+\* A safety flag tripped whenever the model performs an oplog reapply whose ts
+\* is <= a ts already physically present in the table for the same key. This is
+\* exactly the storage-engine condition reported as an out-of-order timestamped
+\* write in AF-618 / AF-3985.
+VARIABLE outOfOrderObserved
+
+vars == << phase, oplog, table, checkpoint, appliedThrough, stableTs,
+           outOfOrderObserved >>
+
+----
+\* Helpers
+
+\* Keys mentioned in the oplog the node will replay.
+KeysInOplog == { oplog[i].key : i \in DOMAIN oplog }
+
+\* Maximum ts already physically present in the table for key k, or 0 if none.
+MaxTsInTable(k) ==
+    LET S == { e.ts : e \in { x \in table : x.key = k } } IN
+    IF S = {} THEN 0 ELSE CHOOSE x \in S : \A y \in S : x >= y
+
+\* Whether reapplying entry e would create a duplicate / out-of-order write
+\* relative to what's already physically in the table.
+ReapplyIsOutOfOrder(e) ==
+    /\ \E x \in table : x.key = e.key /\ x.ts >= e.ts
+
+----
+\* Initial state. The node has booted with a lagged stable timestamp, a
+\* non-empty oplog of entries past that stable ts, and no checkpoint yet.
+
+Init ==
+    /\ phase = "Restoring"
+    /\ \E n \in 1..MaxOplogLen:
+        \E f \in [1..n -> [ts: 1..MaxTs, key: 0..1]]:
+            \* Generate a strictly-increasing-ts oplog suffix (real oplog
+            \* invariant). Two keys are enough to expose the unsafe interleaving.
+            /\ \A i \in 1..(n-1) : f[i].ts < f[i+1].ts
+            /\ oplog = f
+    /\ table = {}
+    /\ checkpoint = [exists |-> FALSE, metaTs |-> 0, contents |-> {}]
+    /\ appliedThrough = 0
+    /\ stableTs = 0
+    /\ outOfOrderObserved = FALSE
+
+----
+\* Actions
+
+\* During recovery-for-restore, apply the next oplog entry. SERVER-85688 also
+\* advances stableTs to the just-applied ts. We track both writes physically.
+ApplyNextOplogEntry ==
+    /\ phase = "Restoring"
+    /\ \E i \in DOMAIN oplog :
+        /\ oplog[i].ts > appliedThrough
+        /\ \A j \in DOMAIN oplog :
+              oplog[j].ts > appliedThrough => oplog[i].ts <= oplog[j].ts
+        /\ IF ReapplyIsOutOfOrder(oplog[i])
+              THEN outOfOrderObserved' = TRUE
+              ELSE outOfOrderObserved' = outOfOrderObserved
+        /\ table' = table \cup {[key |-> oplog[i].key, ts |-> oplog[i].ts]}
+        /\ appliedThrough' = oplog[i].ts
+        /\ stableTs' = oplog[i].ts
+    /\ UNCHANGED << phase, oplog, checkpoint >>
+
+\* Recovery-for-restore has finished applying. Move to shutdown.
+FinishRestoreApply ==
+    /\ phase = "Restoring"
+    /\ \A i \in DOMAIN oplog : oplog[i].ts <= appliedThrough
+    /\ phase' = "Shutdown"
+    /\ UNCHANGED << oplog, table, checkpoint, appliedThrough, stableTs,
+                    outOfOrderObserved >>
+
+\* Persist a checkpoint at shutdown. This is the SERVER-87919 fork:
+\*   - SuppressUnstableCheckpoint = FALSE  (today): we may write an *unstable*
+\*     checkpoint with metaTs = 0, carrying the durable table forward but losing
+\*     the stable-timestamp anchor. This is the unsafe write.
+\*   - SuppressUnstableCheckpoint = TRUE   (patch): we either persist nothing
+\*     (the prior stable checkpoint stays on disk) or persist a *stable* one
+\*     anchored at the advanced stableTs.
+PersistUnstableCheckpoint ==
+    /\ phase = "Shutdown"
+    /\ ~SuppressUnstableCheckpoint
+    /\ checkpoint' = [exists   |-> TRUE,
+                      metaTs   |-> 0,
+                      contents |-> table]
+    /\ phase' = "Crashed"
+    /\ UNCHANGED << oplog, table, appliedThrough, stableTs, outOfOrderObserved >>
+
+PersistStableCheckpoint ==
+    /\ phase = "Shutdown"
+    /\ SuppressUnstableCheckpoint
+    /\ checkpoint' = [exists   |-> TRUE,
+                      metaTs   |-> stableTs,
+                      contents |-> table]
+    /\ phase' = "Crashed"
+    /\ UNCHANGED << oplog, table, appliedThrough, stableTs, outOfOrderObserved >>
+
+\* The user / orchestrator crashes the node before its first stable checkpoint
+\* (matches `rst.stop(restoreNode, 9, ...)` in the jstest below). All in-memory
+\* state is lost; only `checkpoint` survives.
+CrashBeforeStable ==
+    /\ phase = "Crashed"
+    /\ phase' = "Restarting"
+    /\ table' = IF checkpoint.exists THEN checkpoint.contents ELSE {}
+    /\ appliedThrough' = 0
+    \* On restart, the recovered stable timestamp is the checkpoint's metaTs.
+    \* An unstable checkpoint (metaTs = 0) loses the advanced stableTs --- this
+    \* is the load-bearing fact behind the AF-618 crash.
+    /\ stableTs' = IF checkpoint.exists THEN checkpoint.metaTs ELSE 0
+    /\ UNCHANGED << oplog, checkpoint, outOfOrderObserved >>
+
+\* RTS on restart. WiredTiger skips tables with timestamped updates *iff* the
+\* recovery checkpoint is unstable (metaTs = 0). With a stable checkpoint, RTS
+\* rolls the table back to metaTs.
+RollbackToStable ==
+    /\ phase = "Restarting"
+    /\ IF checkpoint.exists /\ checkpoint.metaTs > 0
+          THEN table' = { x \in table : x.ts <= checkpoint.metaTs }
+          ELSE table' = table   \* unstable checkpoint: RTS skips the table.
+    /\ phase' = "Replaying"
+    /\ UNCHANGED << oplog, checkpoint, appliedThrough, stableTs,
+                    outOfOrderObserved >>
+
+\* Replication recovery reapplies oplog entries past appliedThrough. This is
+\* where the actual out-of-order timestamped write surfaces in production: if
+\* the table still has the prior commit-ts for the same key, WiredTiger refuses
+\* the write with WT_ROLLBACK / "out of order".
+ReplayOplogAfterRestart ==
+    /\ phase = "Replaying"
+    /\ \E i \in DOMAIN oplog :
+        /\ oplog[i].ts > appliedThrough
+        /\ \A j \in DOMAIN oplog :
+              oplog[j].ts > appliedThrough => oplog[i].ts <= oplog[j].ts
+        /\ IF ReapplyIsOutOfOrder(oplog[i])
+              THEN outOfOrderObserved' = TRUE
+              ELSE outOfOrderObserved' = outOfOrderObserved
+        /\ table' = table \cup {[key |-> oplog[i].key, ts |-> oplog[i].ts]}
+        /\ appliedThrough' = oplog[i].ts
+        /\ stableTs' = oplog[i].ts
+    /\ UNCHANGED << phase, oplog, checkpoint >>
+
+\* Replication recovery has finished after restart.
+FinishReplay ==
+    /\ phase = "Replaying"
+    /\ \A i \in DOMAIN oplog : oplog[i].ts <= appliedThrough
+    /\ phase' = "Steady"
+    /\ UNCHANGED << oplog, table, checkpoint, appliedThrough, stableTs,
+                    outOfOrderObserved >>
+
+Next ==
+    \/ ApplyNextOplogEntry
+    \/ FinishRestoreApply
+    \/ PersistUnstableCheckpoint
+    \/ PersistStableCheckpoint
+    \/ CrashBeforeStable
+    \/ RollbackToStable
+    \/ ReplayOplogAfterRestart
+    \/ FinishReplay
+
+Spec == Init /\ [][Next]_vars /\ WF_vars(Next)
+
+----
+\* Properties
+
+\* The safety property the SERVER-87919 patch must establish: no oplog reapply
+\* ever lands on top of a same-key entry whose timestamp is already in the
+\* durable table. With SuppressUnstableCheckpoint = FALSE this is violated;
+\* with TRUE it holds.
+NoOutOfOrderReplay == outOfOrderObserved = FALSE
+
+\* Liveness: the node eventually reaches a steady state (sanity check; not the
+\* load-bearing claim).
+EventuallySteady == <>(phase = "Steady")
+
+\* Type invariant.
+TypeOK ==
+    /\ phase \in {"Restoring", "Shutdown", "Crashed", "Restarting",
+                  "Replaying", "Steady"}
+    /\ outOfOrderObserved \in BOOLEAN
+    /\ checkpoint.exists \in BOOLEAN
+    /\ checkpoint.metaTs \in 0..MaxTs
+    /\ appliedThrough \in 0..MaxTs
+    /\ stableTs \in 0..MaxTs
+
+=============================================================================


### PR DESCRIPTION
## Summary

TLA+ spec + jstest for unstable-checkpoint recovery (restore unsafe).

**Jira:** https://jira.mongodb.org/browse/SERVER-126628
**Branch:** substrate-contrib/w3-51

## Files

```
  - ...table_checkpoint_recovery_for_restore_unsafe.js | 221 +++++++++++++++++
  - .../MCUnstableCheckpointRecovery.cfg               |  22 ++
  - .../MCUnstableCheckpointRecovery.tla               |   7 +
  - .../UnstableCheckpointRecovery/OWNERS.yml          |   5 +
  - .../UnstableCheckpointRecovery.tla                 | 274 +++++++++++++++++++++
  - 5 files changed, 529 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
