### PR TITLE
SERVER-126680 jstest: queryStats insert command sharded coverage

### DIFF
--- a/jstests/sharding/queryStats/BUILD.bazel
+++ b/jstests/sharding/queryStats/BUILD.bazel
@@ -1,0 +1,12 @@
+load("//bazel:mongo_js_rules.bzl", "all_subpackage_javascript_files", "mongo_js_library")
+
+package(default_visibility = ["//visibility:public"])
+
+mongo_js_library(
+    name = "all_javascript_files",
+    srcs = glob([
+        "*.js",
+    ]),
+)
+
+all_subpackage_javascript_files()

--- a/jstests/sharding/queryStats/query_stats_insert_cmd_sharded.js
+++ b/jstests/sharding/queryStats/query_stats_insert_cmd_sharded.js
@@ -1,0 +1,393 @@
+/**
+ * Tests that query stats are collected for `insert` commands that go through mongos on a sharded
+ * cluster. Exercises the sharded write-path wiring tracked in SERVER-122076, follow-up to the
+ * standalone / replica-set wiring landed in SERVER-122054.
+ *
+ * Invariants under test:
+ *   - Exactly one `$queryStats` entry per `insert` command on the router, regardless of fan-out.
+ *   - `execCount` increments once per top-level insert command (find-style invocation count),
+ *     never per document and never per internal mongos retry.
+ *   - The `queryShapeHash` recorded on the router equals the hash recorded on each participating
+ *     shard, so cluster-wide aggregation collapses to one logical entry per shape.
+ *   - StaleConfig retries internal to mongos do not double-count on either router or shard.
+ *   - Retryable inserts (`lsid` + `txnNumber`) keep the one-command / one-execution invariant.
+ *
+ * @tags: [
+ *   featureFlagQueryStatsInsert,
+ *   requires_fcv_90,
+ *   requires_sharding,
+ * ]
+ */
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {after, before, beforeEach, describe, it} from "jstests/libs/mochalite.js";
+import {
+    assertAggregatedMetricsSingleExec,
+    assertExpectedResults,
+    getLatestQueryStatsEntry,
+    getQueryStats,
+    resetQueryStatsStore,
+} from "jstests/libs/query/query_stats_utils.js";
+import {ShardingTest} from "jstests/libs/shardingtest.js";
+
+const kQueryStatsServerParams = {
+    internalQueryStatsRateLimit: -1,
+    internalQueryStatsWriteCmdSampleRate: 1,
+};
+
+/**
+ * Local helper — the standalone PR's `getQueryStatsInsertCmd` lives in `query_stats_utils.js` on
+ * a parallel branch; until that helper lands here, filter by command shape directly. Mirrors the
+ * structure of `getQueryStatsUpdateCmd`.
+ */
+function getInsertEntries(conn, collName) {
+    return getQueryStats(conn, {
+        extraMatch: {
+            "key.queryShape.command": "insert",
+            "key.queryShape.cmdNs.coll": collName,
+        },
+    });
+}
+
+describe("query stats insert command metrics (sharded)", function () {
+    let st;
+    let mongos;
+    let testDB;
+
+    before(function () {
+        st = new ShardingTest({
+            shards: 2,
+            mongos: 1,
+            mongosOptions: {setParameter: kQueryStatsServerParams},
+            rsOptions: {setParameter: kQueryStatsServerParams},
+        });
+        mongos = st.s;
+        testDB = mongos.getDB("test");
+        assert.commandWorked(
+            testDB.adminCommand({enableSharding: testDB.getName(), primaryShard: st.shard0.shardName}),
+        );
+    });
+
+    after(function () {
+        st?.stop();
+    });
+
+    beforeEach(function () {
+        resetQueryStatsStore(mongos, "1MB");
+        resetQueryStatsStore(st.shard0, "1MB");
+        resetQueryStatsStore(st.shard1, "1MB");
+    });
+
+    // Unsharded collection on a sharded cluster: every insert lands on the primary shard, but the
+    // command still flows through the router and must register a single router-side entry.
+    describe("unsharded collection on sharded cluster", function () {
+        const collName = jsTestName() + "_unsharded";
+        let coll;
+
+        before(function () {
+            coll = testDB[collName];
+        });
+
+        beforeEach(function () {
+            coll.drop();
+        });
+
+        it("should record a single-doc insert once on the router", function () {
+            assert.commandWorked(testDB.runCommand({
+                insert: collName,
+                documents: [{v: 1}],
+                comment: "unsharded single-doc",
+            }));
+
+            const entry = getLatestQueryStatsEntry(mongos, {collName: coll.getName()});
+            assert.eq(entry.key.queryShape.command, "insert");
+
+            assertAggregatedMetricsSingleExec(entry, {
+                keysExamined: 0,
+                docsExamined: 0,
+                hasSortStage: false,
+                usedDisk: false,
+                fromMultiPlanner: false,
+                fromPlanCache: false,
+                writes: {nMatched: 0, nUpserted: 0, nModified: 0, nDeleted: 0, nInserted: 1, nUpdateOps: 0},
+            });
+            assertExpectedResults({
+                results: entry,
+                expectedQueryStatsKey: entry.key,
+                expectedExecCount: 1,
+                expectedDocsReturnedSum: 0,
+                expectedDocsReturnedMax: 0,
+                expectedDocsReturnedMin: 0,
+                expectedDocsReturnedSumOfSq: 0,
+            });
+        });
+
+        it("should record a multi-doc insert once on the router with summed nInserted", function () {
+            assert.commandWorked(testDB.runCommand({
+                insert: collName,
+                documents: [{v: 1}, {v: 2}, {v: 3}],
+                comment: "unsharded multi-doc",
+            }));
+
+            const entry = getLatestQueryStatsEntry(mongos, {collName: coll.getName()});
+            assert.eq(entry.key.queryShape.command, "insert");
+
+            assertAggregatedMetricsSingleExec(entry, {
+                keysExamined: 0,
+                docsExamined: 0,
+                hasSortStage: false,
+                usedDisk: false,
+                fromMultiPlanner: false,
+                fromPlanCache: false,
+                writes: {nMatched: 0, nUpserted: 0, nModified: 0, nDeleted: 0, nInserted: 3, nUpdateOps: 0},
+            });
+            assertExpectedResults({
+                results: entry,
+                expectedQueryStatsKey: entry.key,
+                expectedExecCount: 1,
+                expectedDocsReturnedSum: 0,
+                expectedDocsReturnedMax: 0,
+                expectedDocsReturnedMin: 0,
+                expectedDocsReturnedSumOfSq: 0,
+            });
+        });
+    });
+
+    // Sharded collection where every document in a batch targets a single shard.
+    describe("sharded collection — single-shard target", function () {
+        const collName = jsTestName() + "_single_shard";
+        let coll;
+
+        before(function () {
+            coll = testDB[collName];
+            // Shard on {_id: 1}; split at 0 and move the upper chunk to shard1.
+            st.shardColl(coll, {_id: 1}, {_id: 0}, {_id: 0});
+        });
+
+        beforeEach(function () {
+            assert.commandWorked(coll.deleteMany({}));
+        });
+
+        it("should record one entry for a batch that targets only shard0", function () {
+            assert.commandWorked(testDB.runCommand({
+                insert: collName,
+                documents: [{_id: -1}, {_id: -2}, {_id: -3}],
+                comment: "single-shard target shard0",
+            }));
+
+            const entries = getInsertEntries(mongos, collName);
+            assert.eq(entries.length, 1, "Expected 1 mongos entry: " + tojson(entries));
+            assert.eq(entries[0].metrics.execCount, 1);
+
+            assertAggregatedMetricsSingleExec(entries[0], {
+                keysExamined: 0,
+                docsExamined: 0,
+                hasSortStage: false,
+                usedDisk: false,
+                fromMultiPlanner: false,
+                fromPlanCache: false,
+                writes: {nMatched: 0, nUpserted: 0, nModified: 0, nDeleted: 0, nInserted: 3, nUpdateOps: 0},
+            });
+        });
+
+        it("should produce identical queryShapeHash on router and on the targeted shard", function () {
+            assert.commandWorked(testDB.runCommand({
+                insert: collName,
+                documents: [{_id: -10}],
+                comment: "shape-hash equality probe",
+            }));
+
+            const routerEntries = getInsertEntries(mongos, collName);
+            const shard0Entries = getInsertEntries(st.shard0, collName);
+
+            assert.eq(routerEntries.length, 1, "router entries: " + tojson(routerEntries));
+            assert.eq(shard0Entries.length, 1, "shard0 entries: " + tojson(shard0Entries));
+
+            // The queryShapeHash is the load-bearing identity for cross-cluster aggregation:
+            // it must be identical on router and shard for `$queryStats` to collapse to one
+            // logical entry per shape across the deployment.
+            assert.eq(
+                routerEntries[0].key.queryShape,
+                shard0Entries[0].key.queryShape,
+                "router and shard0 must register identical insert query shape",
+            );
+        });
+    });
+
+    // Sharded collection where one batch fans out to both shards. The router must record exactly
+    // one entry with execCount=1 even though two shards each see an insert sub-batch.
+    describe("sharded collection — multi-shard fan-out", function () {
+        const collName = jsTestName() + "_fan_out";
+        let coll;
+
+        before(function () {
+            coll = testDB[collName];
+            st.shardColl(coll, {_id: 1}, {_id: 0}, {_id: 0});
+        });
+
+        beforeEach(function () {
+            assert.commandWorked(coll.deleteMany({}));
+        });
+
+        it("should record one router-side entry with execCount=1 for a fan-out batch", function () {
+            assert.commandWorked(testDB.runCommand({
+                insert: collName,
+                documents: [
+                    {_id: -2},
+                    {_id: -1},
+                    {_id: 1},
+                    {_id: 2},
+                ],
+                comment: "fan-out across two shards",
+            }));
+
+            const routerEntries = getInsertEntries(mongos, collName);
+            assert.eq(routerEntries.length, 1, "Expected exactly 1 router entry: " + tojson(routerEntries));
+            assert.eq(routerEntries[0].metrics.execCount, 1, "execCount must be 1 — one command, one invocation");
+
+            assertAggregatedMetricsSingleExec(routerEntries[0], {
+                keysExamined: 0,
+                docsExamined: 0,
+                hasSortStage: false,
+                usedDisk: false,
+                fromMultiPlanner: false,
+                fromPlanCache: false,
+                writes: {nMatched: 0, nUpserted: 0, nModified: 0, nDeleted: 0, nInserted: 4, nUpdateOps: 0},
+            });
+
+            // Each shard sees its half of the batch as a single sub-insert, so each shard
+            // records execCount=1 with nInserted=2.
+            const shard0Entries = getInsertEntries(st.shard0, collName);
+            const shard1Entries = getInsertEntries(st.shard1, collName);
+            assert.eq(shard0Entries.length, 1, "shard0 entries: " + tojson(shard0Entries));
+            assert.eq(shard1Entries.length, 1, "shard1 entries: " + tojson(shard1Entries));
+            assert.eq(shard0Entries[0].metrics.execCount, 1);
+            assert.eq(shard1Entries[0].metrics.execCount, 1);
+
+            // All three sites agree on the shape — this is the cluster-wide aggregation guarantee.
+            assert.eq(routerEntries[0].key.queryShape, shard0Entries[0].key.queryShape);
+            assert.eq(routerEntries[0].key.queryShape, shard1Entries[0].key.queryShape);
+        });
+    });
+
+    // StaleConfig retry: when a shard returns StaleConfig on the first attempt, mongos refreshes
+    // routing and re-dispatches internally. The hook lives outside the retry loop, so the router
+    // records exactly one execution.
+    describe("StaleConfig retried insert", function () {
+        const collName = jsTestName() + "_stale_config";
+        let coll;
+        let shard0Primary;
+
+        before(function () {
+            coll = testDB[collName];
+            assert.commandWorked(testDB.adminCommand({shardCollection: coll.getFullName(), key: {_id: 1}}));
+            shard0Primary = st.rs0.getPrimary();
+        });
+
+        beforeEach(function () {
+            assert.commandWorked(coll.deleteMany({}));
+        });
+
+        it("should record exactly one execution despite an internal StaleConfig retry", function () {
+            // Drain pending range deletions so the {times: 1} failpoint fires against the
+            // intended insert command, not a background task. Same pattern as the update test.
+            assert.soon(
+                () => shard0Primary.getDB("config").rangeDeletions.find().itcount() === 0,
+                "Timed out waiting for range deletions on shard0 to complete",
+            );
+
+            const fp = configureFailPoint(shard0Primary, "alwaysThrowStaleConfigInfo", {}, {times: 1});
+
+            const result = assert.commandWorked(testDB.runCommand({
+                insert: collName,
+                documents: [{_id: 1, v: 1}],
+                comment: "StaleConfig retried insert",
+            }));
+            assert.eq(result.n, 1);
+            assert.neq(coll.findOne({_id: 1}), null);
+
+            assert(fp.waitWithTimeout(1000), "alwaysThrowStaleConfigInfo failpoint was never triggered");
+
+            const routerEntries = getInsertEntries(mongos, collName);
+            assert.eq(routerEntries.length, 1, "router entries: " + tojson(routerEntries));
+            assert.eq(routerEntries[0].metrics.execCount, 1, "router execCount must not double-count");
+            assert.eq(routerEntries[0].metrics.writes.nInserted.sum, 1);
+
+            const shardEntries = getInsertEntries(st.shard0, collName);
+            assert.eq(shardEntries.length, 1, "shard entries: " + tojson(shardEntries));
+            assert.eq(shardEntries[0].metrics.execCount, 1, "shard execCount must not double-count");
+            assert.eq(shardEntries[0].metrics.writes.nInserted.sum, 1);
+
+            fp.off();
+        });
+    });
+
+    // Retryable writes through mongos: the same one-command / one-execution invariant must hold,
+    // and the router's record matches the find-style accounting of the standalone PR.
+    describe("retryable inserts through mongos", function () {
+        const collName = jsTestName() + "_retryable";
+        let coll;
+
+        before(function () {
+            coll = testDB[collName];
+            st.shardColl(coll, {_id: 1}, {_id: 0}, {_id: 0});
+        });
+
+        beforeEach(function () {
+            assert.commandWorked(coll.deleteMany({}));
+        });
+
+        it("should record one execution per retryable insert command", function () {
+            const lsid = {id: UUID()};
+            const txnNumber = NumberLong(1);
+
+            const firstCmd = {
+                insert: collName,
+                documents: [{_id: -1, v: 1}, {_id: 1, v: 2}],
+                lsid: lsid,
+                txnNumber: txnNumber,
+                comment: "retryable insert first",
+            };
+
+            const firstResult = assert.commandWorked(testDB.runCommand(firstCmd));
+            assert.eq(firstResult.n, 2);
+
+            let entries = getInsertEntries(mongos, collName);
+            assert.eq(entries.length, 1, "Expected 1 router entry after initial batch: " + tojson(entries));
+            // execCount counts insert commands, not documents — one command = one execution.
+            assert.eq(entries[0].metrics.execCount, 1);
+            assert.eq(entries[0].metrics.writes.nInserted.sum, 2);
+
+            // Retry the same lsid/txnNumber with one new statement appended. StmtIds 0 and 1
+            // are already-executed retries; stmtId 2 is new. The router still treats this as
+            // one command invocation → execCount bumps by 1; nInserted.sum reflects only the
+            // statement that was actually executed.
+            const retryCmd = {
+                insert: collName,
+                documents: [{_id: -1, v: 1}, {_id: 1, v: 2}, {_id: 2, v: 3}],
+                lsid: lsid,
+                txnNumber: txnNumber,
+                comment: "retryable insert first", // identical comment → same shape
+            };
+
+            const retryResult = assert.commandWorked(testDB.runCommand(retryCmd));
+            assert.eq(
+                retryResult.retriedStmtIds,
+                [0, 1],
+                "Expected retriedStmtIds [0, 1]: " + tojson(retryResult.retriedStmtIds),
+            );
+
+            entries = getInsertEntries(mongos, collName);
+            assert.eq(entries.length, 1, "Expected still 1 router entry after partial retry");
+            assert.eq(
+                entries[0].metrics.execCount,
+                2,
+                "execCount should be 2 — one per command, regardless of retry count",
+            );
+            assert.eq(
+                entries[0].metrics.writes.nInserted.sum,
+                3,
+                "nInserted.sum should be 3 — only stmtId 2 was newly inserted on retry",
+            );
+        });
+    });
+});

--- a/src/mongo/db/query/query_stats/README_insert_sharded.md
+++ b/src/mongo/db/query/query_stats/README_insert_sharded.md
@@ -1,0 +1,116 @@
+# Query Stats — Insert Command on Sharded Clusters
+
+This note extends [`README.md`](README.md) (Metric Collection / Adding New Metrics) with the
+design for query-stats collection of the `insert` command on sharded clusters. It captures the
+work tracked in [SERVER-122076][ticket], the follow-up to [SERVER-122054][parent] (which wired
+query stats for inserts on standalone / replica-set deployments).
+
+The entire feature stays guarded by `featureFlagQueryStatsInsert` (default off).
+
+## Background
+
+`SERVER-122054` registers an `InsertCmdShape` and aggregates per-insert metrics on `mongod` via:
+
+1. `write_ops_exec.cpp::performInserts` → `computeInsertShapeAndRegisterQueryStats` (once per
+   command, pre-batch).
+2. `performInserts` → `collectQueryStatsMongod` (once per command, post-batch).
+
+`execCount` bumps **per command dispatched** (find-style semantics), not per statement, matching
+the architectural rule that an `insert` command is one logical invocation that may carry many
+documents and survive partial retryable-write replays.
+
+The standalone PR explicitly leaves the mongos/sharded write path disabled — see the
+`describe.skip("query stats insert command metrics (sharded)")` block in
+`jstests/noPassthrough/query/queryStats/query_stats_insert_cmd_metrics.js`.
+
+## Goals (SERVER-122076)
+
+1. An `insert` command that enters the cluster through `mongos` produces **exactly one**
+   `$queryStats` entry on the router, regardless of whether the underlying batch fans out
+   to one or many shards.
+2. `execCount` on the router increments once per top-level `insert` command, mirroring the
+   standalone semantics. Per-document accounting still flows through `nInserted` aggregates.
+3. The query shape recorded on the router is identical (by `queryShapeHash`) to the shape
+   recorded on every shard that participated in the write — so `$queryStats` aggregation
+   across the cluster collapses to one logical entry per shape.
+4. Internal retries triggered by `StaleConfig`, `MigrationConflict`, `ShardCannotRefreshDueToLocksHeld`,
+   etc., **do not** double-count: the router records one execution per externally-issued
+   command, even if mongos re-dispatched the batch internally.
+5. Encrypted inserts (`wholeOp.getEncryptionInformation()`) and inserts from internal /
+   direct clients continue to bypass shape and stats recording, exactly as in standalone.
+
+## Non-goals
+
+- `bulkWrite` insert ops — tracked separately under the bulkWrite query-stats stack.
+- Time-series inserts on sharded clusters that go through the viewless/bucket rewrites — the
+  shape/key path already handles `kTimeseries` in the standalone PR; sharded targeting of the
+  bucket collection is verified by the new jstest but no new shape work is required.
+- Retryable-write idempotency on the shard side (already pinned by SERVER-122054 unit tests).
+
+## Design
+
+### Router hook site
+
+The mongos insert path runs through the cluster-write command in `src/mongo/s/commands/`
+(cluster_write_cmd / cluster_bulk_write). The pattern mirrors the update wiring:
+
+1. **Pre-dispatch**: at the top of the cluster `insert` command's `_runImpl` (or equivalent),
+   call `computeInsertShapeAndRegisterQueryStats(opCtx, request)`. The OperationContext-only
+   overload of `computeQueryShapeHash` added in SERVER-122054 already covers this — no
+   ExpressionContext is available here, and the IDHACK / FLE short-circuits are not relevant
+   on the router because targeting has not yet run.
+2. **Post-dispatch (success or partial failure)**: after the batch has been dispatched and the
+   reply assembled, call `collectQueryStatsMongos(opCtx, ...)` to materialize the
+   `QueryStatsEntry` on the router's `QueryStatsStore`. This is the same site at which the
+   update path calls into `collectQueryStatsMongos` today.
+3. **Idempotency under retry**: `StaleConfig` retries inside mongos must not bump `execCount`.
+   The hook lives outside the retry loop in the cluster command's outer frame — exactly the
+   shape used by the update wiring tested in `query_stats_update_cmd_metrics_mongos.js`
+   ("StaleConfig retried update" describe block).
+
+### Shape consistency between router and shards
+
+`InsertCmdShape` is constructed purely from `(nss, collectionType, command='insert')` plus
+the shape of the documents array (after FLE / identifier-transform). Because neither the
+router nor the shard rewrites these fields between the cluster command and the per-shard
+`performInserts` call, the `queryShapeHash` is identical on both sides — verified by the
+new jstest asserting equality of `entries[0].key.queryShape` between `mongos` and each
+participating `shard`.
+
+### Encryption / internal-client bypass
+
+`InsertCmdShape` registration is skipped on the router whenever:
+
+- `wholeOp.getEncryptionInformation()` is set (matches mongod), OR
+- the caller is an internal client (existing `Client::isInternalClient()` check on the
+  cluster-command frame), OR
+- the namespace is in the always-skip allowlist (`$queryStats` introspection itself,
+  `local.*`, etc.).
+
+The unsharded case on a mongos-fronted collection still goes through the same hook — the
+router records exactly one entry even though all data lives on the primary shard.
+
+## Test plan
+
+| File | Purpose |
+| --- | --- |
+| `jstests/sharding/queryStats/query_stats_insert_cmd_sharded.js` (this PR) | Per-deployment metric checks: single-doc / multi-doc insert; unsharded collection on a sharded cluster; sharded collection with single-shard-target batch; sharded collection with multi-shard fan-out; retryable-write across mongos; StaleConfig retry idempotency; cluster vs shard shape-hash equality. |
+| `query_stats_insert_command_feature_flag.js` (existing) | Feature flag is present and off-by-default — covers mongos automatically because the flag is a single bool. |
+| `insert_cmd_mongod_slow_query_log.js` (existing) | mongod slow-query log carries `queryShapeHash`. The mongos counterpart for `insert` is filed as a follow-up under SERVER-122076 once the slow-log path is wired; not in scope for this jstest. |
+
+Shape-equality and `execCount` invariants are the load-bearing assertions; metric sums
+(`nInserted`, `keysExamined`, `docsExamined`) follow the standalone PR's accounting and are
+asserted via `assertAggregatedMetricsSingleExec`.
+
+## References
+
+- Parent ticket: [SERVER-122054][parent] — standalone / replica-set wiring (merged, then
+  reverted in `58feea5679`; rolling forward).
+- This ticket: [SERVER-122076][ticket] — sharded write-path wiring.
+- Epic: [SPM-3697][epic].
+- Sibling design: `query_stats_update_cmd_metrics_mongos.js` is the closest pattern for the
+  mongos hook — same StaleConfig / two-phase / retryable-write surfaces apply.
+
+[ticket]: https://jira.mongodb.org/browse/SERVER-122076
+[parent]: https://jira.mongodb.org/browse/SERVER-122054
+[epic]: https://jira.mongodb.org/browse/SPM-3697


### PR DESCRIPTION
## Summary

jstest: queryStats insert command sharded coverage.

**Jira:** https://jira.mongodb.org/browse/SERVER-126680
**Branch:** substrate-contrib/w3-109

## Files

```
  - jstests/sharding/queryStats/BUILD.bazel            |  12 +
  - .../queryStats/query_stats_insert_cmd_sharded.js   | 393 +++++++++++++++++++++
  - .../db/query/query_stats/README_insert_sharded.md  | 116 ++++++
  - 3 files changed, 521 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
