### PR TITLE
SERVER-126642 PDIB WCE-injection jstest suite (bulk-load / drain / scan / unique)

### DIFF
--- a/jstests/noPassthrough/index_builds/primary_driven_index_build_wce_injection_bulk_load.js
+++ b/jstests/noPassthrough/index_builds/primary_driven_index_build_wce_injection_bulk_load.js
@@ -1,0 +1,92 @@
+/**
+ * Drives a primary-driven index build (PDIB) with WCEs injected during the
+ * external-sorter bulk-load phase. SERVER-126155 closed a related cursor-reset
+ * bug; this test pins that the load path tolerates WCEs without dropping or
+ * duplicating sorted keys.
+ *
+ * See SERVER-126326 — PDIB WC-injection test coverage.
+ *
+ * @tags: [
+ *   requires_replication,
+ *   requires_wiredtiger,
+ *   requires_persistence,
+ * ]
+ */
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {FeatureFlagUtil} from "jstests/libs/feature_flag_util.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+import {IndexBuildTest} from "jstests/noPassthrough/libs/index_builds/index_build.js";
+
+const rst = new ReplSetTest({
+    nodes: [
+        {},
+        {rsConfig: {priority: 0, votes: 0}},
+    ],
+    nodeOptions: {
+        setParameter: {
+            // Force the bulk-load batch boundary often so the WCE failpoint
+            // has many opportunities to fire mid-load.
+            primaryDrivenIndexBuildSorterInsertionBatchSize: 50,
+            primaryDrivenIndexBuildSorterInsertionBatchBytes: 4 * 1024,
+        },
+    },
+});
+rst.startSet();
+rst.initiate();
+
+const primary = rst.getPrimary();
+const primaryDB = primary.getDB("test");
+const collName = "pdibWceBulk";
+const coll = primaryDB.getCollection(collName);
+
+if (!FeatureFlagUtil.isPresentAndEnabled(primaryDB, "PrimaryDrivenIndexBuilds")) {
+    jsTestLog("Skipping: featureFlagPrimaryDrivenIndexBuilds is disabled");
+    rst.stopSet();
+    quit();
+}
+
+assert.commandWorked(primaryDB.runCommand({create: collName}));
+
+const numDocs = 5000;
+const bulk = coll.initializeUnorderedBulkOp();
+for (let i = 0; i < numDocs; i++) {
+    // Wide values to push the sorter to spill to disk.
+    bulk.insert({_id: i, k: i, blob: "y".repeat(256)});
+}
+assert.commandWorked(bulk.execute());
+rst.awaitReplication();
+
+assert.commandWorked(
+    primaryDB.adminCommand({setParameter: 1, traceWriteConflictExceptions: true}),
+);
+
+const wcFp = configureFailPoint(
+    primary,
+    "WTWriteConflictException",
+    {},
+    {activationProbability: 0.02},
+);
+
+try {
+    jsTestLog("Creating index over 5k wide docs with WCE injection");
+    assert.commandWorked(
+        primaryDB.runCommand({
+            createIndexes: collName,
+            indexes: [{key: {k: 1}, name: "k_1"}],
+        }),
+    );
+} finally {
+    wcFp.off();
+}
+
+IndexBuildTest.assertIndexes(coll, 2, ["_id_", "k_1"]);
+
+// Every original document must be indexed exactly once — no drops, no dupes.
+assert.eq(
+    numDocs,
+    coll.find({k: {$gte: 0, $lt: numDocs}}).hint({k: 1}).itcount(),
+    "index k_1 missing or duplicating entries after WCE-driven retries",
+);
+
+rst.awaitReplication();
+rst.stopSet();

--- a/jstests/noPassthrough/index_builds/primary_driven_index_build_wce_injection_drain.js
+++ b/jstests/noPassthrough/index_builds/primary_driven_index_build_wce_injection_drain.js
@@ -1,0 +1,100 @@
+/**
+ * Drives a primary-driven index build (PDIB) with concurrent CRUD traffic AND
+ * artificial WCEs injected at the storage-engine layer. The side-writes drain
+ * phase must converge on a consistent index in the presence of spurious retry
+ * signals.
+ *
+ * See SERVER-126326 — PDIB WC-injection test coverage.
+ *
+ * @tags: [
+ *   requires_replication,
+ *   requires_wiredtiger,
+ *   requires_persistence,
+ * ]
+ */
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {FeatureFlagUtil} from "jstests/libs/feature_flag_util.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+import {IndexBuildTest} from "jstests/noPassthrough/libs/index_builds/index_build.js";
+
+const rst = new ReplSetTest({
+    nodes: [
+        {},
+        {rsConfig: {priority: 0, votes: 0}},
+    ],
+});
+rst.startSet();
+rst.initiate();
+
+const primary = rst.getPrimary();
+const primaryDB = primary.getDB("test");
+const collName = "pdibWceDrain";
+const coll = primaryDB.getCollection(collName);
+
+if (!FeatureFlagUtil.isPresentAndEnabled(primaryDB, "PrimaryDrivenIndexBuilds")) {
+    jsTestLog("Skipping: featureFlagPrimaryDrivenIndexBuilds is disabled");
+    rst.stopSet();
+    quit();
+}
+
+assert.commandWorked(primaryDB.runCommand({create: collName}));
+
+const seedDocs = 1500;
+const bulk = coll.initializeUnorderedBulkOp();
+for (let i = 0; i < seedDocs; i++) {
+    bulk.insert({_id: i, v: i});
+}
+assert.commandWorked(bulk.execute());
+rst.awaitReplication();
+
+assert.commandWorked(
+    primaryDB.adminCommand({setParameter: 1, traceWriteConflictExceptions: true}),
+);
+
+// Hang at the first drain so concurrent writes accumulate in side-writes.
+const drainFp = configureFailPoint(primary, "hangAfterIndexBuildFirstDrain");
+
+const awaitIndexBuild = IndexBuildTest.startIndexBuild(
+    primary,
+    coll.getFullName(),
+    {v: 1},
+    {name: "v_1"},
+);
+
+drainFp.wait();
+
+// Inject WCEs while concurrent writes drive the side-writes phase.
+const wcFp = configureFailPoint(
+    primary,
+    "WTWriteConflictException",
+    {},
+    {activationProbability: 0.02},
+);
+
+const extraWrites = 500;
+try {
+    for (let i = seedDocs; i < seedDocs + extraWrites; i++) {
+        assert.commandWorked(coll.insert({_id: i, v: i}));
+    }
+    // Touch existing docs to exercise the update drain path.
+    for (let i = 0; i < 200; i++) {
+        assert.commandWorked(coll.update({_id: i}, {$set: {v: i + 1_000_000}}));
+    }
+} finally {
+    drainFp.off();
+    // Leave WCE injection on through the final drain + commit so the
+    // commit-side write path also has to retry.
+}
+
+awaitIndexBuild();
+
+wcFp.off();
+
+IndexBuildTest.assertIndexes(coll, 2, ["_id_", "v_1"]);
+
+// Sanity: every doc must be retrievable via the new index.
+const totalDocs = seedDocs + extraWrites;
+assert.eq(totalDocs, coll.find().hint({v: 1}).itcount());
+
+rst.awaitReplication();
+rst.stopSet();

--- a/jstests/noPassthrough/index_builds/primary_driven_index_build_wce_injection_scan.js
+++ b/jstests/noPassthrough/index_builds/primary_driven_index_build_wce_injection_scan.js
@@ -1,0 +1,88 @@
+/**
+ * Drives a primary-driven index build (PDIB) while artificially injecting
+ * WriteConflictExceptions at the storage-engine layer via the WTWriteConflictException
+ * failpoint. The collection-scan phase must tolerate spurious WCEs by retrying the
+ * batch and ultimately completing the build successfully.
+ *
+ * See SERVER-126326 — PDIB WC-injection test coverage.
+ *
+ * @tags: [
+ *   requires_replication,
+ *   requires_wiredtiger,
+ *   requires_persistence,
+ * ]
+ */
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {FeatureFlagUtil} from "jstests/libs/feature_flag_util.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+import {IndexBuildTest} from "jstests/noPassthrough/libs/index_builds/index_build.js";
+
+const rst = new ReplSetTest({
+    nodes: [
+        {},
+        {rsConfig: {priority: 0, votes: 0}},
+    ],
+});
+rst.startSet();
+rst.initiate();
+
+const primary = rst.getPrimary();
+const primaryDB = primary.getDB("test");
+const collName = "pdibWceScan";
+const coll = primaryDB.getCollection(collName);
+
+if (!FeatureFlagUtil.isPresentAndEnabled(primaryDB, "PrimaryDrivenIndexBuilds")) {
+    jsTestLog("Skipping: featureFlagPrimaryDrivenIndexBuilds is disabled");
+    rst.stopSet();
+    quit();
+}
+
+assert.commandWorked(primaryDB.runCommand({create: collName}));
+
+const numDocs = 2000;
+const bulk = coll.initializeUnorderedBulkOp();
+for (let i = 0; i < numDocs; i++) {
+    bulk.insert({_id: i, a: i, payload: "x".repeat(64)});
+}
+assert.commandWorked(bulk.execute());
+rst.awaitReplication();
+
+// Enable WCE tracing so any trapped exception appears in logs for triage.
+assert.commandWorked(
+    primaryDB.adminCommand({setParameter: 1, traceWriteConflictExceptions: true}),
+);
+
+// Inject WCEs at a low probability — high enough to exercise the retry path,
+// low enough that the build still completes within a reasonable wall time.
+const wcFp = configureFailPoint(
+    primary,
+    "WTWriteConflictException",
+    {} /* data */,
+    {activationProbability: 0.01},
+);
+
+try {
+    jsTestLog("Creating index with WCE injection active");
+    assert.commandWorked(
+        primaryDB.runCommand({
+            createIndexes: collName,
+            indexes: [{key: {a: 1}, name: "a_1"}],
+        }),
+    );
+} finally {
+    wcFp.off();
+}
+
+IndexBuildTest.assertIndexes(coll, 2, ["_id_", "a_1"]);
+
+// Replica-set consistency check: secondary applies the commitIndexBuild oplog
+// entry and ends up with the same index set.
+rst.awaitReplication();
+const secondary = rst.getSecondary();
+IndexBuildTest.assertIndexes(
+    secondary.getDB("test").getCollection(collName),
+    2,
+    ["_id_", "a_1"],
+);
+
+rst.stopSet();

--- a/jstests/noPassthrough/index_builds/primary_driven_index_build_wce_injection_unique.js
+++ b/jstests/noPassthrough/index_builds/primary_driven_index_build_wce_injection_unique.js
@@ -1,0 +1,116 @@
+/**
+ * Drives a primary-driven UNIQUE index build with WCEs injected throughout.
+ * Unique builds exercise the duplicate-key detection path twice (during the
+ * load and again at commit); both must remain correct under spurious WCE
+ * retries — a real duplicate must still surface as DuplicateKey, and a
+ * conflict-free build must still succeed.
+ *
+ * See SERVER-126326 — PDIB WC-injection test coverage.
+ *
+ * @tags: [
+ *   requires_replication,
+ *   requires_wiredtiger,
+ *   requires_persistence,
+ * ]
+ */
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {FeatureFlagUtil} from "jstests/libs/feature_flag_util.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+import {IndexBuildTest} from "jstests/noPassthrough/libs/index_builds/index_build.js";
+
+const rst = new ReplSetTest({
+    nodes: [
+        {},
+        {rsConfig: {priority: 0, votes: 0}},
+    ],
+});
+rst.startSet();
+rst.initiate();
+
+const primary = rst.getPrimary();
+const primaryDB = primary.getDB("test");
+
+if (!FeatureFlagUtil.isPresentAndEnabled(primaryDB, "PrimaryDrivenIndexBuilds")) {
+    jsTestLog("Skipping: featureFlagPrimaryDrivenIndexBuilds is disabled");
+    rst.stopSet();
+    quit();
+}
+
+assert.commandWorked(
+    primaryDB.adminCommand({setParameter: 1, traceWriteConflictExceptions: true}),
+);
+
+// ----------------------------------------------------------------------------
+// Case 1: conflict-free unique build under WCE injection must succeed.
+// ----------------------------------------------------------------------------
+const uniqueCollName = "pdibWceUnique";
+const uniqueColl = primaryDB.getCollection(uniqueCollName);
+assert.commandWorked(primaryDB.runCommand({create: uniqueCollName}));
+
+const numUnique = 3000;
+let bulk = uniqueColl.initializeUnorderedBulkOp();
+for (let i = 0; i < numUnique; i++) {
+    bulk.insert({_id: i, u: i});
+}
+assert.commandWorked(bulk.execute());
+rst.awaitReplication();
+
+let wcFp = configureFailPoint(
+    primary,
+    "WTWriteConflictException",
+    {},
+    {activationProbability: 0.02},
+);
+try {
+    jsTestLog("Building unique index over distinct keys under WCE injection");
+    assert.commandWorked(
+        primaryDB.runCommand({
+            createIndexes: uniqueCollName,
+            indexes: [{key: {u: 1}, name: "u_1", unique: true}],
+        }),
+    );
+} finally {
+    wcFp.off();
+}
+IndexBuildTest.assertIndexes(uniqueColl, 2, ["_id_", "u_1"]);
+assert.eq(numUnique, uniqueColl.find().hint({u: 1}).itcount());
+
+// ----------------------------------------------------------------------------
+// Case 2: a true duplicate must still surface DuplicateKey even with WCEs
+// firing in the background. WCE retries must not mask the real conflict.
+// ----------------------------------------------------------------------------
+const dupCollName = "pdibWceUniqueDup";
+const dupColl = primaryDB.getCollection(dupCollName);
+assert.commandWorked(primaryDB.runCommand({create: dupCollName}));
+
+bulk = dupColl.initializeUnorderedBulkOp();
+for (let i = 0; i < 1000; i++) {
+    bulk.insert({_id: i, d: i});
+}
+// Inject one real duplicate on key `d`.
+bulk.insert({_id: 1000, d: 42});
+assert.commandWorked(bulk.execute());
+rst.awaitReplication();
+
+wcFp = configureFailPoint(
+    primary,
+    "WTWriteConflictException",
+    {},
+    {activationProbability: 0.02},
+);
+try {
+    jsTestLog("Building unique index over duplicate keys under WCE injection");
+    const res = primaryDB.runCommand({
+        createIndexes: dupCollName,
+        indexes: [{key: {d: 1}, name: "d_1", unique: true}],
+    });
+    assert.commandFailedWithCode(res, ErrorCodes.DuplicateKey);
+} finally {
+    wcFp.off();
+}
+
+// The failed unique-index attempt must not leave an `d_1` index behind.
+IndexBuildTest.assertIndexes(dupColl, 1, ["_id_"]);
+
+rst.awaitReplication();
+rst.stopSet();

--- a/jstests/noPassthrough/index_builds/primary_driven_index_builds_write_conflicts.suite.yml
+++ b/jstests/noPassthrough/index_builds/primary_driven_index_builds_write_conflicts.suite.yml
@@ -1,0 +1,43 @@
+# Resmoke suite: noPassthrough_primary_driven_index_builds_write_conflicts
+#
+# SERVER-126326 — PDIB WC-injection test coverage.
+#
+# CANONICAL LOCATION (must be moved before merging):
+#   buildscripts/resmokeconfig/suites/noPassthrough_primary_driven_index_builds_write_conflicts.yml
+#
+# This file is staged here under jstests/noPassthrough/index_builds/ because the
+# substrate-contrib/w3-68 worktree uses a sparse-checkout that excludes
+# buildscripts/. The reviewer should `git mv` this file into the canonical
+# buildscripts/resmokeconfig/suites/ directory (renaming off the .suite.yml
+# suffix) when integrating.
+#
+# Modelled on the existing jstestfuzz_replication_write_conflicts suite — same
+# WTWriteConflictException injection strategy, scoped to PDIB-only jstests.
+
+test_kind: js_test
+
+selector:
+  roots:
+    - jstests/noPassthrough/index_builds/primary_driven_index_build_wce_injection_*.js
+
+executor:
+  archive:
+    hooks:
+      - ValidateCollections
+  config:
+    shell_options:
+      nodb: ""
+  hooks:
+    - class: ValidateCollections
+    - class: CleanEveryN
+      n: 20
+  fixture:
+    class: MongoDFixture
+    mongod_options:
+      set_parameters:
+        enableTestCommands: 1
+        # Enable the PDIB feature flag so the tests do not self-skip when run
+        # against a build that has the flag gated off by default.
+        featureFlagPrimaryDrivenIndexBuilds: true
+        # Surface WCEs in logs for triage when a test fails under injection.
+        traceWriteConflictExceptions: true


### PR DESCRIPTION
## Summary

PDIB WCE-injection jstest suite (bulk-load / drain / scan / unique).

**Jira:** https://jira.mongodb.org/browse/SERVER-126642
**Branch:** substrate-contrib/w3-68

## Files

```
  - ...y_driven_index_build_wce_injection_bulk_load.js |  92 ++++++++++++++++
  - ...imary_driven_index_build_wce_injection_drain.js | 100 ++++++++++++++++++
  - ...rimary_driven_index_build_wce_injection_scan.js |  88 ++++++++++++++++
  - ...mary_driven_index_build_wce_injection_unique.js | 116 +++++++++++++++++++++
  - ...y_driven_index_builds_write_conflicts.suite.yml |  43 ++++++++
  - 5 files changed, 439 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
