### PR TITLE
SERVER-126676 jstest + design: queryStats write-latency vs execMicros at router

### DIFF
--- a/jstests/noPassthrough/query/queryStats/query_stats_write_latency_vs_exec_router.js
+++ b/jstests/noPassthrough/query/queryStats/query_stats_write_latency_vs_exec_router.js
@@ -1,0 +1,259 @@
+/**
+ * SERVER-119312: pin the corrected query stats metric semantics for writes on the router.
+ *
+ * Today, on the router, `lastExecutionMicros` and `totalExecMicros` are emitted for write
+ * shapes as the *batch* duration (the router does not yet time individual ops in a batched
+ * write) with pauses subtracted (via `elapsedTimeExcludingPauses`). Both choices are
+ * misleading for write SLOs: pause-subtraction makes the number neither the user-perceived
+ * latency nor the per-shard execution time, and per-batch stamping inflates `totalExecMicros.sum`
+ * roughly linearly in batch size.
+ *
+ * This jstest pins three invariants of the redefined semantics described in
+ * `src/mongo/db/query/query_stats/SERVER-119312-DESIGN.md`:
+ *
+ *   1. boundary tags `executionTimeBoundary` and `routerLatencySource` are present on
+ *      router-side write shapes;
+ *   2. per-shape `.max` wall latency >= per-shape `.max` exec time;
+ *   3. when a single client batch contains multiple ops of the same shape, the wall-latency
+ *      aggregation increments once per batch (not once per op).
+ *
+ * Until the implementation lands, the new fields are absent and the boundary-tag and
+ * cardinality assertions skip themselves. The shape of the test stays stable so the
+ * implementation diff is local. The "latency >= exec" invariant is asserted only when the
+ * new field is present (otherwise there is no second number to compare against).
+ *
+ * @tags: [requires_fcv_90]
+ */
+import {after, before, beforeEach, describe, it} from "jstests/libs/mochalite.js";
+import {getLatestQueryStatsEntry, resetQueryStatsStore} from "jstests/libs/query/query_stats_utils.js";
+import {ShardingTest} from "jstests/libs/shardingtest.js";
+
+// True when the SERVER-119312 redefinition is live and entries carry the boundary tag.
+function hasRedefinition(entry) {
+    return entry &&
+        entry.metrics &&
+        typeof entry.metrics.executionTimeBoundary === "string";
+}
+
+// Return the AggregatedMetric for router latency, or null if not yet emitted.
+function routerLatencyAggregated(entry) {
+    if (!entry || !entry.metrics) {
+        return null;
+    }
+    return entry.metrics.routerLatencyMicros || null;
+}
+
+describe("SERVER-119312 query stats router write latency vs exec semantics", function () {
+    let st;
+    let mongos;
+    let testDB;
+
+    before(function () {
+        const queryStatsParams = {
+            internalQueryStatsWriteCmdSampleRate: 1,
+        };
+        st = new ShardingTest({
+            shards: 2,
+            mongosOptions: {setParameter: queryStatsParams},
+            rsOptions: {setParameter: queryStatsParams},
+        });
+        mongos = st.s;
+        testDB = mongos.getDB("test");
+        assert.commandWorked(
+            testDB.adminCommand({enableSharding: testDB.getName(), primaryShard: st.shard0.shardName}),
+        );
+    });
+
+    after(function () {
+        st?.stop();
+    });
+
+    beforeEach(function () {
+        resetQueryStatsStore(mongos, "1MB");
+    });
+
+    describe("router-side write shape", function () {
+        const collName = jsTestName() + "_router_write";
+        let coll;
+
+        before(function () {
+            coll = testDB[collName];
+            // Targeted shard-key writes: keeps the wall time predictable and avoids the
+            // two-phase / WCOS / StaleConfig paths that have separate metric-propagation gaps.
+            st.shardColl(coll, {_id: 1}, {_id: 0}, {_id: 0});
+        });
+
+        beforeEach(function () {
+            assert.commandWorked(coll.deleteMany({}));
+            assert.commandWorked(
+                coll.insertMany([
+                    {_id: -2, v: 1},
+                    {_id: -1, v: 2},
+                    {_id: 1, v: 3},
+                    {_id: 2, v: 4},
+                ]),
+            );
+        });
+
+        // INVARIANT 1: boundary tags are present on router-side write shapes.
+        //
+        // Skips itself when the new fields are not yet emitted, so the test is harmless on
+        // pre-redefinition builds. Becomes a hard assertion once
+        // featureFlagQueryStatsRouterWriteLatency is on by default.
+        it("should tag the boundary of lastExecutionMicros and routerLatencyMicros", function () {
+            const result = assert.commandWorked(
+                testDB.runCommand({
+                    update: collName,
+                    updates: [{q: {_id: 1}, u: {$set: {v: 100}}, multi: false}],
+                    comment: "boundary tag check",
+                }),
+            );
+            assert.eq(result.nModified, 1);
+
+            const entry = getLatestQueryStatsEntry(testDB.getMongo(), {collName: coll.getName()});
+            assert.eq(entry.key.queryShape.command, "update");
+            assert.gt(entry.metrics.lastExecutionMicros, 0);
+
+            if (!hasRedefinition(entry)) {
+                jsTestLog(
+                    "SERVER-119312 redefinition not live on this build; skipping boundary-tag assertions. " +
+                    "Update consumers when featureFlagQueryStatsRouterWriteLatency flips on.",
+                );
+                return;
+            }
+
+            // executionTimeBoundary documents the aggregation boundary of the legacy
+            // lastExecutionMicros / totalExecMicros fields on this shape.
+            assert.eq(
+                "clientBatch",
+                entry.metrics.executionTimeBoundary,
+                "executionTimeBoundary should be 'clientBatch' until SERVER-121325 introduces " +
+                    "per-op timing on the router for batched writes",
+            );
+
+            // routerLatencySource documents the boundary of the new routerLatencyMicros
+            // aggregation: one sample per client batched command, not per op-index.
+            assert.eq("clientBatch", entry.metrics.routerLatencySource);
+
+            const routerLatency = routerLatencyAggregated(entry);
+            assert.neq(null, routerLatency, "routerLatencyMicros should be present when redefinition is live");
+            for (const field of ["sum", "max", "min", "sumOfSquares"]) {
+                assert(routerLatency.hasOwnProperty(field), "routerLatencyMicros missing field " + field);
+            }
+
+            assert.gt(entry.metrics.lastRouterLatencyMicros, 0);
+        });
+
+        // INVARIANT 2: per-shape wall latency >= per-shape pause-subtracted exec time.
+        //
+        // Asserted only on `.max` (the only AggregatedMetric field that is meaningfully
+        // comparable across shapes without a per-batch label channel). Skips when the new
+        // field is absent.
+        it("should report routerLatencyMicros >= totalExecMicros on .max", function () {
+            // Drive a handful of identical-shape writes so AggregatedMetric.max stabilises.
+            for (let i = 0; i < 5; i++) {
+                assert.commandWorked(
+                    testDB.runCommand({
+                        update: collName,
+                        updates: [{q: {_id: 1}, u: {$set: {v: 100 + i}}, multi: false}],
+                        comment: "latency vs exec",
+                    }),
+                );
+            }
+
+            const entry = getLatestQueryStatsEntry(testDB.getMongo(), {collName: coll.getName()});
+            assert.gte(entry.metrics.execCount, 5);
+
+            const routerLatency = routerLatencyAggregated(entry);
+            if (routerLatency === null) {
+                jsTestLog(
+                    "routerLatencyMicros not yet emitted on this build; skipping latency >= exec " +
+                    "assertion (SERVER-119312 Phase 2 not yet landed).",
+                );
+                return;
+            }
+
+            const totalExec = entry.metrics.totalExecMicros;
+            // Wall latency includes any pauses that elapsedTimeExcludingPauses subtracts, so
+            // for any individual op latency >= exec; the same holds for the per-shape max.
+            assert.gte(
+                routerLatency.max,
+                totalExec.max,
+                "routerLatencyMicros.max should be >= totalExecMicros.max; got " +
+                    tojson({routerLatency: routerLatency, totalExec: totalExec}),
+            );
+        });
+
+        // INVARIANT 3: when a single client batch contains multiple ops of the same shape,
+        // routerLatencyMicros accumulates once per batch while totalExecMicros / execCount
+        // accumulate once per op. Pins the aggregation-boundary distinction.
+        it("should aggregate routerLatencyMicros per batch, not per op", function () {
+            assert.commandWorked(
+                testDB.runCommand({
+                    update: collName,
+                    updates: [
+                        {q: {_id: 1}, u: {$set: {v: 1001}}, multi: false},
+                        {q: {_id: 2}, u: {$set: {v: 1002}}, multi: false},
+                    ],
+                    comment: "two-op batch",
+                }),
+            );
+
+            const entryAfterOne = getLatestQueryStatsEntry(testDB.getMongo(), {collName: coll.getName()});
+            const execAfterOne = entryAfterOne.metrics.execCount;
+            const routerLatencyAfterOne = routerLatencyAggregated(entryAfterOne);
+
+            // Same-shape two-op batch a second time, so we have two batches' worth of samples.
+            assert.commandWorked(
+                testDB.runCommand({
+                    update: collName,
+                    updates: [
+                        {q: {_id: 1}, u: {$set: {v: 2001}}, multi: false},
+                        {q: {_id: 2}, u: {$set: {v: 2002}}, multi: false},
+                    ],
+                    comment: "two-op batch",
+                }),
+            );
+
+            const entryAfterTwo = getLatestQueryStatsEntry(testDB.getMongo(), {collName: coll.getName()});
+            const execAfterTwo = entryAfterTwo.metrics.execCount;
+            const routerLatencyAfterTwo = routerLatencyAggregated(entryAfterTwo);
+
+            // execCount grows by 2 per batch (one per op of this shape).
+            assert.eq(
+                execAfterTwo - execAfterOne,
+                2,
+                "execCount should grow by ops-in-batch (2), got " + (execAfterTwo - execAfterOne),
+            );
+
+            if (routerLatencyAfterOne === null || routerLatencyAfterTwo === null) {
+                jsTestLog(
+                    "routerLatencyMicros not yet emitted; skipping per-batch aggregation assertion " +
+                    "(SERVER-119312 Phase 2 not yet landed).",
+                );
+                return;
+            }
+
+            // The router-latency aggregation should grow by exactly one sample per batch.
+            // AggregatedMetric does not expose a count directly, but `.sum` is the running
+            // total of samples, so sum grows by exactly one batch-duration per batch — i.e.
+            // (sum_after_two - sum_after_one) should be a single sample's value, plausibly
+            // close to lastRouterLatencyMicros from the second batch. We assert the weaker
+            // structural property: sum grew by a value that is consistent with one sample,
+            // not two. Two-op batches that took T each would give sum-delta = T (good) under
+            // per-batch aggregation, vs sum-delta = 2T under per-op aggregation.
+            const sumDelta = routerLatencyAfterTwo.sum - routerLatencyAfterOne.sum;
+            const lastSample = entryAfterTwo.metrics.lastRouterLatencyMicros;
+            // sumDelta should equal exactly one sample (the second batch's latency),
+            // which the runtime exposes as lastRouterLatencyMicros.
+            assert.eq(
+                NumberLong(sumDelta).toString(),
+                NumberLong(lastSample).toString(),
+                "routerLatencyMicros.sum should grow by exactly one sample per batch; got delta=" +
+                    sumDelta +
+                    ", lastSample=" +
+                    lastSample,
+            );
+        });
+    });
+});

--- a/src/mongo/db/query/query_stats/SERVER-119312-DESIGN.md
+++ b/src/mongo/db/query/query_stats/SERVER-119312-DESIGN.md
@@ -1,0 +1,231 @@
+# SERVER-119312: Redefining `lastExecutionMicros` and `totalExecMicros` for router-side writes
+
+Status: design proposal, scoped to query stats observability semantics.
+Priority: Critical - P2.
+Epic: SPM-4598.
+Team: Query Integration.
+
+## 1. Problem statement
+
+The query stats store exposes two timing fields per query shape:
+
+- `lastExecutionMicros` — last execution time, in microseconds.
+- `totalExecMicros` — `AggregatedMetric<uint64_t>` (sum / max / min / sumOfSquares) of
+  execution time, in microseconds, across every execution of the shape.
+
+For queries (find, agg, count, distinct, etc.) these fields have a clean operational
+meaning: a query is executed exactly once per request, the timer is the per-op
+`AdditiveMetrics::executionTime` set in `CurOp::finishCurOp` (which already excludes
+pauses via `CurOp::elapsedTimeExcludingPauses()`), and the captured snapshot is
+written to `lastExecutionMicros` / aggregated into `totalExecMicros` via
+`updateStatistics` in `src/mongo/db/query/query_stats/query_stats.cpp`.
+
+For **writes on a router**, the same fields are misleading along two independent
+axes:
+
+1. **No per-op time exists on the router.** A single `update` / `delete` / `insert`
+   client command can carry multiple ops in `updates[]` / `deletes[]` /
+   `documents[]`. The router holds one `OpDebug::AdditiveMetrics::executionTime`
+   for the whole command — it does **not** time each op individually. The
+   per-op-index `QueryStatsInfo` slot in
+   `OpDebug::_queryStatsInfoForBatchWrites` carries its own
+   `AdditiveMetrics`, but `executionTime` on that per-op slot is currently set
+   from `CurOp::elapsedTimeExcludingPauses()` at end-of-op (see
+   `CurOp::setEndOfOpMetricsForBatchWrites` in `src/mongo/db/curop.cpp`) — i.e.
+   every op in the batch is stamped with the *whole-command* elapsed time. As
+   a result, `lastExecutionMicros` for a shape that fired N times in a batch
+   currently reflects N copies of the same whole-command duration, and
+   `totalExecMicros.sum` for a single client batch grows roughly linearly in the
+   number of ops in that batch, with each summand being the *batch* duration,
+   not the op duration. See README.md row 169–171 for the existing
+   not-quite-honest description.
+
+2. **"Execution time" subtracts pauses.** `CurOp::elapsedTimeExcludingPauses()` deducts
+   intervals during which the op was explicitly paused (e.g. yield points). On the
+   router, the user-perceived dimension is **wall latency** — the interval from
+   the moment the router receives the batched request to the moment it sends the
+   response, *including* any pauses (network round-trips to shards, retries on
+   StaleConfig, sub-transaction handling for WouldChangeOwningShard, etc.).
+   Pause-subtraction makes a router-side execution-time number that is neither
+   the user-perceived latency *nor* the actual shard execution time.
+
+The combined effect: on the router, `lastExecutionMicros` and `totalExecMicros`
+for a write shape are **simultaneously misleading on naming, on aggregation
+boundary, and on definition.**
+
+## 2. Surface area
+
+In code (read-only):
+
+- `src/mongo/db/query/query_stats/query_stats_entry.h:229,239` — field declarations.
+- `src/mongo/db/query/query_stats/query_stats_entry.cpp:48,50` — `toBSON` emit names.
+- `src/mongo/db/query/query_stats/query_stats.cpp:342,346` — `updateStatistics`
+  writes both fields from `QueryStatsSnapshot::queryExecMicros`.
+- `src/mongo/db/query/query_stats/query_stats.h:239` — `queryExecMicros` snapshot
+  field; sourced from `AdditiveMetrics::executionTime` in `captureMetrics`
+  (`query_stats.cpp:554`).
+- `src/mongo/db/curop.cpp:587` — `setEndOfOpMetricsForBatchWrites` stamps
+  per-op-index slots in `OpDebug::_queryStatsInfoForBatchWrites` from
+  `elapsedTimeExcludingPauses`.
+- `src/mongo/db/op_debug.h:575–649` — per-op-index `QueryStatsInfo` plumbing for
+  batched writes on the router.
+- `src/mongo/db/commands/query_cmd/write_commands.cpp:567–587` — router collects
+  `write_ops::QueryStatsMetrics` (per-op-index + per-op `CursorMetrics`) from
+  shards and surfaces them in the update/delete/insert reply.
+
+In observability surfaces:
+
+- `$queryStats` aggregation stage output. Today emits raw
+  `lastExecutionMicros` / `totalExecMicros` for write shapes with no
+  distinguishing flag.
+- README.md row 169–172 already notes "for writes, sum of execution time of all
+  ops in client batch" — i.e. the misleading aggregation boundary is documented
+  but not corrected.
+
+## 3. Proposed metric semantics
+
+Adopt the framing already suggested in the Jira description: include **both**
+a latency view (no pause subtraction, router-bounded) and an
+execution-time view (pause-subtracted, op-bounded if available, else marked as
+batch-bounded). Surface this only for shapes whose first-seen command was a
+write driven by a router; do not change query (find/agg/count/distinct)
+semantics.
+
+### 3.1 Field set
+
+For router-side writes a query stats entry's `metrics` document will
+additionally include:
+
+| Field                       | Type                          | Definition |
+|-----------------------------|-------------------------------|------------|
+| `routerLatencyMicros`       | `AggregatedMetric<uint64_t>`  | Wall-clock interval from router receiving the batched command to router sending the response. Does NOT subtract pauses. One sample per client batch (not per op in the batch). |
+| `lastRouterLatencyMicros`   | `uint64_t`                    | The latest `routerLatencyMicros` sample. |
+| `routerLatencySource`       | string (`"clientBatch"`)      | Documents the aggregation boundary — one sample per client batched command, **not** per op-index. |
+| `executionTimeBoundary`     | string (`"clientBatch"` / `"op"`) | Documents the boundary the existing `lastExecutionMicros` / `totalExecMicros` were captured over. Today on the router for writes this is `"clientBatch"`. When SERVER-121325 lands and per-op timing exists, this flips to `"op"` and the existing field semantics become correct without renaming. |
+
+The existing `lastExecutionMicros` and `totalExecMicros` keep their names but
+their **meaning** is now disambiguated by `executionTimeBoundary`. They
+continue to record what they record today — that is, the
+`elapsedTimeExcludingPauses` value the per-op-index slot was stamped with
+in `setEndOfOpMetricsForBatchWrites` — but consumers no longer have to guess
+whether the duration is op-bounded or batch-bounded.
+
+### 3.2 Where the latency sample comes from
+
+The router-side wall latency for a batched write is the duration between
+`OpDebug` start (when the command enters the router) and the moment the router
+finalizes its reply. This is the *same* `elapsedTimeTotal` that already exists
+on `CurOp` (vs. `elapsedTimeExcludingPauses`); we sample it once per client
+batch, attached to the per-op-index slot of the *first* op-index in the batch
+(i.e. the slot that drives the query stats entry for this shape today).
+
+Aggregation strategy: `AggregatedMetric<uint64_t>::aggregate` is called once per
+client batch — not once per op in the batch — so that `routerLatencyMicros.sum`
+across N client batches equals the sum of N wall-latency samples, and
+`routerLatencyMicros.max` is the worst observed batch latency. This is the
+natural denominator for "p99 router-side write latency for this shape."
+
+### 3.3 Why not just rename / redefine in place
+
+Renaming `lastExecutionMicros` and `totalExecMicros` would be a breaking change
+for every dashboard, BIC pipeline, and Atlas surface consuming `$queryStats`
+today. The proposal preserves the names but adds an honest companion field plus
+boundary tags. This is the pattern README.md already uses for cursor metrics
+("Some metrics computed on the router are sourced differently from those on
+shards" — row 160).
+
+### 3.4 What the consumer sees
+
+For a query shape that has only ever been seen on a router as part of a write,
+`$queryStats` will return:
+
+```json
+{
+  "key": {...},
+  "metrics": {
+    "execCount": 17,
+    "lastExecutionMicros": NumberLong(842),
+    "totalExecMicros": { "sum": NumberLong(15410), "max": NumberLong(2103), ... },
+    "executionTimeBoundary": "clientBatch",
+    "routerLatencyMicros": { "sum": NumberLong(28800), "max": NumberLong(4801), ... },
+    "lastRouterLatencyMicros": NumberLong(2901),
+    "routerLatencySource": "clientBatch",
+    ...
+  }
+}
+```
+
+The boundary tag makes the existing fields' provenance machine-readable;
+`routerLatencyMicros` gives consumers the wall-latency view they actually want
+for write SLOs.
+
+## 4. What we are NOT solving here
+
+- We are not introducing per-op timing on the router. That belongs to SERVER-121325
+  (and the related family of "double-count" / "WouldChangeOwningShard metrics
+  not propagated" bugs). When that lands, the only diff to this design is
+  flipping `executionTimeBoundary: "clientBatch"` → `"op"` for write shapes,
+  which is a one-line change in `updateStatistics`.
+
+- We are not changing query-side (find/agg/count/distinct) semantics.
+  Those shapes never go through `_queryStatsInfoForBatchWrites`; the new
+  fields are emitted only when the entry's first-seen command was a router-side
+  write, gated by `includeWriteMetrics` in `QueryStatsEntry::toBSON`.
+
+- We are not addressing `firstResponseExecMicros`. That field is cursor-shaped
+  ("time to first batch") and has no analog for writes; today it is emitted as
+  zero for write shapes and the README documents it as such.
+
+## 5. Test plan
+
+A new jstest, `jstests/noPassthrough/query/queryStats/query_stats_write_latency_vs_exec_router.js`,
+pins three properties end-to-end on a `ShardingTest`:
+
+1. **Boundary tag is present and consistent.** Every `$queryStats` entry whose
+   key encodes an update/delete/insert command, surfaced via mongos, carries
+   `executionTimeBoundary` and `routerLatencySource` strings.
+
+2. **`routerLatencyMicros` ≥ `totalExecMicros` per-batch.** For a single client
+   command, the wall latency must equal or exceed the pause-subtracted exec time
+   (latency is the bigger bowl). We assert this on `.max` field-to-field, since
+   `.max` is the only `AggregatedMetric` field that is comparable per-shape
+   without a per-batch labeling channel.
+
+3. **Aggregation boundary differs.** When a single client batch contains
+   multiple ops of the same shape (e.g. two `updateOne`s with identical query
+   shape after normalization), `totalExecMicros.sum` is consistent with the
+   number of ops in the batch (i.e. multiple summands; the existing
+   batch-stamped behaviour), while `routerLatencyMicros.sum` increments by
+   exactly one sample per *batch*. Asserted via `execCount` deltas and
+   counts of distinct AggregatedMetric samples (sum/count ratio).
+
+The jstest exercises the targeted-single-shard fan-out path (the common router
+write path) to keep wall time predictable and avoids the StaleConfig / WCOS
+paths that today have their own TODO-tracked metric gaps.
+
+## 6. Rollout
+
+- Phase 1 (this design + jstest): doc the corrected semantics, pin the
+  invariants in a jstest. The jstest skips its boundary assertions when
+  the new fields are absent so it stays green on builds that do not yet ship
+  the implementation.
+- Phase 2 (separate ticket): plumb `routerLatencyMicros` capture and
+  `executionTimeBoundary` tagging through `QueryStatsSnapshot`,
+  `updateStatistics`, and `QueryStatsEntry::toBSON`. Gate behind a new
+  feature flag `featureFlagQueryStatsRouterWriteLatency`.
+- Phase 3: drop the skip in the jstest, flip the feature flag on by default,
+  update the README.md table row 169–172 to refer to the boundary tag.
+
+## 7. Open questions
+
+- Should `executionTimeBoundary` also be emitted for query (non-write) shapes
+  as `"op"` for symmetry / forward-compat? Default is no — only emit for
+  writes, since the absence of the tag on query shapes is itself the contract
+  ("query shapes have always been op-bounded"). Reversible later.
+
+- Aggregation boundary for ordered vs. unordered batched writes: today both
+  share the per-op-index slot machinery (`_queryStatsInfoForBatchWrites`); the
+  proposal aggregates `routerLatencyMicros` once per client batch in both
+  cases. If ordered batches grow short-circuit semantics that cause the router
+  to send back early, the latency sample remains correct (it is whatever the
+  router observed end-to-end).


### PR DESCRIPTION
## Summary

jstest + design: queryStats write-latency vs execMicros at router.

**Jira:** https://jira.mongodb.org/browse/SERVER-126676
**Branch:** substrate-contrib/w3-105

## Files

```
  - .../query_stats_write_latency_vs_exec_router.js    | 259 +++++++++++++++++++++
  - .../db/query/query_stats/SERVER-119312-DESIGN.md   | 231 ++++++++++++++++++
  - 2 files changed, 490 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
