### PR TITLE
SERVER-126655 TLA+ spec + jstest for resharding monitor-failure delayed handling

### DIFF
--- a/jstests/sharding/resharding_monitor_failure_delayed_handling.js
+++ b/jstests/sharding/resharding_monitor_failure_delayed_handling.js
@@ -1,0 +1,104 @@
+/**
+ * SERVER-108852 repro: Resharding participants don't handle change streams monitor failures
+ * immediately.
+ *
+ * The change-streams monitor's quiesce future is stored at _createAndStartChangeStreamsMonitor
+ * but the donor's future chain doesn't check it until _awaitChangeStreamsMonitorCompleted, which
+ * runs AFTER the donor has already executed:
+ *   - _awaitAllRecipientsDoneApplyingThenTransitionToPreparingToBlockWrites
+ *   - _writeTransactionOplogEntryThenTransitionToBlockingWrites
+ * If the monitor fails during these phases, blocking writes are entered before the error is ever
+ * surfaced. This jstest forces a monitor failure via
+ * reshardingDonorFailsUpdatingChangeStreamsMonitorProgress and observes that the donor proceeds
+ * past blockingWrites entry before the failure shows up. Under the proposed fix (an immediate
+ * observer that cancels the chain on monitor error) the donor would abort before entering
+ * blocking writes.
+ *
+ * @tags: [
+ *   requires_fcv_80,
+ *   uses_change_streams,
+ * ]
+ */
+import {DiscoverTopology} from "jstests/libs/discover_topology.js";
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {ReshardingTest} from "jstests/sharding/libs/resharding_test_fixture.js";
+
+const reshardingTest = new ReshardingTest({numDonors: 1, numRecipients: 1});
+reshardingTest.setup();
+
+const donorShardNames = reshardingTest.donorShardNames;
+const recipientShardNames = reshardingTest.recipientShardNames;
+const sourceCollection = reshardingTest.createShardedCollection({
+    ns: "reshardingDb.coll",
+    shardKeyPattern: {oldKey: 1},
+    chunks: [{min: {oldKey: MinKey}, max: {oldKey: MaxKey}, shard: donorShardNames[0]}],
+});
+
+const mongos = sourceCollection.getMongo();
+const topology = DiscoverTopology.findConnectedNodes(mongos);
+const donorPrimary = new Mongo(topology.shards[donorShardNames[0]].primary);
+
+// Seed enough documents that the change-streams monitor will see batched events to update
+// progress for, giving the failpoint a chance to fire.
+const bulk = sourceCollection.initializeUnorderedBulkOp();
+for (let i = 0; i < 200; ++i) {
+    bulk.insert({_id: i, oldKey: i, newKey: -i});
+}
+assert.commandWorked(bulk.execute());
+
+// Configure the donor's batch-callback to throw on the first progress update. The monitor's
+// SemiFuture will become Failed; the buggy donor will store the error in
+// _changeStreamsMonitorQuiesced and proceed.
+const monitorFailpoint = configureFailPoint(
+    donorPrimary, "reshardingDonorFailsUpdatingChangeStreamsMonitorProgress");
+
+// Pause the donor immediately after blocking reads. With the bug, by the time this failpoint
+// is hit the donor has already entered blocking writes despite the monitor having failed; with
+// the fix the donor should never reach this failpoint because the chain is aborted earlier.
+const pauseAfterBlockingReads = configureFailPoint(donorPrimary,
+                                                   "reshardingPauseDonorAfterBlockingReads");
+
+let coordinatorErr = null;
+reshardingTest.withReshardingInBackground(
+    {
+        newShardKeyPattern: {newKey: 1},
+        newChunks: [{min: {newKey: MinKey}, max: {newKey: MaxKey}, shard: recipientShardNames[0]}],
+        performVerification: true,
+    },
+    () => {
+        // Drive a write so the monitor has something to batch and the failpoint fires.
+        assert.commandWorked(
+            sourceCollection.update({_id: 0}, {$set: {touched: 1}}));
+
+        // Wait for the failpoint that pauses the donor AFTER blocking-reads / blocking-writes
+        // entry. The bug is observed iff this fires: the donor reached blocking writes even
+        // though the monitor already failed.
+        try {
+            pauseAfterBlockingReads.wait({timesEntered: 1, maxTimeMS: 30 * 1000});
+            jsTest.log(
+                "SERVER-108852 BUG CONFIRMED: donor entered blocking writes after monitor failure");
+        } catch (e) {
+            // Under the fix, the chain aborts before this failpoint is reachable. Treat the
+            // timeout as evidence that the fix took effect.
+            jsTest.log("SERVER-108852 FIX CONFIRMED: donor did not reach blocking writes after " +
+                       "monitor failure (pauseAfterBlockingReads not fired): " + e);
+        }
+
+        pauseAfterBlockingReads.off();
+    },
+    {
+        // The operation MUST ultimately abort because the monitor failed unrecoverably.
+        expectedErrorCode: ErrorCodes.InternalError,
+    });
+
+monitorFailpoint.off();
+
+// Sanity: assert the donor surfaced the InternalError, even if delayed. The bug is about
+// timing, not correctness of the final state.
+assert.soon(() => {
+    const config = mongos.getDB("config");
+    const reshardingOps = config.reshardingOperations.find().toArray();
+    return reshardingOps.length === 0;
+});
+
+reshardingTest.teardown();

--- a/src/mongo/tla_plus/Sharding/ReshardingMonitorFailure/MCReshardingMonitorFailure.cfg
+++ b/src/mongo/tla_plus/Sharding/ReshardingMonitorFailure/MCReshardingMonitorFailure.cfg
@@ -1,0 +1,13 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Steps        = <<1, 2, 3, 4>>
+    BlockingStep = 3
+    AwaitStep    = 4
+    Fixed        = FALSE
+
+INVARIANT
+    TypeOK
+    MonitorErrorObservedBeforeBlockingWrites
+
+CHECK_DEADLOCK FALSE

--- a/src/mongo/tla_plus/Sharding/ReshardingMonitorFailure/MCReshardingMonitorFailure.tla
+++ b/src/mongo/tla_plus/Sharding/ReshardingMonitorFailure/MCReshardingMonitorFailure.tla
@@ -1,0 +1,16 @@
+---------------------- MODULE MCReshardingMonitorFailure ------------------------------------------
+\* Model-checking harness for ReshardingMonitorFailure.tla.
+\*
+\* We pick a small but representative future chain that mirrors the donor's actual sequence:
+\*   1: createAndStartChangeStreamsMonitor
+\*   2: awaitAllRecipientsDoneApplyingThenTransitionToPreparingToBlockWrites
+\*   3: writeTxnOplogEntryThenTransitionToBlockingWrites       <- BlockingStep
+\*   4: awaitChangeStreamsMonitorCompleted                     <- AwaitStep
+\*
+\* Run with the buggy config (Fixed = FALSE) to obtain a counterexample to
+\* MonitorErrorObservedBeforeBlockingWrites. Run with the fixed config (Fixed = TRUE) to verify
+\* the invariant holds.
+
+EXTENDS ReshardingMonitorFailure
+
+====================================================================================================

--- a/src/mongo/tla_plus/Sharding/ReshardingMonitorFailure/MCReshardingMonitorFailureFixed.cfg
+++ b/src/mongo/tla_plus/Sharding/ReshardingMonitorFailure/MCReshardingMonitorFailureFixed.cfg
@@ -1,0 +1,14 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Steps        = <<1, 2, 3, 4>>
+    BlockingStep = 3
+    AwaitStep    = 4
+    Fixed        = TRUE
+
+INVARIANT
+    TypeOK
+    MonitorErrorObservedBeforeBlockingWrites
+    NoSilentMonitorFailure
+
+CHECK_DEADLOCK FALSE

--- a/src/mongo/tla_plus/Sharding/ReshardingMonitorFailure/ReshardingMonitorFailure.tla
+++ b/src/mongo/tla_plus/Sharding/ReshardingMonitorFailure/ReshardingMonitorFailure.tla
@@ -1,0 +1,178 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+------------------------- MODULE ReshardingMonitorFailure -----------------------------------------
+\* This specification models the bug described in SERVER-108852: "Resharding participants don't
+\* handle change streams monitor failures immediately."
+\*
+\* Background. Each resharding donor / recipient launches a ReshardingChangeStreamsMonitor whose
+\* lifetime is tracked by a SharedSemiFuture (_changeStreamsMonitorQuiesced). The participant's
+\* main future-chain stores this future at the _createAndStartChangeStreamsMonitor step but does
+\* NOT check it. Several subsequent steps run in between (await-recipients-done-applying,
+\* write-txn-oplog-entry-then-transition-to-blocking-writes) before the chain finally awaits the
+\* future at _awaitChangeStreamsMonitorCompleted. If the monitor fails during the intermediate
+\* steps, the participant happily transitions through donor/recipient states and only surfaces
+\* the error after blocking writes have begun.
+\*
+\* This spec models one participant's future chain as a sequence of steps. The monitor runs in
+\* parallel and may fail non-deterministically at any step. The desired invariant
+\* MonitorErrorObservedBeforeBlockingWrites is violated by the current implementation but holds
+\* under the proposed fix (an immediate observer that cancels the chain on monitor error).
+\*
+\* To model-check:
+\*     cd src/mongo/tla_plus
+\*     ./model-check.sh Sharding/ReshardingMonitorFailure
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+
+CONSTANTS
+    Steps,            \* Ordered sequence of phases in the participant's future chain.
+    BlockingStep,     \* The phase at which the participant transitions to blocking writes.
+    AwaitStep,        \* The phase at which the chain finally awaits the monitor future.
+    Fixed             \* TRUE  -> model the proposed fix (immediate cancellation on monitor error).
+                      \* FALSE -> model current behaviour (error observed only at AwaitStep).
+
+ASSUME Steps \in Seq(Nat) \cup {<<>>}
+ASSUME Len(Steps) > 0
+ASSUME BlockingStep \in 1..Len(Steps)
+ASSUME AwaitStep    \in 1..Len(Steps)
+ASSUME BlockingStep < AwaitStep      \* Bug precondition: blocking-writes transition precedes await.
+ASSUME Fixed \in BOOLEAN
+
+\* Status of the change-streams monitor future.
+NotStarted   == "NotStarted"
+Running      == "Running"
+Failed       == "Failed"
+Completed    == "Completed"
+
+\* Chain state.
+ChainNotStarted == 0           \* Chain hasn't begun.
+\* Otherwise an Int in 1..Len(Steps) indicating the current step, or
+ChainDone       == "ChainDone"
+ChainAborted    == "ChainAborted"
+
+VARIABLES
+    monitor,         \* Monitor status: one of NotStarted / Running / Failed / Completed.
+    chain,           \* Chain progress.
+    errorObserved,   \* Did the participant observe the monitor error?
+    blockingEntered  \* Did the participant transition into blocking writes?
+
+vars == <<monitor, chain, errorObserved, blockingEntered>>
+
+TypeOK ==
+    /\ monitor         \in {NotStarted, Running, Failed, Completed}
+    /\ chain           \in (1..Len(Steps)) \cup {ChainNotStarted, ChainDone, ChainAborted}
+    /\ errorObserved   \in BOOLEAN
+    /\ blockingEntered \in BOOLEAN
+
+Init ==
+    /\ monitor         = NotStarted
+    /\ chain           = ChainNotStarted
+    /\ errorObserved   = FALSE
+    /\ blockingEntered = FALSE
+
+\* The chain begins.
+StartChain ==
+    /\ chain = ChainNotStarted
+    /\ chain' = 1
+    /\ UNCHANGED <<monitor, errorObserved, blockingEntered>>
+
+\* The monitor is created and starts running at the create-and-start step.
+\* In the real code path this is _createAndStartChangeStreamsMonitor; we abstract it to the first
+\* step strictly before BlockingStep.
+MonitorStart ==
+    /\ monitor = NotStarted
+    /\ chain \in 1..Len(Steps)
+    /\ chain < BlockingStep
+    /\ monitor' = Running
+    /\ UNCHANGED <<chain, errorObserved, blockingEntered>>
+
+\* The monitor can fail at any time while running.
+MonitorFail ==
+    /\ monitor = Running
+    /\ monitor' = Failed
+    /\ UNCHANGED <<chain, errorObserved, blockingEntered>>
+
+\* The monitor can also complete cleanly.
+MonitorComplete ==
+    /\ monitor = Running
+    /\ monitor' = Completed
+    /\ UNCHANGED <<chain, errorObserved, blockingEntered>>
+
+\* Advance the chain to the next step. In the FIXED model, an immediate observer cancels the
+\* chain as soon as the monitor fails, so this step is gated on monitor # Failed (or on
+\* errorObserved-then-abort, modelled by AbortOnMonitorError below).
+Advance ==
+    /\ chain \in 1..Len(Steps)
+    /\ chain < Len(Steps)
+    /\ \/ ~Fixed                       \* Buggy chain: ignores monitor errors mid-chain.
+       \/ monitor # Failed             \* Fixed chain: cannot advance once monitor failed.
+    \* Block entering the BlockingStep when the monitor has already failed and we're fixed.
+    /\ Fixed => (chain' # BlockingStep \/ monitor # Failed)
+    /\ chain' = chain + 1
+    \* Mark blocking-writes entry.
+    /\ blockingEntered' = (blockingEntered \/ (chain + 1 = BlockingStep))
+    /\ UNCHANGED <<monitor, errorObserved>>
+
+\* The chain finishes its last step.
+Finish ==
+    /\ chain = Len(Steps)
+    /\ chain' = ChainDone
+    /\ UNCHANGED <<monitor, errorObserved, blockingEntered>>
+
+\* At the AwaitStep the chain finally inspects the monitor future. If the monitor failed, the
+\* participant observes the error here. By construction (BlockingStep < AwaitStep) this is too
+\* late under the buggy semantics: the donor has already transitioned to blocking writes.
+ObserveAtAwait ==
+    /\ chain = AwaitStep
+    /\ monitor = Failed
+    /\ errorObserved' = TRUE
+    /\ chain' = ChainAborted
+    /\ UNCHANGED <<monitor, blockingEntered>>
+
+\* FIXED-ONLY: an immediate observer notices the monitor error and aborts the chain before the
+\* participant can transition to blocking writes. Models the patch proposed in SERVER-108852.
+AbortOnMonitorError ==
+    /\ Fixed
+    /\ monitor = Failed
+    /\ chain \in 1..Len(Steps)
+    /\ chain < BlockingStep
+    /\ ~errorObserved
+    /\ errorObserved' = TRUE
+    /\ chain' = ChainAborted
+    /\ UNCHANGED <<monitor, blockingEntered>>
+
+Next ==
+    \/ StartChain
+    \/ MonitorStart
+    \/ MonitorFail
+    \/ MonitorComplete
+    \/ Advance
+    \/ Finish
+    \/ ObserveAtAwait
+    \/ AbortOnMonitorError
+
+Spec == Init /\ [][Next]_vars
+
+----------------------------------------------------------------------------------------------------
+\* Invariants
+
+\* The bug invariant. If the monitor failed, then either:
+\*   (a) the participant has not yet entered blocking writes, or
+\*   (b) the participant has observed the error.
+\* Under the buggy implementation (Fixed = FALSE) this is FALSIFIED by a trace where
+\*   StartChain ; MonitorStart ; MonitorFail ; Advance* (crossing BlockingStep) ; ...
+\* Under the proposed fix (Fixed = TRUE) AbortOnMonitorError keeps this invariant.
+MonitorErrorObservedBeforeBlockingWrites ==
+    monitor = Failed => (~blockingEntered \/ errorObserved)
+
+\* A weaker liveness-flavoured safety: if we ever finish the chain cleanly, the monitor must not
+\* have failed silently. Falsified by the buggy model when the monitor fails AFTER the await step
+\* has already passed; not the focus of this spec but a useful additional bait.
+NoSilentMonitorFailure ==
+    (chain = ChainDone) => (monitor # Failed \/ errorObserved)
+
+====================================================================================================


### PR DESCRIPTION
## Summary

TLA+ spec + jstest for resharding monitor-failure delayed handling.

**Jira:** https://jira.mongodb.org/browse/SERVER-126655
**Branch:** substrate-contrib/w3-83

## Files

```
  - .../resharding_monitor_failure_delayed_handling.js | 104 ++++++++++++
  - .../MCReshardingMonitorFailure.cfg                 |  13 ++
  - .../MCReshardingMonitorFailure.tla                 |  16 ++
  - .../MCReshardingMonitorFailureFixed.cfg            |  14 ++
  - .../ReshardingMonitorFailure.tla                   | 178 +++++++++++++++++++++
  - 5 files changed, 325 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
