### PR TITLE
SERVER-126640 TLA+ spec + jstest for ShardRegistry full-host rotation refresh

### DIFF
--- a/jstests/sharding/shard_registry_full_host_rotation_refresh.js
+++ b/jstests/sharding/shard_registry_full_host_rotation_refresh.js
@@ -1,0 +1,131 @@
+/**
+ * SERVER-110328 reproducer + regression guard.
+ *
+ * Scenario modelled in src/mongo/tla_plus/Sharding/ShardRegistryHostRotation:
+ *
+ *   Since SERVER-91121 the ShardRegistry refreshes from the configsvr only when it observes that
+ *   `topologyTime' has advanced. A replSetReconfig that rotates the `hosts' field of a shard's
+ *   `config.shards' entry (SERVER-21185) does NOT advance `topologyTime'. The cluster relies on the
+ *   ReplicaSetMonitor (RSM) side channel to push the new connection string into the ShardRegistry.
+ *
+ *   If a router-node is partitioned away from every member it currently knows AND every host of the
+ *   shard is then replaced, the RSM has no surviving reachable member to learn from, no
+ *   topologyTime bump fires, and the ShardRegistry never refreshes - the node cannot talk to the
+ *   shard until restart.
+ *
+ * This test exercises the happy path that the production fix must preserve: after a full host
+ * rotation, the ShardRegistry on a mongos must eventually catch up to the new connection string
+ * and route operations successfully. The test is deliberately conservative and does NOT simulate
+ * the network-partition tail of the bug (which would deadlock without the production fix); that
+ * tail is covered by the TLA+ bait invariant `BaitDivergenceStuck' in the spec.
+ *
+ * @tags: [
+ *   requires_persistence,
+ *   requires_replication,
+ *   requires_sharding,
+ * ]
+ */
+
+import {ShardingTest} from "jstests/libs/shardingtest.js";
+
+// Two shard replica sets, three nodes each. We rotate every host of rs1 and verify that the mongos
+// ShardRegistry learns the new connection string without a restart.
+const st = new ShardingTest({
+    shards: 2,
+    rs: {nodes: 3},
+    mongos: 1,
+});
+
+const dbName = "shardRegistryHostRotationDB";
+const collName = "coll";
+const ns = dbName + "." + collName;
+
+const mongos = st.s0;
+const adminDB = mongos.getDB("admin");
+const testColl = mongos.getDB(dbName).getCollection(collName);
+
+assert.commandWorked(adminDB.runCommand({enableSharding: dbName, primaryShard: st.shard1.shardName}));
+assert.commandWorked(adminDB.runCommand({shardCollection: ns, key: {_id: 1}}));
+assert.commandWorked(testColl.insert({_id: 0, payload: "before-rotation"}));
+
+const shardsColl = mongos.getCollection("config.shards");
+
+function getShardDoc(rsName) {
+    const doc = shardsColl.findOne({_id: rsName});
+    assert.neq(null, doc, "config.shards entry missing for " + rsName);
+    return doc;
+}
+
+function hostListSize(rsName) {
+    return getShardDoc(rsName).host.split("/")[1].split(",").length;
+}
+
+const targetRs = st.rs1;
+const rsName = targetRs.name;
+const initialDoc = getShardDoc(rsName);
+const initialHosts = initialDoc.host;
+const initialTopologyTime = initialDoc.topologyTime;
+
+jsTest.log("SERVER-110328: starting full host rotation on " + rsName +
+           " (initial hosts=" + initialHosts + ")");
+
+// Drive a full rotation by repeatedly adding a fresh node and removing the oldest one until none of
+// the originally-known hosts remain. This mirrors the operational `replace every node` runbook the
+// bug ticket describes.
+const originalNodes = targetRs.nodes.slice();
+const replConfigForNewNode = {rsConfig: {votes: 1, priority: 1}, shardsvr: ""};
+
+for (let i = 0; i < originalNodes.length; i++) {
+    const newNode = targetRs.add(replConfigForNewNode);
+    targetRs.reInitiate();
+    targetRs.awaitSecondaryNodes();
+
+    const stepDownTarget = originalNodes[i];
+    if (targetRs.getPrimary() === stepDownTarget) {
+        assert.commandWorked(
+            stepDownTarget.adminCommand({replSetStepDown: 60, secondaryCatchUpPeriodSecs: 30}));
+        targetRs.awaitNodesAgreeOnPrimary();
+    }
+    targetRs.remove(stepDownTarget);
+    const rsConfig = targetRs.getReplSetConfigFromNode();
+    rsConfig.version++;
+    assert.commandWorked(targetRs.getPrimary().adminCommand({replSetReconfig: rsConfig, force: true}));
+    targetRs.awaitNodesAgreeOnPrimary();
+
+    // Wait for the config.shards entry to reflect the new host count.
+    assert.soon(
+        () => hostListSize(rsName) === targetRs.nodes.length,
+        () => "config.shards hosts not updated after rotation step " + i +
+              ": " + tojson(getShardDoc(rsName)),
+        5 * 60 * 1000);
+
+    jsTest.log("SERVER-110328: rotation step " + i + " complete, hosts=" +
+               getShardDoc(rsName).host);
+}
+
+const postRotationDoc = getShardDoc(rsName);
+jsTest.log("SERVER-110328: post-rotation config.shards doc: " + tojson(postRotationDoc));
+
+// Sanity: the host-set actually rotated; no original host remains.
+const originalHostSet = new Set(initialHosts.split("/")[1].split(","));
+const finalHostSet = new Set(postRotationDoc.host.split("/")[1].split(","));
+for (const h of finalHostSet) {
+    assert(!originalHostSet.has(h),
+           "expected full host rotation; surviving host " + h + " is present in both sets");
+}
+
+// Sanity: topologyTime did NOT advance across the rotation (this is the SERVER-110328 precondition).
+assert.eq(initialTopologyTime,
+          postRotationDoc.topologyTime,
+          "topologyTime unexpectedly advanced across host rotation; bug precondition no longer holds");
+
+// The actual regression check: route a write through the same mongos without restarting it. With
+// the fix in place, the ShardRegistry on this mongos must learn the new connection string via
+// the configsvr-pull path that the fix introduces. Without the fix, this write hangs until the
+// operation timeout because the ShardRegistry is pinned to the rotated-out host-set.
+assert.commandWorked(testColl.insert({_id: 1, payload: "after-rotation"}),
+                     "mongos failed to route post-rotation write; ShardRegistry did not refresh");
+
+assert.eq(2, testColl.countDocuments({}), "post-rotation read disagrees with write history");
+
+st.stop();

--- a/src/mongo/tla_plus/Sharding/ShardRegistryHostRotation/MCShardRegistryHostRotation.cfg
+++ b/src/mongo/tla_plus/Sharding/ShardRegistryHostRotation/MCShardRegistryHostRotation.cfg
@@ -1,0 +1,28 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Hosts = {h1, h2, h3, h4}
+    MAX_ROTATIONS = 2
+    MAX_TOPOLOGY_BUMPS = 1
+
+INVARIANTS
+    \* Type invariants. Enable when changing the spec.
+    \* TypeOK
+    \* Safety invariants. Must always be enabled.
+    RegistryConfigVersionMonotone
+    ConfigMonotone
+    \* Bait invariants. Enable one at a time to generate counterexamples.
+    \* BaitDivergenceStuck
+    \* BaitAnyDivergence
+
+PROPERTIES
+    \* Liveness. Disable when running with a CONSTRAINT; TLC cannot soundly check liveness under a
+    \* state constraint that may cut off the witnessing tail of an eventually-property.
+    \* EventuallyConverges
+    \* ConvergesViaRSMWhenSharedHostReachable
+    \* ConvergesViaTopologyTimeWhenBumped
+
+CONSTRAINT
+    StateConstraint
+
+SYMMETRY Symmetry

--- a/src/mongo/tla_plus/Sharding/ShardRegistryHostRotation/MCShardRegistryHostRotation.tla
+++ b/src/mongo/tla_plus/Sharding/ShardRegistryHostRotation/MCShardRegistryHostRotation.tla
@@ -1,0 +1,27 @@
+---------------------------- MODULE MCShardRegistryHostRotation ------------------------------------
+\* This module defines ShardRegistryHostRotation.tla constants/constraints for model-checking.
+
+EXTENDS ShardRegistryHostRotation
+
+(**************************************************************************************************)
+(* State constraints.                                                                              *)
+(**************************************************************************************************)
+
+\* Bound the state space along the version axes. The interesting dynamics are exhausted within a
+\* handful of rotations and topology bumps; allowing arbitrary growth blows up the search without
+\* surfacing new behaviours.
+StateConstraint ==
+    /\ cfgConfigVersion <= MAX_ROTATIONS + 1
+    /\ cfgTopologyTime <= MAX_TOPOLOGY_BUMPS + 1
+    /\ srCachedConfigVersion <= MAX_ROTATIONS + 1
+    /\ srLastSeenTopologyTime <= MAX_TOPOLOGY_BUMPS + 1
+
+(**************************************************************************************************)
+(* Symmetry.                                                                                       *)
+(**************************************************************************************************)
+
+\* Hosts are interchangeable up to identity; permutations of the host universe preserve all
+\* observable behaviour.
+Symmetry == Permutations(Hosts)
+
+====================================================================================================

--- a/src/mongo/tla_plus/Sharding/ShardRegistryHostRotation/ShardRegistryHostRotation.tla
+++ b/src/mongo/tla_plus/Sharding/ShardRegistryHostRotation/ShardRegistryHostRotation.tla
@@ -1,0 +1,279 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+------------------------------ MODULE ShardRegistryHostRotation ------------------------------------
+\* Formal specification for the ShardRegistry refresh protocol when shard host-sets rotate, modelling
+\* the bug described in SERVER-110328:
+\*
+\*   "ShardRegistry can be unable to refresh when all hosts of a shard have been changed."
+\*
+\* Behavioural summary of the modelled subsystem
+\* ---------------------------------------------
+\* Since SERVER-91121, the ShardRegistry refreshes from the configsvr only when it observes that
+\* `topologyTime' has advanced. A replica-set reconfig that swaps the `hosts' field of the
+\* corresponding `config.shards' entry (SERVER-21185) does NOT advance `topologyTime'. The cluster
+\* relies on a *side channel* to keep the ShardRegistry honest: the ReplicaSetMonitor (RSM) notifies
+\* the ShardRegistry whenever it learns a new connection string from any replica it can still reach.
+\*
+\* The bug
+\* -------
+\* If, while a router-node is partitioned away from *every* member it currently knows, every host of
+\* the shard is replaced (a full rotation), the RSM has no surviving member to learn the new
+\* connection string from, the configsvr never bumps `topologyTime', and the ShardRegistry has no
+\* trigger to refresh. The node remains unable to communicate with the shard until restart.
+\*
+\* This specification:
+\* - Models a single shard (replica set) whose host-set is a SUBSET of a small global host universe.
+\*   Distinct generations of the host-set are tracked via `shardHostsGen', a monotonically advancing
+\*   counter that is bumped on every reconfig (a proxy for `replSetConfigVersion').
+\* - Models the configsvr-side `config.shards' document as (hosts, configVersion, topologyTime). The
+\*   `topologyTime' field is bumped only on shard add/remove (modelled as `TopologyTimeAdvance'),
+\*   never on a host rotation.
+\* - Models a router-side ShardRegistry as (cachedHosts, cachedConfigVersion, lastSeenTopologyTime).
+\* - Models RSM connectivity as a per-host boolean `nodeCanReach', which can be flipped to FALSE by
+\*   `NetworkPartition' (the router-node loses contact with a host) and to TRUE by `NetworkHeal'.
+\* - Models three independent refresh triggers, mirroring the production code:
+\*     (a) PeriodicTopologyTimeRefresh: refresh iff `cfgTopologyTime > lastSeenTopologyTime'.
+\*     (b) RSMNotifiesShardRegistry:    refresh when the RSM observes a new connection string from a
+\*                                      reachable surviving member.
+\*     (c) NodeRestart:                 wipes the registry; on reload it fetches fresh hosts.
+\*
+\* What we prove
+\* -------------
+\* The headline correctness invariant `EventuallyConverges' (a temporal property) states that as
+\* long as the cluster eventually heals at least one host shared with the current shard host-set, or
+\* a restart eventually occurs, the ShardRegistry catches up. We additionally encode the SERVER-110328
+\* bait invariant `BaitDivergenceStuck' which is satisfied by exactly the traces the bug describes:
+\* full host rotation while every previous host is unreachable, with no restart.
+\*
+\* To run the model-checker:
+\*     cd src/mongo/tla_plus
+\*     ./model-check.sh Sharding/ShardRegistryHostRotation
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+
+CONSTANTS
+    Hosts,              \* Global host universe (e.g. {h1, h2, h3, h4}). At least 2 elements.
+    MAX_ROTATIONS,      \* Bound on host rotations (replSetReconfig events).
+    MAX_TOPOLOGY_BUMPS  \* Bound on add/remove-shard events that bump topologyTime.
+
+ASSUME Cardinality(Hosts) >= 2
+ASSUME MAX_ROTATIONS \in 0..10
+ASSUME MAX_TOPOLOGY_BUMPS \in 0..5
+
+(* Configsvr-side variables: the `config.shards' projection. *)
+VARIABLE cfgHosts            \* Current host-set of the shard, SUBSET Hosts, non-empty.
+VARIABLE cfgConfigVersion    \* Monotonic; bumped on every reconfig (host rotation).
+VARIABLE cfgTopologyTime     \* Monotonic; bumped ONLY by `TopologyTimeAdvance'.
+
+(* Router-side ShardRegistry cache. *)
+VARIABLE srHosts                  \* What the registry currently believes the host-set to be.
+VARIABLE srCachedConfigVersion    \* Last config version the registry learned.
+VARIABLE srLastSeenTopologyTime   \* Last topologyTime the registry observed at refresh time.
+
+(* RSM-style connectivity for the router-node. nodeCanReach[h] = TRUE iff the node can RPC h. *)
+VARIABLE nodeCanReach
+
+(* Ancillary bound counters. *)
+VARIABLE rotations
+VARIABLE topologyBumps
+
+vars == <<cfgHosts, cfgConfigVersion, cfgTopologyTime,
+          srHosts, srCachedConfigVersion, srLastSeenTopologyTime,
+          nodeCanReach, rotations, topologyBumps>>
+
+cfg_vars   == <<cfgHosts, cfgConfigVersion, cfgTopologyTime>>
+sr_vars    == <<srHosts, srCachedConfigVersion, srLastSeenTopologyTime>>
+rsm_vars   == <<nodeCanReach>>
+bound_vars == <<rotations, topologyBumps>>
+
+(* Helpers *)
+NonEmptySubsets(S) == { T \in SUBSET S : T # {} }
+ReachableMembers   == { h \in cfgHosts : nodeCanReach[h] }
+KnownReachable     == { h \in srHosts : nodeCanReach[h] }
+
+(*************************************************************************)
+(* Init                                                                  *)
+(*************************************************************************)
+\* The router-node starts with a warm cache that matches the current host-set, and the network is
+\* fully connected. This is the only configuration in which the ShardRegistry trivially knows the
+\* truth; from here all interesting traces are reached by Next.
+Init ==
+    /\ cfgHosts \in NonEmptySubsets(Hosts)
+    /\ cfgConfigVersion = 1
+    /\ cfgTopologyTime = 1
+    /\ srHosts = cfgHosts
+    /\ srCachedConfigVersion = cfgConfigVersion
+    /\ srLastSeenTopologyTime = cfgTopologyTime
+    /\ nodeCanReach = [h \in Hosts |-> TRUE]
+    /\ rotations = 0
+    /\ topologyBumps = 0
+
+(*************************************************************************)
+(* Actions: configsvr / shard side                                       *)
+(*************************************************************************)
+
+\* Action: a replSetReconfig replaces the shard's host-set. This is SERVER-21185: the
+\* `hosts' field of `config.shards' is rewritten with the new connection string. Crucially,
+\* `topologyTime' is NOT advanced. `configVersion' is bumped (it mirrors `replSetConfigVersion').
+HostRotation(newHosts) ==
+    /\ rotations < MAX_ROTATIONS
+    /\ newHosts \in NonEmptySubsets(Hosts)
+    /\ newHosts # cfgHosts                       \* A reconfig is meaningful iff hosts actually change.
+    /\ cfgHosts'         = newHosts
+    /\ cfgConfigVersion' = cfgConfigVersion + 1
+    /\ rotations'        = rotations + 1
+    /\ UNCHANGED <<cfgTopologyTime, sr_vars, rsm_vars, topologyBumps>>
+
+\* Action: addShard / removeShard advances topologyTime. We do not model the membership change
+\* itself; we model only that topologyTime moves forward and the ShardRegistry has a fresh
+\* refresh-trigger as a result.
+TopologyTimeAdvance ==
+    /\ topologyBumps < MAX_TOPOLOGY_BUMPS
+    /\ cfgTopologyTime' = cfgTopologyTime + 1
+    /\ topologyBumps'   = topologyBumps + 1
+    /\ UNCHANGED <<cfgHosts, cfgConfigVersion, sr_vars, rsm_vars, rotations>>
+
+(*************************************************************************)
+(* Actions: network / RSM side                                           *)
+(*************************************************************************)
+
+\* Action: the router-node loses connectivity with `h'.
+NetworkPartition(h) ==
+    /\ nodeCanReach[h] = TRUE
+    /\ nodeCanReach' = [nodeCanReach EXCEPT ![h] = FALSE]
+    /\ UNCHANGED <<cfg_vars, sr_vars, bound_vars>>
+
+\* Action: the router-node regains connectivity with `h'.
+NetworkHeal(h) ==
+    /\ nodeCanReach[h] = FALSE
+    /\ nodeCanReach' = [nodeCanReach EXCEPT ![h] = TRUE]
+    /\ UNCHANGED <<cfg_vars, sr_vars, bound_vars>>
+
+(*************************************************************************)
+(* Actions: ShardRegistry refresh triggers                               *)
+(*************************************************************************)
+
+\* Trigger (a): the ShardRegistry's periodic refresh fires, observes that `topologyTime' has
+\* advanced beyond what it last saw, and refreshes from the configsvr.
+\*
+\* IMPORTANT: This is the only configsvr-pull path the registry has. If `topologyTime' has not
+\* advanced (the SERVER-110328 scenario), this guard is FALSE and the path is dead.
+PeriodicTopologyTimeRefresh ==
+    /\ cfgTopologyTime > srLastSeenTopologyTime
+    /\ srHosts'                = cfgHosts
+    /\ srCachedConfigVersion'  = cfgConfigVersion
+    /\ srLastSeenTopologyTime' = cfgTopologyTime
+    /\ UNCHANGED <<cfg_vars, rsm_vars, bound_vars>>
+
+\* Trigger (b): the ReplicaSetMonitor observes a new connection string from a *surviving* member of
+\* the shard (a host that's still in `cfgHosts' AND is currently in the registry's cached host-set
+\* AND is reachable by the node), and pushes the updated host-set into the ShardRegistry.
+\*
+\* This is the load-bearing side channel: when the shard is reconfigured but at least one previous
+\* host remains in the new host-set AND is reachable, this trigger fires and the registry converges.
+RSMNotifiesShardRegistry ==
+    /\ \E h \in cfgHosts \cap srHosts : nodeCanReach[h] = TRUE
+    /\ srHosts'                = cfgHosts
+    /\ srCachedConfigVersion'  = cfgConfigVersion
+    \* RSM-driven refreshes do NOT update topologyTime tracking; they push host-set only.
+    /\ srLastSeenTopologyTime' = srLastSeenTopologyTime
+    /\ UNCHANGED <<cfg_vars, rsm_vars, bound_vars>>
+
+\* Trigger (c): the node restarts. The ShardRegistry is wiped and reloads from the configsvr; the
+\* reload is an unconditional fetch (no `topologyTime' guard on first read).
+NodeRestart ==
+    /\ srHosts'                = cfgHosts
+    /\ srCachedConfigVersion'  = cfgConfigVersion
+    /\ srLastSeenTopologyTime' = cfgTopologyTime
+    \* Restart re-establishes connectivity to every host (a coarse model of process restart).
+    /\ nodeCanReach'           = [h \in Hosts |-> TRUE]
+    /\ UNCHANGED <<cfg_vars, bound_vars>>
+
+(*************************************************************************)
+(* Next                                                                  *)
+(*************************************************************************)
+Next ==
+    \/ \E newHosts \in NonEmptySubsets(Hosts) : HostRotation(newHosts)
+    \/ TopologyTimeAdvance
+    \/ \E h \in Hosts : NetworkPartition(h)
+    \/ \E h \in Hosts : NetworkHeal(h)
+    \/ PeriodicTopologyTimeRefresh
+    \/ RSMNotifiesShardRegistry
+    \/ NodeRestart
+
+Spec ==
+    /\ Init
+    /\ [][Next]_vars
+    \* Fairness: assume `topologyTime'-driven refresh, the RSM side channel, and restart are all
+    \* eventually attempted when enabled. Without this, the spec admits trivial stuttering traces
+    \* that never refresh.
+    /\ WF_vars(PeriodicTopologyTimeRefresh)
+    /\ WF_vars(RSMNotifiesShardRegistry)
+    /\ WF_vars(NodeRestart)
+
+(*************************************************************************)
+(* Type invariants                                                       *)
+(*************************************************************************)
+TypeOK ==
+    /\ cfgHosts \in NonEmptySubsets(Hosts)
+    /\ cfgConfigVersion \in Nat
+    /\ cfgTopologyTime \in Nat
+    /\ srHosts \in SUBSET Hosts
+    /\ srCachedConfigVersion \in Nat
+    /\ srLastSeenTopologyTime \in Nat
+    /\ nodeCanReach \in [Hosts -> BOOLEAN]
+    /\ rotations \in 0..MAX_ROTATIONS
+    /\ topologyBumps \in 0..MAX_TOPOLOGY_BUMPS
+
+(*************************************************************************)
+(* Safety / liveness                                                     *)
+(*************************************************************************)
+
+\* Monotonicity: ShardRegistry's view of configVersion never moves backward.
+RegistryConfigVersionMonotone == srCachedConfigVersion <= cfgConfigVersion
+
+\* Monotonicity: configsvr versions only ever move forward.
+ConfigMonotone ==
+    /\ cfgConfigVersion >= 1
+    /\ cfgTopologyTime >= 1
+
+\* Liveness (the headline property): if the network eventually heals enough that some current host
+\* is reachable, OR a restart eventually fires, the registry catches up to the current host-set.
+\* This is the SERVER-110328 contract: the bug is exactly a violation of this in the absence of a
+\* topology-time bump and with no shared, reachable member.
+EventuallyConverges ==
+    <>[](srHosts = cfgHosts)
+
+\* Defensive liveness when only the RSM channel is available: if the rotation preserves at least one
+\* previously-known host that's reachable, the registry catches up via the RSM side channel.
+ConvergesViaRSMWhenSharedHostReachable ==
+    [](\E h \in cfgHosts \cap srHosts : nodeCanReach[h] = TRUE) => <>(srHosts = cfgHosts)
+
+\* Defensive liveness when only the topologyTime channel is available: if topologyTime is bumped
+\* infinitely often, the registry catches up.
+ConvergesViaTopologyTimeWhenBumped ==
+    []<>(cfgTopologyTime > srLastSeenTopologyTime) => <>(srHosts = cfgHosts)
+
+(*************************************************************************)
+(* Bait invariants (negated to surface as counterexamples in TLC)        *)
+(*************************************************************************)
+
+\* The SERVER-110328 bait: there exists a reachable state in which the registry's view diverges
+\* from the configsvr truth AND the RSM has no surviving reachable member to learn from AND the
+\* topologyTime hasn't advanced past what the registry has seen. In that state, no refresh trigger
+\* fires and (absent restart) divergence is permanent.
+\*
+\* If TLC reports this invariant as violated, the trace IS the SERVER-110328 reproducer.
+BaitDivergenceStuck ==
+    ~ ( /\ srHosts # cfgHosts
+        /\ (cfgHosts \cap srHosts) \cap { h \in Hosts : nodeCanReach[h] } = {}
+        /\ cfgTopologyTime <= srLastSeenTopologyTime )
+
+\* The trivial bait: any divergence at all (used to confirm the search space is non-empty).
+BaitAnyDivergence == srHosts = cfgHosts
+
+====================================================================================================


### PR DESCRIPTION
## Summary

TLA+ spec + jstest for ShardRegistry full-host rotation refresh.

**Jira:** https://jira.mongodb.org/browse/SERVER-126640
**Branch:** substrate-contrib/w3-65

## Files

```
  - .../shard_registry_full_host_rotation_refresh.js   | 131 ++++++++++
  - .../MCShardRegistryHostRotation.cfg                |  28 +++
  - .../MCShardRegistryHostRotation.tla                |  27 ++
  - .../ShardRegistryHostRotation.tla                  | 279 +++++++++++++++++++++
  - 4 files changed, 465 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
