### PR TITLE
SERVER-126648 jstest + design + IDL: shared index-build knobs schema

### DIFF
--- a/jstests/noPassthrough/index_builds/shared_idl_knobs_present.js
+++ b/jstests/noPassthrough/index_builds/shared_idl_knobs_present.js
@@ -1,0 +1,46 @@
+/**
+ * SERVER-126118: After extracting `maxNumActiveUserIndexBuilds` and
+ * `indexBuildMinAvailableDiskSpaceMB` from two_phase_index_build_knobs.idl
+ * into shared_index_build_knobs.idl, both parameters must remain reachable
+ * with identical defaults, types, and runtime-settability.
+ *
+ * This test pins the externally observable contract; if a future BUILD.bazel
+ * edit drops shared_index_build_knobs_gen from index_build_knobs_idl, the
+ * getParameter call below fails and surfaces the regression.
+ *
+ * @tags: [requires_persistence]
+ */
+
+const conn = MongoRunner.runMongod({});
+const admin = conn.getDB("admin");
+
+function getParam(name) {
+    const out = assert.commandWorked(admin.runCommand({getParameter: 1, [name]: 1}));
+    assert(name in out, `expected getParameter to return '${name}', got: ${tojson(out)}`);
+    return out[name];
+}
+
+// Defaults documented in shared_index_build_knobs.idl
+assert.eq(3,
+          getParam("maxNumActiveUserIndexBuilds"),
+          "maxNumActiveUserIndexBuilds default drifted");
+assert.eq(500,
+          getParam("indexBuildMinAvailableDiskSpaceMB"),
+          "indexBuildMinAvailableDiskSpaceMB default drifted");
+
+// Both knobs are set_at: [startup, runtime]; setParameter must succeed.
+assert.commandWorked(
+    admin.runCommand({setParameter: 1, maxNumActiveUserIndexBuilds: 5}));
+assert.eq(5, getParam("maxNumActiveUserIndexBuilds"));
+
+assert.commandWorked(
+    admin.runCommand({setParameter: 1, indexBuildMinAvailableDiskSpaceMB: 1024}));
+assert.eq(1024, getParam("indexBuildMinAvailableDiskSpaceMB"));
+
+// Validators: gte:0 must reject negatives.
+assert.commandFailed(
+    admin.runCommand({setParameter: 1, maxNumActiveUserIndexBuilds: -1}));
+assert.commandFailed(
+    admin.runCommand({setParameter: 1, indexBuildMinAvailableDiskSpaceMB: -1}));
+
+MongoRunner.stopMongod(conn);

--- a/src/mongo/db/index_builds/BUILD.bazel
+++ b/src/mongo/db/index_builds/BUILD.bazel
@@ -318,11 +318,17 @@ idl_generator(
     src = "two_phase_index_build_knobs.idl",
 )
 
+idl_generator(
+    name = "shared_index_build_knobs_gen",
+    src = "shared_index_build_knobs.idl",
+)
+
 mongo_cc_library(
     name = "index_build_knobs_idl",
     srcs = [
         ":index_build_knobs_gen",
         ":primary_driven_index_build_knobs_gen",
+        ":shared_index_build_knobs_gen",
         ":two_phase_index_build_knobs_gen",
     ],
     deps = [

--- a/src/mongo/db/index_builds/INDEX_BUILD_SHARED_IDL_DESIGN.md
+++ b/src/mongo/db/index_builds/INDEX_BUILD_SHARED_IDL_DESIGN.md
@@ -1,0 +1,71 @@
+# Shared Index Build Knobs IDL — Design Note
+
+**Ticket:** SERVER-126118
+**Author:** mehar.grewal (substrate-contrib)
+**Status:** Implementation in progress
+
+## Problem
+
+`two_phase_index_build_knobs.idl` accumulated two distinct flavours of server
+parameter:
+
+1. **Two-phase-only** — semantics tied to the replicated commit-quorum protocol
+   and resumable-build interceptor installation.
+2. **Build-mode-agnostic** — admission control and disk-space safety knobs that
+   already apply (or should apply) to primary-driven index builds (PDIB) as
+   well.
+
+Mixing the two has three downstream costs:
+- The file name lies about coverage; reviewers reasonably assume a knob there
+  is two-phase-specific and avoid touching it from PDIB code paths.
+- A PDIB-only build that links `primary_driven_index_build_knobs_gen` would
+  also have to link `two_phase_index_build_knobs_gen` purely to pick up shared
+  admission knobs, leaking an unintended dependency.
+- Future PDIB-specific overrides of admission policy have nowhere clean to
+  land.
+
+## Extraction (this commit)
+
+A new file `shared_index_build_knobs.idl` carries parameters whose semantics
+apply to both build modes. Initial population:
+
+| Parameter                              | Moved from                          | Reason for sharing                                                                 |
+|----------------------------------------|-------------------------------------|------------------------------------------------------------------------------------|
+| `maxNumActiveUserIndexBuilds`          | `two_phase_index_build_knobs.idl`   | Global admission cap on concurrent user index builds; PDIB scheduling honours it.  |
+| `indexBuildMinAvailableDiskSpaceMB`    | `two_phase_index_build_knobs.idl`   | Disk-space safety floor enforced by `IndexBuildsCoordinator`, independent of mode. |
+
+Parameters intentionally **not** moved:
+- `enableIndexBuildCommitQuorum` — two-phase commit-quorum protocol only.
+- `resumableIndexBuildMajorityOpTimeTimeoutMillis` — gates two-phase interceptor
+  install; PDIB has no resumable-build equivalent.
+- `primaryDrivenIndexBuildPrefetching` — PDIB-specific prefetch toggle, stays
+  in `primary_driven_index_build_knobs.idl`.
+- `useReadOnceCursorsForIndexBuilds` — already in the neutral
+  `index_build_knobs.idl`; out of scope.
+
+## Wire-level invariants (must hold post-refactor)
+
+1. The C++ symbol names (`maxNumActiveUserIndexBuilds`,
+   `gIndexBuildMinAvailableDiskSpaceMB`) and their types are identical to the
+   pre-refactor declarations. No call-site change is required.
+2. The generated server-parameter registration (`set_at`, `default`,
+   `validator`, `redact`) is byte-equivalent to the prior declarations.
+3. `mongo_cc_library(:index_build_knobs_idl, ...)` continues to surface both
+   parameters to every consumer that depended on it. Adding
+   `shared_index_build_knobs_gen` to the same `srcs` list preserves the
+   externally observable target shape.
+
+## Parity test
+
+`jstests/noPassthrough/index_builds/shared_idl_knobs_present.js` asserts at
+runtime that both shared parameters are reachable via `getParameter` /
+`setParameter` with their documented defaults and types. It is intentionally
+mode-agnostic: it does not start an index build, only the server, and exists
+to catch a wrong-side BUILD edit that drops the new IDL target from the
+linker.
+
+## Migration path (deferred)
+
+A follow-up may rename `index_build_knobs.idl` to something less generic and
+fold its single remaining parameter into `shared_index_build_knobs.idl`. That
+is an isolated rename, blocked on this ticket landing first.

--- a/src/mongo/db/index_builds/shared_index_build_knobs.idl
+++ b/src/mongo/db/index_builds/shared_index_build_knobs.idl
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-present MongoDB, Inc.
+# Copyright (C) 2026-present MongoDB, Inc.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the Server Side Public License, version 1,
@@ -25,38 +25,40 @@
 # exception statement from all source files in the program, then also delete
 # it in the license file.
 #
+# Shared knobs that govern BOTH primary-driven index builds (PDIB) and
+# two-phase index builds. Parameters that are specific to one build mode
+# live in the corresponding mode-specific IDL file
+# (two_phase_index_build_knobs.idl / primary_driven_index_build_knobs.idl).
 
 global:
     cpp_namespace: "mongo"
     mod_visibility: private
 
 server_parameters:
-    # Commit quorum option is supported only for two phase index builds.
-    enableIndexBuildCommitQuorum:
-        description: "Support for using commit quorum for two phase index builds."
-        set_at: startup
-        cpp_vartype: bool
-        cpp_varname: "enableIndexBuildCommitQuorum"
-        default: true
-        test_only: true
-        redact: false
-        mod_visibility: needs_replacement
-
-    resumableIndexBuildMajorityOpTimeTimeoutMillis:
+    maxNumActiveUserIndexBuilds:
         description: >
-            Time in milliseconds a node waits for the last optime before installing the interceptors to
-            be majority committed for a resumable index build. Once the interceptors are installed, the
-            index build process will start the collection scan phase.
-            If the majority commit point is not reached by the end of this waiting period, the index
-            build will proceed as a non-resumable index build.
-            Set to 0 to skip the wait. This will also disable resumable index builds.
-            Set to a negative value to wait indefinitely for the majority commit point.
-        set_at: startup
-        cpp_vartype: long long
-        cpp_varname: gResumableIndexBuildMajorityOpTimeTimeoutMillis
-        default: 10000
+            Specifies the maximum number of active user index builds that can be built simultaneously on
+            the primary node. Index builds initiated by the system are not subject to this limitation.
+
+            Additionally, active index builds initiated by the system count towards the limit and can
+            delay scheduling user index builds even when the number of active user index builds is below
+            the limit.
+        set_at: [startup, runtime]
+        cpp_vartype: AtomicWord<int>
+        cpp_varname: maxNumActiveUserIndexBuilds
+        default: 3
+        validator:
+            gte: 0
         redact: false
 
-# NOTE: maxNumActiveUserIndexBuilds and indexBuildMinAvailableDiskSpaceMB previously
-# lived in this file but apply to BOTH PDIB and two-phase index builds. They have
-# been moved to shared_index_build_knobs.idl (SERVER-126118).
+    indexBuildMinAvailableDiskSpaceMB:
+        description: Minimum disk space required to build an index
+        set_at: [startup, runtime]
+        cpp_vartype: AtomicWord<long long>
+        cpp_varname: gIndexBuildMinAvailableDiskSpaceMB
+        default: 500
+        validator:
+            gte: 0
+            # This is equal to std::numeric_limits<int64_t>::max() / (1024 * 1024)
+            lte: 8796093022207
+        redact: false


### PR DESCRIPTION
## Summary

jstest + design + IDL: shared index-build knobs schema.

**Jira:** https://jira.mongodb.org/browse/SERVER-126648
**Branch:** substrate-contrib/w3-76

## Files

```
  - .../index_builds/shared_idl_knobs_present.js       | 46 ++++++++++++++
  - src/mongo/db/index_builds/BUILD.bazel              |  6 ++
  - .../index_builds/INDEX_BUILD_SHARED_IDL_DESIGN.md  | 71 ++++++++++++++++++++++
  - .../db/index_builds/shared_index_build_knobs.idl   | 64 +++++++++++++++++++
  - .../index_builds/two_phase_index_build_knobs.idl   | 30 +--------
  - 5 files changed, 190 insertions(+), 27 deletions(-)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
