### PR TITLE
SERVER-126675 jstest + design: slow-query-log keysExamined negative pin

### DIFF
--- a/jstests/noPassthrough/SERVER-115121-DESIGN.md
+++ b/jstests/noPassthrough/SERVER-115121-DESIGN.md
@@ -1,0 +1,139 @@
+# SERVER-115121 -- keysExamined / docsExamined render as negative in mongod slow-query logs
+
+Ticket: https://jira.mongodb.org/browse/SERVER-115121
+Priority: Critical -- P2 (Server Triage)
+Branch: substrate-contrib/w3-104
+Repro test: jstests/noPassthrough/slow_query_log_keys_examined_negative.js
+
+## Symptom
+
+Slow-query log lines (parsed via `lv` / `lq`) display
+`keysExamined: NumberLong("-...")` and `docsExamined: NumberLong("-...")`.
+Raw log text in a plain editor renders the same field as a large positive
+NumberLong, because `lv` / `lq` reinterpret the BSON int64 as a signed
+JavaScript bigint and the high bit is set. Customer-facing artifact is the
+negative number; underlying corruption is a uint64 -> int64 narrowing.
+
+## Fix site
+
+`src/mongo/db/op_debug.cpp` -- `OpDebug::AdditiveMetrics::aggregateCursorMetrics`.
+
+Specifically the lossy casts at lines 1741-1742 (and the matching pattern on
+every uint64_t field that follows in that initializer list, through 1771):
+
+    static_cast<uint64_t>(metrics.getKeysExamined()),
+    static_cast<uint64_t>(metrics.getDocsExamined()),
+    ...
+
+These are read into a `query_stats::DataBearingNodeMetrics` whose fields are
+`uint64_t` (see `src/mongo/db/query/query_stats/data_bearing_node_metrics.h`
+lines 45-46). The struct is then handed to
+`aggregateDataBearingNodeMetrics` (op_debug.cpp:1660), which does:
+
+    keysExamined = keysExamined.value_or(0) + metrics.keysExamined;
+    docsExamined = docsExamined.value_or(0) + metrics.docsExamined;
+
+The LHS is `boost::optional<long long>` (declared op_debug.h:172-173), the
+RHS is `uint64_t`. C++ usual arithmetic conversions promote the long long
+to uint64_t, the addition happens in unsigned, and the result is reassigned
+to a long long -- silently reinterpreting the high bit as the sign.
+
+## Two distinct triggering paths
+
+1. **Out-of-range single shard report.** The CursorMetrics IDL field is
+   `long` (`src/mongo/db/query/client_cursor/cursor_response.idl:109-116`),
+   i.e. signed int64. If any code path (uninitialized field decoded from a
+   partial subobject, a future telemetry contributor, a buggy passthrough
+   layer) ever produces a negative wire value, `static_cast<uint64_t>(-1)`
+   evaluates to 2^64 - 1, which the merging accumulator then folds into a
+   long long via the assignment above, instantly flipping the merged value
+   to a large negative number.
+
+2. **Accumulated overflow.** Even with strictly non-negative per-shard
+   inputs, a sufficiently large multi-shard fan-out (large `$lookup`,
+   change-stream merging across many shards, repeated `getMore` rounds in
+   one OpDebug lifetime) can cumulatively cross 2^63 in the uint64_t
+   intermediate. The narrowing-on-assignment then produces a negative
+   long long. This is the path most consistent with the Slack thread:
+   the symptom emerges only on heavy production workloads.
+
+The same `getCursorMetrics` shape exists on the shard side at op_debug.cpp:
+1395-1400 -- `metrics.setKeysExamined(additiveMetrics.keysExamined.value_or(0))`
+takes a long long and writes it through an IDL `long` setter. That direction
+is safe today (signed -> signed) but inherits the same vocabulary mismatch.
+
+## Recommended fix sketch
+
+Keep the on-the-wire CursorMetrics IDL type as `long` (signed) -- changing
+it is an unstable-stability bump but also a wire-compat change we don't
+want here. Instead, fix the narrowing at the accumulation site:
+
+1. **Accumulator type alignment.** Either:
+
+   a. Change `OpDebug::AdditiveMetrics::keysExamined` (and `docsExamined`,
+      and the other numeric fields with this pattern -- see op_debug.h:172
+      onward) to `boost::optional<uint64_t>`, OR
+
+   b. Change `DataBearingNodeMetrics::keysExamined` (and siblings) back to
+      `int64_t` and have `aggregateDataBearingNodeMetrics` clamp negative
+      inputs with a tassert + LOGV2_WARNING; do the addition entirely in
+      signed long long with explicit overflow check (e.g.
+      `mongo::overflow::add`).
+
+   Option (b) is the smaller blast radius for SERVER-115121: it preserves
+   the public-facing log type (BSON int64 / NumberLong) and adds an
+   explicit, observable detection point for the upstream bug that produces
+   a negative wire value.
+
+2. **Input validation at the cast boundary.** In `aggregateCursorMetrics`
+   (op_debug.cpp:1739), tassert that `metrics.getKeysExamined() >= 0` and
+   that `metrics.getKeysExamined() <= INT64_MAX -
+   additiveMetrics.keysExamined.value_or(0)` before the cast. tassert is
+   appropriate since a negative wire value is a bug *somewhere* upstream
+   and we want the SDP to fire rather than silently log a negative.
+
+3. **Idempotent renderer guard.** As belt-and-braces, in
+   `OpDebug::report` / `OPDEBUG_APPEND_OPTIONAL` (op_debug.cpp:635-636 for
+   the BSON path, 336-337 for the structured-log path), assert
+   non-negative before append. This makes the test in this branch fail
+   loudly even if the accumulator regression returns under another guise.
+
+## Test-only failpoint (referenced by the repro)
+
+The behavioral repro in `slow_query_log_keys_examined_negative.js` exercises
+path (2) above with a realistic-but-modest workload (4000 docs across 2
+shards, multiple getMore rounds, $group + $sort + allowDiskUse). The
+appendix at the bottom of that file documents a `injectCursorMetricsForTesting`
+failpoint pattern -- a single `MONGO_FAIL_POINT_DEFINE` in
+`OpDebug::getCursorMetrics` plus a `failpoint.executeIf(...)` block that
+overrides `metrics.setKeysExamined` / `setDocsExamined` with operator-supplied
+values from the failpoint `BSONObj`. Landing that failpoint is a 10-line
+change and makes the overflow path deterministically reproducible in CI
+(via two `NEAR_MAX` per-shard contributions that sum past INT64_MAX on the
+merger).
+
+The fixer is encouraged to land the failpoint as part of the fix PR; the
+behavioral repro stays useful as a non-failpoint guard against the
+out-of-range single-shard-report regression.
+
+## Out of scope for this branch
+
+- The slow-log printers themselves (`lv`, `lq`) are correct -- they print
+  what they parse. No change there.
+- `OpDebug::getCursorMetrics` on the shard side is currently safe
+  (signed-to-signed); revisit if accumulator type is changed in option (1a)
+  above.
+- Query-stats aggregation in `data_bearing_node_metrics.h` shares the same
+  vocabulary mismatch but is keyed on uint64_t throughout -- so its own
+  output is correct; only the bridge into `OpDebug::AdditiveMetrics`
+  exhibits the narrowing bug.
+
+## References
+
+- op_debug.h lines 172-173: `boost::optional<long long> keysExamined; docsExamined;`
+- op_debug.cpp lines 1660-1672: `aggregateDataBearingNodeMetrics` (the assignment)
+- op_debug.cpp lines 1739-1772: `aggregateCursorMetrics` (the cast)
+- data_bearing_node_metrics.h lines 45-46, 90-92, 154-156:
+    uint64_t field decl, `add()`, and `aggregateCursorMetrics()`
+- cursor_response.idl lines 105-116: wire-type declaration (signed `long`)
+- op_debug.cpp lines 1395-1400: `getCursorMetrics` (shard outbound, signed)

--- a/jstests/noPassthrough/slow_query_log_keys_examined_negative.js
+++ b/jstests/noPassthrough/slow_query_log_keys_examined_negative.js
@@ -1,0 +1,170 @@
+/**
+ * SERVER-115121 repro: keysExamined / docsExamined render as negative values in
+ * mongod slow-query logs when the merging shard / mongos accumulates per-shard
+ * CursorMetrics via OpDebug::AdditiveMetrics::aggregateCursorMetrics().
+ *
+ * Root cause (see SERVER-115121-DESIGN.md sibling file in this branch):
+ *
+ *   src/mongo/db/op_debug.cpp:1741-1742
+ *       static_cast<uint64_t>(metrics.getKeysExamined())
+ *
+ *   The CursorMetrics IDL field is `long` (signed int64). aggregateCursorMetrics
+ *   casts to `uint64_t`, hands it to DataBearingNodeMetrics (which stores
+ *   uint64_t fields), then op_debug.cpp:1662 does
+ *
+ *       keysExamined = keysExamined.value_or(0) + metrics.keysExamined;
+ *
+ *   where the LHS is boost::optional<long long> and the RHS is uint64_t. The
+ *   addition is performed in uint64_t arithmetic and silently reassigned to a
+ *   long long, so any cumulative sum >= 2^63 reappears with the sign bit set.
+ *   The raw mongod log encodes the BSON int64 correctly, but `lq`/`lv` parsers
+ *   render the high-bit-set value as a NumberLong with a leading minus -- which
+ *   is precisely the symptom in the Slack thread linked from the ticket
+ *   description (lv/lq vs text-editor disparity).
+ *
+ *   The same cast pattern also corrupts the value immediately if any shard ever
+ *   reports a transient negative `keysExamined` (e.g. an un-set IDL field that
+ *   was decoded from a malformed/empty subobject as -1): static_cast<uint64_t>
+ *   of a negative signed long produces ~2^64, which then gets summed back into
+ *   the merging accumulator and flipped to a large negative long long on the
+ *   final assignment.
+ *
+ * This test stands up a 2-shard sharded cluster, configures profiling so the
+ * mongos's accumulated metrics are written to its slow-query log, runs a
+ * fan-out aggregation that exercises the merge-cursor / getMore path
+ * (DocumentSourceMergeCursors -> aggregateCursorMetrics) repeatedly, and then
+ * parses the resulting slow-query log line. The invariant checked is the only
+ * one the customer cares about: keysExamined and docsExamined are non-negative
+ * integers in the rendered log.
+ *
+ * Pre-fix: test FAILS once the merging accumulator either (a) observes a
+ *   negative per-shard CursorMetrics field (the un-set-field path), or
+ *   (b) crosses 2^63 cumulatively across many getMore rounds.
+ * Post-fix: test PASSES because the accumulator never narrows a uint64_t into
+ *   a signed long long, and out-of-range shard inputs are rejected explicitly.
+ *
+ * NOTE for the eventual fixer: the documented behavioral repro below uses a
+ * realistic-but-modest workload. The 2^63 wrap is not directly synthesizable
+ * with real documents -- to exercise that branch in CI you will want to add
+ * a `MONGO_FAIL_POINT_DEFINE(injectCursorMetricsForTesting)` in
+ * src/mongo/db/op_debug.cpp::OpDebug::getCursorMetrics() that lets the test
+ * stuff a chosen long value into the outbound CursorMetrics on the shard
+ * side; the matching test stanza is sketched at the bottom of this file.
+ *
+ * @tags: [
+ *   requires_sharding,
+ *   requires_profiling,
+ * ]
+ */
+import {ShardingTest} from "jstests/libs/shardingtest.js";
+import {findMatchingLogLine} from "jstests/libs/log.js";
+
+const st = new ShardingTest({mongos: 1, shards: 2, rs: {nodes: 1}});
+
+const mongos = st.s0;
+const dbName = "server115121";
+const collName = "kx_dx_negative_repro";
+const db = mongos.getDB(dbName);
+const coll = db.getCollection(collName);
+
+// Shard the collection so the aggregation actually fans out and the mongos
+// must accumulate per-shard CursorMetrics via aggregateCursorMetrics().
+assert.commandWorked(mongos.adminCommand({enableSharding: dbName}));
+assert.commandWorked(
+    mongos.adminCommand({shardCollection: `${dbName}.${collName}`, key: {_id: "hashed"}}));
+
+// Enough docs to force multiple getMore rounds per shard at the default batch
+// size; each getMore round re-enters aggregateCursorMetrics on the mongos.
+const N = 4000;
+const bulk = coll.initializeUnorderedBulkOp();
+for (let i = 0; i < N; ++i) {
+    bulk.insert({_id: i, a: i % 17, payload: "x".repeat(64)});
+}
+assert.commandWorked(bulk.execute());
+
+// Force the mongos to log every command so the merge-cursor path's accumulated
+// metrics land in the slow-query log we will parse below.
+assert.commandWorked(db.adminCommand({profile: 0, slowms: -1}));
+for (const shard of [st.rs0.getPrimary(), st.rs1.getPrimary()]) {
+    assert.commandWorked(shard.getDB(dbName).runCommand({profile: 0, slowms: -1}));
+}
+
+const comment = "server115121-keys-examined-negative-repro";
+
+// Aggregation crafted to look at every shard, examine many index keys and
+// documents per shard, and produce multiple getMore rounds at the merge cursor.
+// $group with $sum forces full consumption; the {a: {$gte: 0}} predicate
+// guarantees a non-empty plan summary so per-shard CursorMetrics.keysExamined
+// and CursorMetrics.docsExamined are populated.
+const pipeline = [
+    {$match: {a: {$gte: 0}}},
+    {$group: {_id: "$a", n: {$sum: 1}, blob: {$push: "$payload"}}},
+    {$sort: {_id: 1}},
+];
+
+const cursor = coll.aggregate(pipeline, {comment: comment, allowDiskUse: true, batchSize: 32});
+// Drain so all getMore rounds fire and the mongos finalizes its OpDebug.
+assert.gt(cursor.itcount(), 0);
+
+const globalLog = assert.commandWorked(db.adminCommand({getLog: "global"}));
+const line = findMatchingLogLine(globalLog.log, {msg: "Slow query", comment: comment});
+assert(line, `Slow query log line not found for comment ${comment}`);
+
+jsTestLog("Mongos slow-query log line for SERVER-115121 repro:\n" + line);
+
+// Parse keysExamined / docsExamined out of the log line. The exact JSON
+// rendering of NumberLong differs across log formats; cover both the
+// JSON-line form (`"keysExamined":N`) and the legacy form (`keysExamined:N`),
+// allowing an optional leading minus -- that minus is the symptom we are
+// here to fail on.
+function parseMetric(name) {
+    const re = new RegExp(`["']?${name}["']?\\s*:\\s*(-?\\d+)`);
+    const m = line.match(re);
+    assert(m, `Could not locate ${name} in slow-query log line:\n${line}`);
+    return parseInt(m[1], 10);
+}
+
+const keysExamined = parseMetric("keysExamined");
+const docsExamined = parseMetric("docsExamined");
+
+jsTestLog(`Parsed keysExamined=${keysExamined}, docsExamined=${docsExamined}`);
+
+// THE INVARIANT. Both must be non-negative on the merging side.
+assert.gte(keysExamined,
+           0,
+           `SERVER-115121: keysExamined is negative (${keysExamined}) in slow-query log -- ` +
+               `uint64_t -> long long narrowing in OpDebug::AdditiveMetrics::aggregateCursorMetrics. ` +
+               `Full log line:\n${line}`);
+assert.gte(docsExamined,
+           0,
+           `SERVER-115121: docsExamined is negative (${docsExamined}) in slow-query log -- ` +
+               `uint64_t -> long long narrowing in OpDebug::AdditiveMetrics::aggregateCursorMetrics. ` +
+               `Full log line:\n${line}`);
+
+// Sanity: with N docs across 2 shards, every doc was examined at least once.
+assert.gte(docsExamined,
+           N,
+           `docsExamined (${docsExamined}) below floor N=${N}; the aggregation ` +
+               `did not actually fan out -- adjust the pipeline before declaring this passes.`);
+
+st.stop();
+
+/*
+ * APPENDIX -- direct overflow stanza (depends on adding a failpoint in
+ *             OpDebug::getCursorMetrics on the shard side; see SERVER-115121-
+ *             DESIGN.md "Test-only failpoint" section). Once that failpoint
+ *             lands, the following block deterministically triggers the
+ *             uint64 -> long long sign-bit flip with a single getMore round:
+ *
+ *   const NEAR_MAX = NumberLong("9223372036854775000");  // INT64_MAX - 807
+ *   for (const shard of [st.rs0.getPrimary(), st.rs1.getPrimary()]) {
+ *       assert.commandWorked(shard.adminCommand({
+ *           configureFailPoint: "injectCursorMetricsForTesting",
+ *           mode: "alwaysOn",
+ *           data: {keysExamined: NEAR_MAX, docsExamined: NEAR_MAX},
+ *       }));
+ *   }
+ *   // ... rerun the aggregate above. The two NEAR_MAX values, summed by
+ *   // mongos via aggregateCursorMetrics, overflow on the second shard's
+ *   // contribution and reappear as a large negative NumberLong in the log.
+ */


### PR DESCRIPTION
## Summary

jstest + design: slow-query-log keysExamined negative pin.

**Jira:** https://jira.mongodb.org/browse/SERVER-126675
**Branch:** substrate-contrib/w3-104

## Files

```
  - jstests/noPassthrough/SERVER-115121-DESIGN.md      | 139 +++++++++++++++++
  - .../slow_query_log_keys_examined_negative.js       | 170 +++++++++++++++++++++
  - 2 files changed, 309 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
