### PR TITLE
SERVER-126638 TLA+ spec + jstest for time-series collMod abort releases critsec

### DIFF
--- a/jstests/sharding/timeseries/timeseries_coll_mod_abort_releases_crit_sec.js
+++ b/jstests/sharding/timeseries/timeseries_coll_mod_abort_releases_crit_sec.js
@@ -1,0 +1,115 @@
+/**
+ * SERVER-125921: Sharded time-series collMod must not leave participant critical sections held
+ * after aborting on a non-retriable error.
+ *
+ * Repro:
+ *   1. Shard a time-series collection across two shards.
+ *   2. Issue a granularity collMod (drives the coordinator into kBlockShards, which engages
+ *      _shardsvrParticipantBlock kReadsAndWrites on every participant owning chunks).
+ *   3. Inject a non-retriable error on _shardsvrCollModParticipant via failCommand so the
+ *      coordinator throws out of Phase::kUpdateShards after the critical section was taken but
+ *      before every participant ran the unblock side-effect.
+ *   4. Assert (a) the collMod returned an error, (b) resumeMigrations ran (allowMigrations is
+ *      not stuck), and (c) NO shard still has a recoverable critical section for the namespace.
+ *
+ * On the buggy build (no kReleaseCritSec / no _cleanupOnAbort that unblocks), the assertion in
+ * step 4(c) is expected to fail: at least one participant's
+ * config.collection_critical_sections still has a "blocked: kReadsAndWrites" entry for the ns,
+ * and follow-up CRUD on that shard times out.
+ *
+ * @tags: [
+ *   requires_fcv_82,
+ *   requires_sharding,
+ *   requires_timeseries,
+ *   featureFlagShardAuthoritativeCollMetadata_incompatible,
+ * ]
+ */
+import {getTimeseriesCollForDDLOps} from "jstests/core/timeseries/libs/viewless_timeseries_util.js";
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {ShardingTest} from "jstests/libs/shardingtest.js";
+
+const dbName = "testDB";
+const collName = "tsCollModAbort";
+const timeField = "tm";
+const metaField = "mt";
+
+const st = new ShardingTest({shards: 2, rs: {nodes: 1}});
+const mongos = st.s0;
+const db = mongos.getDB(dbName);
+
+assert.commandWorked(
+    db.createCollection(collName, {timeseries: {timeField: timeField, metaField: metaField}}));
+
+assert.commandWorked(mongos.adminCommand({enableSharding: dbName, primaryShard: st.shard0.shardName}));
+assert.commandWorked(mongos.adminCommand({
+    shardCollection: `${dbName}.${collName}`,
+    key: {[metaField]: 1},
+}));
+
+// Seed a doc on each shard so both shards own chunks for the namespace and thus both will receive
+// the participant block.
+assert.commandWorked(mongos.adminCommand(
+    {split: `${dbName}.${getTimeseriesCollForDDLOps(db, collName)}`, middle: {meta: 0}}));
+assert.commandWorked(mongos.adminCommand({
+    moveChunk: `${dbName}.${getTimeseriesCollForDDLOps(db, collName)}`,
+    find: {meta: 0},
+    to: st.shard1.shardName,
+}));
+
+const coll = db.getCollection(collName);
+assert.commandWorked(coll.insert({[timeField]: new Date(), [metaField]: -1}));
+assert.commandWorked(coll.insert({[timeField]: new Date(), [metaField]: 1}));
+
+// Inject a non-retriable error on _shardsvrCollModParticipant on shard1 so the coordinator
+// completes kBlockShards (taking critical sections on BOTH shards), advances into kUpdateShards,
+// and then throws while processing the participant command on shard1.
+//
+// ErrorCodes::OperationFailed (96) is non-retriable for the DDL coordinator and is the canonical
+// way to drive _isRetriableErrorForDDLCoordinator -> false in this test.
+const failPoint = configureFailPoint(st.shard1, "failCommand", {
+    errorCode: ErrorCodes.OperationFailed,
+    failInternalCommands: true,
+    failCommands: ["_shardsvrCollModParticipant"],
+});
+
+const collModRes =
+    db.runCommand({collMod: collName, timeseries: {granularity: "hours"}, maxTimeMS: 60000});
+failPoint.off();
+
+// (a) The collMod returns an error (the non-retriable abort surfaces to the caller).
+assert.commandFailed(collModRes, () => `collMod unexpectedly succeeded: ${tojson(collModRes)}`);
+
+// (b) Migrations are resumed (allowMigrations:false should not be left set on config.collections).
+assert.soon(
+    () => st.config.collections.countDocuments({
+              _id: `${dbName}.${getTimeseriesCollForDDLOps(db, collName)}`,
+              allowMigrations: false,
+          }) === 0,
+    "coordinator left allowMigrations:false set after aborting collMod",
+);
+
+// (c) SERVER-125921 invariant: NO participant shard may still hold a recoverable critical
+//     section for the (raw) time-series namespace. Without the fix, this assertion fails on
+//     shard1 (the participant that received the non-retriable error), because the coordinator
+//     never sent the unblock command.
+const rawNs = `${dbName}.${getTimeseriesCollForDDLOps(db, collName)}`;
+for (const shard of [st.shard0, st.shard1]) {
+    const stuck =
+        shard.getDB("config").collection_critical_sections.find({_id: rawNs}).toArray();
+    assert.eq(
+        0,
+        stuck.length,
+        `SERVER-125921: participant ${shard.shardName} left a critical section after collMod abort: ${
+            tojson(stuck)}`,
+    );
+}
+
+// Smoke check: CRUD goes through on both shards after the abort (would otherwise hang on the
+// still-blocked participant).
+assert.commandWorked(db.runCommand({
+    insert: collName,
+    documents: [{[timeField]: new Date(), [metaField]: -2}, {[timeField]: new Date(), [metaField]: 2}],
+    maxTimeMS: 10000,
+}));
+
+st.stop();

--- a/src/mongo/tla_plus/DDL/TimeSeriesCollModCritSec/MCTimeSeriesCollModCritSec.cfg
+++ b/src/mongo/tla_plus/DDL/TimeSeriesCollModCritSec/MCTimeSeriesCollModCritSec.cfg
@@ -1,0 +1,17 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Shards     = {s1, s2}
+    MAX_ABORTS = 1
+    FIX_ENABLED = TRUE
+
+INVARIANT
+    TypeOK
+    NoStrayCriticalSectionOnTermination
+    CritSecImpliesActivePhase
+    MigrationsResumedOnTermination
+
+PROPERTIES
+    EventuallyClean
+
+SYMMETRY Symmetry

--- a/src/mongo/tla_plus/DDL/TimeSeriesCollModCritSec/MCTimeSeriesCollModCritSec.tla
+++ b/src/mongo/tla_plus/DDL/TimeSeriesCollModCritSec/MCTimeSeriesCollModCritSec.tla
@@ -1,0 +1,28 @@
+---------------------------- MODULE MCTimeSeriesCollModCritSec ------------------------------------
+\* Model-checking harness for TimeSeriesCollModCritSec.tla. Constants/symmetry/baits.
+\*
+\* Flip FIX_ENABLED in MCTimeSeriesCollModCritSec.cfg between FALSE (reproduce SERVER-125921 as a
+\* counterexample to NoStrayCriticalSectionOnTermination) and TRUE (verify the proposed fix).
+
+EXTENDS TimeSeriesCollModCritSec
+
+(* State constraints / symmetry *)
+
+\* Symmetry over participant shards: ordering of ApplyCollModOnShard / ReleaseCritSecOnShard does
+\* not matter for the safety invariants.
+Symmetry == Permutations(Shards)
+
+(*  Counterexample baits.                                                                        *)
+
+\* Bait: at least one non-retriable abort fires. Used to confirm the model is exercising the
+\* aborting branches and not just the happy path.
+BaitAbortFires == aborts = 0
+
+\* Bait: the coordinator actually drives all shards through the apply path. Used to confirm the
+\* model can reach kDone with every participant having applied.
+BaitAllShardsApplied == \E s \in Shards : sCollModApplied[s] = FALSE
+
+\* Bait: model can reach Aborted with the fix wired up.
+BaitAbortedTerminal == phase # PhaseAborted
+
+====================================================================================================

--- a/src/mongo/tla_plus/DDL/TimeSeriesCollModCritSec/TimeSeriesCollModCritSec.tla
+++ b/src/mongo/tla_plus/DDL/TimeSeriesCollModCritSec/TimeSeriesCollModCritSec.tla
@@ -1,0 +1,218 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+------------------------- MODULE TimeSeriesCollModCritSec -----------------------------------------
+\* This specification models the sharded time-series collMod coordinator phase machine and the
+\* recoverable critical section lifecycle on participant shards. It targets SERVER-125921.
+\*
+\* The bug: CollModCoordinator engages participant critical sections in kBlockShards by sending
+\* _shardsvrParticipantBlock with kReadsAndWrites, and only releases them as a side effect of
+\* _shardsvrCollModParticipant in kUpdateShards (when needsUnblock=true). If a non-retriable error
+\* fires after kBlockShards but before all participants have released their critical section, the
+\* coordinator aborts: it calls resumeMigrations, but it never sends an unblock command. Result:
+\* CRUD stays blocked on the still-prepared participants even after the coordinator returns.
+\*
+\* Phase transitions modelled:
+\*   kUnset -> kFreezeMigrations -> kBlockShards -> kUpdateConfig -> kUpdateShards -> Done
+\*                                       \         \                       |
+\*                                        \         +---(non-retriable)----+--> Aborted
+\*                                         +---(non-retriable)-------+--> Aborted
+\*
+\* The buggy spec lets Aborted leave shard critical sections held. The fixed spec routes through
+\* a kReleaseCritSec phase, modelling the fix proposed in the ticket (dedicated release phase
+\* and/or a collMod-specific _cleanupOnAbort that issues kUnblock to participants).
+\*
+\* To run the model-checker:
+\*     cd src/mongo/tla_plus
+\*     ./model-check.sh DDL/TimeSeriesCollModCritSec
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+
+CONSTANTS
+    Shards,              \* set of participant shards owning chunks
+    MAX_ABORTS,          \* bound non-retriable error injections (state space)
+    FIX_ENABLED          \* TRUE  -> coordinator routes abort through kReleaseCritSec
+                         \* FALSE -> reproduce buggy behaviour (no release on abort)
+
+ASSUME Cardinality(Shards) > 0
+ASSUME MAX_ABORTS \in 0..3
+ASSUME FIX_ENABLED \in BOOLEAN
+
+(* Coordinator state *)
+VARIABLE phase           \* coordinator phase, one of the Phase* constants below
+VARIABLE migrationsFrozen \* models the stopMigrations / resumeMigrations side effect
+VARIABLE aborts          \* count of injected non-retriable errors (for state-space bound)
+
+(* Per-participant state *)
+VARIABLE sCritSec        \* sCritSec[s] \in {"none", "blocked"} - kReadsAndWrites on the shard
+VARIABLE sCollModApplied \* sCollModApplied[s] \in BOOLEAN - whether the shard's local collMod ran
+
+vars == <<phase, migrationsFrozen, aborts, sCritSec, sCollModApplied>>
+
+(* Phases *)
+PhaseUnset           == "kUnset"
+PhaseFreezeMig       == "kFreezeMigrations"
+PhaseBlockShards     == "kBlockShards"
+PhaseUpdateConfig    == "kUpdateConfig"
+PhaseUpdateShards    == "kUpdateShards"
+PhaseReleaseCritSec  == "kReleaseCritSec"   \* present only in the fixed model
+PhaseDone            == "kDone"
+PhaseAborted         == "kAborted"
+
+Phases == {PhaseUnset, PhaseFreezeMig, PhaseBlockShards, PhaseUpdateConfig,
+           PhaseUpdateShards, PhaseReleaseCritSec, PhaseDone, PhaseAborted}
+
+Init ==
+    /\ phase = PhaseUnset
+    /\ migrationsFrozen = FALSE
+    /\ aborts = 0
+    /\ sCritSec = [s \in Shards |-> "none"]
+    /\ sCollModApplied = [s \in Shards |-> FALSE]
+
+(* Coordinator transitions *)
+
+\* kUnset -> kFreezeMigrations: coordinator persists FreezeMigrations and calls stopMigrations.
+EnterFreezeMigrations ==
+    /\ phase = PhaseUnset
+    /\ phase' = PhaseFreezeMig
+    /\ migrationsFrozen' = TRUE
+    /\ UNCHANGED <<aborts, sCritSec, sCollModApplied>>
+
+\* kFreezeMigrations -> kBlockShards: coordinator sends _shardsvrParticipantBlock kReadsAndWrites to
+\* every participant owning chunks. Modelled as a single-step write to every shard's critical
+\* section, matching CollModCoordinator::_runImpl Phase::kBlockShards.
+EnterBlockShards ==
+    /\ phase = PhaseFreezeMig
+    /\ phase' = PhaseBlockShards
+    /\ sCritSec' = [s \in Shards |-> "blocked"]
+    /\ UNCHANGED <<migrationsFrozen, aborts, sCollModApplied>>
+
+\* kBlockShards -> kUpdateConfig: commit timeseries options to the global / shard catalog.
+EnterUpdateConfig ==
+    /\ phase = PhaseBlockShards
+    /\ phase' = PhaseUpdateConfig
+    /\ UNCHANGED <<migrationsFrozen, aborts, sCritSec, sCollModApplied>>
+
+\* kUpdateConfig -> kUpdateShards: send _shardsvrCollModParticipant with needsUnblock=true to each
+\* participant. Each participant applies its local collMod, then calls
+\* ShardingRecoveryService::releaseRecoverableCriticalSection() (modelled by ApplyCollModOnShard).
+EnterUpdateShards ==
+    /\ phase = PhaseUpdateConfig
+    /\ phase' = PhaseUpdateShards
+    /\ UNCHANGED <<migrationsFrozen, aborts, sCritSec, sCollModApplied>>
+
+\* While in kUpdateShards, each shard independently applies the participant command, which also
+\* releases its critical section (the needsUnblock side effect).
+ApplyCollModOnShard(s) ==
+    /\ phase = PhaseUpdateShards
+    /\ sCollModApplied[s] = FALSE
+    /\ sCollModApplied' = [sCollModApplied EXCEPT ![s] = TRUE]
+    /\ sCritSec' = [sCritSec EXCEPT ![s] = "none"]
+    /\ UNCHANGED <<phase, migrationsFrozen, aborts>>
+
+\* kUpdateShards -> kDone: all participants have applied and unblocked. Coordinator calls
+\* resumeMigrations and returns success.
+FinishUpdateShards ==
+    /\ phase = PhaseUpdateShards
+    /\ \A s \in Shards : sCollModApplied[s] = TRUE
+    /\ phase' = PhaseDone
+    /\ migrationsFrozen' = FALSE
+    /\ UNCHANGED <<aborts, sCritSec, sCollModApplied>>
+
+(* Non-retriable abort injection.
+   Models any path that throws a non-retriable DBException after kBlockShards has entered the
+   critical section: e.g. shard catalog commit failure, participant collMod failure surfaced as
+   IndexNotFound, an interrupted-but-not-retriable error in _sendCollModToParticipantShards, etc.
+   The buggy behaviour: resumeMigrations is invoked, but no unblock command is sent. *)
+NonRetriableAbort ==
+    /\ aborts < MAX_ABORTS
+    /\ phase \in {PhaseBlockShards, PhaseUpdateConfig, PhaseUpdateShards}
+    /\ aborts' = aborts + 1
+    /\ migrationsFrozen' = FALSE   \* matches resumeMigrations in the catch
+    /\ IF FIX_ENABLED
+         THEN phase' = PhaseReleaseCritSec   \* fix: route through a dedicated release phase
+         ELSE phase' = PhaseAborted          \* buggy: jump straight to terminal Aborted
+    /\ UNCHANGED <<sCritSec, sCollModApplied>>
+
+\* Fixed model: in kReleaseCritSec, the coordinator sends an explicit _shardsvrParticipantBlock
+\* kUnblock (or equivalent _shardsvrCollModParticipant with needsUnblock=true and a no-op spec)
+\* to every shard, then transitions to Aborted.
+ReleaseCritSecOnShard(s) ==
+    /\ FIX_ENABLED
+    /\ phase = PhaseReleaseCritSec
+    /\ sCritSec[s] = "blocked"
+    /\ sCritSec' = [sCritSec EXCEPT ![s] = "none"]
+    /\ UNCHANGED <<phase, migrationsFrozen, aborts, sCollModApplied>>
+
+FinishReleaseCritSec ==
+    /\ FIX_ENABLED
+    /\ phase = PhaseReleaseCritSec
+    /\ \A s \in Shards : sCritSec[s] = "none"
+    /\ phase' = PhaseAborted
+    /\ UNCHANGED <<migrationsFrozen, aborts, sCritSec, sCollModApplied>>
+
+Next ==
+    \/ EnterFreezeMigrations
+    \/ EnterBlockShards
+    \/ EnterUpdateConfig
+    \/ EnterUpdateShards
+    \/ \E s \in Shards : ApplyCollModOnShard(s)
+    \/ FinishUpdateShards
+    \/ NonRetriableAbort
+    \/ \E s \in Shards : ReleaseCritSecOnShard(s)
+    \/ FinishReleaseCritSec
+
+Fairness ==
+    /\ WF_vars(EnterFreezeMigrations)
+    /\ WF_vars(EnterBlockShards)
+    /\ WF_vars(EnterUpdateConfig)
+    /\ WF_vars(EnterUpdateShards)
+    /\ \A s \in Shards : WF_vars(ApplyCollModOnShard(s))
+    /\ WF_vars(FinishUpdateShards)
+    /\ \A s \in Shards : WF_vars(ReleaseCritSecOnShard(s))
+    /\ WF_vars(FinishReleaseCritSec)
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+----------------------------------------------------------------------------------------------------
+(*  Type invariants                                                                              *)
+
+TypeOK ==
+    /\ phase \in Phases
+    /\ migrationsFrozen \in BOOLEAN
+    /\ aborts \in 0..MAX_ABORTS
+    /\ \A s \in Shards : sCritSec[s] \in {"none", "blocked"}
+    /\ \A s \in Shards : sCollModApplied[s] \in BOOLEAN
+
+(*  Correctness properties                                                                       *)
+
+\* The headline safety property: if the coordinator has reached a terminal state, no participant
+\* shard is still holding a critical section. This is the invariant SERVER-125921 violates when
+\* FIX_ENABLED = FALSE.
+NoStrayCriticalSectionOnTermination ==
+    (phase \in {PhaseDone, PhaseAborted}) =>
+        (\A s \in Shards : sCritSec[s] = "none")
+
+\* Critical sections may only be held while the coordinator is actively in or past kBlockShards
+\* and has not yet terminated.
+CritSecImpliesActivePhase ==
+    \A s \in Shards :
+        sCritSec[s] = "blocked" =>
+            phase \in {PhaseBlockShards, PhaseUpdateConfig, PhaseUpdateShards,
+                       PhaseReleaseCritSec}
+
+\* Migrations must be unfrozen by the time the coordinator terminates (this part already holds in
+\* the buggy implementation; pinning it here prevents regressions in the fix).
+MigrationsResumedOnTermination ==
+    (phase \in {PhaseDone, PhaseAborted}) => (migrationsFrozen = FALSE)
+
+(*  Liveness                                                                                     *)
+
+\* Eventually the coordinator reaches a terminal phase with no critical section held.
+EventuallyClean ==
+    <>((phase \in {PhaseDone, PhaseAborted}) /\ (\A s \in Shards : sCritSec[s] = "none"))
+
+====================================================================================================


### PR DESCRIPTION
## Summary

TLA+ spec + jstest for time-series collMod abort releases critsec.

**Jira:** https://jira.mongodb.org/browse/SERVER-126638
**Branch:** substrate-contrib/w3-63

## Files

```
  - .../timeseries_coll_mod_abort_releases_crit_sec.js | 115 +++++++++++
  - .../MCTimeSeriesCollModCritSec.cfg                 |  17 ++
  - .../MCTimeSeriesCollModCritSec.tla                 |  28 +++
  - .../TimeSeriesCollModCritSec.tla                   | 218 +++++++++++++++++++++
  - 4 files changed, 378 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
