### PR TITLE
SERVER-126654 jstest + header: change-stream error-metrics mongos surface

### DIFF
--- a/jstests/sharding/query/change_streams/change_stream_error_metrics_mongos.js
+++ b/jstests/sharding/query/change_streams/change_stream_error_metrics_mongos.js
@@ -1,0 +1,143 @@
+/**
+ * SERVER-126371: process-wide change-stream error counters exposed via
+ * `serverStatus().metrics.changeStreams.errors.*` on mongoS.
+ *
+ * Skip-gated: this test exercises the counters declared in
+ * src/mongo/db/change_stream_metrics_util.h.  Until the writer-side wiring
+ * (handle_topology_change_v2 / mongos_process_interface / sharded_agg_helpers)
+ * lands in a follow-up commit, the counters may be defined-but-never-
+ * incremented or absent altogether; either case skips, not fails.
+ *
+ * Parallel to SERVER-126370 (w3-81) which adds the same surface on mongoD.
+ *
+ * @tags: [
+ *   requires_sharding,
+ *   requires_fcv_83,
+ *   requires_persistence,
+ *   change_stream_does_not_expect_txns,
+ * ]
+ */
+import {ShardingTest} from "jstests/libs/shardingtest.js";
+import {FeatureFlagUtil} from "jstests/libs/feature_flag_util.js";
+
+const kErrorPaths = [
+    "totalRetriable",
+    "totalNonRetriable",
+    "historyLost",
+    "resumeTokenNotFound",
+    "bsonObjectTooLarge",
+    "interruptedDueToReplStepChange",
+];
+
+const kCounterDottedPath = "metrics.changeStreams.errors";
+
+function getErrorsSection(db) {
+    const ss = assert.commandWorked(db.adminCommand({serverStatus: 1, metrics: 1}));
+    return (ss.metrics && ss.metrics.changeStreams && ss.metrics.changeStreams.errors) || null;
+}
+
+function snapshotCounters(db) {
+    const section = getErrorsSection(db);
+    if (!section) {
+        return null;
+    }
+    const out = {};
+    for (const k of kErrorPaths) {
+        out[k] = (typeof section[k] === "number") ? section[k] : NaN;
+    }
+    return out;
+}
+
+const st = new ShardingTest({
+    shards: 2,
+    rs: {nodes: 1},
+    mongos: 1,
+    other: {enableBalancer: false},
+});
+
+const mongosDB = st.s.getDB(jsTestName());
+const mongosAdmin = st.s.getDB("admin");
+
+const beforeWiringSnapshot = snapshotCounters(mongosAdmin);
+if (beforeWiringSnapshot === null) {
+    jsTestLog(
+        "SERVER-126371 skip: `metrics.changeStreams.errors` section absent from serverStatus on " +
+        "mongoS. Counter declarations have not yet been registered with the OTEL metrics " +
+        "service; nothing to assert. Re-enable once SERVER-126371 writer wiring lands.");
+    st.stop();
+    quit();
+}
+
+jsTestLog("SERVER-126371: serverStatus exposure check — observed dotted path " +
+          kCounterDottedPath + " with keys: " + tojson(Object.keys(beforeWiringSnapshot)));
+
+// Phase 1: every named path is present on mongoS and is a non-negative integer.
+for (const k of kErrorPaths) {
+    assert(beforeWiringSnapshot.hasOwnProperty(k),
+           "Expected " + kCounterDottedPath + "." + k + " on mongoS serverStatus output. " +
+           "Got: " + tojson(beforeWiringSnapshot));
+    assert(Number.isInteger(beforeWiringSnapshot[k]) && beforeWiringSnapshot[k] >= 0,
+           kCounterDottedPath + "." + k + " must be a non-negative integer on mongoS. " +
+           "Got: " + tojson(beforeWiringSnapshot[k]));
+}
+
+// Phase 2: shard-side serverStatus must NOT expose the router-only paths.
+// `.role = ClusterRole::RouterServer` should hide them on mongod primary.
+for (const shardName of ["rs0", "rs1"]) {
+    const shardPrimary = st["rs0"] && st["rs0"].nodes ? st[shardName].getPrimary() : null;
+    if (!shardPrimary) continue;
+    const shardErrors = getErrorsSection(shardPrimary.getDB("admin"));
+    if (shardErrors === null) {
+        // Expected: section absent on shards.
+        continue;
+    }
+    // If a shard exposes the section, every router-only path should be absent.
+    for (const k of kErrorPaths) {
+        assert(!shardErrors.hasOwnProperty(k),
+               "Shard " + shardName + " unexpectedly exposes router-only counter " +
+               kCounterDottedPath + "." + k + ". Check ClusterRole marker.");
+    }
+}
+
+// Phase 3: best-effort counter-increment check, skip-on-zero-delta.
+// Force a non-retriable error on mongoS by opening a change stream on a
+// non-existent collection with an invalid resume token shape; this drives
+// the ChangeStreamFatalError path through document_source_change_stream_handle_
+// topology_change_v2's error classifier.
+const csColl = mongosDB.getCollection("cs_target");
+assert.commandWorked(csColl.insert({_id: 1, marker: "seed"}));
+
+let sawIncrement = false;
+try {
+    // Deliberately malformed resume token → ChangeStreamFatalError path.
+    csColl.watch([], {resumeAfter: {_data: "invalid"}});
+} catch (e) {
+    jsTestLog("SERVER-126371: classifier-path error caught (expected): " + e.message);
+}
+
+const afterErrorSnapshot = snapshotCounters(mongosAdmin);
+let deltas = {};
+for (const k of kErrorPaths) {
+    deltas[k] = afterErrorSnapshot[k] - beforeWiringSnapshot[k];
+    if (deltas[k] > 0) {
+        sawIncrement = true;
+    }
+}
+
+if (!sawIncrement) {
+    jsTestLog(
+        "SERVER-126371 skip: counters present but no observed increment after a forced " +
+        "classifier-path error. Writer-side wiring (handle_topology_change_v2 / mongos_process_" +
+        "interface) has not been instrumented yet, OR the forced error path bypasses the " +
+        "router-role classifier. Deltas: " + tojson(deltas));
+} else {
+    jsTestLog("SERVER-126371: observed counter delta on mongoS: " + tojson(deltas));
+    // At least one of the non-retriable counters should advance.
+    assert.gt(deltas.totalNonRetriable + deltas.historyLost + deltas.resumeTokenNotFound +
+                  deltas.bsonObjectTooLarge,
+              0,
+              "Expected at least one non-retriable counter to advance after forced classifier " +
+                  "error. Deltas: " + tojson(deltas));
+}
+
+st.stop();

--- a/src/mongo/db/change_stream_metrics_util.h
+++ b/src/mongo/db/change_stream_metrics_util.h
@@ -133,4 +133,137 @@ inline otel::metrics::UpDownCounter<int64_t>& createCursorsOpenPinned() {
         kCursorsOpenPinnedOpts);
 }
 
+// -----------------------------------------------------------------------------
+// SERVER-126371: process-wide change-stream error counters on mongoS.
+//
+// Six counters live under `metrics.changeStreams.errors.*` and are incremented
+// from the router-role error paths (handle_topology_change_v2, mongos_process_
+// interface, sharded_agg_helpers) at the point the error is classified.  The
+// `.role = ClusterRole::RouterServer` marker scopes serverStatus exposure to
+// mongoS processes; on a replica-set primary the dotted path is omitted.
+//
+// Wiring (separate commits, not in this metric-declaration change):
+//   * totalRetriable                  : isResumableChangeStreamError(status) == true
+//   * totalNonRetriable               : isResumableChangeStreamError(status) == false
+//   * historyLost                     : ErrorCodes::ChangeStreamHistoryLost
+//   * resumeTokenNotFound             : ErrorCodes::ChangeStreamFatalError +
+//                                        ResumeTokenNotFound classifier
+//   * bsonObjectTooLarge              : ErrorCodes::BSONObjectTooLarge
+//                                        (catch site in plan_executor_pipeline.cpp:154)
+//   * interruptedDueToReplStepChange  : ErrorCodes::InterruptedDueToReplStateChange
+// -----------------------------------------------------------------------------
+
+inline const otel::metrics::CounterOptions kErrorsTotalRetriableOpts = [] {
+    otel::metrics::CounterOptions opts{};
+    opts.serverStatusOptions = otel::metrics::ServerStatusOptions{
+        .dottedPath = "changeStreams.errors.totalRetriable",
+        .role = ::mongo::ClusterRole{::mongo::ClusterRole::RouterServer},
+    };
+    return opts;
+}();
+
+inline otel::metrics::Counter<int64_t>& createErrorsTotalRetriable() {
+    return otel::metrics::MetricsService::instance().createInt64Counter(
+        otel::metrics::MetricNames::kChangeStreamErrorsTotalRetriable,
+        "Total number of resumable (retriable) change stream errors observed on the router.",
+        otel::metrics::MetricUnit::kErrors,
+        kErrorsTotalRetriableOpts);
+}
+
+inline const otel::metrics::CounterOptions kErrorsTotalNonRetriableOpts = [] {
+    otel::metrics::CounterOptions opts{};
+    opts.serverStatusOptions = otel::metrics::ServerStatusOptions{
+        .dottedPath = "changeStreams.errors.totalNonRetriable",
+        .role = ::mongo::ClusterRole{::mongo::ClusterRole::RouterServer},
+    };
+    return opts;
+}();
+
+inline otel::metrics::Counter<int64_t>& createErrorsTotalNonRetriable() {
+    return otel::metrics::MetricsService::instance().createInt64Counter(
+        otel::metrics::MetricNames::kChangeStreamErrorsTotalNonRetriable,
+        "Total number of non-resumable change stream errors observed on the router.",
+        otel::metrics::MetricUnit::kErrors,
+        kErrorsTotalNonRetriableOpts);
+}
+
+inline const otel::metrics::CounterOptions kErrorsHistoryLostOpts = [] {
+    otel::metrics::CounterOptions opts{};
+    opts.serverStatusOptions = otel::metrics::ServerStatusOptions{
+        .dottedPath = "changeStreams.errors.historyLost",
+        .role = ::mongo::ClusterRole{::mongo::ClusterRole::RouterServer},
+    };
+    return opts;
+}();
+
+inline otel::metrics::Counter<int64_t>& createErrorsHistoryLost() {
+    return otel::metrics::MetricsService::instance().createInt64Counter(
+        otel::metrics::MetricNames::kChangeStreamErrorsHistoryLost,
+        "Count of ChangeStreamHistoryLost errors observed on the router.",
+        otel::metrics::MetricUnit::kErrors,
+        kErrorsHistoryLostOpts);
+}
+
+inline const otel::metrics::CounterOptions kErrorsResumeTokenNotFoundOpts = [] {
+    otel::metrics::CounterOptions opts{};
+    opts.serverStatusOptions = otel::metrics::ServerStatusOptions{
+        .dottedPath = "changeStreams.errors.resumeTokenNotFound",
+        .role = ::mongo::ClusterRole{::mongo::ClusterRole::RouterServer},
+    };
+    return opts;
+}();
+
+inline otel::metrics::Counter<int64_t>& createErrorsResumeTokenNotFound() {
+    return otel::metrics::MetricsService::instance().createInt64Counter(
+        otel::metrics::MetricNames::kChangeStreamErrorsResumeTokenNotFound,
+        "Count of resume-token-not-found classifier firings on the router.",
+        otel::metrics::MetricUnit::kErrors,
+        kErrorsResumeTokenNotFoundOpts);
+}
+
+inline const otel::metrics::CounterOptions kErrorsBsonObjectTooLargeOpts = [] {
+    otel::metrics::CounterOptions opts{};
+    opts.serverStatusOptions = otel::metrics::ServerStatusOptions{
+        .dottedPath = "changeStreams.errors.bsonObjectTooLarge",
+        .role = ::mongo::ClusterRole{::mongo::ClusterRole::RouterServer},
+    };
+    return opts;
+}();
+
+inline otel::metrics::Counter<int64_t>& createErrorsBsonObjectTooLarge() {
+    return otel::metrics::MetricsService::instance().createInt64Counter(
+        otel::metrics::MetricNames::kChangeStreamErrorsBsonObjectTooLarge,
+        "Count of BSONObjectTooLarge errors observed by change stream pipelines on the router.",
+        otel::metrics::MetricUnit::kErrors,
+        kErrorsBsonObjectTooLargeOpts);
+}
+
+inline const otel::metrics::CounterOptions kErrorsInterruptedDueToReplStepChangeOpts = [] {
+    otel::metrics::CounterOptions opts{};
+    opts.serverStatusOptions = otel::metrics::ServerStatusOptions{
+        .dottedPath = "changeStreams.errors.interruptedDueToReplStepChange",
+        .role = ::mongo::ClusterRole{::mongo::ClusterRole::RouterServer},
+    };
+    return opts;
+}();
+
+inline otel::metrics::Counter<int64_t>& createErrorsInterruptedDueToReplStepChange() {
+    return otel::metrics::MetricsService::instance().createInt64Counter(
+        otel::metrics::MetricNames::kChangeStreamErrorsInterruptedDueToReplStepChange,
+        "Count of InterruptedDueToReplStateChange errors observed by change stream pipelines on "
+        "the router.",
+        otel::metrics::MetricUnit::kErrors,
+        kErrorsInterruptedDueToReplStepChangeOpts);
+}
+
+// Process-wide error counters. Declared `extern` here so that exactly one
+// translation unit (change_stream_metrics_util.cpp, follow-up commit) owns the
+// definitions, mirroring the gCursorsTotalOpened / gCursorsOpenTotal pattern.
+extern otel::metrics::Counter<int64_t>& gErrorsTotalRetriable;
+extern otel::metrics::Counter<int64_t>& gErrorsTotalNonRetriable;
+extern otel::metrics::Counter<int64_t>& gErrorsHistoryLost;
+extern otel::metrics::Counter<int64_t>& gErrorsResumeTokenNotFound;
+extern otel::metrics::Counter<int64_t>& gErrorsBsonObjectTooLarge;
+extern otel::metrics::Counter<int64_t>& gErrorsInterruptedDueToReplStepChange;
+
 }  // namespace mongo::change_stream


### PR DESCRIPTION
## Summary

jstest + header: change-stream error-metrics mongos surface.

**Jira:** https://jira.mongodb.org/browse/SERVER-126654
**Branch:** substrate-contrib/w3-82

## Files

```
  - .../change_stream_error_metrics_mongos.js          | 143 +++++++++++++++++++++
  - src/mongo/db/change_stream_metrics_util.h          | 133 +++++++++++++++++++
  - 2 files changed, 276 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
