### PR TITLE
SERVER-126644 jstests: PDIB write-conflict coverage (combined / drain / merge / spill)

### DIFF
--- a/jstests/noPassthrough/index_builds/primary_driven_index_build_write_conflict_combined.js
+++ b/jstests/noPassthrough/index_builds/primary_driven_index_build_write_conflict_combined.js
@@ -1,0 +1,107 @@
+/**
+ * End-to-end PDIB hardening test: a single index build is exercised across the spill, merge, and
+ * drain phases all while WriteConflictExceptions are continuously injected at a moderate rate
+ * (`skip` semantics so the failpoint fires intermittently rather than burst-and-done).
+ *
+ * The combined harness catches regressions where any one of the three writeConflictRetry loops
+ * (ContainerBasedSpiller::_spill, ContainerBasedSpiller::mergeSpills insert path,
+ * ContainerBasedSpiller::mergeSpills remove path, plus the side_writes_tracker / multi_index_block
+ * drain inserts) is removed or weakened — even if the per-phase tests still pass under bursty
+ * `times` semantics.
+ *
+ * Companion full-stack coverage for SERVER-118892 + SERVER-122301.
+ *
+ * @tags: [
+ *   requires_replication,
+ *   requires_wiredtiger,
+ * ]
+ */
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {FeatureFlagUtil} from "jstests/libs/feature_flag_util.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+import {IndexBuildTest} from "jstests/noPassthrough/libs/index_builds/index_build.js";
+
+TestData.testingDiagnosticsEnabled = false;
+
+const rst = new ReplSetTest({nodes: 2});
+rst.startSet();
+rst.initiate();
+
+const primary = rst.getPrimary();
+const dbName = "test";
+const collName = jsTestName();
+const db = primary.getDB(dbName);
+const coll = db.getCollection(collName);
+const indexName = "x_1";
+const indexSpec = {x: 1};
+
+// TODO(SERVER-109578): Remove this check when the feature flag is removed.
+if (!FeatureFlagUtil.isPresentAndEnabled(db, "PrimaryDrivenIndexBuilds")) {
+    jsTest.log.info("Skipping test because featureFlagPrimaryDrivenIndexBuilds is disabled");
+    rst.stopSet();
+    quit();
+}
+
+// TODO(SERVER-109578): Remove this check when the feature flag is removed.
+if (!FeatureFlagUtil.isPresentAndEnabled(db, "ContainerWrites")) {
+    jsTest.log.info("Skipping test because featureFlagContainerWrites is disabled");
+    rst.stopSet();
+    quit();
+}
+
+// Aggressive spill threshold so spill + merge happen.
+assert.commandWorked(primary.adminCommand({setParameter: 1, maxIndexBuildMemoryUsageMegabytes: 50}));
+
+// Seed a moderately large corpus so the scan + spill + merge phases all do real work.
+const seed = 30000;
+const padding = "c".repeat(4096);
+let d = 0;
+const batchSize = 500;
+while (d < seed) {
+    const bulk = coll.initializeUnorderedBulkOp();
+    for (let i = 0; i < batchSize && d + i < seed; i++) {
+        bulk.insert({_id: d + i, x: d + i, pad: padding});
+    }
+    assert.commandWorked(bulk.execute());
+    d += batchSize;
+}
+rst.awaitReplication();
+
+// Pause the build long enough to stage some side writes (drain coverage).
+IndexBuildTest.pauseIndexBuilds(primary);
+const awaitIndex = IndexBuildTest.startIndexBuild(primary, coll.getFullName(), indexSpec, {name: indexName});
+IndexBuildTest.waitForIndexBuildToStart(db, collName, indexName);
+
+const sideWrites = 1000;
+let sideBulk = coll.initializeUnorderedBulkOp();
+for (let i = seed; i < seed + sideWrites; i++) {
+    sideBulk.insert({_id: i, x: i, pad: padding});
+}
+assert.commandWorked(sideBulk.execute());
+
+// `skip` semantics: drop the failpoint check on the first 50 calls, then fire on every call until
+// the build is finished and `fp.off()` is called. This produces sustained, intermittent WCEs across
+// every remaining write — spill, merge, and drain alike — instead of a single burst at one phase.
+const fp = configureFailPoint(primary, "WTWriteConflictException", {}, {skip: 50});
+
+IndexBuildTest.resumeIndexBuilds(primary);
+awaitIndex();
+
+fp.off();
+
+IndexBuildTest.assertIndexes(coll, /*numIndexes=*/ 2, [indexName], [], {includeBuildUUIDs: false});
+rst.awaitReplication();
+const secondary = rst.getSecondary();
+IndexBuildTest.assertIndexes(
+    secondary.getDB(dbName).getCollection(collName),
+    /*numIndexes=*/ 2,
+    [indexName],
+    [],
+    {includeBuildUUIDs: false},
+);
+
+// Full-corpus coverage check via the new index.
+const expectedCount = seed + sideWrites;
+assert.eq(coll.find({}).hint({x: 1}).itcount(), expectedCount);
+
+rst.stopSet();

--- a/jstests/noPassthrough/index_builds/primary_driven_index_build_write_conflict_drain.js
+++ b/jstests/noPassthrough/index_builds/primary_driven_index_build_write_conflict_drain.js
@@ -1,0 +1,113 @@
+/**
+ * Tests that a primary-driven index build (PDIB) succeeds when WriteConflictExceptions are injected
+ * during the drain phase, when side writes captured concurrently with the build are applied to the
+ * actual index table (side_writes_tracker.cpp drain path and multi_index_block.cpp insertion
+ * batches).
+ *
+ * Pattern:
+ *   - Pre-populate a small base corpus so the build starts quickly.
+ *   - Pause the build at the start of the collection scan so side writes accumulate.
+ *   - Drive a substantial volume of concurrent writes against the collection while the build is
+ *     paused — these land in the side writes table.
+ *   - Arm WTWriteConflictException with a bounded `times` and resume the build. The conflicts fire
+ *     during the drain (and replicated index inserts on the secondary), and the writeConflictRetry
+ *     loops on the drain path must absorb them.
+ *
+ * Companion to SERVER-118892 / SERVER-122301 covering the *index*-table write path (the spill /
+ * merge tests cover the *sorter*-table write path).
+ *
+ * @tags: [
+ *   requires_replication,
+ *   requires_wiredtiger,
+ * ]
+ */
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {FeatureFlagUtil} from "jstests/libs/feature_flag_util.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+import {IndexBuildTest} from "jstests/noPassthrough/libs/index_builds/index_build.js";
+
+const rst = new ReplSetTest({nodes: 2});
+rst.startSet();
+rst.initiate();
+
+const primary = rst.getPrimary();
+const dbName = "test";
+const collName = jsTestName();
+const db = primary.getDB(dbName);
+const coll = db.getCollection(collName);
+const indexName = "x_1";
+const indexSpec = {x: 1};
+
+// TODO(SERVER-109578): Remove this check when the feature flag is removed.
+if (!FeatureFlagUtil.isPresentAndEnabled(db, "PrimaryDrivenIndexBuilds")) {
+    jsTest.log.info("Skipping test because featureFlagPrimaryDrivenIndexBuilds is disabled");
+    rst.stopSet();
+    quit();
+}
+
+// TODO(SERVER-109578): Remove this check when the feature flag is removed.
+if (!FeatureFlagUtil.isPresentAndEnabled(db, "ContainerWrites")) {
+    jsTest.log.info("Skipping test because featureFlagContainerWrites is disabled");
+    rst.stopSet();
+    quit();
+}
+
+// Seed the collection so the build has scan work but completes quickly once resumed.
+const seed = 5000;
+let bulk = coll.initializeUnorderedBulkOp();
+for (let i = 0; i < seed; i++) {
+    bulk.insert({_id: i, x: i});
+}
+assert.commandWorked(bulk.execute());
+rst.awaitReplication();
+
+// Pause the build so concurrent writes accumulate in the side writes tracker rather than being
+// drained immediately.
+IndexBuildTest.pauseIndexBuilds(primary);
+
+const awaitIndex = IndexBuildTest.startIndexBuild(primary, coll.getFullName(), indexSpec, {name: indexName});
+IndexBuildTest.waitForIndexBuildToStart(db, collName, indexName);
+
+// While the build is paused, drive concurrent writes — these become side writes that the drain
+// phase must replay against the actual index table.
+const sideWrites = 2000;
+bulk = coll.initializeUnorderedBulkOp();
+for (let i = seed; i < seed + sideWrites; i++) {
+    bulk.insert({_id: i, x: i});
+}
+assert.commandWorked(bulk.execute());
+
+// Also update a chunk of the base corpus to exercise the side-writes update path (delete + insert
+// pair on the index table during drain).
+const updates = 500;
+for (let i = 0; i < updates; i++) {
+    assert.commandWorked(coll.update({_id: i}, {$set: {x: -i}}));
+}
+
+// Now arm the failpoint and let the build (and its drain phase) run.
+const writeConflicts = 30;
+const fp = configureFailPoint(primary, "WTWriteConflictException", {}, {times: writeConflicts});
+
+IndexBuildTest.resumeIndexBuilds(primary);
+awaitIndex();
+
+fp.off();
+
+// The build must have completed and produced an index containing every base + side-write record.
+IndexBuildTest.assertIndexes(coll, /*numIndexes=*/ 2, [indexName], [], {includeBuildUUIDs: false});
+
+rst.awaitReplication();
+const secondary = rst.getSecondary();
+IndexBuildTest.assertIndexes(
+    secondary.getDB(dbName).getCollection(collName),
+    /*numIndexes=*/ 2,
+    [indexName],
+    [],
+    {includeBuildUUIDs: false},
+);
+
+// Index scan must return every row that's currently in the collection.
+const expectedCount = seed + sideWrites;
+assert.eq(coll.find({}).hint({x: 1}).itcount(), expectedCount);
+
+rst.stopSet();

--- a/jstests/noPassthrough/index_builds/primary_driven_index_build_write_conflict_merge.js
+++ b/jstests/noPassthrough/index_builds/primary_driven_index_build_write_conflict_merge.js
@@ -1,0 +1,100 @@
+/**
+ * Tests that a primary-driven index build (PDIB) succeeds when WriteConflictExceptions are injected
+ * during the merge phase of the container-based sorter
+ * (ContainerBasedSpiller::mergeSpills - insert and remove paths).
+ *
+ * The test forces the sorter through multiple spill cycles (so a merge phase is actually executed)
+ * by inserting a corpus large enough to overflow the per-build memory budget several times. It then
+ * injects a moderate number of WriteConflictExceptions during the merge. With the writeConflictRetry
+ * loops added in SERVER-122301 wrapping both (1) inserts of merged entries and (2) deletes of source
+ * spill records, the build must still complete and produce a consistent index.
+ *
+ * Regression coverage for SERVER-122301.
+ *
+ * @tags: [
+ *   requires_replication,
+ *   requires_wiredtiger,
+ * ]
+ */
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {FeatureFlagUtil} from "jstests/libs/feature_flag_util.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+import {IndexBuildTest} from "jstests/noPassthrough/libs/index_builds/index_build.js";
+
+TestData.testingDiagnosticsEnabled = false;
+
+const rst = new ReplSetTest({nodes: 2});
+rst.startSet();
+rst.initiate();
+
+const primary = rst.getPrimary();
+const dbName = "test";
+const collName = jsTestName();
+const db = primary.getDB(dbName);
+const coll = db.getCollection(collName);
+const indexName = "x_1";
+const indexSpec = {x: 1};
+
+// TODO(SERVER-109578): Remove this check when the feature flag is removed.
+if (!FeatureFlagUtil.isPresentAndEnabled(db, "PrimaryDrivenIndexBuilds")) {
+    jsTest.log.info("Skipping test because featureFlagPrimaryDrivenIndexBuilds is disabled");
+    rst.stopSet();
+    quit();
+}
+
+// TODO(SERVER-109578): Remove this check when the feature flag is removed.
+if (!FeatureFlagUtil.isPresentAndEnabled(db, "ContainerWrites")) {
+    jsTest.log.info("Skipping test because featureFlagContainerWrites is disabled");
+    rst.stopSet();
+    quit();
+}
+
+// Clamp the per-build memory budget to its minimum so that several spill files are produced.
+// Several spill files are required for the merge phase to do real work.
+assert.commandWorked(primary.adminCommand({setParameter: 1, maxIndexBuildMemoryUsageMegabytes: 50}));
+
+// Insert ~200MB of data — that comfortably forces at least three spill files (50MB budget) and a
+// non-trivial merge phase.
+const docCount = 50000;
+const padding = "m".repeat(4096);
+let d = 0;
+const batchSize = 500;
+while (d < docCount) {
+    const bulk = coll.initializeUnorderedBulkOp();
+    for (let i = 0; i < batchSize && d + i < docCount; i++) {
+        bulk.insert({_id: d + i, x: d + i, pad: padding});
+    }
+    assert.commandWorked(bulk.execute());
+    d += batchSize;
+}
+rst.awaitReplication();
+
+// Inject WCEs across the lifetime of the build. They will fire during the spill phase first; a
+// surplus persists into the merge phase, which is what we are exercising here. The
+// writeConflictRetry loops around the insert-merged-entries and delete-source-records paths in
+// ContainerBasedSpiller::mergeSpills must absorb every one.
+const writeConflicts = 40;
+const fp = configureFailPoint(primary, "WTWriteConflictException", {}, {times: writeConflicts});
+
+assert.commandWorked(coll.createIndex(indexSpec, {name: indexName}));
+
+fp.off();
+
+// Verify the index was built on the primary and replicated to the secondary.
+IndexBuildTest.assertIndexes(coll, /*numIndexes=*/ 2, [indexName], [], {includeBuildUUIDs: false});
+
+rst.awaitReplication();
+const secondary = rst.getSecondary();
+IndexBuildTest.assertIndexes(
+    secondary.getDB(dbName).getCollection(collName),
+    /*numIndexes=*/ 2,
+    [indexName],
+    [],
+    {includeBuildUUIDs: false},
+);
+
+// Spot-check the index actually contains every doc (catches silent merge corruption that a
+// pure success-code assertion would miss).
+assert.eq(coll.find({x: {$gte: 0}}).hint({x: 1}).itcount(), docCount);
+
+rst.stopSet();

--- a/jstests/noPassthrough/index_builds/primary_driven_index_build_write_conflict_spill.js
+++ b/jstests/noPassthrough/index_builds/primary_driven_index_build_write_conflict_spill.js
@@ -1,0 +1,94 @@
+/**
+ * Tests that a primary-driven index build (PDIB) succeeds when WriteConflictExceptions are injected
+ * during the spill phase of the container-based sorter (ContainerBasedSpiller::_spill).
+ *
+ * Drives the spiller by capping maxIndexBuildMemoryUsageMegabytes to its minimum (50MB) and inserting
+ * a corpus large enough to force at least one spill. The WTWriteConflictException failpoint is set
+ * with a bounded `times` so the writeConflictRetry loop must absorb the conflicts and the build must
+ * still complete successfully.
+ *
+ * Regression coverage for SERVER-118892 (writeConflictRetry around batched inserts in
+ * ContainerBasedSpiller::_spill()).
+ *
+ * @tags: [
+ *   requires_replication,
+ *   requires_wiredtiger,
+ * ]
+ */
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {FeatureFlagUtil} from "jstests/libs/feature_flag_util.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+import {IndexBuildTest} from "jstests/noPassthrough/libs/index_builds/index_build.js";
+
+// Lower-memory diagnostics path must be off so we hit the production 50MB floor.
+TestData.testingDiagnosticsEnabled = false;
+
+const rst = new ReplSetTest({nodes: 2});
+rst.startSet();
+rst.initiate();
+
+const primary = rst.getPrimary();
+const dbName = "test";
+const collName = jsTestName();
+const db = primary.getDB(dbName);
+const coll = db.getCollection(collName);
+const indexName = "x_1";
+const indexSpec = {x: 1};
+
+// TODO(SERVER-109578): Remove this check when the feature flag is removed.
+if (!FeatureFlagUtil.isPresentAndEnabled(db, "PrimaryDrivenIndexBuilds")) {
+    jsTest.log.info("Skipping test because featureFlagPrimaryDrivenIndexBuilds is disabled");
+    rst.stopSet();
+    quit();
+}
+
+// TODO(SERVER-109578): Remove this check when the feature flag is removed.
+if (!FeatureFlagUtil.isPresentAndEnabled(db, "ContainerWrites")) {
+    jsTest.log.info("Skipping test because featureFlagContainerWrites is disabled");
+    rst.stopSet();
+    quit();
+}
+
+// Force the sorter to spill aggressively by clamping the memory budget.
+assert.commandWorked(primary.adminCommand({setParameter: 1, maxIndexBuildMemoryUsageMegabytes: 50}));
+
+// Insert enough data so that scanning the collection during the index build forces the
+// ContainerBasedSpiller through at least one _spill() invocation.
+const docCount = 25000;
+const padding = "p".repeat(4096); // ~4KB / doc -> ~100MB on-disk, well past the 50MB spill threshold.
+let d = 0;
+const batchSize = 500;
+while (d < docCount) {
+    const bulk = coll.initializeUnorderedBulkOp();
+    for (let i = 0; i < batchSize && d + i < docCount; i++) {
+        bulk.insert({_id: d + i, x: d + i, pad: padding});
+    }
+    assert.commandWorked(bulk.execute());
+    d += batchSize;
+}
+rst.awaitReplication();
+
+// Inject a bounded number of WriteConflictExceptions. writeConflictRetry inside
+// ContainerBasedSpiller::_spill() must absorb every one of these and the build must succeed.
+const writeConflicts = 15;
+const fp = configureFailPoint(primary, "WTWriteConflictException", {}, {times: writeConflicts});
+
+assert.commandWorked(coll.createIndex(indexSpec, {name: indexName}));
+
+fp.off();
+
+// The index must be present and usable on the primary.
+IndexBuildTest.assertIndexes(coll, /*numIndexes=*/ 2, [indexName], [], {includeBuildUUIDs: false});
+
+// And it must be present on the secondary after replication.
+rst.awaitReplication();
+const secondary = rst.getSecondary();
+IndexBuildTest.assertIndexes(
+    secondary.getDB(dbName).getCollection(collName),
+    /*numIndexes=*/ 2,
+    [indexName],
+    [],
+    {includeBuildUUIDs: false},
+);
+
+rst.stopSet();


### PR DESCRIPTION
## Summary

jstests: PDIB write-conflict coverage (combined / drain / merge / spill).

**Jira:** https://jira.mongodb.org/browse/SERVER-126644
**Branch:** substrate-contrib/w3-72

## Files

```
  - ...y_driven_index_build_write_conflict_combined.js | 107 +++++++++++++++++++
  - ...mary_driven_index_build_write_conflict_drain.js | 113 +++++++++++++++++++++
  - ...mary_driven_index_build_write_conflict_merge.js | 100 ++++++++++++++++++
  - ...mary_driven_index_build_write_conflict_spill.js |  94 +++++++++++++++++
  - 4 files changed, 414 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
