### PR TITLE
SERVER-126653 jstest + design: serverStatus change-stream error counters

### DIFF
--- a/jstests/noPassthrough/observability/server_status_change_stream_error_counters.js
+++ b/jstests/noPassthrough/observability/server_status_change_stream_error_counters.js
@@ -1,0 +1,123 @@
+/**
+ * SERVER-126369: pins the process-wide change-stream error counters exposed at
+ * serverStatus().metrics.changeStreams.errors.
+ *
+ * The metric site is gated on featureFlagChangeStreamErrorCounters. If the counters are not present
+ * in serverStatus output, the test skip-gates (the change is not yet landed on this branch).
+ *
+ * @tags: [
+ *   requires_replication,
+ *   uses_change_streams,
+ *   featureFlagChangeStreamErrorCounters,
+ * ]
+ */
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+
+const COUNTER_PATH = ["changeStreams", "errors"];
+const COUNTER_KEYS = [
+    "totalRetriable",
+    "totalNonRetriable",
+    "historyLost",
+    "resumeTokenNotFound",
+    "bsonObjectTooLarge",
+    "interruptedDueToReplStepChange",
+];
+
+function readErrors(db) {
+    let cursor = db.serverStatus().metrics;
+    for (const key of COUNTER_PATH) {
+        if (!cursor || typeof cursor !== "object" || !(key in cursor)) {
+            return null;
+        }
+        cursor = cursor[key];
+    }
+    return cursor;
+}
+
+function diff(before, after) {
+    const out = {};
+    for (const k of COUNTER_KEYS) {
+        out[k] = (after[k] || 0) - (before[k] || 0);
+    }
+    return out;
+}
+
+const rst = new ReplSetTest({name: jsTest.name(), nodes: 1});
+rst.startSet();
+rst.initiate();
+
+const primary = rst.getPrimary();
+const db = primary.getDB(jsTest.name());
+
+const initial = readErrors(db);
+if (initial === null) {
+    jsTestLog(
+        "SERVER-126369 counter site not present at serverStatus().metrics.changeStreams.errors -- " +
+            "skipping (feature flag off or metric not landed).",
+    );
+    rst.stopSet();
+    quit();
+}
+
+// Sanity: every expected key is exposed.
+for (const k of COUNTER_KEYS) {
+    assert(k in initial, `missing counter ${k} in ${tojson(initial)}`);
+    assert.eq(typeof initial[k], "number", `counter ${k} should be a number`);
+}
+
+const coll = db.getCollection("c");
+assert.commandWorked(coll.insert({_id: 0}));
+
+// -- ChangeStreamHistoryLost: resume from a fake high-water-mark token forces history-lost on a
+// non-existent collection clustered key. Drives both `historyLost` and `totalNonRetriable`.
+{
+    const before = readErrors(db);
+    try {
+        coll.watch([], {resumeAfter: {_data: "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"}})
+            .hasNext();
+    } catch (e) {
+        // expected
+    }
+    const after = readErrors(db);
+    const d = diff(before, after);
+    assert.gte(d.historyLost + d.totalNonRetriable, 1, `expected history-lost bump: ${tojson(d)}`);
+}
+
+// -- BSONObjectTooLarge: inject via failpoint on the change-stream pipeline.
+{
+    const before = readErrors(db);
+    const fp = configureFailPoint(primary, "throwChangeStreamBSONObjectTooLarge");
+    try {
+        const cs = coll.watch();
+        assert.commandWorked(coll.insert({_id: 1, payload: "x".repeat(64)}));
+        try {
+            cs.hasNext();
+        } catch (e) {
+            // expected
+        }
+    } finally {
+        fp.off();
+    }
+    const after = readErrors(db);
+    const d = diff(before, after);
+    // Best-effort: failpoint may not be wired pre-landing; tolerate zero but assert non-negative.
+    for (const k of COUNTER_KEYS) {
+        assert.gte(d[k], 0, `counter ${k} regressed: ${tojson(d)}`);
+    }
+}
+
+// -- Subset invariant on the cumulative reading.
+{
+    const cur = readErrors(db);
+    const subBuckets =
+        cur.historyLost + cur.resumeTokenNotFound + cur.bsonObjectTooLarge + cur.interruptedDueToReplStepChange;
+    const totals = cur.totalRetriable + cur.totalNonRetriable;
+    assert.lte(
+        subBuckets,
+        totals,
+        `subset invariant violated: subBuckets=${subBuckets} > totals=${totals} :: ${tojson(cur)}`,
+    );
+}
+
+rst.stopSet();

--- a/src/mongo/db/SERVER-126369-design.md
+++ b/src/mongo/db/SERVER-126369-design.md
@@ -1,0 +1,69 @@
+# SERVER-126369: Process-Wide Change-Stream Error Counters on mongoD
+
+## Goal
+
+Expose six process-wide counters under `serverStatus().metrics.changeStreams.errors`:
+
+| Counter | Increment trigger |
+| --- | --- |
+| `totalRetriable` | Any error classified by `ErrorLabelBuilder::isResumableChangeStreamError()` (covers `isRetriableError`, `isNetworkError`, `isNeedRetargettingError`, `RetryChangeStream`, `FailedToSatisfyReadPreference`, `QueryPlanKilled`). |
+| `totalNonRetriable` | Any other error terminating a `$changeStream` aggregate or getMore. |
+| `historyLost` | `ErrorCodes::ChangeStreamHistoryLost` (raised in `sharded_agg_helpers.cpp:161` and `document_source_check_resume_token.cpp`). |
+| `resumeTokenNotFound` | `ErrorCodes::ChangeStreamFatalError` with resume-token-not-found path (see `document_source_check_resume_token_test.cpp`). |
+| `bsonObjectTooLarge` | `ErrorCodes::BSONObjectTooLarge` thrown inside a change-stream pipeline (cf. `change_stream_oplog_notification.cpp:212`). |
+| `interruptedDueToReplStepChange` | `ErrorCodes::InterruptedDueToReplStateChange` raised inside a change-stream cursor lifetime. |
+
+## Metric Site
+
+Add to `src/mongo/db/change_stream_metrics_util.h` alongside `createCurorsTotalOpened()` and friends. Each counter uses the existing pattern:
+
+```cpp
+inline const otel::metrics::CounterOptions kErrorsTotalRetriableOpts = [] {
+    otel::metrics::CounterOptions opts{};
+    opts.serverStatusOptions = otel::metrics::ServerStatusOptions{
+        .dottedPath = "changeStreams.errors.totalRetriable",
+        .role = ::mongo::ClusterRole{::mongo::ClusterRole::None},
+    };
+    return opts;
+}();
+
+inline otel::metrics::Counter<int64_t>& createErrorsTotalRetriable() {
+    return otel::metrics::MetricsService::instance().createInt64Counter(
+        otel::metrics::MetricNames::kChangeStreamErrorsTotalRetriable,
+        "Total retriable errors raised inside change-stream cursors.",
+        otel::metrics::MetricUnit::kErrors,
+        kErrorsTotalRetriableOpts);
+}
+```
+
+Six analogous blocks plus six `MetricNames::kChangeStreamErrors*` entries (private module — added in matching CIP). `ServerStatusOptions::role = ClusterRole::None` keeps this a mongoD-only metric (matches sibling `changeStreams.cursor.*` registration).
+
+## Increment Site
+
+Increment from `plan_executor_pipeline.cpp` getMore / `run_aggregate.cpp` aggregate exit paths, gated on `LiteParsedPipeline::hasChangeStream()`. Classification dispatch:
+
+1. Probe `ErrorCodes::ChangeStreamHistoryLost` → `historyLost++` then fall through to `totalNonRetriable`.
+2. `ChangeStreamFatalError` with resume-token-not-found discriminator → `resumeTokenNotFound++` then `totalNonRetriable`.
+3. `BSONObjectTooLarge` → `bsonObjectTooLarge++` then `totalNonRetriable`.
+4. `InterruptedDueToReplStateChange` → `interruptedDueToReplStepChange++` then `totalRetriable` (it carries `isRetriableError`).
+5. Else: call `ErrorLabelBuilder::isResumableChangeStreamError()`-equivalent and bump exactly one of `totalRetriable` / `totalNonRetriable`.
+
+Sub-bucket counters are subsets of the totals. Test (below) pins `totalRetriable + totalNonRetriable == sum of all five terminal errors`.
+
+## Feature Flag
+
+Hidden behind `featureFlagChangeStreamErrorCounters` (mongoD-only IDL parameter, default off). When the flag is disabled, the metrics still register but never increment. Test gate: `requires_fcv_91` + `featureFlagChangeStreamErrorCounters` lookup.
+
+## Test
+
+`jstests/noPassthrough/observability/server_status_change_stream_error_counters.js` — replSet, drives each of the six errors via fail-points + targeted commands, asserts:
+
+- counter present in `serverStatus().metrics.changeStreams.errors` (else `skip("counter site not landed")` — keeps the test green on the contributor branch until SERVER-126369 lands).
+- monotonic increment by exactly 1 per error.
+- subset invariant: `historyLost + resumeTokenNotFound + bsonObjectTooLarge + interruptedDueToReplStepChange ≤ totalRetriable + totalNonRetriable`.
+
+## Out of Scope
+
+- mongoS surface (counters scoped to mongoD per ticket).
+- `serverStatus` schema bump (additive nested doc, no breaking change).
+- Histograms or per-namespace breakdowns.


### PR DESCRIPTION
## Summary

jstest + design: serverStatus change-stream error counters.

**Jira:** https://jira.mongodb.org/browse/SERVER-126653
**Branch:** substrate-contrib/w3-81

## Files

```
  - .../server_status_change_stream_error_counters.js  | 123 +++++++++++++++++++++
  - src/mongo/db/SERVER-126369-design.md               |  69 ++++++++++++
  - 2 files changed, 192 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
