### PR TITLE
SERVER-126651 jstest + suite: change-streams resumable after collection move

### DIFF
--- a/jstests/change_streams/changes_resumable_after_collection_move.js
+++ b/jstests/change_streams/changes_resumable_after_collection_move.js
@@ -1,0 +1,147 @@
+/**
+ * SERVER-86751: Companion coverage test for the
+ * change_streams_mongos_passthrough_with_balancer suite.
+ *
+ * Verifies that a change stream opened against a mongos router on an
+ * unsharded collection:
+ *   1. continues to deliver inserts whose oplog entries are produced
+ *      *after* the collection has been relocated to a different shard via
+ *      `moveCollection`, and
+ *   2. can be resumed from a token captured *before* the move and replay
+ *      every post-move write.
+ *
+ * The passthrough suite supplies the background `moveCollection` activity
+ * via the ContinuousMoveCollection hook for the rest of jstests/change_streams/**;
+ * this companion exercises the same surface explicitly so the suite has at
+ * least one test whose failure mode is unambiguously "stream lost an event
+ * across a routing-table change".
+ *
+ *  @tags: [
+ *    requires_fcv_80,
+ *    requires_sharding,
+ *    uses_change_streams,
+ *    change_stream_does_not_expect_txns,
+ *    assumes_read_preference_unchanged,
+ *  ]
+ */
+import {ChangeStreamTest} from "jstests/libs/query/change_stream_util.js";
+import {ShardingTest} from "jstests/libs/shardingtest.js";
+
+const dbName = jsTestName();
+const collName = "test";
+const ns = {db: dbName, coll: collName};
+
+const st = new ShardingTest({
+    shards: 2,
+    rs: {nodes: 1, setParameter: {writePeriodicNoops: true, periodicNoopIntervalSecs: 1}},
+    other: {
+        // Long resharding critical-section budget so `moveCollection` (which is
+        // implemented via resharding under the hood for unsharded collections)
+        // doesn't time out the test on slow variants.
+        configOptions:
+            {setParameter: {reshardingCriticalSectionTimeoutMillis: 24 * 60 * 60 * 1000}},
+    },
+});
+
+const mongos = st.s;
+const db = mongos.getDB(dbName);
+const coll = db[collName];
+
+// Place the database (and therefore the unsharded `coll`) on shard0.
+assert.commandWorked(
+    mongos.adminCommand({enableSharding: dbName, primaryShard: st.shard0.shardName}));
+assert.commandWorked(db.runCommand({create: collName}));
+
+// Pre-move insert so we have a known oplog event to resume from.
+assert.commandWorked(coll.insert({_id: 0, phase: "pre-move"}));
+
+const cst = new ChangeStreamTest(db);
+const pipeline = [{$changeStream: {}}];
+const cursor = cst.startWatchingChanges({pipeline, collection: collName});
+
+// Capture a resume token whose clusterTime predates the move. We grab it from
+// the oplog event for the pre-move insert that the stream is about to yield.
+const preMoveEvent = cst.assertNextChangesEqual({
+    cursor: cursor,
+    expectedChanges: [{
+        operationType: "insert",
+        ns: ns,
+        fullDocument: {_id: 0, phase: "pre-move"},
+        documentKey: {_id: 0},
+    }],
+})[0];
+const resumeToken = preMoveEvent._id;
+assert(resumeToken, "expected the pre-move insert event to carry a resume token");
+
+// Move the unsharded collection to shard1. This is the topology mutation the
+// passthrough suite stresses continuously.
+assert.commandWorked(mongos.adminCommand({
+    moveCollection: coll.getFullName(),
+    toShard: st.shard1.shardName,
+}));
+
+// Post-move inserts. These oplog entries are produced on the new owning shard
+// (shard1) and must still be routed back through mongos to the stream that
+// was opened against shard0's view of the collection.
+for (let i = 1; i <= 5; i++) {
+    assert.commandWorked(coll.insert({_id: i, phase: "post-move"}));
+}
+
+// 1) The originally-open cursor must deliver every post-move insert in order
+// without losing an event across the routing-table flip.
+cst.assertNextChangesEqual({
+    cursor: cursor,
+    expectedChanges: [
+        {
+            operationType: "insert",
+            ns: ns,
+            fullDocument: {_id: 1, phase: "post-move"},
+            documentKey: {_id: 1},
+        },
+        {
+            operationType: "insert",
+            ns: ns,
+            fullDocument: {_id: 2, phase: "post-move"},
+            documentKey: {_id: 2},
+        },
+        {
+            operationType: "insert",
+            ns: ns,
+            fullDocument: {_id: 3, phase: "post-move"},
+            documentKey: {_id: 3},
+        },
+        {
+            operationType: "insert",
+            ns: ns,
+            fullDocument: {_id: 4, phase: "post-move"},
+            documentKey: {_id: 4},
+        },
+        {
+            operationType: "insert",
+            ns: ns,
+            fullDocument: {_id: 5, phase: "post-move"},
+            documentKey: {_id: 5},
+        },
+    ],
+});
+
+// 2) A fresh cursor resumed from the pre-move token must replay every
+// post-move insert. This is the resumability invariant that the suite is
+// designed to guard.
+const resumedCursor = cst.startWatchingChanges({
+    pipeline: [{$changeStream: {resumeAfter: resumeToken}}],
+    collection: collName,
+});
+
+cst.assertNextChangesEqual({
+    cursor: resumedCursor,
+    expectedChanges: [
+        {operationType: "insert", ns: ns, fullDocument: {_id: 1, phase: "post-move"}},
+        {operationType: "insert", ns: ns, fullDocument: {_id: 2, phase: "post-move"}},
+        {operationType: "insert", ns: ns, fullDocument: {_id: 3, phase: "post-move"}},
+        {operationType: "insert", ns: ns, fullDocument: {_id: 4, phase: "post-move"}},
+        {operationType: "insert", ns: ns, fullDocument: {_id: 5, phase: "post-move"}},
+    ],
+});
+
+st.stop();

--- a/jstests/suites/catalog-and-routing/BUILD.bazel
+++ b/jstests/suites/catalog-and-routing/BUILD.bazel
@@ -64,6 +64,40 @@ resmoke_suite_test(
     ],
 )
 
+# SERVER-86751: Passthrough running jstests/change_streams/** while the
+# balancer continuously moves unsharded collections in the background.
+# Exercises change-stream resumability + shard-targeting under topology
+# mutation. See change_streams_mongos_passthrough_with_balancer.yml for the
+# selector/hook/fixture deltas vs change_streams_mongos_passthrough.
+resmoke_suite_test(
+    name = "change_streams_mongos_passthrough_with_balancer",
+    config = ":change_streams_mongos_passthrough_with_balancer.yml",
+    data = [
+        "//jstests/change_streams:all_javascript_files",
+        "//jstests/libs/query:all_javascript_files",
+        "//jstests/sharding/libs:all_subpackage_javascript_files",
+    ] + CORE_DATA,
+    shard_count = 12,
+    tags = [
+        "ci-default",
+        "change_streams",
+        "common",
+        "cpu:2",
+        "sharded",
+    ],
+    target_compatible_with = select({
+        "@platforms//cpu:ppc64le": ["@platforms//:incompatible"],
+        "@platforms//cpu:s390x": ["@platforms//:incompatible"],
+        "@platforms//os:macos": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
+    deps = [
+        "//src/mongo/db:mongod",
+        "//src/mongo/s:mongos",
+        "//src/mongo/shell:mongo",
+    ],
+)
+
 resmoke_suite_test(
     name = "sharding_stepdown_fcv_upgrade_downgrade_jscore_passthrough",
     config = "//buildscripts/resmokeconfig:matrix_suites/generated_suites/sharding_stepdown_fcv_upgrade_downgrade_jscore_passthrough.yml",

--- a/jstests/suites/catalog-and-routing/change_streams_mongos_passthrough_with_balancer.yml
+++ b/jstests/suites/catalog-and-routing/change_streams_mongos_passthrough_with_balancer.yml
@@ -1,0 +1,98 @@
+# SERVER-86751: Passthrough that runs jstests/change_streams/** while the
+# balancer continuously moves unsharded collections in the background. This
+# exercises change-stream resumability and shard-targeting against the
+# topology-mutation events emitted by moveCollection / movePrimary while a
+# stream is open against a mongos router.
+#
+# The base behaviour (selectors, mongos fixture, change_stream hooks) mirrors
+# `change_streams_mongos_passthrough.yml`. The delta vs the base suite is:
+#   - selector excludes that are incompatible with background collection moves;
+#   - the ContinuousMoveCollection hook is added to executor.hooks;
+#   - the fixture turns the balancer on and lowers
+#     `balancerMigrationsThrottlingMs` so movements occur frequently enough to
+#     interleave with the streamed test workload.
+#
+# Run locally:
+#   bazel test //jstests/suites/catalog-and-routing:change_streams_mongos_passthrough_with_balancer
+#
+# Or, outside the bazel sandbox:
+#   python buildscripts/resmoke.py run \
+#     --suites=change_streams_mongos_passthrough_with_balancer
+
+test_kind: js_test
+
+selector:
+  roots:
+    - jstests/change_streams/**/*.js
+  exclude_with_any_tags:
+    ##
+    # Tags inherited from change_streams_mongos_passthrough.yml.
+    ##
+    - assumes_against_mongod_not_mongos
+    - assumes_standalone_mongod
+    - requires_profiling
+    ##
+    # Background collection moves are incompatible with tests that depend on a
+    # collection staying on the same shard for the duration of the test, or
+    # that orchestrate their own balancer / chunk migrations.
+    ##
+    - assumes_balancer_off
+    - assumes_no_track_upon_creation
+    - assumes_unsharded_collection
+    - requires_collection_stays_on_same_shard
+    - does_not_support_concurrent_moves
+    - uses_parallel_shell
+
+executor:
+  archive:
+    hooks:
+      - CheckReplDBHash
+      - CheckMetadataConsistencyInBackground
+      - ValidateCollections
+  config:
+    shell_options:
+      eval: |
+        await import("jstests/libs/override_methods/set_read_and_write_concerns.js");
+        await import("jstests/libs/override_methods/enable_sessions.js");
+      global_vars:
+        TestData:
+          defaultReadConcernLevel: "majority"
+          enableMajorityReadConcern: true
+          # Surface to tests + libraries that the balancer is running and may
+          # relocate unsharded collections in the background.
+          runningWithBalancer: true
+          runningWithMoveCollectionInBackground: true
+  hooks:
+    # Continuously emit `moveCollection` against random unsharded collections
+    # owned by the test database while the change-stream is open. This is the
+    # SERVER-86751 coverage delta vs the existing
+    # change_streams_mongos_passthrough suite.
+    - class: ContinuousMoveCollection
+    # Background topology mutation can race with FCV transitions, so re-check
+    # routing metadata once the stream-consuming workload settles.
+    - class: CheckMetadataConsistencyInBackground
+    - class: CheckReplDBHash
+    - class: ValidateCollections
+    - class: CleanEveryN
+      n: 20
+  fixture:
+    class: ShardedClusterFixture
+    enable_balancer: true
+    num_shards: 2
+    num_rs_nodes_per_shard: 2
+    mongos_options:
+      set_parameters:
+        enableTestCommands: 1
+    mongod_options:
+      set_parameters:
+        enableTestCommands: 1
+        # Drive the balancer hot so moves interleave with the open
+        # change-stream's getMore cadence (~1s).
+        balancerMigrationsThrottlingMs: 250
+        writePeriodicNoops: true
+        periodicNoopIntervalSecs: 1
+        reshardingMinimumOperationDurationMillis: 0
+    configsvr_options:
+      set_parameters:
+        enableTestCommands: 1
+        reshardingCriticalSectionTimeoutMillis: 86400000  # 24h


### PR DESCRIPTION
## Summary

jstest + suite: change-streams resumable after collection move.

**Jira:** https://jira.mongodb.org/browse/SERVER-126651
**Branch:** substrate-contrib/w3-79

## Files

```
  - .../changes_resumable_after_collection_move.js     | 147 +++++++++++++++++++++
  - jstests/suites/catalog-and-routing/BUILD.bazel     |  34 +++++
  - ...ge_streams_mongos_passthrough_with_balancer.yml |  98 ++++++++++++++
  - 3 files changed, 279 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
