### PR TITLE
SERVER-126661 jstests: TTL clustered-collection / runtime-toggle / subpass coverage

### DIFF
--- a/jstests/noPassthrough/ttl/ttl_clustered_collection_standalone.js
+++ b/jstests/noPassthrough/ttl/ttl_clustered_collection_standalone.js
@@ -1,0 +1,80 @@
+/**
+ * Verify TTL expiration on a clustered collection (clusteredIndex + expireAfterSeconds) in a
+ * standalone, exercising the collection-scan TTL code path distinct from index-scan TTL covered
+ * elsewhere. Confirms: (a) expired docs are reaped, (b) non-expired docs are retained,
+ * (c) collMod-adjusted expireAfterSeconds takes effect at runtime, and (d) ttl.passes advances
+ * across the deletions.
+ *
+ * SERVER-96179: extends TTL unit testing into the clustered-collection collection-scan path.
+ */
+import {TTLUtil} from "jstests/libs/ttl/ttl_util.js";
+
+const conn = MongoRunner.runMongod({setParameter: "ttlMonitorSleepSecs=1"});
+const db = conn.getDB("test");
+const collName = "ttl_clustered";
+
+db[collName].drop();
+assert.commandWorked(
+    db.createCollection(collName, {
+        clusteredIndex: {key: {_id: 1}, unique: true},
+        expireAfterSeconds: 10,
+    }),
+);
+const coll = db[collName];
+
+const now = new Date();
+const expiredTs = new Date(now.getTime() - 3600 * 1000 * 24); // 24h old
+const freshTs = new Date(now.getTime() + 3600 * 1000); // 1h in the future
+
+// Mix expired and not-yet-expired documents. The clustered TTL path keys on _id, which must be a
+// Date for expiration to apply.
+for (let i = 0; i < 30; i++) {
+    assert.commandWorked(coll.insert({_id: new Date(expiredTs.getTime() + i), payload: i}));
+}
+for (let i = 0; i < 10; i++) {
+    assert.commandWorked(coll.insert({_id: new Date(freshTs.getTime() + i), payload: 1000 + i}));
+}
+assert.eq(40, coll.find().itcount(), "all clustered docs should be present pre-expiry");
+
+// Wait for the TTL monitor to reap the 30 expired docs; the 10 future-dated docs must remain.
+assert.soon(function () {
+    return coll.find().itcount() == 10;
+}, "Clustered TTL should reap expired docs and retain future-dated docs");
+
+// Confirm survivors are exactly the future-dated docs.
+const survivors = coll.find({}, {payload: 1}).toArray();
+for (const doc of survivors) {
+    assert.gte(doc.payload, 1000, "Only future-dated payloads should survive: " + tojson(doc));
+}
+
+// collMod to a much larger expireAfterSeconds — the previously-future docs are still in-window
+// and must remain. Insert a fresh batch of slightly-old docs that are within the new window.
+assert.commandWorked(
+    db.runCommand({collMod: collName, expireAfterSeconds: 3600 * 24 * 7}),
+);
+
+const recentTs = new Date(now.getTime() - 60 * 1000); // 1m old, inside 7-day window
+for (let i = 0; i < 5; i++) {
+    assert.commandWorked(coll.insert({_id: new Date(recentTs.getTime() + i), payload: 5000 + i}));
+}
+
+const passesBefore = db.serverStatus().metrics.ttl.passes;
+TTLUtil.waitForPass(db);
+assert.gt(
+    db.serverStatus().metrics.ttl.passes,
+    passesBefore,
+    "ttl.passes must advance after collMod regardless of whether deletions occurred",
+);
+assert.eq(
+    15,
+    coll.find().itcount(),
+    "5 fresh + 10 future docs must all remain inside the widened TTL window",
+);
+
+// Tighten the window so the recent-but-now-expired batch becomes reapable.
+assert.commandWorked(db.runCommand({collMod: collName, expireAfterSeconds: 30}));
+assert.soon(function () {
+    return coll.find().itcount() == 10;
+}, "After tightening TTL, recent docs should expire and only the future-dated 10 remain");
+
+MongoRunner.stopMongod(conn);

--- a/jstests/noPassthrough/ttl/ttl_index_delete_target_docs_runtime.js
+++ b/jstests/noPassthrough/ttl/ttl_index_delete_target_docs_runtime.js
@@ -1,0 +1,77 @@
+/**
+ * Verify the runtime semantics of 'ttlIndexDeleteTargetDocs' — when set to a small positive
+ * value, a single sub-pass over a heavily-expired TTL index removes at most that many docs.
+ * Subsequent passes drain the remainder. Validates that the knob is honored at runtime, not just
+ * startup, and that batched-deletes accounting tracks the per-pass cap.
+ *
+ * SERVER-96179: extends TTL unit testing to cover runtime tuning of batch-delete caps.
+ *
+ * @tags: [
+ *     requires_fcv_70,
+ * ]
+ */
+import {TTLUtil} from "jstests/libs/ttl/ttl_util.js";
+
+const conn = MongoRunner.runMongod({
+    setParameter: {
+        ttlMonitorSleepSecs: 1,
+        ttlMonitorBatchDeletes: true,
+        // Large default that won't bound deletions on its own.
+        ttlIndexDeleteTargetTimeMS: 0,
+    },
+});
+const db = conn.getDB("test");
+const coll = db.ttl_target_docs;
+coll.drop();
+
+const docCount = 200;
+const batchCap = 25;
+
+// Pause the monitor while we set up so initial conditions are deterministic.
+assert.commandWorked(db.adminCommand({setParameter: 1, ttlMonitorEnabled: false}));
+
+assert.commandWorked(coll.createIndex({x: 1}, {expireAfterSeconds: 0}));
+
+const past = new Date(new Date().getTime() - 3600 * 1000 * 24);
+const bulk = coll.initializeUnorderedBulkOp();
+for (let i = 0; i < docCount; i++) {
+    bulk.insert({x: past, i: i});
+}
+assert.commandWorked(bulk.execute());
+assert.eq(docCount, coll.find().itcount());
+
+// Set the per-index per-pass cap and re-enable.
+assert.commandWorked(db.adminCommand({setParameter: 1, ttlIndexDeleteTargetDocs: batchCap}));
+assert.commandWorked(db.adminCommand({setParameter: 1, ttlMonitorEnabled: true}));
+
+// Drain — every pass should remove at most 'batchCap' documents, so the count strictly decreases
+// by no more than batchCap per pass. We don't assert exact per-pass counts (the monitor may make
+// multiple sub-passes per wall pass at small sleep intervals), but we do assert eventual drain
+// and that the cap is not silently ignored on the very first observable pass after toggling.
+const startCount = coll.find().itcount();
+TTLUtil.waitForPass(db);
+const afterOnePass = coll.find().itcount();
+assert.lt(afterOnePass, startCount, "TTL pass should make progress");
+assert.gte(
+    afterOnePass,
+    startCount - batchCap * 4,
+    "Per-pass deletion should remain bounded by ttlIndexDeleteTargetDocs across a small number" +
+        " of sub-passes; expected at most ~4× cap removed but saw " +
+        (startCount - afterOnePass),
+);
+
+// Loosen the cap and confirm eventual full drain.
+assert.commandWorked(db.adminCommand({setParameter: 1, ttlIndexDeleteTargetDocs: 0}));
+assert.soon(function () {
+    return coll.find().itcount() == 0;
+}, "TTL index must fully drain once batch cap is removed");
+
+// Confirm that batched-deletes accounting reflects real deletions.
+const status = db.serverStatus();
+assert.gte(
+    status.batchedDeletes.docs,
+    docCount,
+    "batchedDeletes.docs should account for every TTL deletion",
+);
+
+MongoRunner.stopMongod(conn);

--- a/jstests/noPassthrough/ttl/ttl_monitor_enabled_runtime_toggle.js
+++ b/jstests/noPassthrough/ttl/ttl_monitor_enabled_runtime_toggle.js
@@ -1,0 +1,61 @@
+/**
+ * Verify that toggling 'ttlMonitorEnabled' at runtime correctly pauses and resumes TTL
+ * deletions. With the monitor disabled, expired documents must persist across passes; once
+ * re-enabled, the next pass must reclaim them.
+ *
+ * SERVER-96179: extends TTL unit testing for runtime parameter toggles.
+ */
+import {TTLUtil} from "jstests/libs/ttl/ttl_util.js";
+
+const conn = MongoRunner.runMongod({setParameter: "ttlMonitorSleepSecs=1"});
+const db = conn.getDB("test");
+const coll = db.ttl_runtime_toggle;
+coll.drop();
+
+// Disable the monitor before inserting expired docs so the first observation is deterministic.
+assert.commandWorked(db.adminCommand({setParameter: 1, ttlMonitorEnabled: false}));
+
+assert.commandWorked(coll.createIndex({x: 1}, {expireAfterSeconds: 0}));
+
+const now = new Date();
+const past = new Date(now.getTime() - 3600 * 1000 * 24);
+for (let i = 0; i < 50; i++) {
+    assert.commandWorked(coll.insert({x: past}));
+}
+assert.eq(50, coll.find().itcount(), "expired docs should not be reaped while monitor is disabled");
+
+// Sleep enough wall-clock for several would-be passes; documents must remain.
+const passesAtDisable = db.serverStatus().metrics.ttl.passes;
+sleep(3000);
+assert.eq(
+    passesAtDisable,
+    db.serverStatus().metrics.ttl.passes,
+    "ttl.passes must not advance while ttlMonitorEnabled=false",
+);
+assert.eq(50, coll.find().itcount(), "documents must persist while monitor is disabled");
+
+// Re-enable; expired docs should be reaped on the next pass.
+assert.commandWorked(db.adminCommand({setParameter: 1, ttlMonitorEnabled: true}));
+TTLUtil.waitForPass(db);
+assert.eq(0, coll.find().itcount(), "all expired docs should be deleted after re-enabling monitor");
+
+// Toggle off again, insert more expired docs, confirm they survive.
+assert.commandWorked(db.adminCommand({setParameter: 1, ttlMonitorEnabled: false}));
+for (let i = 0; i < 25; i++) {
+    assert.commandWorked(coll.insert({x: past}));
+}
+const passesAfterReDisable = db.serverStatus().metrics.ttl.passes;
+sleep(2500);
+assert.eq(
+    passesAfterReDisable,
+    db.serverStatus().metrics.ttl.passes,
+    "ttl.passes must not advance after re-disabling monitor",
+);
+assert.eq(25, coll.find().itcount(), "re-inserted expired docs must persist with monitor off");
+
+// Final re-enable to confirm symmetry.
+assert.commandWorked(db.adminCommand({setParameter: 1, ttlMonitorEnabled: true}));
+TTLUtil.waitForPass(db);
+assert.eq(0, coll.find().itcount(), "all docs should drain after final re-enable");
+
+MongoRunner.stopMongod(conn);

--- a/jstests/noPassthrough/ttl/ttl_subpass_target_secs_runtime.js
+++ b/jstests/noPassthrough/ttl/ttl_subpass_target_secs_runtime.js
@@ -1,0 +1,87 @@
+/**
+ * Verify that 'ttlMonitorSubPassTargetSecs' can be adjusted at runtime and continues to bound
+ * the sub-pass loop without stranding documents. With a small sub-pass target on a multi-index
+ * workload, the monitor must still drive all collections to zero over consecutive passes — the
+ * knob bounds per-sub-pass effort, it does not skip indexes.
+ *
+ * SERVER-96179: extends TTL unit testing to exercise the sub-pass scheduler.
+ */
+import {TTLUtil} from "jstests/libs/ttl/ttl_util.js";
+
+const conn = MongoRunner.runMongod({
+    setParameter: {
+        ttlMonitorSleepSecs: 1,
+        ttlMonitorBatchDeletes: true,
+    },
+});
+const db = conn.getDB("test");
+
+// Pause the monitor so multi-collection seed lands atomically.
+assert.commandWorked(db.adminCommand({setParameter: 1, ttlMonitorEnabled: false}));
+
+const collNames = ["ttl_sub_a", "ttl_sub_b", "ttl_sub_c"];
+const docsPerColl = 60;
+const past = new Date(new Date().getTime() - 3600 * 1000 * 24);
+
+for (const name of collNames) {
+    const c = db[name];
+    c.drop();
+    assert.commandWorked(c.createIndex({x: 1}, {expireAfterSeconds: 0}));
+    const bulk = c.initializeUnorderedBulkOp();
+    for (let i = 0; i < docsPerColl; i++) {
+        bulk.insert({x: past, i: i});
+    }
+    assert.commandWorked(bulk.execute());
+    assert.eq(docsPerColl, c.find().itcount(), name + " seed count");
+}
+
+// Set the smallest legal sub-pass target (0 means each TTL index iterated exactly once per
+// sub-pass) and resume.
+assert.commandWorked(db.adminCommand({setParameter: 1, ttlMonitorSubPassTargetSecs: 0}));
+assert.commandWorked(db.adminCommand({setParameter: 1, ttlMonitorEnabled: true}));
+
+// Each pass must visit every collection at least once; eventually all must drain.
+assert.soon(
+    function () {
+        for (const name of collNames) {
+            if (db[name].find().itcount() != 0) return false;
+        }
+        return true;
+    },
+    "All TTL indexes must drain under ttlMonitorSubPassTargetSecs=0",
+    60 * 1000,
+);
+
+// Raise the sub-pass target while the monitor is active and confirm new inserts also drain. This
+// covers the on-update path where the knob changes mid-flight.
+assert.commandWorked(db.adminCommand({setParameter: 1, ttlMonitorSubPassTargetSecs: 30}));
+
+for (const name of collNames) {
+    const c = db[name];
+    const bulk = c.initializeUnorderedBulkOp();
+    for (let i = 0; i < 20; i++) {
+        bulk.insert({x: past, i: i});
+    }
+    assert.commandWorked(bulk.execute());
+}
+
+// Wait for one full pass then verify drain.
+TTLUtil.waitForPass(db);
+assert.soon(
+    function () {
+        for (const name of collNames) {
+            if (db[name].find().itcount() != 0) return false;
+        }
+        return true;
+    },
+    "Second-round inserts must drain after raising ttlMonitorSubPassTargetSecs",
+    60 * 1000,
+);
+
+// Sanity: the parameter rejects negative values.
+assert.commandFailedWithCode(
+    db.adminCommand({setParameter: 1, ttlMonitorSubPassTargetSecs: -1}),
+    ErrorCodes.BadValue,
+);
+
+MongoRunner.stopMongod(conn);


### PR DESCRIPTION
## Summary

jstests: TTL clustered-collection / runtime-toggle / subpass coverage.

**Jira:** https://jira.mongodb.org/browse/SERVER-126661
**Branch:** substrate-contrib/w3-89

## Files

```
  - .../ttl/ttl_clustered_collection_standalone.js     | 80 ++++++++++++++++++++
  - .../ttl/ttl_index_delete_target_docs_runtime.js    | 77 +++++++++++++++++++
  - .../ttl/ttl_monitor_enabled_runtime_toggle.js      | 61 +++++++++++++++
  - .../ttl/ttl_subpass_target_secs_runtime.js         | 87 ++++++++++++++++++++++
  - 4 files changed, 305 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
