### PR TITLE
SERVER-126663 jstest + design: queryStats TTL-delete origin label

### DIFF
--- a/jstests/noPassthrough/query/queryStats/query_stats_ttl_delete_origin.js
+++ b/jstests/noPassthrough/query/queryStats/query_stats_ttl_delete_origin.js
@@ -1,0 +1,114 @@
+/**
+ * SERVER-119359: $queryStats must label TTL-driven deletes distinctly from
+ * user-driven deletes. A TTL pass and a peer user delete against the same
+ * shape land in two separate query stats keys, distinguished by
+ * `key.origin`.
+ *
+ * Pins:
+ *   - DeleteKey is registered for both origins (rows exist).
+ *   - `key.origin == "ttl"` for the TTL-monitor delete.
+ *   - `key.origin == "client"` for the user delete.
+ *   - No cross-contamination: each row's exec count is its own.
+ *
+ * @tags: [
+ *   requires_replication,
+ *   requires_fcv_90,
+ *   uses_ttl,
+ *   featureFlagQueryStatsDeleteCommand,
+ * ]
+ */
+import {getQueryStats} from "jstests/libs/query/query_stats_utils.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+const collName = jsTestName();
+
+const replTest = new ReplSetTest({
+    nodes: 1,
+    nodeOptions: {
+        setParameter: {
+            ttlMonitorSleepSecs: 1,
+            internalQueryStatsRateLimit: -1,
+            internalQueryStatsCacheSize: "1MB",
+        },
+        slowms: 0,
+    },
+});
+replTest.startSet();
+replTest.initiate();
+
+const primary = replTest.getPrimary();
+const testDB = primary.getDB(jsTestName());
+const coll = testDB[collName];
+
+// Reset store so we observe only this test's deletes.
+assert.commandWorked(testDB.adminCommand({setParameter: 1, internalQueryStatsCacheSize: "1MB"}));
+coll.drop();
+
+// TTL index, immediate expiry semantics.
+assert.commandWorked(coll.createIndex({expireAt: 1}, {expireAfterSeconds: 0}));
+
+// One expired doc (TTL monitor will reap) + one live doc (user will delete).
+const past = new Date(Date.now() - 60 * 60 * 1000);
+const future = new Date(Date.now() + 60 * 60 * 1000);
+assert.commandWorked(coll.insert([
+    {_id: "ttl-victim", expireAt: past, payload: 1},
+    {_id: "user-victim", expireAt: future, payload: 2},
+]));
+
+// Wait for the TTL monitor to reap the expired doc.
+assert.soon(
+    () => coll.findOne({_id: "ttl-victim"}) === null,
+    "TTL monitor did not reap expired doc within timeout",
+    30 * 1000,
+);
+
+// Peer user delete, same shape (predicate on `_id`).
+assert.commandWorked(testDB.runCommand({
+    delete: collName,
+    deletes: [{q: {_id: "user-victim"}, limit: 1}],
+    comment: "user-driven delete for SERVER-119359 origin pinning",
+}));
+
+// Both targets gone — confirm physical state matches recorded stats.
+assert.eq(0, coll.countDocuments({}), "both docs should be gone before reading queryStats");
+
+// Read $queryStats — expect two `delete` rows on this collection, one per origin.
+const deleteEntries = getQueryStats(primary, {collName: coll.getName()}).filter(
+    (e) => e.key.queryShape && e.key.queryShape.command === "delete",
+);
+
+assert.gte(
+    deleteEntries.length,
+    2,
+    "Expected at least 2 delete entries (ttl + client). Got: " + tojson(deleteEntries),
+);
+
+const byOrigin = {};
+for (const e of deleteEntries) {
+    const origin = e.key.origin;
+    assert(
+        origin === "ttl" || origin === "client" || origin === "internal",
+        "Unexpected origin label on delete key: " + tojson(e.key),
+    );
+    byOrigin[origin] = (byOrigin[origin] || []).concat([e]);
+}
+
+assert(byOrigin.ttl && byOrigin.ttl.length >= 1, "Missing TTL-origin delete entry: " + tojson(deleteEntries));
+assert(byOrigin.client && byOrigin.client.length >= 1, "Missing client-origin delete entry: " + tojson(deleteEntries));
+
+// No cross-contamination: each row's exec count is its own bucket.
+const ttlExec = byOrigin.ttl[0].metrics.execCount.sum;
+const clientExec = byOrigin.client[0].metrics.execCount.sum;
+assert.gte(ttlExec, 1, "TTL delete exec count should be >= 1: " + tojson(byOrigin.ttl[0]));
+assert.gte(clientExec, 1, "Client delete exec count should be >= 1: " + tojson(byOrigin.client[0]));
+
+// Shape parity — both rows describe deletes against the same namespace.
+assert.eq(
+    byOrigin.ttl[0].key.queryShape.cmdNs.coll,
+    byOrigin.client[0].key.queryShape.cmdNs.coll,
+    "ttl + client delete keys should share collection name; only origin differs",
+);
+
+jsTest.log("SERVER-119359: ttl vs client delete origins observed distinctly in $queryStats");
+
+replTest.stopSet();

--- a/src/mongo/db/query/query_stats/SERVER-119359-ttl-delete-label.md
+++ b/src/mongo/db/query/query_stats/SERVER-119359-ttl-delete-label.md
@@ -1,0 +1,97 @@
+# SERVER-119359 — Distinguish TTL deletes from user deletes in QueryStats
+
+Status: design, w3-92 (branch `substrate-contrib/w3-92`). Epic SPM-4328.
+Team: Query Integration. Reporter: Arun Banala.
+
+## Problem
+
+`queryStats` collects per-shape metrics for `find`/`aggregate`/`update`/`insert`
+but cannot answer "which deletes are driven by the TTL monitor versus a user
+connection?" Today there is no `DeleteKey` class and no per-key origin label —
+operators reading `$queryStats` cannot separate housekeeping pressure from
+client traffic when sizing the cache or chasing a regression.
+
+## Annotation site
+
+The TTL monitor enters delete execution at exactly two points in
+`src/mongo/db/ttl/ttl_monitor.cpp`:
+
+- `TTLMonitor::_deleteExpiredWithIndex` (line ~564) — indexed TTL collections,
+  constructs `DeleteStageParams` + `CanonicalQuery` then calls
+  `InternalPlanner::deleteWithIndexScan` → `exec->executeDelete()`.
+- `TTLMonitor::_performDeleteExpiredWithCollscan` (line ~759) — clustered /
+  collscan path, used by `_deleteExpiredWithCollscan` and the timeseries
+  extended-range variant.
+
+Both paths converge on a single `OperationContext*` owned by the TTL monitor
+thread. The annotation is a one-line decoration on that `OperationContext`
+*before* the delete executor runs — every downstream QueryStats key derived
+from this op-context inherits the label.
+
+Proposed annotation: a small `OperationContext` decoration
+`TTLDeleteOriginDecoration` (bool, default `false`) flipped to `true` inside
+both `_deleteExpiredWithIndex` and `_performDeleteExpiredWithCollscan` before
+executor construction. Lives in `src/mongo/db/query/query_stats/` so the
+QueryStats layer owns the surface; TTL monitor only writes it.
+
+## QueryStats key surface
+
+A new `DeleteKey` (peer of `UpdateKey` / `InsertKey`) is required — registered
+from the existing delete dispatch in `write_ops_exec.cpp` behind a feature flag
+`featureFlagQueryStatsDeleteCommand`, mirroring the update wiring at
+`computeShapeAndRegisterQueryStats` (line 507) and
+`computeInsertShapeAndRegisterQueryStats` (line 567).
+
+`DeleteCmdComponents` (peer of `UpdateCmdComponents`) carries:
+- `_ordered` (existing pattern)
+- `_bypassDocumentValidation`
+- `_origin` enum `{kClient, kTTL, kInternal}` — read from the
+  `TTLDeleteOriginDecoration` at key-construction time. The TTL monitor never
+  routes through user-facing CRUD, but the decoration is the single
+  authoritative source.
+
+`appendTo()` emits `origin: "ttl"|"client"|"internal"` in the serialized key
+output. Hashing includes `_origin` so TTL deletes and user deletes against the
+same shape land in different buckets — operators reading
+`$queryStats({transformIdentifiers: ...})` can group by `key.origin` directly.
+
+`static_assert` on `sizeof(DeleteKey) == sizeof(Key) + sizeof(DeleteCmdComponents)`
+follows the `UpdateKey` precedent (update_key.h:106).
+
+## Why a key-level label, not a metric
+
+A supplemental metric (à la `nUpdateOps`) would collapse TTL and user deletes
+onto the same shape entry — exactly the conflation the ticket asks us to undo.
+Promoting origin into the key gives operators independent rows, independent
+LRU pressure, and independent rate-limiting.
+
+## Test surface
+
+Pinned by `jstests/noPassthrough/query/queryStats/query_stats_ttl_delete_origin.js`
+(this changeset). The jstest:
+
+1. Starts a single-node replica set with `ttlMonitorSleepSecs: 1`, slow-ms 0.
+2. Creates a TTL index `{expireAt: 1}` with `expireAfterSeconds: 0`.
+3. Inserts a doc with `expireAt` in the past, waits for one TTL pass.
+4. Issues a peer `deleteOne({ _id: ... })` from the user shell against a fresh
+   non-expired doc with the same shape.
+5. Reads `$queryStats` and asserts two entries exist for `command: "delete"`
+   on the same collection: one with `key.origin == "ttl"`, one with
+   `key.origin == "client"`. Asserts neither row reports the other origin's
+   count under `metrics.execCount.sum`.
+
+Failure modes the test pins:
+- Annotation not propagated → both rows collapse to `client` → assertion fires.
+- Annotation leaks across ops → user delete shows `ttl` → assertion fires.
+- DeleteKey not registered → `getQueryStats` returns no `delete` rows →
+  `getLatestQueryStatsEntry` throws on `assert.neq([], sortedEntries)`.
+
+## Out of scope (follow-ups)
+
+- Resharding / migration / chunk-cleanup deletes — same annotation hook can
+  carry `kInternal`, but those callers are not in this change.
+- mongos-side aggregation of `origin` across shards — covered by the existing
+  `query_stats_update_cmd_metrics_mongos.js` pattern; deferred to a sibling
+  ticket.
+- Feature-flag rollout / FCV gating — follows the
+  `gFeatureFlagQueryStatsUpdateCommand` precedent (write_ops_exec.cpp:452).


### PR DESCRIPTION
## Summary

jstest + design: queryStats TTL-delete origin label.

**Jira:** https://jira.mongodb.org/browse/SERVER-126663
**Branch:** substrate-contrib/w3-92

## Files

```
  - .../queryStats/query_stats_ttl_delete_origin.js    | 114 +++++++++++++++++++++
  - .../query_stats/SERVER-119359-ttl-delete-label.md  |  97 ++++++++++++++++++
  - 2 files changed, 211 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
