### PR TITLE
SERVER-126659 jstests: TTL collection/index dropped mid-pass + initial-sync window

### DIFF
--- a/jstests/noPassthrough/ttl/ttl_collection_dropped_mid_pass.js
+++ b/jstests/noPassthrough/ttl/ttl_collection_dropped_mid_pass.js
@@ -1,0 +1,98 @@
+/**
+ * SERVER-97659: Reproduce the timing condition where the underlying collection is
+ * dropped AFTER the TTL monitor has begun _doTTLIndexDelete for that collection. We
+ * use hangTTLMonitorWithLock to pin the monitor inside the per-collection critical
+ * section, drop the collection from another client, and assert that the monitor
+ * either:
+ *   (a) sees collection.exists() == false after re-acquiring the catalog snapshot
+ *       and returns false cleanly, OR
+ *   (b) sees the UUID mismatch and returns false cleanly.
+ *
+ * Either path must NOT crash the server and MUST NOT count as an
+ * invalidTTLIndexSkips error.
+ *
+ * Timing model:
+ *   _doTTLIndexDelete -> acquireCollection MODE_IX -> FAILPOINT HANG ->
+ *   dropCollection (another client) -> failpoint released ->
+ *   !coll.exists() || coll.uuid() != uuid -> return false.
+ *
+ * @tags: [
+ *   requires_replication,
+ * ]
+ */
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+const rst = new ReplSetTest({
+    nodes: 1,
+    nodeOptions: {setParameter: {ttlMonitorSleepSecs: 1}},
+});
+rst.startSet();
+rst.initiate();
+
+const primary = rst.getPrimary();
+const admin = primary.getDB("admin");
+const testDB = primary.getDB("test");
+const coll = testDB.ttl_coll_dropped_mid_pass;
+coll.drop();
+
+// Seed expired docs and create a TTL index while the monitor is paused so we
+// deterministically know the index exists at the start of the next pass.
+const pauseBetween = configureFailPoint(primary, "hangTTLMonitorBetweenPasses");
+pauseBetween.wait();
+
+const past = new Date(new Date().getTime() - 3600 * 1000 * 24);
+const bulk = coll.initializeUnorderedBulkOp();
+for (let i = 0; i < 200; i++) {
+    bulk.insert({x: past, i: i});
+}
+assert.commandWorked(bulk.execute());
+assert.commandWorked(coll.createIndex({x: 1}, {expireAfterSeconds: 60}));
+
+// Arm mid-pass hang, then release the inter-pass hang. The monitor will enter
+// _doTTLIndexDelete, acquire MODE_IX on our collection, and stop at the failpoint.
+const hangWithLock = configureFailPoint(primary, "hangTTLMonitorWithLock");
+pauseBetween.off();
+hangWithLock.wait();
+
+// Capture metrics before we drop. invalidTTLIndexSkips must not be incremented by a
+// vanished collection: the index was conforming, the collection just disappeared.
+const passesBefore = admin.serverStatus().metrics.ttl.passes;
+const invalidSkipsBefore = admin.serverStatus().metrics.ttl.invalidTTLIndexSkips;
+
+// Drop the collection while the monitor holds MODE_IX. The drop will queue behind
+// the IX lock until the failpoint is released.
+const dropAwait = startParallelShell(function () {
+    assert.commandWorked(db.getSiblingDB("test").runCommand({drop: "ttl_coll_dropped_mid_pass"}));
+}, primary.port);
+
+// Yield the failpoint so the monitor's lock is released and the queued drop runs.
+hangWithLock.off();
+dropAwait();
+
+// The monitor must complete at least one more pass cleanly.
+assert.soon(
+    () => admin.serverStatus().metrics.ttl.passes >= passesBefore + 1,
+    "TTL monitor did not advance after collection drop mid-pass",
+);
+
+// The collection is gone, so itcount is zero — but the disappearance must come from
+// the drop, not from TTL reaping. The crucial invariant is that the monitor did not
+// crash and did not flag the index as invalid.
+assert.eq(false, coll.exists(), "Collection should be dropped");
+
+const invalidSkipsAfter = admin.serverStatus().metrics.ttl.invalidTTLIndexSkips;
+assert.eq(
+    invalidSkipsBefore,
+    invalidSkipsAfter,
+    "Dropping the collection mid-pass must not increment invalidTTLIndexSkips",
+);
+
+// Sanity: the TTL monitor thread is still alive and advancing passes.
+const passesMid = admin.serverStatus().metrics.ttl.passes;
+assert.soon(
+    () => admin.serverStatus().metrics.ttl.passes > passesMid,
+    "TTL monitor thread did not survive a mid-pass collection drop",
+);
+
+rst.stopSet();

--- a/jstests/noPassthrough/ttl/ttl_index_dropped_mid_pass.js
+++ b/jstests/noPassthrough/ttl/ttl_index_dropped_mid_pass.js
@@ -1,0 +1,84 @@
+/**
+ * SERVER-97659: Reproduce the timing condition where a TTL index is dropped AFTER
+ * _doTTLIndexDelete has begun (and the lock has been acquired in _doTTLIndexDelete via
+ * hangTTLMonitorWithLock) but BEFORE _deleteExpiredWithIndex's call to getValidTTLIndex
+ * runs. Under this timing, getValidTTLIndex finds the index entry missing and the TTL
+ * monitor must abort the per-index pass cleanly without crashing.
+ *
+ * Timing model:
+ *   _doTTLSubPass -> _doTTLIndexDelete -> [acquire MODE_IX, FAILPOINT HANG] ->
+ *                    dropIndex (from another client) ->
+ *                    _deleteExpiredWithIndex -> getValidTTLIndex returns nullptr ->
+ *                    LOGV2_DEBUG(22535, "index not found; skipping ttl job")
+ *
+ * @tags: [
+ *   requires_replication,
+ * ]
+ */
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+const rst = new ReplSetTest({
+    nodes: 1,
+    nodeOptions: {setParameter: {ttlMonitorSleepSecs: 1}},
+});
+rst.startSet();
+rst.initiate();
+
+const primary = rst.getPrimary();
+const admin = primary.getDB("admin");
+const testDB = primary.getDB("test");
+const coll = testDB.ttl_drop_mid_pass;
+coll.drop();
+
+// Seed an unclustered collection with expired documents.
+const past = new Date(new Date().getTime() - 3600 * 1000 * 24);
+const bulk = coll.initializeUnorderedBulkOp();
+for (let i = 0; i < 200; i++) {
+    bulk.insert({x: past, i: i});
+}
+assert.commandWorked(bulk.execute());
+assert.eq(200, coll.find().itcount());
+
+// Block the monitor BEFORE it picks up any indexes, then create the TTL index. This
+// guarantees that the index will be visible on the very next pass.
+const pauseBetween = configureFailPoint(primary, "hangTTLMonitorBetweenPasses");
+pauseBetween.wait();
+assert.commandWorked(coll.createIndex({x: 1}, {expireAfterSeconds: 60}));
+
+// Arm the mid-pass hang BEFORE we release the inter-pass hang, so we deterministically
+// catch the monitor while it holds MODE_IX inside _doTTLIndexDelete for our collection.
+const hangWithLock = configureFailPoint(primary, "hangTTLMonitorWithLock");
+pauseBetween.off();
+hangWithLock.wait();
+
+// The monitor is now inside _doTTLIndexDelete with the lock held. Drop the index on
+// another connection. After we release the failpoint, _deleteExpiredWithIndex will run
+// and getValidTTLIndex must return nullptr (the index entry no longer exists), causing
+// the pass to be skipped cleanly.
+const passesBefore = admin.serverStatus().metrics.ttl.passes;
+const invalidSkipsBefore = admin.serverStatus().metrics.ttl.invalidTTLIndexSkips;
+assert.commandWorked(coll.dropIndex({x: 1}));
+
+hangWithLock.off();
+
+// The monitor must complete at least one more pass without crashing.
+assert.soon(
+    () => admin.serverStatus().metrics.ttl.passes >= passesBefore + 1,
+    "TTL monitor did not advance after dropping a TTL index mid-pass",
+);
+
+// The collection itself should be intact: no docs deleted on this pass because the
+// index was dropped before _deleteExpiredWithIndex ran the bounded plan.
+assert.eq(200, coll.find().itcount(), "TTL monitor must not delete docs after the index disappears");
+
+// Validate that the monitor did NOT count this as an invalid-index skip (the index was
+// gone, not malformed). invalidTTLIndexSkips is reserved for non-conformant indexes.
+const invalidSkipsAfter = admin.serverStatus().metrics.ttl.invalidTTLIndexSkips;
+assert.eq(
+    invalidSkipsBefore,
+    invalidSkipsAfter,
+    "Dropping a TTL index mid-pass must not increment invalidTTLIndexSkips",
+);
+
+rst.stopSet();

--- a/jstests/noPassthrough/ttl/ttl_skipped_during_initial_sync.js
+++ b/jstests/noPassthrough/ttl/ttl_skipped_during_initial_sync.js
@@ -1,0 +1,101 @@
+/**
+ * SERVER-97659: Reproduce the timing condition where the TTL monitor fires while the
+ * node is part of a replica set but is NOT in a readable state (e.g. STARTUP2 during
+ * initial sync). The very first check at the top of _doTTLSubPass:
+ *
+ *     if (isReplSet && !memberState.readable()) return false;
+ *
+ * must short-circuit the entire sub-pass: no documents are deleted and no per-index
+ * work runs.
+ *
+ * Timing model:
+ *   secondary starts initial sync ->
+ *   initialSyncHangBeforeFinish pins it in STARTUP2 ->
+ *   ttlMonitorSleepSecs=1 forces multiple TTL passes during the hang ->
+ *   ttl.subPasses metric must advance, but coll.count() must remain unchanged.
+ *
+ * @tags: [
+ *   requires_replication,
+ * ]
+ */
+import {kDefaultWaitForFailPointTimeout} from "jstests/libs/fail_point_util.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+const rst = new ReplSetTest({
+    name: jsTestName(),
+    nodes: [{}, {rsConfig: {priority: 0}}],
+    nodeOptions: {setParameter: {ttlMonitorSleepSecs: 1}},
+});
+rst.startSet();
+rst.initiate();
+
+const primary = rst.getPrimary();
+const primaryDB = primary.getDB("test");
+const coll = primaryDB.ttl_initial_sync;
+coll.drop();
+
+// Seed expired docs on the primary so the syncing node will replicate them and they
+// would be eligible for TTL reaping if the monitor did not skip during initial sync.
+const past = new Date(new Date().getTime() - 3600 * 1000 * 24);
+const bulk = coll.initializeUnorderedBulkOp();
+for (let i = 0; i < 100; i++) {
+    bulk.insert({x: past, i: i});
+}
+assert.commandWorked(bulk.execute({w: 1}));
+assert.commandWorked(coll.createIndex({x: 1}, {expireAfterSeconds: 60}));
+
+// Add a new node pinned in STARTUP2 via initialSyncHangBeforeFinish.
+jsTestLog("Adding a node that will hang in initial sync (STARTUP2 / not readable)");
+const syncingNode = rst.add({
+    rsConfig: {priority: 0, votes: 0},
+    setParameter: {
+        ttlMonitorSleepSecs: 1,
+        "failpoint.forceSyncSourceCandidate":
+            tojson({mode: "alwaysOn", data: {hostAndPort: primary.host}}),
+        "failpoint.initialSyncHangBeforeFinish": tojson({mode: "alwaysOn"}),
+        numInitialSyncAttempts: 1,
+    },
+});
+rst.reInitiate();
+rst.waitForState(syncingNode, ReplSetTest.State.STARTUP_2);
+
+// Wait until the syncing node is parked in STARTUP2 at the end-of-initial-sync hang
+// failpoint. At this point the TTL monitor thread is running but every sub-pass must
+// short-circuit because !memberState.readable() is true.
+assert.commandWorked(syncingNode.adminCommand({
+    waitForFailPoint: "initialSyncHangBeforeFinish",
+    timesEntered: 1,
+    maxTimeMS: kDefaultWaitForFailPointTimeout,
+}));
+
+const syncingAdmin = syncingNode.getDB("admin");
+
+// Confirm the node is unreadable.
+const memberState = assert.commandWorked(syncingAdmin.runCommand({replSetGetStatus: 1})).myState;
+assert.eq(ReplSetTest.State.STARTUP_2, memberState,
+          "Syncing node must be in STARTUP2 for this test to be meaningful");
+
+// Force the monitor to advance several sub-passes while not readable.
+const subPassesBefore = syncingAdmin.serverStatus().metrics.ttl.subPasses;
+const deletedDocsBefore = syncingAdmin.serverStatus().metrics.ttl.deletedDocuments;
+assert.soon(
+    () => syncingAdmin.serverStatus().metrics.ttl.subPasses >= subPassesBefore + 2,
+    "TTL monitor did not advance sub-passes while in initial sync",
+);
+
+// While not readable, the monitor must NOT have deleted anything. The
+// deletedDocuments counter is process-global and monotonic; assert no growth.
+const deletedDocsAfter = syncingAdmin.serverStatus().metrics.ttl.deletedDocuments;
+assert.eq(
+    deletedDocsBefore,
+    deletedDocsAfter,
+    "TTL monitor must not delete documents while the node is not readable (STARTUP2)",
+);
+
+// Release initial sync and let the node finish syncing.
+assert.commandWorked(
+    syncingNode.adminCommand({configureFailPoint: "initialSyncHangBeforeFinish", mode: "off"}),
+);
+rst.awaitSecondaryNodes(null, [syncingNode]);
+
+rst.stopSet();


### PR DESCRIPTION
## Summary

jstests: TTL collection/index dropped mid-pass + initial-sync window.

**Jira:** https://jira.mongodb.org/browse/SERVER-126659
**Branch:** substrate-contrib/w3-87

## Files

```
  - .../ttl/ttl_collection_dropped_mid_pass.js         |  98 ++++++++++++++++++++
  - .../ttl/ttl_index_dropped_mid_pass.js              |  84 +++++++++++++++++
  - .../ttl/ttl_skipped_during_initial_sync.js         | 101 +++++++++++++++++++++
  - 3 files changed, 283 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
