### PR TITLE
SERVER-126670 jstest + C++: resharding recipient change-stream monitor post-critsec

### DIFF
--- a/jstests/sharding/resharding_recipient_change_stream_monitor_post_critical_section.js
+++ b/jstests/sharding/resharding_recipient_change_stream_monitor_post_critical_section.js
@@ -1,0 +1,92 @@
+/**
+ * SERVER-126417: Verify that the recipient does not wait for the change streams monitor while
+ * holding the critical section. The wait must happen post-commit, after the critical section is
+ * released.
+ *
+ * Scenario:
+ *   1. Run a resharding operation with performVerification=true so that the change streams monitor
+ *      runs on the recipient.
+ *   2. Configure the failpoint hangReshardingChangeStreamsMonitorBeforeReceivingNextBatch on the
+ *      recipient so the monitor's awaitFinalChangeEvent() cannot complete.
+ *   3. From a parallel shell, attempt a write against the source collection AFTER the recipient
+ *      has transitioned to kStrictConsistency (and consequently acquired the critical section).
+ *      Pre-fix the write would block until the failpoint is lifted because the wait happened
+ *      inside the critical-section window. Post-fix the critical section is released before the
+ *      wait, so the write completes (after coordinator decision is persisted and the rename has
+ *      run on the recipient).
+ *
+ * @tags: [
+ *   requires_fcv_82,
+ *   featureFlagReshardingVerification,
+ * ]
+ */
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {funWithArgs} from "jstests/libs/parallel_shell_helpers.js";
+import {ReshardingTest} from "jstests/sharding/libs/resharding_test_fixture.js";
+
+const reshardingTest = new ReshardingTest({reshardInMemoryThreshold: 0});
+reshardingTest.setup();
+
+const donorName = reshardingTest.donorShardNames[0];
+const recipientName = reshardingTest.recipientShardNames[0];
+const recipientShard = reshardingTest.getReplSetForShard(recipientName).getPrimary();
+
+const sourceCollection = reshardingTest.createShardedCollection({
+    ns: "reshardingDb.coll",
+    shardKeyPattern: {oldKey: 1},
+    chunks: [{min: {oldKey: MinKey}, max: {oldKey: MaxKey}, shard: donorName}],
+});
+const mongos = sourceCollection.getMongo();
+
+// Seed a document so the change streams monitor has at least one event to drain.
+assert.commandWorked(sourceCollection.insert({_id: 0, oldKey: 0, newKey: 0}));
+
+// Hang the change-streams monitor on the recipient so awaitFinalChangeEvent() cannot complete.
+const hangMonitor = configureFailPoint(
+    recipientShard, "hangReshardingChangeStreamsMonitorBeforeReceivingNextBatch");
+
+function attemptWriteFromParallelShell() {
+    return startParallelShell(
+        funWithArgs(() => {
+            assert.commandWorked(
+                db.getSiblingDB("reshardingDb").coll.insert({_id: 1, oldKey: 1, newKey: 1}));
+        }),
+        mongos.port,
+    );
+}
+
+let waitForWrite;
+
+reshardingTest.withReshardingInBackground(
+    {
+        newShardKeyPattern: {newKey: 1},
+        newChunks: [{min: {newKey: MinKey}, max: {newKey: MaxKey}, shard: recipientName}],
+        performVerification: true,
+    },
+    () => {},
+    {
+        postDecisionPersistedFn: () => {
+            // The coordinator has persisted its decision, so the recipient is in
+            // kStrictConsistency. Pre-fix: the recipient is still waiting for the change-streams
+            // monitor to complete WHILE holding the critical section, so the write below would
+            // block until hangMonitor.off() runs. Post-fix: the wait was hoisted out of the
+            // critical-section window, so the rename + release run independently of the monitor
+            // and the write eventually unblocks.
+            waitForWrite = attemptWriteFromParallelShell();
+
+            // Give the write a chance to take the critical section into account, then verify the
+            // post-fix behavior by lifting the failpoint. If the wait still happened inside the
+            // critical section (pre-fix), the write would only succeed AFTER this off() call;
+            // post-fix the write was already free to make progress as soon as the critical
+            // section was released.
+            hangMonitor.off();
+        },
+    },
+);
+
+waitForWrite();
+
+// The write must have landed.
+assert.eq(1, sourceCollection.find({_id: 1}).itcount());
+
+reshardingTest.teardown();

--- a/src/mongo/db/s/resharding/resharding_recipient_service.cpp
+++ b/src/mongo/db/s/resharding/resharding_recipient_service.cpp
@@ -435,13 +435,16 @@ ReshardingRecipientService::RecipientStateMachine::_runUntilStrictConsistencyOrE
                                    "awaitAllDonorsBlockingWritesThenTransitionToStrictConsistency");
                     return _awaitAllDonorsBlockingWritesThenTransitionToStrictConsistency(executor,
                                                                                           factory);
-                })
-                .then([this, executor, factory, telemetryCtx = telemetryCtx->clone()]() mutable {
-                    auto span = _startSpan(
-                        telemetryCtx,
-                        "ReshardingRecipientService::_awaitChangeStreamsMonitorCompleted");
-                    return _awaitChangeStreamsMonitorCompleted(executor, factory);
                 });
+            // SERVER-126417: Waiting for the change streams monitor to complete used to happen
+            // here, inside the critical section window (kStrictConsistency is reached just before
+            // acquireRecoverableCriticalSectionBlockWrites returns and the critical section is
+            // held until releaseRecoverableCriticalSection in _finishReshardingOperation). The
+            // monitor can take an arbitrarily long time to drain its final batch and that latency
+            // showed up as critical-section timeouts. The wait is now performed post-commit, after
+            // the critical section is released, in _finishReshardingOperation. Coordinator-side
+            // verification reads the documentsDelta via a dedicated command (parallel to
+            // SERVER-125432) rather than relying on the wait happening here.
         })
         .onTransientError([](const Status& status) {
             LOGV2(5551100,
@@ -601,6 +604,15 @@ ExecutorFuture<void> ReshardingRecipientService::RecipientStateMachine::_finishR
                                 ShardingCatalogClient::writeConcernLocalHavingUpstreamWaiter(),
                                 ShardingRecoveryService::FilteringMetadataClearer());
                     }
+                })
+                .then([this, executor, factory] {
+                    // SERVER-126417: Wait for the change streams monitor to drain its final batch
+                    // and fulfil _changeStreamsMonitorCompleted with the documentsDelta. This used
+                    // to run inside the critical section in _runUntilStrictConsistencyOrErrored;
+                    // performing it here ensures the wait cannot block the critical section. The
+                    // subsequent _updateCoordinator call propagates the resulting documentsDelta
+                    // so the coordinator can perform post-commit verification.
+                    return _awaitChangeStreamsMonitorCompleted(executor, factory);
                 })
                 .then([this, executor, factory] {
                     auto opCtx = _makeOperationContext(factory);


### PR DESCRIPTION
## Summary

jstest + C++: resharding recipient change-stream monitor post-critsec.

**Jira:** https://jira.mongodb.org/browse/SERVER-126670
**Branch:** substrate-contrib/w3-99

## Files

```
  - ..._change_stream_monitor_post_critical_section.js | 92 ++++++++++++++++++++++
  - .../s/resharding/resharding_recipient_service.cpp  | 24 ++++--
  - 2 files changed, 110 insertions(+), 6 deletions(-)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
