### PR TITLE
SERVER-126656 matrix suite: change-streams pre-images replica-sets kill-secondary passthrough

### DIFF
--- a/buildscripts/resmokeconfig/matrix_suites/generated_suites/change_streams_pre_images_replica_sets_kill_secondary_jscore_passthrough.yml
+++ b/buildscripts/resmokeconfig/matrix_suites/generated_suites/change_streams_pre_images_replica_sets_kill_secondary_jscore_passthrough.yml
@@ -42,6 +42,9 @@ executor:
         electionTimeoutMillis: 5000
     voting_secondaries: false
   hooks:
+    - class: CleanEveryN
+      n: 20
+      skip_fixture_restart: true
     - class: PeriodicKillSecondaries
     - class: ClusterParameter
       key: changeStreamOptions

--- a/buildscripts/resmokeconfig/matrix_suites/overrides/replica_sets_kill_secondary.yml
+++ b/buildscripts/resmokeconfig/matrix_suites/overrides/replica_sets_kill_secondary.yml
@@ -43,6 +43,13 @@
         hooks:
           - PeriodicKillSecondaries
       hooks:
+        # CleanEveryN guarantees that the cluster is wiped between tests so that residual databases
+        # from prior tests do not bleed into later ones (SERVER-104983). skip_fixture_restart is
+        # required because PeriodicKillSecondaries installs the rsSyncApplyStop failpoint, which
+        # would cause CleanEveryN's default fixture restart to hang (SERVER-105309).
+        - class: CleanEveryN
+          n: 20
+          skip_fixture_restart: true
         - class: PeriodicKillSecondaries
 
 - name: hooks_with_legacy_validate


### PR DESCRIPTION
## Summary

matrix suite: change-streams pre-images replica-sets kill-secondary passthrough.

**Jira:** https://jira.mongodb.org/browse/SERVER-126656
**Branch:** substrate-contrib/w3-84

## Files

```
  - ...s_pre_images_replica_sets_kill_secondary_jscore_passthrough.yml | 3 +++
  - .../matrix_suites/overrides/replica_sets_kill_secondary.yml        | 7 +++++++
  - 2 files changed, 10 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
