### PR TITLE
SERVER-126662 jstest: TTL replication coverage (NoPassthroughWithMongod)

### DIFF
--- a/jstests/noPassthroughWithMongod/ttl/ttl_repl.js
+++ b/jstests/noPassthroughWithMongod/ttl/ttl_repl.js
@@ -9,7 +9,6 @@
 
 import {ReplSetTest} from "jstests/libs/replsettest.js";
 import {reconfig} from "jstests/replsets/rslib.js";
-import {FeatureFlagUtil} from "jstests/libs/feature_flag_util.js";
 
 let rt = new ReplSetTest({name: "ttl_repl", nodes: 2});
 
@@ -73,16 +72,19 @@ let config = rt.getReplSetConfig();
 config.version = rt.getReplSetConfigFromNode().version + 1;
 reconfig(rt, config);
 
+// Wait for the new secondary to finish initial sync and reach SECONDARY state,
+// then wait for replication to drain so the replicated fast count collection is
+// fully populated on the new node before we assert on count().
+rt.awaitSecondaryNodes();
+rt.awaitReplication();
+
 let secondary2col = secondary.getDB("d")["c"];
 
 // check that the new secondary has the correct number of docs
 print("New Secondary stats:");
 printjson(secondary2col.stats());
 
-// TODO(SERVER-122560): Remove this check.
-if (!FeatureFlagUtil.isPresentAndEnabled(primary, "featureFlagReplicatedFastCount")) {
-    assert.eq(6, secondary2col.count(), "wrong number of docs on new secondary");
-}
+assert.eq(6, secondary2col.count(), "wrong number of docs on new secondary");
 
 /******* Part 3 *****************/
 // Check that the collMod command successfully updates the expireAfterSeconds field


### PR DESCRIPTION
## Summary

jstest: TTL replication coverage (NoPassthroughWithMongod).

**Jira:** https://jira.mongodb.org/browse/SERVER-126662
**Branch:** substrate-contrib/w3-90

## Files

```
  - jstests/noPassthroughWithMongod/ttl/ttl_repl.js | 12 +++++++-----
  - 1 file changed, 7 insertions(+), 5 deletions(-)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
