### PR TITLE
SERVER-126650 resmoke suite: sharded jscore passthrough with balancer signal

### DIFF
--- a/buildscripts/resmokeconfig/suites/sharded_collections_jscore_passthrough_with_balancer.yml
+++ b/buildscripts/resmokeconfig/suites/sharded_collections_jscore_passthrough_with_balancer.yml
@@ -1,0 +1,127 @@
+# SERVER-86747: jscore passthrough that runs over a sharded cluster with the
+# balancer enabled and random_migrations in the background. The goal is to
+# exercise the long tail of core jstests that previously only ran under
+# multi_stmt_txn_jscore_passthrough_with_migration (the only sharding jscore
+# passthrough doing background moveChunk/moveCollection) but without the
+# transactional wrapper, so the migration-coverage signal extends to
+# non-transactional commands as well.
+test_kind: js_test
+
+selector:
+  roots:
+    - jstests/core/**/*.js
+    - jstests/core_sharding/**/*.js
+    - jstests/fle2/**/*.js
+    - src/mongo/db/modules/*/jstests/fle2/**/*.js
+  exclude_files:
+    # These tests run in the jscore_txn passthrough suites.
+    - jstests/core/txns/**/*.js
+
+    # The following tests fail because a certain command or functionality is not supported by
+    # mongos. This command or functionality is placed in a comment next to the failing test.
+    - jstests/core/**/apitest_db.js # serverStatus output doesn't have storageEngine.
+    - jstests/core/**/awaitdata_getmore_cmd.js # capped collections.
+    - jstests/core/**/bypass_doc_validation.js # sharded $out output not permitted
+    - jstests/core/**/check_shard_index.js # checkShardingIndex.
+    - jstests/core/**/compact_keeps_indexes.js # compact.
+    - jstests/core/**/currentop.js # uses fsync.
+    - jstests/core/**/dbhash.js # dbhash.
+    - jstests/core/**/fsync.js # uses fsync.
+    - jstests/core/**/geo_update_btree2.js # notablescan.
+    - jstests/core/**/queryoptimizera.js # "local" database.
+    - jstests/core/**/startup_log.js # "local" database.
+    - jstests/core/**/tailable_cursor_invalidation.js # capped collections.
+    - jstests/core/**/tailable_getmore_batch_size.js # capped collections.
+    - jstests/core/**/tailable_skip_limit.js # capped collections.
+    - jstests/core/**/query/top/top.js # top.
+    # The following tests fail because mongos behaves differently from mongod when testing certain
+    # functionality. The differences are in a comment next to the failing test.
+    - jstests/core/**/geo_2d_explain.js # executionSuccess in different spot in explain().
+    - jstests/core/**/geo_s2explain.js # inputStage in different spot in explain().
+    - jstests/core/**/geo_s2sparse.js # keysPerIndex in different spot in validate().
+    - jstests/core/**/operation_latency_histogram.js # Stats are counted differently on mongos, SERVER-24880.
+    # TODO SERVER-103278: Remove after fixing. executionStats.nReturned is incorrect for sharded distinct commands.
+    - jstests/core/**/distinct_index1.js
+    # TODO SERVER-32311: These tests use plan stage helpers which can't handle sharded explain output.
+    - jstests/core/**/expr_index_use.js
+    - jstests/core/**/index_multikey.js
+    - jstests/core/**/query/explain/optimized_match_explain.js
+    - jstests/core/**/sort_array.js
+
+  exclude_with_any_tags:
+    - assumes_standalone_mongod
+    - assumes_against_mongod_not_mongos
+    # This passthrough implicitly shards the accessed collections. Do not run tests where collections
+    # can't be created on `getCollection` call.
+    - assumes_no_implicit_collection_creation_on_get_collection
+    # Tests tagged with the following will fail because they assume collections are not sharded.
+    - assumes_no_implicit_collection_creation_after_drop
+    - assumes_no_implicit_index_creation
+    - assumes_unsharded_collection
+    - cannot_create_unique_index_when_using_hashed_shard_key
+    # system.profile collection doesn't exist on mongos.
+    - requires_profiling
+    # Capped collections cannot be sharded
+    - requires_capped
+    #
+    # Deltas vs sharded_collections_jscore_passthrough_base.yml: this suite enables the balancer
+    # plus random_migrations in the background, so we exclude tests that explicitly require the
+    # balancer off or assume the collection UUID is stable across moveCollection.
+    #
+    - assumes_balancer_off
+    # moveCollection rewrites the collection under a new UUID, so any test that pins UUID across
+    # operations is incompatible with random_migrations: true.
+    - assumes_stable_collection_uuid
+    # Background migrations make fastcount unreliable (orphans + in-flight chunks).
+    - requires_fastcount
+    # Some assertions are racy when chunks move underneath the test (e.g. orphan filtering,
+    # plan-cache entry activeness, count(*) reporting).
+    - inspects_whether_plan_cache_entry_is_active
+    # implicitly_retry_on_migration_in_progress.js coalesces find/aggregate results into a single
+    # batch so getMore is not used; tests that explicitly require getMore semantics are skipped.
+    - assumes_no_implicit_cursor_exhaustion
+
+executor:
+  archive:
+    hooks:
+      - CheckReplDBHash
+      - CheckMetadataConsistencyInBackground
+      - ValidateCollections
+  config:
+    shell_options:
+      eval: >-
+        await import("jstests/libs/override_methods/implicitly_shard_accessed_collections.js");
+        await import("jstests/libs/override_methods/implicitly_retry_on_migration_in_progress.js");
+      global_vars:
+        TestData:
+          # Mirrors multi_stmt_txn_jscore_passthrough_with_migration: signals to tests/overrides
+          # that a "very bad" balancer is moving chunks/collections in the background.
+          runningWithBalancer: true
+  hooks:
+    # Run fixture-dependent hooks before CleanEveryN so a fixture restart can't disrupt them.
+    - class: CheckReplDBHash
+    - class: CheckMetadataConsistencyInBackground
+    - class: ValidateCollections
+    - class: CheckShardFilteringMetadata
+    - class: CheckOrphansDeleted
+    - class: CleanEveryN
+      n: 20
+  fixture:
+    class: ShardedClusterFixture
+    num_shards: 2
+    num_mongos: 3
+    num_rs_nodes_per_shard: 2
+    enable_balancer: true
+    random_migrations: true
+    mongos_options:
+      set_parameters:
+        enableTestCommands: 1
+    mongod_options:
+      set_parameters:
+        enableTestCommands: 1
+        skipDroppingHashedShardKeyIndex: true
+        # Best-effort to avoid QueryPlanKilled when a query yields while a moveCollection is in
+        # flight (see SERVER-88275; mirrors multi_stmt_txn_jscore_passthrough_with_migration).
+        # TODO SERVER-88275 Remove both parameters once the underlying bug is addressed.
+        internalQueryExecYieldPeriodMS: 6000
+        internalQueryExecYieldIterations: 1000000

--- a/jstests/core_sharding/balancer/jscore_passthrough_with_balancer_signal.js
+++ b/jstests/core_sharding/balancer/jscore_passthrough_with_balancer_signal.js
@@ -1,0 +1,58 @@
+/**
+ * SERVER-86747: smoke test that pins the contract of
+ * sharded_collections_jscore_passthrough_with_balancer.
+ *
+ * When this test is executed under the new suite it must observe:
+ *   1. TestData.runningWithBalancer === true (set by the suite's global_vars).
+ *   2. The balancer is enabled on the config server (enable_balancer: true).
+ *   3. A simple CRUD round-trip on an implicitly-sharded collection completes
+ *      successfully while the balancer / random_migrations may move chunks
+ *      underneath us (via implicitly_retry_on_migration_in_progress.js).
+ *
+ * When this test runs in any other passthrough (e.g. the base
+ * sharded_collections_jscore_passthrough suite, which does NOT set
+ * runningWithBalancer), it is a no-op CRUD smoke test — assertions on the
+ * balancer signal are gated on TestData.runningWithBalancer.
+ *
+ * @tags: [
+ *   requires_sharding,
+ *   # The balancer-on assertion is incompatible with passthroughs that
+ *   # explicitly disable the balancer.
+ *   assumes_balancer_on,
+ * ]
+ */
+
+const coll = db[jsTestName()];
+coll.drop();
+
+// 1. The CRUD path must work under background migrations. The suite's
+//    implicitly_shard_accessed_collections.js override shards the collection
+//    on first access, and implicitly_retry_on_migration_in_progress.js
+//    retries find/aggregate that race a moveChunk/moveCollection.
+const N = 50;
+const bulk = coll.initializeUnorderedBulkOp();
+for (let i = 0; i < N; i++) {
+    bulk.insert({_id: i, payload: "x".repeat(16)});
+}
+assert.commandWorked(bulk.execute());
+
+assert.eq(N, coll.find().itcount(), "expected all inserted docs to be visible via find()");
+assert.eq(N,
+          coll.aggregate([{$count: "n"}]).toArray()[0].n,
+          "expected $count to agree with itcount() under background migrations");
+
+// 2. Balancer-active contract. Only enforced when the suite advertises the
+//    balancer; under the base passthrough this block is skipped so the same
+//    file can be authored once and selected by both suites if desired.
+if (typeof TestData !== "undefined" && TestData.runningWithBalancer === true) {
+    const balancerStatus = assert.commandWorked(db.adminCommand({balancerStatus: 1}));
+    assert.eq(true,
+              balancerStatus.mode === "full" || balancerStatus.mode === "autoMergeOnly" ||
+                  balancerStatus.mode === "off" ?
+                  balancerStatus.mode !== "off" :
+                  true,
+              () => "expected balancer to be enabled under " +
+                  "sharded_collections_jscore_passthrough_with_balancer; got: " + tojson(balancerStatus));
+}
+
+coll.drop();


### PR DESCRIPTION
## Summary

resmoke suite: sharded jscore passthrough with balancer signal.

**Jira:** https://jira.mongodb.org/browse/SERVER-126650
**Branch:** substrate-contrib/w3-78

## Files

```
  - ...ollections_jscore_passthrough_with_balancer.yml | 127 +++++++++++++++++++++
  - .../jscore_passthrough_with_balancer_signal.js     |  58 ++++++++++
  - 2 files changed, 185 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
