### PR TITLE
SERVER-126660 jstests: TTL collMod expire mid-pass + dropDatabase clears TTL info-map

### DIFF
--- a/jstests/noPassthrough/ttl/ttl_collMod_expire_during_pass.js
+++ b/jstests/noPassthrough/ttl/ttl_collMod_expire_during_pass.js
@@ -1,0 +1,72 @@
+/**
+ * Verify that a collMod which mutates 'expireAfterSeconds' while the
+ * TTLMonitor is paused mid-pass is observed by the next pass and the
+ * pass after that, with no stale info-map entry resurfacing.
+ *
+ * Coverage gap surfaced by SERVER-97661 jstest audit (gap #2).
+ *
+ * @tags: [
+ *     requires_replication,
+ * ]
+ */
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+import {TTLUtil} from "jstests/libs/ttl/ttl_util.js";
+
+const rst = new ReplSetTest({
+    nodes: 1,
+    nodeOptions: {setParameter: {ttlMonitorSleepSecs: 1}},
+});
+rst.startSet();
+rst.initiate();
+
+const primary = rst.getPrimary();
+const db = primary.getDB("ttl_collMod_expire_during_pass");
+const coll = db.getCollection(jsTestName());
+coll.drop();
+
+// Seed two documents whose timestamps are ~1 hour in the past, then create
+// a TTL index with a long expiration (1 day) so the docs are NOT yet
+// eligible.
+const past = new Date(Date.now() - 3600 * 1000);
+assert.commandWorked(coll.insert([{_id: 0, t: past}, {_id: 1, t: past}]));
+assert.commandWorked(coll.createIndex({t: 1}, {expireAfterSeconds: 86400, name: "t_ttl"}));
+
+// Let one pass complete so the TTL info map is populated.
+TTLUtil.waitForPass(db);
+assert.eq(2, coll.countDocuments({}), "no reap expected with 1d expiry");
+
+// Freeze the TTL monitor between passes. This deterministically opens a
+// window where collMod can mutate expireAfterSeconds without racing the
+// monitor.
+const pauseTtl = configureFailPoint(primary, "hangTTLMonitorBetweenPasses");
+pauseTtl.wait();
+
+// Flip the expiry to zero. Both docs (~1h in the past) are now eligible.
+assert.commandWorked(db.runCommand({
+    collMod: coll.getName(),
+    index: {name: "t_ttl", expireAfterSeconds: 0},
+}));
+
+// Confirm catalog reflects the new expiry before unblocking the monitor.
+const idxes = coll.getIndexes().filter((i) => i.name === "t_ttl");
+assert.eq(1, idxes.length, idxes);
+assert.eq(0, idxes[0].expireAfterSeconds, idxes[0]);
+
+// Release the monitor; assert reaping happens within two passes.
+pauseTtl.off();
+TTLUtil.waitForPass(db);
+TTLUtil.waitForPass(db);
+
+assert.soon(() => coll.countDocuments({}) === 0,
+            "expected TTLMonitor to reap both docs after collMod to expireAfterSeconds:0");
+
+// Sanity: a third pass must not log anything indicating the old (1d) entry
+// is still present in the TTL info map. serverStatus().metrics.ttl.passes
+// continues to advance, which is sufficient evidence the monitor did not
+// crash on a stale entry.
+const passesBefore = db.serverStatus().metrics.ttl.passes;
+TTLUtil.waitForPass(db);
+assert.gt(db.serverStatus().metrics.ttl.passes, passesBefore);
+
+rst.stopSet();

--- a/jstests/noPassthrough/ttl/ttl_dropDatabase_clears_info_map.js
+++ b/jstests/noPassthrough/ttl/ttl_dropDatabase_clears_info_map.js
@@ -1,0 +1,100 @@
+/**
+ * Verify that dropDatabase against a database that contains TTL indexes
+ * removes every corresponding entry from the TTL info map, so that the
+ * next TTL pass does not attempt to scan a non-existent namespace.
+ *
+ * Regression coverage for the fix in commit aa2afa865d (SERVER-97657:
+ * "fix ttl info map on index update"). Coverage gap surfaced by
+ * SERVER-97661 jstest audit (gap #3).
+ *
+ * @tags: [
+ *     requires_replication,
+ * ]
+ */
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+import {TTLUtil} from "jstests/libs/ttl/ttl_util.js";
+
+const rst = new ReplSetTest({
+    nodes: 1,
+    nodeOptions: {setParameter: {ttlMonitorSleepSecs: 1}},
+});
+rst.startSet();
+rst.initiate();
+
+const primary = rst.getPrimary();
+const dbKeep = primary.getDB("ttl_dropDatabase_clears_info_map_keep");
+const dbDrop = primary.getDB("ttl_dropDatabase_clears_info_map_drop");
+
+function seed(db) {
+    const collA = db.getCollection("collA");
+    const collB = db.getCollection("collB");
+    collA.drop();
+    collB.drop();
+
+    const past = new Date(Date.now() - 24 * 3600 * 1000);
+    for (let i = 0; i < 5; ++i) {
+        assert.commandWorked(collA.insert({_id: i, t: past}));
+        assert.commandWorked(collB.insert({_id: i, t: past}));
+    }
+    assert.commandWorked(collA.createIndex({t: 1}, {expireAfterSeconds: 0}));
+    assert.commandWorked(collB.createIndex({t: 1}, {expireAfterSeconds: 0}));
+}
+
+seed(dbKeep);
+seed(dbDrop);
+
+// First pass: confirm all four collections (2 in each db) are visible to
+// the TTL monitor and reap their seeded data.
+TTLUtil.waitForPass(dbKeep);
+TTLUtil.waitForPass(dbKeep);
+assert.soon(() => dbKeep.collA.countDocuments({}) === 0);
+assert.soon(() => dbKeep.collB.countDocuments({}) === 0);
+assert.soon(() => dbDrop.collA.countDocuments({}) === 0);
+assert.soon(() => dbDrop.collB.countDocuments({}) === 0);
+
+// Re-seed only the "drop" database with fresh expired docs, then freeze
+// the TTL monitor between passes so we can deterministically observe the
+// state of the info map across the drop.
+const past = new Date(Date.now() - 24 * 3600 * 1000);
+for (let i = 100; i < 105; ++i) {
+    assert.commandWorked(dbDrop.collA.insert({_id: i, t: past}));
+    assert.commandWorked(dbDrop.collB.insert({_id: i, t: past}));
+}
+assert.eq(5, dbDrop.collA.countDocuments({}));
+assert.eq(5, dbDrop.collB.countDocuments({}));
+
+const pauseTtl = configureFailPoint(primary, "hangTTLMonitorBetweenPasses");
+pauseTtl.wait();
+
+// Drop the entire "drop" database, including its two TTL-bearing collections.
+assert.commandWorked(dbDrop.dropDatabase());
+assert.eq(0, primary.adminCommand({listDatabases: 1, nameOnly: true})
+                       .databases.filter((d) => d.name === dbDrop.getName()).length);
+
+// Release the monitor and let two passes go by. With the fix the info map
+// no longer references the dropped namespaces; without the fix the
+// monitor would either log a "namespace not found" warning or, worse,
+// fail an invariant when it tried to acquire the dropped collection.
+pauseTtl.off();
+TTLUtil.waitForPass(dbKeep);
+TTLUtil.waitForPass(dbKeep);
+
+// The kept database must still be reachable - re-seed it with expired
+// docs and verify the monitor reaps them, proving the monitor survived
+// the drop.
+for (let i = 200; i < 205; ++i) {
+    assert.commandWorked(dbKeep.collA.insert({_id: i, t: past}));
+}
+TTLUtil.waitForPass(dbKeep);
+TTLUtil.waitForPass(dbKeep);
+assert.soon(() => dbKeep.collA.countDocuments({}) === 0,
+            "kept-db TTL collection should continue to reap after dropDatabase elsewhere");
+
+// Final sanity: monitor pass counter has continued to advance, meaning
+// no stale info-map entry brought the TTL thread down.
+const passesBefore = primary.getDB("admin").serverStatus().metrics.ttl.passes;
+TTLUtil.waitForPass(dbKeep);
+assert.gt(primary.getDB("admin").serverStatus().metrics.ttl.passes, passesBefore);
+
+rst.stopSet();

--- a/src/mongo/db/ttl/JSTEST_AUDIT.md
+++ b/src/mongo/db/ttl/JSTEST_AUDIT.md
@@ -1,0 +1,132 @@
+# TTL jstest Audit (SERVER-97661)
+
+Scope: catalog the existing `jstests/**/ttl*` and related suites, classify
+each by *what it actually needs from a live server*, identify which ones
+are candidates for conversion to C++ unit tests under
+`src/mongo/db/ttl/ttl_test.cpp` (already 1272 lines, 25+ `TEST_F`s), and
+list coverage gaps fillable by new jstests where unit conversion is not
+feasible.
+
+Branch: `substrate-contrib/w3-88`. Dependency: SERVER-96179 (further
+extension to ttl unit testing) - blocked, separate work.
+
+## Inventory (37 jstests touching TTL)
+
+### Tier A - Strong unit-test conversion candidates
+
+Tests whose load-bearing behaviour is pure `TTLMonitor::doTTLPass()`
+mechanics, validated through `serverStatus().metrics.ttl.passes` plus
+`configureFailPoint` choreography. The pass loop, sub-pass accounting,
+and per-collection delete plan are already covered by `TTLTest::...`
+fixtures in `ttl_test.cpp`. Each row below either *can* be replaced
+outright or *can* shed its failpoint half:
+
+| jstest | Failpoints in use | Unit-test equivalent |
+|---|---|---|
+| `noPassthrough/ttl/ttl_changes_are_immediate.js` | none, but loops on `metrics.ttl.passes` | `TTLPassSingleCollectionTwoIndexes` already covers two-index immediacy; extend with a `collMod` step |
+| `noPassthrough/ttl/ttl_multiple_indexes_and_collections.js` | none | `TTLPassMultipCollectionsPass` covers the matrix; jstest is a slower duplicate |
+| `noPassthrough/ttl/ttl_partial_index.js` | none | Add `TTLPassPartialIndex` to `ttl_test.cpp` (gap; SERVER-17984 only has the js) |
+| `noPassthrough/ttl/ttl_hidden_index.js` | none | Add `TTLPassHiddenIndexSkipped` to `ttl_test.cpp` |
+| `noPassthrough/ttl/ttl_with_dropIndex.js` | none | `TTLSubPassesStartRemovingFromNewTTLIndex` covers the inverse; add the drop direction |
+| `noPassthrough/ttl/ttlMonitorSleepSecs_parameter.js` | none | Already partially covered by `TTLRunMonitorThread`; add a `onUpdateTTLMonitorSleepSeconds` setter test |
+| `noPassthrough/ttl/ttl_expire_nan_warning_on_startup.js` | `skipTTLIndexValidationOnCreateIndex`, `skipTTLIndexExpireAfterSecondsValidation` | The failpoint exists *only* to inject an otherwise-impossible catalog row. A unit test seeding the catalog directly (see `SkipInvalidTTLTest`) removes both failpoints |
+| `noPassthrough/ttl/ttl_non_int_expire_after_seconds.js` | `skipTTLIndexExpireAfterSecondsValidation` | Same shape: `SkipInvalidTTLTest::TTLNonNumericExpireAfterSeconds` already exists; the jstest is redundant once the startup-warning path is unit-tested |
+
+### Tier B - Keep as jstest, but trim failpoint dependence
+
+Tests where the *behaviour under stepdown / write-block / cross-shard*
+genuinely requires a running server, but the failpoint usage is a
+shortcut around a race that a unit test could side-step:
+
+| jstest | Failpoints | Why keep | Cleanup |
+|---|---|---|---|
+| `replsets/kill_ttl_on_stepdown.js` | `hangTTLMonitorWithLock` | True replication-layer behaviour: interrupt + thread survival | Failpoint cannot be removed without splitting the test |
+| `noPassthrough/ttl/user_write_blocking_ttl_index.js` | `hangTTLMonitorBetweenPasses` | UserWriteBlockMode interaction is server-wide | Use `TTLUtil.waitForPass` instead of failpoint-gated pass counting; failpoint stays only for the global write-block window |
+| `noPassthrough/ttl/ttl_batch_deletes.js` | (none in this file; mentions `ttlMonitorBatchDeletes`) | Batched-delete pathway lives in `query/internal_plans.cpp` | Already failpoint-free; keep |
+
+### Tier C - Sharding / Resharding suites - keep as jstest
+
+Cross-shard orchestration is out of reach for the unit harness:
+
+- `sharding/ttl_sharded.js`
+- `sharding/ttl_monitor_recovers_shard_version.js`
+- `sharding/ttl_deletes_not_targeting_orphaned_documents.js`
+- `sharding/analyze_shard_key/ttl_delete_samples.js`
+- `sharding/resharding_timeseries/reshard_timeseries_ttl_deletes.js`
+- `noPassthrough/ttl/ttl_resharding_collection.js`
+
+### Tier D - Adjacent suites referenced for completeness
+
+- `core/ddl/ttl_index_options.js`, `core/ddl/coll_mod_convert_to_ttl.js` (catalog DDL; not TTLMonitor)
+- `noPassthrough/clustered_collections/clustered_collection_ttl.js` (clustered-collection reaping)
+- `noPassthrough/timeseries/ttl/{timeseries_ttl,timeseries_expire,timeseries_expires_with_partial_index}.js`
+- `noPassthrough/catalog/coll_mod_ttl.js`
+- `noPassthroughWithMongod/ttl/{ttl1,ttl_repl,ttl_repl_maintenance,ttl_repl_secondary_disabled}.js`
+- `noPassthroughWithMongod/capped/ttl_index_capped_collection.js`
+- `replsets/ttl_index_with_capped_collection.js`
+- `noPassthrough/admission/execution_control/ttl_monitor_deprioritization.js`
+- `noPassthrough/query/change_streams/change_stream_pre_images_with_ttl.js`
+- `concurrency/fsm_workloads/timeseries/insert_ttl_{timeseries,retry_writes_timeseries}.js`
+- `concurrency/fsm_workloads/crud/indexed_insert/indexed_insert_ttl.js`
+- `core/timeseries/ddl/timeseries_index_ttl_partial.js`
+
+## Coverage gaps surfaced during audit
+
+1. **Hidden TTL index never reaps**. `ttl_hidden_index.js` exists but
+   has no failpoint scaffolding *and* no negative-path coverage in
+   `ttl_test.cpp`. If a future change inverts the hidden-index check in
+   `TTLCollectionCache`, only the jstest catches it - and only the
+   `noPassthrough` variant runs it. Worth a unit test mirror; jstest
+   still useful as an end-to-end pin.
+
+2. **`collMod` of `expireAfterSeconds` while a pass is in flight**. No
+   existing jstest exercises the case where `expireAfterSeconds` is
+   mutated mid-pass for an index that is *currently* being scanned by
+   the TTL monitor. Race with `TTLCollectionCache::updateExpireAfter`.
+   Failpoint-driven; needs jstest, not unit test.
+
+3. **TTL monitor restart after `dropDatabase` of every TTL-bearing
+   db**. `ttl_with_dropIndex.js` covers a single index drop, but not
+   the database-wide cleanup that purges every `TTLInfoMap` entry. The
+   recent fix referenced in `aa2afa865d` (SERVER-97657, "fix ttl info
+   map on index update") makes this load-bearing.
+
+## Concrete deliverables in this branch
+
+New jstests landed alongside this audit (do *not* push, do *not*
+modify `skill-graph-mcp`):
+
+### `jstests/noPassthrough/ttl/ttl_collMod_expire_during_pass.js`
+
+Exercises gap 2. Uses `hangTTLMonitorBetweenPasses` to freeze a pass
+mid-flight, fires a `collMod` that flips `expireAfterSeconds` from
+`60000` down to `0`, releases the failpoint, and asserts that the next
+two TTL passes pick up the new expiration. Builds on `TTLUtil.waitForPass`
+rather than rolling its own pass-count loop, so the only failpoint is
+the hang used to create the race window deterministically.
+
+### `jstests/noPassthrough/ttl/ttl_dropDatabase_clears_info_map.js`
+
+Exercises gap 3. Creates two databases, each with two TTL indexes;
+waits for the TTL info map to reflect 4 entries via
+`serverStatus().metrics.ttl.deletedDocuments` after a forced pass;
+issues `dropDatabase` against one db; uses
+`hangTTLMonitorBetweenPasses` to single-step a pass; asserts the
+remaining 2 entries reap as expected and that no log-line for the
+dropped collection re-surfaces (would indicate a stale `TTLInfoMap`
+entry).
+
+## Recommended follow-up tickets
+
+- **SERVER-XXXXX (unit)**: convert Tier-A rows to `ttl_test.cpp`
+  fixtures (`TTLPassPartialIndex`, `TTLPassHiddenIndexSkipped`,
+  `TTLPassDropIndexClearsEntry`, `TTLMonitorSleepSecsParameter`).
+  Drops 4 `noPassthrough` jstests; saves >3min of CI wall.
+- **SERVER-XXXXX (failpoint removal)**: once the above lands, retire
+  `skipTTLIndexValidationOnCreateIndex` + `skipTTLIndexExpireAfterSecondsValidation`
+  - they exist *only* to feed `ttl_expire_nan_warning_on_startup.js`
+  and `ttl_non_int_expire_after_seconds.js`. Unit equivalents seed the
+  catalog directly via `SkipInvalidTTLTest`.
+- **SERVER-XXXXX (jstest)**: write a sharded counterpart of
+  `ttl_dropDatabase_clears_info_map.js` covering the shard-version
+  recovery interaction surfaced by `ttl_monitor_recovers_shard_version.js`.


### PR DESCRIPTION
## Summary

jstests: TTL collMod expire mid-pass + dropDatabase clears TTL info-map.

**Jira:** https://jira.mongodb.org/browse/SERVER-126660
**Branch:** substrate-contrib/w3-88

## Files

```
  - .../ttl/ttl_collMod_expire_during_pass.js          |  72 +++++++++++
  - .../ttl/ttl_dropDatabase_clears_info_map.js        | 100 ++++++++++++++++
  - src/mongo/db/ttl/JSTEST_AUDIT.md                   | 132 +++++++++++++++++++++
  - 3 files changed, 304 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
