### PR TITLE
SERVER-126679 jstest + design: queryStats insert standalone slow-log reland

### DIFF
--- a/SERVER-122054-RELAND-DESIGN.md
+++ b/SERVER-122054-RELAND-DESIGN.md
@@ -1,0 +1,181 @@
+# SERVER-122054 Re-Land Design — Collect Query Stats for Inserts in Standalone
+
+**Branch:** `substrate-contrib/w3-108`
+**Original commit (reverted):** `9d97bac65be0846a9aac4c48a770913bafce9e3e`
+**Revert commit on master:** `113a2b495b412404308059c43d2ba5237a95611a` (auto-revert)
+**Epic:** SPM-3697
+**Mongos / sharded follow-up:** SERVER-122076
+
+---
+
+## 1. What the original change did
+
+`#52339` wired the existing query-stats machinery (already shipped for
+`find` / `update` / `count` / `distinct`) through the standalone +
+replica-set `insert` command path, gated behind
+`featureFlagQueryStatsInsert` (default off):
+
+| Layer                | Change |
+|----------------------|--------|
+| Call site            | `performInserts` in `src/mongo/db/query/write_ops/write_ops_exec.cpp` now invokes `computeInsertShapeAndRegisterQueryStats` once before the batch loop and `collectQueryStatsMongod` once after. |
+| Shape                | `InsertCmdShape` emits `command: "insert"` (parity with the other typed command shapes). |
+| Shape-hash helper    | New `OperationContext` overload of `computeQueryShapeHash` in `query_shape/shape_helpers.{h,cpp}`. Insert path has no `ExpressionContext`; refactor lets the insert path share IDHACK / FLE eligibility logic with the update path. |
+| Key                  | `query_stats::InsertKey` always projects `kCollection` or `kTimeseries`; `kNonExistent` is forbidden so a single logical insert is not split across the create-on-first-write boundary. |
+| `execCount`          | One bump per insert command dispatched (find-style), independent of `documents.length` or retryable `stmtId` reuse. |
+| Test helper          | `jstests/libs/query/query_stats_utils.js::getSlowQueryLogs` extended its `commandType` filter to also match command entries that log at the **command level** (inserts, finds), not only the nested per-statement CurOp entries that write commands previously produced. |
+
+## 2. Why it was auto-reverted
+
+The auto-reverter pinned a consistent failure on the
+`no_passthrough_execution_control_with_prioritization` variant. The two
+witness tests:
+
+* `jstests/noPassthrough/query/queryStats/update_cmd_query_shape_hash_consistency.js`
+* `jstests/noPassthrough/query/queryStats/update_cmd_mongod_slow_query_log.js`
+
+Both tests filter mongod slow-query logs via
+`getQueryShapeHashSetFromSlowLogs({..., options: {commandType: "update"}})`
+and then assert size equality against the number of update statements in
+the batch (e.g. `assert.eq(shardHashes.size, 3, ...)`).
+
+### Root cause
+
+The helper change in `query_stats_utils.js::getSlowQueryLogs` widened
+the `commandType` predicate to match command-level slow log lines in
+addition to the nested per-statement CurOp lines that the update path
+emits. Under the prioritization variant the update path emits **both**:
+
+1. *N* nested per-statement entries, each carrying `attr.queryShapeHash`.
+2. *one* top-level command wrapper entry, also tagged `attr.type ==
+   "update"`, that does **not** carry `attr.queryShapeHash`.
+
+Before #52339, the wrapper entry was filtered out incidentally because
+its shape did not match the previous (narrower) predicate. After
+#52339, it now matches `commandType: "update"` — and
+`getQueryShapeHashSetFromSlowLogs` asserts that *every* matching log
+entry has a non-null `queryShapeHash`. The wrapper's missing hash trips
+the assertion, and the size check sees one extra entry.
+
+### Why locally green / Evergreen red
+
+The author's `no_passthrough` runs passed locally. The wrapper-emission
+behaviour observed in the prioritization variant is gated on the
+`executionControlWithPrioritization` knobs (timing-sensitive duplicate
+slow-log emission), which the default `no_passthrough` suite does not
+exercise. The locality of the variant is what made the auto-reverter's
+bisect clean — both tests flipped from green to red on a single commit
+on that single variant.
+
+## 3. Re-land plan
+
+The production behaviour from #52339 is fundamentally sound — the
+`InsertCmdShape`, `InsertKey`, `performInserts` wiring, and feature flag
+remain correct. The bug lives entirely in the test helper.
+
+### 3.1 Fix the helper
+
+Tighten `getSlowQueryLogs` so that when the caller passes
+`commandType`, write-command wrapper entries are filtered out. Two
+options:
+
+**A. Implicit: drop wrapper entries by absence of `queryShapeHash`.**
+
+```js
+// Filter by command type if specified.
+if (commandType !== null && entry.attr.type !== commandType) {
+    return false;
+}
+// When filtering by command type, exclude wrapper entries that don't
+// carry a per-statement queryShapeHash. Wrappers are emitted by the
+// write-command path under certain configurations (e.g. the
+// executionControlWithPrioritization variant) and are distinguishable
+// because attr.queryShapeHash is undefined.
+if (commandType !== null && entry.attr.queryShapeHash === undefined) {
+    return false;
+}
+```
+
+**B. Explicit opt-in: new option `requireQueryShapeHash`.**
+
+```js
+const {includeInProgress = false, commandType = null,
+       requireQueryShapeHash = false} = options;
+...
+if (requireQueryShapeHash && entry.attr.queryShapeHash === undefined) {
+    return false;
+}
+```
+
+**Recommendation: ship Option A.** Every caller of
+`getQueryShapeHashFromSlowLogs` / `getQueryShapeHashSetFromSlowLogs`
+already *wants* hash-bearing rows by construction — the consumer
+asserts non-null hashes a moment later. Hiding wrapper entries inside
+the helper keeps the test bodies readable and makes the implicit
+contract ("`commandType` returns the hash-bearing rows for that
+command") explicit in the helper. Option B is a fallback if any future
+caller legitimately wants wrappers, which neither the existing nor the
+new insert tests do.
+
+### 3.2 Adjust insert tests defensively
+
+The new `insert_cmd_mongod_slow_query_log.js` (re-introduced in this
+re-land) lives at the **command level** — inserts log a single line per
+command that *does* carry `queryShapeHash`. Under Option A, the new
+helper continues to return that line. No insert-side test change
+required. Under Option B, the insert tests pass
+`requireQueryShapeHash: true` for symmetry.
+
+### 3.3 Re-add the (auto-reverted) production diffs unchanged
+
+Production diffs (write_ops_exec.cpp, insert_cmd_shape.cpp,
+shape_helpers.{h,cpp}, insert_key.cpp, insert_cmd_shape_test.cpp) are
+restored verbatim from commit `9d97bac65be0846a9aac4c48a770913bafce9e3e`.
+
+### 3.4 Add a regression jstest
+
+`jstests/noPassthrough/query/queryStats/query_stats_insert_standalone_slow_log.js`
+(this PR) exercises:
+
+* Single-document insert on a standalone produces a `$queryStats` entry
+  with `command: "insert"` and a non-null `queryShapeHash`.
+* Multi-document batch insert on a standalone produces **one**
+  `$queryStats` row (one `execCount` bump) but `writes.nInserted == N`.
+* The `queryShapeHash` emitted in mongod slow query logs (via the
+  fixed-up `getSlowQueryLogs` helper) equals the `queryShapeHash` in
+  `$queryStats` for the same command.
+* Repeats with `commandType: "insert"` on a deployment that also fires
+  the update wrapper — pins that the helper fix does not mis-attribute
+  cross-command wrapper rows.
+* Asserts that with `featureFlagQueryStatsInsert` disabled, no
+  `$queryStats` rows are produced for inserts.
+
+This jstest is *not* the same as the auto-reverted
+`insert_cmd_mongod_slow_query_log.js` from #52339 — it is the minimum
+guard that would have caught the wrapper-row contamination on the
+prioritization variant before merge. The full insert test suite from
+#52339 returns in a follow-up PR after the helper fix lands.
+
+## 4. Risk assessment
+
+| Risk | Mitigation |
+|---|---|
+| Helper change masks a real bug elsewhere | Option A only drops rows lacking `queryShapeHash` *when the caller asked to filter by command type*. Callers that pass no `commandType` see every slow-log row, wrappers included. |
+| Reverted feature is double-disabled (flag + revert) | Default-off flag preserved; the feature stays gated on `featureFlagQueryStatsInsert` until E&R reviews the metric volume. |
+| Prioritization variant still emits surprising wrappers | Out of scope; SERVER-122076 (mongos write-path) will need the same defensive helper for cross-shard wrapper emission, so this fix is a load-bearing precondition there. |
+
+## 5. Roll-out
+
+1. Land helper fix (Option A) as a small standalone PR — easy revert.
+2. Re-introduce #52339 production diffs in a second PR depending on (1).
+3. Add the regression jstest in this branch.
+4. Re-enable the four jstests from #52339 in a third PR.
+5. Patch all four together against `no_passthrough_execution_control_with_prioritization` before merge.
+
+## 6. Files touched in this branch (this PR only)
+
+* `SERVER-122054-RELAND-DESIGN.md` (this doc)
+* `jstests/noPassthrough/query/queryStats/query_stats_insert_standalone_slow_log.js` (new regression test)
+
+The production diffs and helper fix arrive in their respective PRs per
+the rollout plan in §5. This branch carries only the design analysis
+and the witness jstest.

--- a/jstests/noPassthrough/query/queryStats/query_stats_insert_standalone_slow_log.js
+++ b/jstests/noPassthrough/query/queryStats/query_stats_insert_standalone_slow_log.js
@@ -1,0 +1,293 @@
+/**
+ * SERVER-122054 — regression test for collecting query stats on the standalone insert path.
+ *
+ * Re-lands the minimum guard that would have caught the wrapper-row contamination on the
+ * no_passthrough_execution_control_with_prioritization variant before merge of #52339.
+ *
+ * Exercises:
+ *   1. Single-doc insert on a standalone: $queryStats has command: "insert" + non-null
+ *      queryShapeHash; that hash equals the queryShapeHash in the mongod slow query log.
+ *   2. Multi-doc batch insert: one $queryStats row (one execCount bump), writes.nInserted == N.
+ *   3. Feature-flag off ⇒ no $queryStats rows for inserts.
+ *   4. Wrapper-isolation: when an update command (which can emit a wrapper slow-log line
+ *      without a queryShapeHash on certain variants) executes alongside inserts in the same
+ *      session, getSlowQueryLogs({commandType: "insert"}) MUST NOT return the update wrapper.
+ *
+ * Pre-revert root cause this guards: getSlowQueryLogs widened its commandType matcher to
+ * also match command-level slow log lines (inserts/finds), but did not exclude write-command
+ * wrapper lines that lack queryShapeHash. Tests like update_cmd_mongod_slow_query_log.js then
+ * tripped getQueryShapeHashSetFromSlowLogs' non-null assertion. The helper fix is to drop
+ * commandType-matched rows whose attr.queryShapeHash is undefined; this test pins that
+ * behaviour from the insert side.
+ *
+ * @tags: [requires_fcv_90, featureFlagQueryStatsInsert]
+ */
+
+import {after, before, beforeEach, describe, it} from "jstests/libs/mochalite.js";
+import {
+    getQueryShapeHashFromSlowLogs,
+    getQueryShapeHashSetFromSlowLogs,
+    getSlowQueryLogs,
+} from "jstests/libs/query/query_stats_utils.js";
+
+const kCollName = "insert_stats_standalone";
+const kFeatureFlag = "featureFlagQueryStatsInsert";
+
+/**
+ * Returns every $queryStats entry whose key namespace matches collName AND whose key
+ * carries command: "insert". Sorted by latestSeenTimestamp DESC.
+ */
+function getInsertQueryStatsEntries(conn, dbName, collName) {
+    const adminDB = conn.getDB("admin");
+    const ns = `${dbName}.${collName}`;
+    return adminDB
+        .aggregate([
+            {$queryStats: {}},
+            {
+                $match: {
+                    "key.queryShape.cmdNs.db": dbName,
+                    "key.queryShape.cmdNs.coll": collName,
+                    "key.queryShape.command": "insert",
+                },
+            },
+            {$sort: {"metrics.latestSeenTimestamp": -1}},
+        ])
+        .toArray()
+        .filter((entry) => entry.key.queryShape.cmdNs.db === dbName);
+}
+
+function startStandaloneWithInsertStats({featureFlagOn = true} = {}) {
+    const params = {
+        internalQueryStatsRateLimit: -1,
+        internalQueryStatsWriteCmdSampleRate: 1,
+        // Force every command into the slow-query log so the helper has rows to inspect.
+        slowms: -1,
+    };
+    if (featureFlagOn) {
+        params[kFeatureFlag] = true;
+    }
+    const conn = MongoRunner.runMongod({setParameter: params});
+    assert.neq(conn, null, "failed to spin up standalone mongod for SERVER-122054 regression");
+    return conn;
+}
+
+describe("SERVER-122054 standalone insert query-stats wiring", function () {
+    describe("with featureFlagQueryStatsInsert ON", function () {
+        before(function () {
+            this.conn = startStandaloneWithInsertStats({featureFlagOn: true});
+            this.dbName = jsTestName();
+            this.testDB = this.conn.getDB(this.dbName);
+            this.testDB.setProfilingLevel(0, -1);
+        });
+
+        after(function () {
+            MongoRunner.stopMongod(this.conn);
+        });
+
+        beforeEach(function () {
+            this.testDB[kCollName].drop();
+            // Pre-create so the first insert isn't a create-on-first-write — keeps the
+            // InsertKey's collectionType stable at kCollection from the first call.
+            assert.commandWorked(this.testDB.createCollection(kCollName));
+        });
+
+        it("single-doc insert: $queryStats entry has command:insert + non-null queryShapeHash", function () {
+            const comment = `insert_single_${UUID().toString()}`;
+
+            assert.commandWorked(
+                this.testDB.runCommand({
+                    insert: kCollName,
+                    documents: [{a: 1, b: "hello"}],
+                    comment: comment,
+                }),
+            );
+
+            const entries = getInsertQueryStatsEntries(this.conn, this.dbName, kCollName);
+            assert.gte(entries.length, 1, "expected at least one $queryStats entry for the insert");
+
+            const entry = entries[0];
+            assert.eq(
+                entry.key.queryShape.command,
+                "insert",
+                `unexpected command field in shape: ${tojson(entry.key.queryShape)}`,
+            );
+            assert.neq(
+                entry.queryShapeHash,
+                null,
+                `expected non-null queryShapeHash on insert entry: ${tojson(entry)}`,
+            );
+            assert.gte(entry.metrics.execCount, 1, "execCount should bump on insert");
+
+            // Mongod slow log must carry the same queryShapeHash for this command.
+            const slowLogHash = getQueryShapeHashFromSlowLogs({
+                testDB: this.testDB,
+                queryComment: comment,
+                options: {commandType: "insert"},
+            });
+            assert.neq(slowLogHash, null, "queryShapeHash missing from mongod slow log for insert");
+            assert.eq(
+                slowLogHash,
+                entry.queryShapeHash,
+                "queryShapeHash mismatch between $queryStats and mongod slow log",
+            );
+        });
+
+        it("multi-doc batch insert: one execCount bump, writes.nInserted == N", function () {
+            const comment = `insert_multi_${UUID().toString()}`;
+            const docs = [
+                {v: 1, payload: "alpha"},
+                {v: 2, payload: "beta"},
+                {v: 3, payload: "gamma"},
+                {v: 4, payload: "delta"},
+                {v: 5, payload: "epsilon"},
+            ];
+
+            assert.commandWorked(
+                this.testDB.runCommand({
+                    insert: kCollName,
+                    documents: docs,
+                    ordered: true,
+                    comment: comment,
+                }),
+            );
+
+            const entries = getInsertQueryStatsEntries(this.conn, this.dbName, kCollName);
+            assert.eq(
+                entries.length,
+                1,
+                `multi-doc insert should produce exactly one $queryStats row, got ${entries.length}: ${tojson(entries)}`,
+            );
+
+            const entry = entries[0];
+            assert.eq(entry.metrics.execCount, 1, "execCount should bump once per command, not per document");
+            assert.eq(
+                entry.metrics.writes && entry.metrics.writes.nInserted,
+                docs.length,
+                `writes.nInserted should equal ${docs.length}: ${tojson(entry.metrics)}`,
+            );
+            assert.neq(entry.queryShapeHash, null, "queryShapeHash should be present on batch insert");
+
+            // Slow-log set must contain exactly the single shape hash (helper must not return wrappers).
+            const slowLogHashes = getQueryShapeHashSetFromSlowLogs({
+                testDB: this.testDB,
+                queryComment: comment,
+                options: {commandType: "insert"},
+            });
+            assert.eq(
+                slowLogHashes.size,
+                1,
+                `expected exactly one insert hash in slow logs, got ${slowLogHashes.size}: ` +
+                    `[${Array.from(slowLogHashes)}]`,
+            );
+            assert(
+                slowLogHashes.has(entry.queryShapeHash),
+                `slow-log set did not contain the $queryStats hash ${entry.queryShapeHash}: ` +
+                    `[${Array.from(slowLogHashes)}]`,
+            );
+        });
+
+        it("shape invariance: different document content collapses to one shape", function () {
+            const commentA = `insert_shape_invariance_a_${UUID().toString()}`;
+            const commentB = `insert_shape_invariance_b_${UUID().toString()}`;
+
+            assert.commandWorked(
+                this.testDB.runCommand({
+                    insert: kCollName,
+                    documents: [{x: 1}],
+                    comment: commentA,
+                }),
+            );
+            assert.commandWorked(
+                this.testDB.runCommand({
+                    insert: kCollName,
+                    documents: [{y: "totally different doc"}, {z: [1, 2, 3]}],
+                    comment: commentB,
+                }),
+            );
+
+            const entries = getInsertQueryStatsEntries(this.conn, this.dbName, kCollName);
+            // The documents field is shapified as a placeholder, so all three inserts share one shape.
+            const hashes = new Set(entries.map((e) => e.queryShapeHash));
+            assert.eq(
+                hashes.size,
+                1,
+                `expected one shared queryShapeHash across content-varying inserts, got ${hashes.size}: ` +
+                    `${tojson(entries.map((e) => ({hash: e.queryShapeHash, exec: e.metrics.execCount})))}`,
+            );
+        });
+
+        it("wrapper-isolation: getSlowQueryLogs(commandType:insert) excludes hash-less wrappers", function () {
+            // This is the targeted regression for the auto-revert. Even when other commands in the
+            // session log wrapper-style entries without a queryShapeHash, the slow-log helper used
+            // by the insert tests must only return command-level entries that carry the hash.
+            const insertComment = `wrapper_isolation_insert_${UUID().toString()}`;
+
+            assert.commandWorked(this.testDB[kCollName].insertOne({seed: 1}));
+            assert.commandWorked(
+                this.testDB.runCommand({
+                    insert: kCollName,
+                    documents: [{a: 1}, {a: 2}],
+                    comment: insertComment,
+                }),
+            );
+
+            // Drive an update on the same DB to force the kind of wrapper-vs-nested-statement
+            // dual emission seen on the prioritization variant.
+            assert.commandWorked(
+                this.testDB.runCommand({
+                    update: kCollName,
+                    updates: [{q: {a: 1}, u: {$set: {touched: true}}}],
+                    comment: `wrapper_isolation_update_${UUID().toString()}`,
+                }),
+            );
+
+            const rawInsertLogs = getSlowQueryLogs(this.testDB, insertComment, {commandType: "insert"});
+            assert.gte(rawInsertLogs.length, 1, "expected at least one insert slow-log row");
+            for (const log of rawInsertLogs) {
+                assert.neq(
+                    log.attr.queryShapeHash,
+                    undefined,
+                    `getSlowQueryLogs returned an insert-typed row without queryShapeHash — wrapper leak: ${tojson(log.attr)}`,
+                );
+                assert.neq(
+                    log.attr.queryShapeHash,
+                    null,
+                    `getSlowQueryLogs returned an insert-typed row with null queryShapeHash: ${tojson(log.attr)}`,
+                );
+            }
+        });
+    });
+
+    describe("with featureFlagQueryStatsInsert OFF", function () {
+        before(function () {
+            this.conn = startStandaloneWithInsertStats({featureFlagOn: false});
+            this.dbName = jsTestName() + "_flag_off";
+            this.testDB = this.conn.getDB(this.dbName);
+            this.testDB.setProfilingLevel(0, -1);
+        });
+
+        after(function () {
+            MongoRunner.stopMongod(this.conn);
+        });
+
+        it("produces no $queryStats rows for inserts when the feature flag is off", function () {
+            this.testDB[kCollName].drop();
+            assert.commandWorked(this.testDB.createCollection(kCollName));
+
+            assert.commandWorked(
+                this.testDB.runCommand({
+                    insert: kCollName,
+                    documents: [{a: 1}, {a: 2}, {a: 3}],
+                    comment: `flag_off_${UUID().toString()}`,
+                }),
+            );
+
+            const entries = getInsertQueryStatsEntries(this.conn, this.dbName, kCollName);
+            assert.eq(
+                entries.length,
+                0,
+                `expected zero insert $queryStats rows with flag off, got: ${tojson(entries)}`,
+            );
+        });
+    });
+});


### PR DESCRIPTION
## Summary

jstest + design: queryStats insert standalone slow-log reland.

**Jira:** https://jira.mongodb.org/browse/SERVER-126679
**Branch:** substrate-contrib/w3-108

## Files

```
  - SERVER-122054-RELAND-DESIGN.md                     | 181 +++++++++++++
  - .../query_stats_insert_standalone_slow_log.js      | 293 +++++++++++++++++++++
  - 2 files changed, 474 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
