### PR TITLE
SERVER-126669 jstest + design + C++: resharding donor critsec does not wait for change-streams monitor

### DIFF
--- a/jstests/sharding/resharding_donor_critical_section_does_not_wait_for_change_streams_monitor.js
+++ b/jstests/sharding/resharding_donor_critical_section_does_not_wait_for_change_streams_monitor.js
@@ -1,0 +1,103 @@
+/**
+ * SERVER-126445: The donor critical section must not hold open while waiting for the change
+ * streams monitor to drain. The wait has been moved out of the
+ * _runUntilBlockingWritesOrErrored chain (which runs while writes are blocked) and into
+ * _finishReshardingOperation, AFTER releaseRecoverableCriticalSection has been called.
+ *
+ * This test pins the new ordering by:
+ *  1) Enabling resharding verification so the change streams monitor is created.
+ *  2) Hanging the donor's change streams monitor mid-flight via the
+ *     hangReshardingChangeStreamsMonitorBeforeReceivingNextBatch failpoint.
+ *  3) Letting the resharding operation reach the donor's blocking-writes state.
+ *  4) Asserting that the donor transitions PAST blocking-writes (i.e. its critical section
+ *     is released and writes are unblocked) WHILE the monitor is still hung. Pre-fix the
+ *     donor would remain stuck at donorState=blocking-writes until the monitor drained.
+ *  5) Lifting the failpoint and letting the operation complete normally.
+ *
+ * @tags: [
+ *   requires_fcv_80,
+ * ]
+ */
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {DiscoverTopology} from "jstests/libs/discover_topology.js";
+import {ReshardingTest} from "jstests/sharding/libs/resharding_test_fixture.js";
+
+const reshardingTest = new ReshardingTest({numDonors: 1, numRecipients: 1});
+reshardingTest.setup();
+
+const donorShardNames = reshardingTest.donorShardNames;
+const recipientShardNames = reshardingTest.recipientShardNames;
+
+const sourceCollection = reshardingTest.createShardedCollection({
+    ns: "reshardingDb.coll",
+    shardKeyPattern: {oldKey: 1},
+    chunks: [{min: {oldKey: MinKey}, max: {oldKey: MaxKey}, shard: donorShardNames[0]}],
+});
+const mongos = sourceCollection.getMongo();
+const topology = DiscoverTopology.findConnectedNodes(mongos);
+const donorPrimary = new Mongo(topology.shards[donorShardNames[0]].primary);
+
+// Seed a couple of documents so the change streams monitor sees real events to process.
+assert.commandWorked(sourceCollection.insert([{_id: 0, oldKey: 0, newKey: 0}, {_id: 1, oldKey: 1, newKey: 1}]));
+
+function getDonorState() {
+    const ops = donorPrimary
+        .getDB("admin")
+        .aggregate([
+            {$currentOp: {allUsers: true, localOps: false}},
+            {$match: {type: "op", desc: /ReshardingDonorService/, donorState: {$exists: true}}},
+        ])
+        .toArray();
+    if (ops.length === 0) {
+        return undefined;
+    }
+    return ops[0].donorState;
+}
+
+// Hang the donor's change streams monitor between batches. With the SERVER-126445 fix, the
+// donor must still be able to release its critical section and advance past blocking-writes
+// while this failpoint is engaged. Pre-fix the wait happened inside the critical section, so
+// the donor would block here indefinitely.
+const monitorHang = configureFailPoint(donorPrimary, "hangReshardingChangeStreamsMonitorBeforeReceivingNextBatch");
+
+reshardingTest.withReshardingInBackground(
+    {
+        newShardKeyPattern: {newKey: 1},
+        newChunks: [{min: {newKey: MinKey}, max: {newKey: MaxKey}, shard: recipientShardNames[0]}],
+        performVerification: true,
+    },
+    () => {
+        // Wait until the donor reaches blocking-writes. This is the moment the critical section
+        // has been acquired and the bug-fix is observable: pre-fix the donor would now block on
+        // the change streams monitor; post-fix it must move on.
+        assert.soon(
+            () => getDonorState() === "blocking-writes" || getDonorState() === "done",
+            () => `Donor never reached blocking-writes. Current state: ${getDonorState()}`,
+        );
+
+        // Wait for the monitor failpoint to actually trip — this proves the monitor is running
+        // and is being held back. If we proceeded without this, a fast cluster could drain the
+        // monitor's only batch before the failpoint engaged, making the test vacuous.
+        monitorHang.wait();
+
+        // The load-bearing assertion: with the monitor still hung, the donor must transition
+        // past blocking-writes. Pre-fix this assertion times out because the donor is parked
+        // inside the critical section waiting for the monitor.
+        assert.soon(
+            () => {
+                const s = getDonorState();
+                return s === "done" || s === undefined; // undefined => donor doc already removed
+            },
+            () =>
+                `Donor stuck at donorState=${getDonorState()} while change streams monitor is hung. ` +
+                `Pre-SERVER-126445 the donor would wait for the monitor inside the critical section.`,
+            5 * 60 * 1000,
+            1000,
+        );
+
+        // Lift the failpoint so the monitor can drain and the resharding operation can finish.
+        monitorHang.off();
+    },
+);
+
+reshardingTest.teardown();

--- a/src/mongo/db/s/resharding/SERVER-126445-design.md
+++ b/src/mongo/db/s/resharding/SERVER-126445-design.md
@@ -1,0 +1,80 @@
+# SERVER-126445 — Remove waiting for change streams monitor from donor critical section
+
+## Problem
+
+When resharding verification is enabled, the donor creates a `ReshardingChangeStreamsMonitor`
+that tails the source collection's change stream and counts inserts/updates/deletes to compare
+against the recipient post-commit. Until this ticket, the donor `awaited` that monitor's
+completion future *inside* `_runUntilBlockingWritesOrErrored`, immediately after
+`_writeTransactionOplogEntryThenTransitionToBlockingWrites` had acquired the recoverable
+critical section and transitioned the donor to `kBlockingWrites`. The relevant chain in
+`resharding_donor_service.cpp` was:
+
+```
+_runUntilBlockingWritesOrErrored
+  -> _writeTransactionOplogEntryThenTransitionToBlockingWrites      // critsec acquired
+  -> _awaitChangeStreamsMonitorCompleted                            // <-- blocking inside critsec
+```
+
+The monitor drains the final tail batch from the change stream after writes are blocked, and
+under load this tail can be tens to hundreds of milliseconds (the `kCriticalSection` →
+`kChangeStreamMonitor` cross-phase elapsed metric, `blockingWritesToMonitorCompletionSecs`,
+exists specifically to surface this delay). For the duration of that wait the user-visible
+critical section stays held — every read/write to the source namespace gets
+`InterruptedDueToReshardingCriticalSection`.
+
+## Fix
+
+Move `_awaitChangeStreamsMonitorCompleted` out of the chain that runs while writes are
+blocked. It now lives in `_finishReshardingOperation`, after
+`ShardingRecoveryService::releaseRecoverableCriticalSection` has been called on the source
+namespace. The donor still drives the monitor to completion before it removes its state
+document and reports `kDone` to the coordinator (the monitor's output, the documents delta,
+is still required for verification), but writes are no longer blocked during the drain.
+
+New chain:
+
+```
+_runUntilBlockingWritesOrErrored
+  -> _writeTransactionOplogEntryThenTransitionToBlockingWrites      // critsec acquired
+                                                                    // (no more monitor wait here)
+_notifyCoordinatorAndAwaitDecision                                  // unchanged
+_finishReshardingOperation
+  -> ... releaseRecoverableCriticalSection ...                      // critsec released
+  -> _awaitChangeStreamsMonitorCompleted                            // <-- monitor wait now here
+  -> _updateCoordinator + _removeDonorDocument
+```
+
+Sibling ticket SERVER-126444 moves the coordinator's consumption of the monitor's output
+(the documents-delta verification) to a post-commit, post-critical-section path on the
+coordinator side, so the donor's local wait no longer needs to land before the coordinator
+commits.
+
+## Invariants preserved
+
+- `_changeStreamsMonitor` is still fully drained on the donor before the donor doc is
+  removed. The existing `_changeStreamsMonitorQuiesced` future in `_runMandatoryCleanup`
+  remains the final guarantor on shutdown / error paths.
+- The `_changeStreamsMonitorCompleted` promise is still fulfilled with the documents delta
+  on success and with the error status on failure; only the call site of the fulfilling
+  `.then()` chain changed.
+- The `kCriticalSection` metric is still ended at the same place
+  (`_finishReshardingOperation`), and the cross-phase elapsed metric
+  `blockingWritesToMonitorCompletionSecs` continues to be reported; under the new behavior
+  its value will trend toward zero on the donor side, which is the intended effect.
+- The abort / step-down paths in `onError` and `_runMandatoryCleanup` already fulfilled the
+  monitor promises with the propagated status; nothing about those paths changed.
+
+## Test
+
+`jstests/sharding/resharding_donor_critical_section_does_not_wait_for_change_streams_monitor.js`
+pins the new ordering. It:
+
+1. Enables verification on a `moveCollection`-shaped resharding op so the monitor is created.
+2. Engages `hangReshardingChangeStreamsMonitorBeforeReceivingNextBatch` on the donor.
+3. Waits for the donor to reach `donorState=blocking-writes` and for the failpoint to trip.
+4. Asserts that the donor transitions PAST `blocking-writes` to `done` (or removes its doc)
+   while the monitor is still hung — i.e., the critical section was released before the
+   monitor wait. Pre-fix this assertion times out because the donor was parked inside the
+   critical section waiting for the monitor.
+5. Lifts the failpoint so the operation can finish.

--- a/src/mongo/db/s/resharding/resharding_donor_service.cpp
+++ b/src/mongo/db/s/resharding/resharding_donor_service.cpp
@@ -386,13 +386,11 @@ ExecutorFuture<void> ReshardingDonorService::DonorStateMachine::_runUntilBlockin
                                    "ReshardingDonorService::_"
                                    "writeTransactionOplogEntryThenTransitionToBlockingWrites");
                     _writeTransactionOplogEntryThenTransitionToBlockingWrites(factory);
-                })
-                .then([this, executor, telemetryCtx = telemetryCtx->clone()]() mutable {
-                    auto span =
-                        _startSpan(telemetryCtx,
-                                   "ReshardingDonorService::_awaitChangeStreamsMonitorCompleted");
-                    return _awaitChangeStreamsMonitorCompleted(executor);
                 });
+            // SERVER-126445: The change streams monitor wait used to live here, inside the
+            // donor critical section. It is now performed in _finishReshardingOperation,
+            // after the critical section has been released, so writes are not blocked while
+            // we drain the monitor's tail batches.
         })
         .onTransientError([](const Status& status) {
             LOGV2(5633603,
@@ -562,13 +560,18 @@ ExecutorFuture<void> ReshardingDonorService::DonorStateMachine::_finishReshardin
                 }
             }
 
-            auto opCtx = _makeOperationContext(factory);
-            return _updateCoordinator(opCtx.get(), executor, factory).then([this, factory] {
-                {
-                    auto opCtx = _makeOperationContext(factory);
-                    removeDonorDocFailpoint.pauseWhileSet(opCtx.get());
-                }
-                _removeDonorDocument(factory);
+            // SERVER-126445: Wait for the change streams monitor to complete here, AFTER the
+            // donor's critical section has been released above. Previously this wait happened
+            // at the tail of _runUntilBlockingWritesOrErrored, while writes were still blocked.
+            return _awaitChangeStreamsMonitorCompleted(executor).then([this, executor, factory] {
+                auto opCtx = _makeOperationContext(factory);
+                return _updateCoordinator(opCtx.get(), executor, factory).then([this, factory] {
+                    {
+                        auto opCtx = _makeOperationContext(factory);
+                        removeDonorDocFailpoint.pauseWhileSet(opCtx.get());
+                    }
+                    _removeDonorDocument(factory);
+                });
             });
         })
         .onTransientError([](const Status& status) {


### PR DESCRIPTION
## Summary

jstest + design + C++: resharding donor critsec does not wait for change-streams monitor.

**Jira:** https://jira.mongodb.org/browse/SERVER-126669
**Branch:** substrate-contrib/w3-98

## Files

```
  - ...ion_does_not_wait_for_change_streams_monitor.js | 103 +++++++++++++++++++++
  - src/mongo/db/s/resharding/SERVER-126445-design.md  |  80 ++++++++++++++++
  - .../db/s/resharding/resharding_donor_service.cpp   |  29 +++---
  - 3 files changed, 199 insertions(+), 13 deletions(-)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
