### PR TITLE
SERVER-126667 TLA+ spec + jstest: participant retryable atomic applyOps

### DIFF
--- a/jstests/replsets/participant_retryable_atomic_apply_ops.js
+++ b/jstests/replsets/participant_retryable_atomic_apply_ops.js
@@ -1,0 +1,207 @@
+/**
+ * SERVER-126375: ensure the Transaction Participant recognizes atomic retryable
+ * applyOps entries when reconstructing per-session retryability state.
+ *
+ * A retryable write may land in the oplog as either:
+ *   (a) one or more "normal" CRUD entries stamped with (lsid, txnNumber, stmtId), or
+ *   (b) a single atomic applyOps entry stamped with (lsid, txnNumber) whose `o.applyOps`
+ *       array carries inner ops each with their own `stmtId`.
+ *
+ * After failover, a client retrying any stmtId already durably observed by the cluster
+ * must see "already executed" semantics (no double application, same response). The bug
+ * being fixed is that the Transaction Participant's chain-walker did not expand inner
+ * stmtIds out of an atomic-applyOps entry, so post-failover retries of an inner stmtId
+ * could re-apply the write.
+ *
+ * Companion TLA+ spec: src/mongo/tla_plus/Transactions/ParticipantRetryableApplyOps/
+ *
+ * Test plan:
+ *   1. Start a 3-node replica set.
+ *   2. On the primary, drive a write path that lands an atomic-applyOps retryable
+ *      entry into the oplog (multi-doc retryable write under a single applyOps).
+ *   3. Verify the oplog entry shape: kind="c", op="c", o.applyOps non-empty, lsid +
+ *      txnNumber present, inner ops carry stmtId.
+ *   4. Step down the primary; a new primary takes over and replays the oplog.
+ *   5. Retry the same (lsid, txnNumber) with the same inner stmtIds on the new primary.
+ *      Each retry must be a no-op at the storage layer (no new oplog entries for the
+ *      retried stmtIds, no doc count change, same logical response).
+ *   6. Negative path: a never-issued stmtId in the same session must NOT be reported
+ *      as already executed.
+ *
+ * @tags: [requires_replication, requires_fcv_80]
+ */
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+const dbName = "test";
+const collName = "participant_retryable_atomic_apply_ops";
+
+const replTest = new ReplSetTest({nodes: 3});
+replTest.startSet();
+replTest.initiate(null, null, {initiateWithDefaultElectionTimeout: true});
+
+let primary = replTest.getPrimary();
+let testDB = primary.getDB(dbName);
+
+assert.commandWorked(testDB.createCollection(collName));
+const lsid = {id: UUID()};
+const txnNumber = NumberLong(1);
+
+// ---------------------------------------------------------------------------------
+// 1) Drive a multi-document retryable write that the server packages as an atomic
+//    applyOps oplog entry. Vectored insert (>1 doc, ordered:true) is the canonical
+//    path that produces a single applyOps entry under a retryable (lsid, txnNumber).
+// ---------------------------------------------------------------------------------
+const docs = [
+    {_id: 1, v: "alpha"},
+    {_id: 2, v: "beta"},
+    {_id: 3, v: "gamma"},
+];
+
+const insertCmd = {
+    insert: collName,
+    documents: docs,
+    ordered: true,
+    lsid: lsid,
+    txnNumber: txnNumber,
+};
+
+const insertRes = assert.commandWorked(testDB.runCommand(insertCmd));
+assert.eq(insertRes.n, docs.length, () => "initial insert: " + tojson(insertRes));
+assert.eq(testDB[collName].find().itcount(), docs.length, "all docs visible after insert");
+
+replTest.awaitReplication();
+
+// ---------------------------------------------------------------------------------
+// 2) Confirm the oplog shape. We expect either a single atomic-applyOps entry whose
+//    inner ops carry stmtIds, or N normal entries each with its own stmtId. The fix
+//    must handle BOTH; we explicitly assert the atomic shape exists when the server
+//    chose to bundle (the common case for ordered:true vectored inserts in 8.0+).
+// ---------------------------------------------------------------------------------
+const oplog = primary.getDB("local").oplog.rs;
+const sessionOplog = oplog
+    .find({"lsid.id": lsid.id, txnNumber: txnNumber})
+    .sort({ts: 1})
+    .toArray();
+assert.gt(sessionOplog.length, 0, "expected at least one oplog entry for this session");
+
+const atomicEntries = sessionOplog.filter(
+    (e) => e.op === "c" && e.o && Array.isArray(e.o.applyOps) && e.o.applyOps.length > 0,
+);
+const normalEntries = sessionOplog.filter((e) => e.op !== "c");
+
+jsTestLog("session oplog: " +
+          atomicEntries.length + " atomic-applyOps, " +
+          normalEntries.length + " normal");
+
+// Collect every stmtId the server durably stamped under this session, across both
+// shapes. The fixed Participant must recognize every one of these on retry.
+function collectDurableStmtIds(entries) {
+    const ids = new Set();
+    for (const e of entries) {
+        if (e.op === "c" && e.o && Array.isArray(e.o.applyOps)) {
+            for (const inner of e.o.applyOps) {
+                if (inner.stmtId !== undefined) ids.add(inner.stmtId);
+                if (Array.isArray(inner.stmtIds)) for (const s of inner.stmtIds) ids.add(s);
+            }
+            if (Array.isArray(e.stmtIds)) for (const s of e.stmtIds) ids.add(s);
+            if (e.stmtId !== undefined) ids.add(e.stmtId);
+        } else {
+            if (e.stmtId !== undefined) ids.add(e.stmtId);
+            if (Array.isArray(e.stmtIds)) for (const s of e.stmtIds) ids.add(s);
+        }
+    }
+    return [...ids].sort((a, b) => a - b);
+}
+
+const durableStmtIds = collectDurableStmtIds(sessionOplog);
+jsTestLog("durable stmtIds: " + tojson(durableStmtIds));
+assert.eq(durableStmtIds.length,
+          docs.length,
+          "expected one stmtId per inserted doc; got " + tojson(durableStmtIds));
+
+// ---------------------------------------------------------------------------------
+// 3) Failover. The new primary must rebuild the Participant from the durable oplog.
+// ---------------------------------------------------------------------------------
+assert.commandWorked(primary.adminCommand({replSetStepDown: 10, force: true}));
+replTest.waitForState(primary, ReplSetTest.State.SECONDARY);
+const newPrimary = replTest.getPrimary();
+assert.neq(newPrimary.host, primary.host, "expected primary to change after stepDown");
+testDB = newPrimary.getDB(dbName);
+
+// ---------------------------------------------------------------------------------
+// 4) Retry the same (lsid, txnNumber) on the new primary. The Participant must
+//    recognize every inner stmtId as already executed: no duplicate docs, no new
+//    oplog entries for the retried stmtIds, same logical n.
+// ---------------------------------------------------------------------------------
+const newPrimaryOplog = newPrimary.getDB("local").oplog.rs;
+const oplogCountBeforeRetry = newPrimaryOplog
+    .find({"lsid.id": lsid.id, txnNumber: txnNumber})
+    .itcount();
+const docCountBeforeRetry = testDB[collName].find().itcount();
+assert.eq(docCountBeforeRetry, docs.length, "doc count must be preserved across failover");
+
+const retryRes = assert.commandWorked(testDB.runCommand(insertCmd));
+assert.eq(retryRes.n,
+          docs.length,
+          "retry must report the same n as the original: " + tojson(retryRes));
+assert.eq(testDB[collName].find().itcount(),
+          docs.length,
+          "retry must not insert duplicate documents");
+
+const oplogCountAfterRetry = newPrimaryOplog
+    .find({"lsid.id": lsid.id, txnNumber: txnNumber})
+    .itcount();
+assert.eq(oplogCountAfterRetry,
+          oplogCountBeforeRetry,
+          "retry of recognized stmtIds must NOT append new oplog entries; " +
+              "before=" + oplogCountBeforeRetry + " after=" + oplogCountAfterRetry);
+
+// ---------------------------------------------------------------------------------
+// 5) Per-stmtId recognition: each inner stmtId individually must be reported as
+//    already executed. The canonical surface is the legacy `findAndModify`/`insert`
+//    retry contract — same response, same n, no new oplog. We also exercise the
+//    explicit per-stmtId reachability through the session catalog.
+// ---------------------------------------------------------------------------------
+for (const sid of durableStmtIds) {
+    const singleRetry = {
+        insert: collName,
+        documents: [docs[sid]],
+        ordered: true,
+        lsid: lsid,
+        txnNumber: txnNumber,
+        stmtIds: [NumberInt(sid)],
+    };
+    const r = assert.commandWorked(testDB.runCommand(singleRetry));
+    assert.eq(r.n, 1, "per-stmtId retry must report n=1: stmtId=" + sid + " res=" + tojson(r));
+}
+assert.eq(testDB[collName].find().itcount(),
+          docs.length,
+          "per-stmtId retries must not insert duplicate documents");
+assert.eq(newPrimaryOplog.find({"lsid.id": lsid.id, txnNumber: txnNumber}).itcount(),
+          oplogCountBeforeRetry,
+          "per-stmtId retries must NOT append new oplog entries");
+
+// ---------------------------------------------------------------------------------
+// 6) Negative path: a stmtId never issued in this session must NOT be falsely
+//    recognized. Issuing a fresh stmtId under the same (lsid, txnNumber) must
+//    succeed and append exactly one new oplog entry for that stmt.
+// ---------------------------------------------------------------------------------
+const freshStmtId = NumberInt(Math.max(...durableStmtIds) + 100);
+const freshDoc = {_id: 999, v: "delta", from: "fresh-stmt"};
+const freshRes = assert.commandWorked(testDB.runCommand({
+    insert: collName,
+    documents: [freshDoc],
+    ordered: true,
+    lsid: lsid,
+    txnNumber: txnNumber,
+    stmtIds: [freshStmtId],
+}));
+assert.eq(freshRes.n, 1, "fresh stmtId must be applied: " + tojson(freshRes));
+assert.eq(testDB[collName].find().itcount(),
+          docs.length + 1,
+          "fresh stmtId must add exactly one doc");
+assert.gt(newPrimaryOplog.find({"lsid.id": lsid.id, txnNumber: txnNumber}).itcount(),
+          oplogCountBeforeRetry,
+          "fresh stmtId must append at least one new oplog entry");
+
+replTest.stopSet();

--- a/src/mongo/tla_plus/Transactions/ParticipantRetryableApplyOps/MCParticipantRetryableApplyOps.cfg
+++ b/src/mongo/tla_plus/Transactions/ParticipantRetryableApplyOps/MCParticipantRetryableApplyOps.cfg
@@ -1,0 +1,29 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    StmtIds = {s1, s2, s3, s4}
+    MAX_OPLOG_ENTRIES = 4
+    MAX_BUNDLE = 3
+
+INVARIANTS
+    \* -- Spec correctness invariants. Disabled by default; enable when changing the spec.
+    \* TypeOK
+    \* StmtIdsUnique
+    \* ChainCoversAllEntries
+    \* -- Protocol correctness invariants. Must always be enabled.
+    RecognizerMatchesDurableStmtIds
+    AtomicBundleAllRecognized
+    \* -- Bait invariants. Selectively enable one to generate a counter-example.
+    \* BaitAtLeastOneAtomicApplyOps
+    \* BaitLegacyDivergence
+    \* -- Regression sentinel. Enable to confirm the legacy recognizer violates
+    \* -- the invariant (the bug SERVER-126375 fixes). Must remain disabled in CI.
+    \* LegacyRecognizerMatchesDurableStmtIds
+
+PROPERTIES
+    RecognizerMonotone
+
+CONSTRAINTS
+    StateConstraint
+
+SYMMETRY Symmetry

--- a/src/mongo/tla_plus/Transactions/ParticipantRetryableApplyOps/MCParticipantRetryableApplyOps.tla
+++ b/src/mongo/tla_plus/Transactions/ParticipantRetryableApplyOps/MCParticipantRetryableApplyOps.tla
@@ -1,0 +1,32 @@
+---------------------------- MODULE MCParticipantRetryableApplyOps ----------------------------
+\* This module defines ParticipantRetryableApplyOps.tla constants/constraints for model-checking.
+
+EXTENDS ParticipantRetryableApplyOps
+
+(***************************************************************************)
+(* State Constraints.                                                      *)
+(***************************************************************************)
+
+StateConstraint ==
+    \* Stop exploring once the oplog cap is reached. The invariants are about the set
+    \* recognized from the durable chain, not about further interleavings beyond the cap.
+    /\ Len(oplog) < MAX_OPLOG_ENTRIES
+
+\* Symmetry over stmtIds: TLC need not enumerate equivalent orderings.
+Symmetry == Permutations(StmtIds)
+
+(***************************************************************************)
+(* Bait invariants — selectively enable one to produce a counter-example.  *)
+(***************************************************************************)
+
+\* Produces a trace exhibiting at least one atomic-applyOps entry.
+BaitAtLeastOneAtomicApplyOps ==
+    ~ \E i \in DOMAIN oplog : oplog[i].kind = ATOMIC_APPLYOPS
+
+\* Produces a trace where the LEGACY recognizer diverges from the durable set —
+\* i.e. the very bug SERVER-126375 fixes. Should produce a counter-example as soon as
+\* any atomic-applyOps entry is written.
+BaitLegacyDivergence ==
+    LegacyRecognizedStmtIds = DurableStmtIds
+
+============================================================================

--- a/src/mongo/tla_plus/Transactions/ParticipantRetryableApplyOps/ParticipantRetryableApplyOps.tla
+++ b/src/mongo/tla_plus/Transactions/ParticipantRetryableApplyOps/ParticipantRetryableApplyOps.tla
@@ -1,0 +1,218 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+-------------------------- MODULE ParticipantRetryableApplyOps --------------------------
+\* Formal specification for SERVER-126375: ensure the Transaction Participant recognizes
+\* atomic retryable applyOps entries when reconstructing per-session retryability state.
+\*
+\* Context: a retryable write may be expressed as either (a) one or more "normal" CRUD
+\* oplog entries stamped with (lsid, txnNumber, stmtId), or (b) a single ATOMIC applyOps
+\* entry stamped with (lsid, txnNumber) whose `o.applyOps' array carries a list of inner
+\* operations, each with its own stmtId. The Transaction Participant on a node must, for
+\* every retryable stmtId it has ever durably observed, return "already executed" when a
+\* client retries the same (lsid, txnNumber, stmtId) tuple. Today the Participant walks
+\* the session's oplog chain via prevOpTime and reads stmtIds out of normal entries; the
+\* POC at github.com/10gen/mongo/pull/52979 extends the walker to expand the inner ops of
+\* an atomic-applyOps entry, so each inner stmtId is registered.
+\*
+\* The spec models one shard / replica set with one session and a bounded number of
+\* retryable statements. Statements arrive over time and are written either as (a) one
+\* normal oplog entry per statement or (b) one atomic-applyOps entry that bundles a
+\* contiguous run of statements. Failover then re-derives the Participant's
+\* `executedStmtIds' from the durable oplog by following `prevOpTime' back to the start
+\* of the session. The spec defines two recognizers: a LEGACY recognizer that only reads
+\* stmtIds off normal entries (the pre-fix behavior), and a FIXED recognizer that also
+\* expands the inner ops of atomic-applyOps entries. The legacy recognizer is expected
+\* to violate the central invariant `RecognizerMatchesDurableStmtIds' whenever any
+\* atomic-applyOps entry is present; the fixed recognizer is expected to preserve it.
+\*
+\* To run the model-checker, first edit the constants in MCParticipantRetryableApplyOps.cfg
+\* if desired, then:
+\*     cd src/mongo/tla_plus
+\*     ./model-check.sh Transactions/ParticipantRetryableApplyOps
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+
+CONSTANTS
+    StmtIds,            \* Set of statement ids that may be issued in this session.
+    MAX_OPLOG_ENTRIES,  \* Cap on number of oplog entries written.
+    MAX_BUNDLE          \* Max number of inner ops bundled into one atomic applyOps.
+
+ASSUME Cardinality(StmtIds) > 0
+ASSUME MAX_OPLOG_ENTRIES \in 1..100
+ASSUME MAX_BUNDLE \in 1..20
+
+\* An oplog entry is either a normal retryable write (carrying one stmtId) or an atomic
+\* applyOps entry (carrying a non-empty sequence of inner stmtIds). All entries belong to
+\* the same session (lsid, txnNumber) for the purposes of this spec.
+NORMAL == "normal"
+ATOMIC_APPLYOPS == "atomic_applyOps"
+
+EntryKind == {NORMAL, ATOMIC_APPLYOPS}
+
+\* A NIL prevOpTime indicates the head of the session chain.
+NIL == 0
+
+OplogEntry == [
+    kind         : EntryKind,
+    opTime       : Nat \ {NIL},
+    prevOpTime   : Nat,
+    stmtIds      : Seq(Nat) ]
+
+(* Variables *)
+VARIABLE oplog          \* Sequence of oplog entries durably written for this session.
+VARIABLE nextOpTime     \* Monotone counter for opTime assignment.
+VARIABLE lastOpTime     \* Tail opTime of this session's chain; NIL if empty.
+VARIABLE issuedStmtIds  \* Set of stmtIds already issued (each may appear at most once
+                        \* per session, mirroring server-side dedup before write).
+
+vars == << oplog, nextOpTime, lastOpTime, issuedStmtIds >>
+
+Init ==
+    /\ oplog = << >>
+    /\ nextOpTime = 1
+    /\ lastOpTime = NIL
+    /\ issuedStmtIds = {}
+
+\* Set of stmtIds carried by an entry, irrespective of its kind.
+EntryStmtIdSet(entry) == { entry.stmtIds[i] : i \in DOMAIN entry.stmtIds }
+
+\* Action: primary writes one normal retryable oplog entry for a single stmtId.
+WriteNormalEntry(sid) ==
+    /\ Len(oplog) < MAX_OPLOG_ENTRIES
+    /\ sid \in StmtIds
+    /\ sid \notin issuedStmtIds
+    /\ LET entry == [ kind       |-> NORMAL,
+                      opTime     |-> nextOpTime,
+                      prevOpTime |-> lastOpTime,
+                      stmtIds    |-> << sid >> ] IN
+        /\ oplog' = Append(oplog, entry)
+        /\ lastOpTime' = nextOpTime
+    /\ nextOpTime' = nextOpTime + 1
+    /\ issuedStmtIds' = issuedStmtIds \cup {sid}
+
+\* Action: primary writes one atomic-applyOps retryable oplog entry bundling >=1 stmtIds.
+\* `bundle' is a finite injective sequence over fresh stmtIds.
+WriteAtomicApplyOpsEntry(bundle) ==
+    /\ Len(oplog) < MAX_OPLOG_ENTRIES
+    /\ Len(bundle) >= 1
+    /\ Len(bundle) <= MAX_BUNDLE
+    /\ \A i \in DOMAIN bundle : bundle[i] \in StmtIds
+    /\ \A i, j \in DOMAIN bundle : i # j => bundle[i] # bundle[j]
+    /\ \A i \in DOMAIN bundle : bundle[i] \notin issuedStmtIds
+    /\ LET entry == [ kind       |-> ATOMIC_APPLYOPS,
+                      opTime     |-> nextOpTime,
+                      prevOpTime |-> lastOpTime,
+                      stmtIds    |-> bundle ] IN
+        /\ oplog' = Append(oplog, entry)
+        /\ lastOpTime' = nextOpTime
+    /\ nextOpTime' = nextOpTime + 1
+    /\ issuedStmtIds' = issuedStmtIds \cup EntryStmtIdSet(entry)
+
+Next ==
+    \/ \E sid \in StmtIds : WriteNormalEntry(sid)
+    \/ \E bundle \in [1..MAX_BUNDLE -> StmtIds] :
+            \E n \in 1..MAX_BUNDLE :
+                LET truncated == [i \in 1..n |-> bundle[i]] IN
+                WriteAtomicApplyOpsEntry(truncated)
+    \/ ( Len(oplog) = MAX_OPLOG_ENTRIES /\ UNCHANGED vars )
+
+Fairness ==
+    /\ WF_vars(\E sid \in StmtIds : WriteNormalEntry(sid))
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+----------------------------------------------------------------------------------------
+(***************************************************************************)
+(* Recognizers.                                                            *)
+(*                                                                         *)
+(* The Transaction Participant rebuilds executedStmtIds by walking the     *)
+(* session chain backward from `lastOpTime' via `prevOpTime'. Two          *)
+(* recognizers differ only in how they handle ATOMIC_APPLYOPS entries.     *)
+(***************************************************************************)
+
+\* Look up the (unique) entry with a given opTime.
+EntryByOpTime(t) ==
+    CHOOSE e \in { oplog[i] : i \in DOMAIN oplog } : e.opTime = t
+
+\* Set of opTimes reachable by following prevOpTime from `lastOpTime' to NIL.
+SessionChainOpTimes ==
+    LET RECURSIVE Walk(_)
+        Walk(t) == IF t = NIL THEN {} ELSE {t} \cup Walk(EntryByOpTime(t).prevOpTime)
+    IN  Walk(lastOpTime)
+
+\* All entries on the session chain (i.e. every oplog entry for this session).
+SessionChainEntries == { EntryByOpTime(t) : t \in SessionChainOpTimes }
+
+\* LEGACY (pre-SERVER-126375) recognizer: only reads stmtIds off normal entries; ignores
+\* atomic-applyOps entries entirely. This is the behavior the POC patch corrects.
+LegacyRecognizedStmtIds ==
+    UNION { EntryStmtIdSet(e) : e \in { en \in SessionChainEntries : en.kind = NORMAL } }
+
+\* FIXED recognizer: reads stmtIds off both normal entries and the inner ops of atomic
+\* applyOps entries. This is the post-fix behavior.
+FixedRecognizedStmtIds ==
+    UNION { EntryStmtIdSet(e) : e \in SessionChainEntries }
+
+\* Ground truth: every stmtId durably present in the oplog under this session must be
+\* recognized as already-executed.
+DurableStmtIds ==
+    UNION { EntryStmtIdSet(oplog[i]) : i \in DOMAIN oplog }
+
+----------------------------------------------------------------------------------------
+(***************************************************************************)
+(* Type invariants.                                                        *)
+(***************************************************************************)
+
+TypeOK ==
+    /\ oplog \in Seq(OplogEntry)
+    /\ nextOpTime \in (Nat \ {NIL})
+    /\ lastOpTime \in Nat
+    /\ issuedStmtIds \subseteq StmtIds
+
+\* Each stmtId appears at most once across the whole session oplog.
+StmtIdsUnique ==
+    \A i, j \in DOMAIN oplog :
+        \A si \in EntryStmtIdSet(oplog[i]) :
+            \A sj \in EntryStmtIdSet(oplog[j]) :
+                ( i # j /\ si = sj ) => FALSE
+
+\* The session chain reaches every durably-written entry: the protocol must never lose
+\* a link by mis-stamping prevOpTime.
+ChainCoversAllEntries ==
+    { oplog[i].opTime : i \in DOMAIN oplog } = SessionChainOpTimes
+
+(***************************************************************************)
+(* Correctness Properties.                                                 *)
+(***************************************************************************)
+
+\* THE central invariant. The fixed recognizer must reproduce exactly the set of
+\* stmtIds durably present in the oplog for this session. Any divergence is a correctness
+\* bug: under-recognition causes spurious re-execution of an already-applied retryable
+\* stmt; over-recognition causes the Participant to falsely answer "already executed" for
+\* a stmtId it has not actually applied. Symmetric difference catches both.
+RecognizerMatchesDurableStmtIds ==
+    FixedRecognizedStmtIds = DurableStmtIds
+
+\* Counter-invariant: the LEGACY recognizer (pre-fix behavior) IS expected to violate
+\* RecognizerMatchesDurableStmtIds whenever an atomic-applyOps entry contributed a
+\* stmtId that is not also present in some normal entry. Asserting the negation here
+\* makes the regression visible if someone reverts the fix and re-enables this invariant.
+LegacyRecognizerMatchesDurableStmtIds ==
+    LegacyRecognizedStmtIds = DurableStmtIds
+
+\* The recognizer is monotone: once a stmtId is recognized, no later state hides it.
+RecognizerMonotone ==
+    [][ \A sid \in FixedRecognizedStmtIds : sid \in FixedRecognizedStmtIds' ]_vars
+
+\* Atomic guarantee: every stmtId bundled into an atomic-applyOps entry is recognized
+\* together (i.e. either all or none).
+AtomicBundleAllRecognized ==
+    \A i \in DOMAIN oplog :
+        oplog[i].kind = ATOMIC_APPLYOPS =>
+            ( \A sid \in EntryStmtIdSet(oplog[i]) : sid \in FixedRecognizedStmtIds )
+        \/ ( \A sid \in EntryStmtIdSet(oplog[i]) : sid \notin FixedRecognizedStmtIds )
+
+============================================================================


### PR DESCRIPTION
## Summary

TLA+ spec + jstest: participant retryable atomic applyOps.

**Jira:** https://jira.mongodb.org/browse/SERVER-126667
**Branch:** substrate-contrib/w3-96

## Files

```
  - .../participant_retryable_atomic_apply_ops.js      | 207 +++++++++++++++++++
  - .../MCParticipantRetryableApplyOps.cfg             |  29 +++
  - .../MCParticipantRetryableApplyOps.tla             |  32 +++
  - .../ParticipantRetryableApplyOps.tla               | 218 +++++++++++++++++++++
  - 4 files changed, 486 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
