### PR TITLE
SERVER-126681 jstest + design: FTDC connPoolStats parity

### DIFF
--- a/jstests/noPassthrough/ftdc/ftdc_conn_pool_stats_parity.js
+++ b/jstests/noPassthrough/ftdc/ftdc_conn_pool_stats_parity.js
@@ -1,0 +1,88 @@
+/**
+ * SERVER-126178: pin parity between the connPoolStats command and the FTDC
+ * connPoolStats collector. Both surfaces should expose the same top-level
+ * key set, modulo a small list of intentional forks (FTDC drops `hosts` when
+ * forFTDC=true; the command carries the standard reply envelope).
+ *
+ * This test fails today against the pre-unification code because:
+ *   - FTDC reports `mongot` / `searchIndex` and the command does not.
+ *   - The command reports replication-pool counters and FTDC does not (on
+ *     replSet nodes; this test asserts the structural parity on a sharded
+ *     fixture where the gap is observable via the `pools` map).
+ *
+ * After the SERVER-126178 unification this test passes without changes.
+ *
+ * @tags: [requires_sharding, requires_fcv_82]
+ */
+import {verifyGetDiagnosticData} from "jstests/libs/ftdc.js";
+import {ShardingTest} from "jstests/libs/shardingtest.js";
+
+const testPath = MongoRunner.toRealPath("ftdc_parity_dir");
+const st = new ShardingTest({
+    shards: 2,
+    mongos: {
+        s0: {setParameter: {diagnosticDataCollectionDirectoryPath: testPath}},
+    },
+});
+
+const admin = st.s0.getDB("admin");
+
+// Pull both surfaces.
+const cmdReply = assert.commandWorked(admin.runCommand({connPoolStats: 1}));
+const ftdcReply = verifyGetDiagnosticData(admin).connPoolStats;
+
+jsTestLog(`connPoolStats command keys: ${tojson(Object.keys(cmdReply).sort())}`);
+jsTestLog(`FTDC connPoolStats keys:    ${tojson(Object.keys(ftdcReply).sort())}`);
+
+// Keys that legitimately appear only on one side.
+const CMD_ONLY_INTENTIONAL = new Set([
+    "hosts",            // FTDC drops `hosts` when forFTDC=true (pinned by ftdc_connection_pool.js)
+    "ok",               // command reply envelope
+    "$clusterTime",     // command reply envelope
+    "operationTime",    // command reply envelope
+    "$configTime",      // command reply envelope, when present
+    "$topologyTime",    // command reply envelope, when present
+    "lastCommittedOpTime",
+]);
+
+const FTDC_ONLY_INTENTIONAL = new Set([
+    // None today. The whole point of SERVER-126178 is that this set should
+    // stay empty: anything FTDC reports that the command does not is a
+    // divergence we want to surface, not paper over.
+]);
+
+const cmdKeys = new Set(Object.keys(cmdReply));
+const ftdcKeys = new Set(Object.keys(ftdcReply));
+
+const cmdOnly = [...cmdKeys].filter((k) => !ftdcKeys.has(k) && !CMD_ONLY_INTENTIONAL.has(k));
+const ftdcOnly = [...ftdcKeys].filter((k) => !cmdKeys.has(k) && !FTDC_ONLY_INTENTIONAL.has(k));
+
+assert.eq(cmdOnly,
+          [],
+          `connPoolStats command exposes top-level keys that FTDC does not (after ` +
+              `excluding envelope/intentional forks): ${tojson(cmdOnly)}`);
+assert.eq(ftdcOnly,
+          [],
+          `FTDC connPoolStats exposes top-level keys that the command does not: ` +
+              `${tojson(ftdcOnly)}. This is the SERVER-126178 divergence.`);
+
+// Additive parity expectations introduced by SERVER-126178: mongot and
+// searchIndex diagnostics must be reachable from both surfaces. These keys
+// are only present when the corresponding task executors are wired in; on a
+// plain ShardingTest fixture they may or may not exist, so we only assert
+// joint presence (both or neither), never asymmetric presence.
+for (const k of ["mongot", "searchIndex"]) {
+    assert.eq(cmdKeys.has(k),
+              ftdcKeys.has(k),
+              `Asymmetric presence of "${k}" subsection. command=${cmdKeys.has(k)}, ` +
+                  `ftdc=${ftdcKeys.has(k)}. SERVER-126178 requires symmetric emission.`);
+}
+
+// Sanity: shared structural keys remain on both sides. Regression-pins so a
+// future refactor cannot quietly drop one.
+for (const k of ["pools", "replicaSetMonitor", "numClientConnections", "numAScopedConnections"]) {
+    assert(cmdKeys.has(k), `command lost expected key "${k}"`);
+    assert(ftdcKeys.has(k), `FTDC lost expected key "${k}"`);
+}
+
+st.stop();

--- a/src/mongo/db/ftdc/SERVER-126178-conn-pool-stats-unification.md
+++ b/src/mongo/db/ftdc/SERVER-126178-conn-pool-stats-unification.md
@@ -1,0 +1,132 @@
+# SERVER-126178: Unify connPoolStats command and FTDC collector
+
+## Status
+
+Proposal. Targets `Networking & Observability` sprint queue. Owner: Joseph
+Prince. References:
+
+- Command body: `src/mongo/db/commands/conn_pool_stats.cpp` (`PoolStats::run`)
+- FTDC body: `src/mongo/db/ftdc/networking_collectors.cpp` (`ConnPoolStatsCollector::collect`)
+- Adjacent fix that exposed this divergence:
+  [SERVER-125516](https://jira.mongodb.org/browse/SERVER-125516) /
+  [SERVER-126186](https://jira.mongodb.org/browse/SERVER-126186) — search task
+  executor stats had to land in `serverStatus` rather than `connPoolStats`
+  because FTDC's `connPoolStats` collector did not pick them up.
+
+## Problem
+
+The two implementations have drifted. They share `ConnectionPoolStats`,
+`globalConnPool`, and `Grid::getExecutorPool()`, but diverge in five concrete
+ways. The drift is silent: each path compiles, each emits BSON, neither
+references the other, and there is no test that pins them as equivalent
+surfaces.
+
+### Divergence table
+
+| Field / source                                                             | `connPoolStats` command | FTDC `ConnPoolStatsCollector` | Effect |
+| -------------------------------------------------------------------------- | ----------------------- | ----------------------------- | ------ |
+| `globalConnPool.appendConnectionStats(&stats)`                             | yes                     | yes                           | parity |
+| `numClientConnections` / `numAScopedConnections`                           | top-level on `result`   | top-level on FTDC builder     | parity (different builders) |
+| `ReplicationCoordinator::appendConnectionStats` (replSet only)             | yes                     | **missing**                   | FTDC silently omits replication-pool counters on replSet nodes |
+| `Grid::getExecutorPool()->appendConnectionStats`                           | yes (null-checked)      | yes (**not** null-checked)    | FTDC dereferences whatever `getExecutorPool()` returns; brittle if a future grid initialization order leaves it null |
+| `customConnPoolStatsFn` (e.g. search task executors, mongot pool, etc.)    | yes                     | yes                           | parity for the closure path |
+| `stats.appendToBSON(result)` vs `stats.appendToBSON(builder, forFTDC=true)`| `forFTDC=false`         | `forFTDC=true`                | intentional schema fork — FTDC drops `hosts`, keeps aggregates; pinned by existing `ftdc_connection_pool.js` |
+| `ReplicaSetMonitorManager::get()->report(&result)`                         | `forFTDC=false`         | `forFTDC=true`                | intentional, same reason |
+| `appendDiagnosticInfo(builder, "mongot", …)`                               | **missing**             | yes                           | mongot task-executor diagnostics emit to FTDC but **not** to the command |
+| `appendDiagnosticInfo(builder, "searchIndex", …)`                          | **missing**             | yes                           | same — searchIndex diagnostics asymmetric |
+| `ScopedAdmissionPriority(kExempt)`                                         | yes (command priority)  | n/a (FTDC runs out of band)   | not load-bearing for parity |
+
+The two material divergences are: **(A)** the command reports
+`ReplicationCoordinator::appendConnectionStats` and FTDC does not, and **(B)**
+FTDC reports `mongot` / `searchIndex` `appendDiagnosticInfo` subsections and
+the command does not. (A) is the bug that SERVER-126186 routed around by
+moving search-task-executor stats to `serverStatus`. (B) is the reverse-shape
+of the same gap.
+
+## Proposed unification
+
+Introduce a single helper, `appendConnPoolStatsCommon`, in
+`src/mongo/db/ftdc/networking_collectors.{h,cpp}` (header re-exposed; no new
+public package). Signature:
+
+```cpp
+void appendConnPoolStatsCommon(OperationContext* opCtx,
+                               BSONObjBuilder& builder,
+                               bool forFTDC);
+```
+
+Body: every line that is in **both** implementations today, plus the two
+asymmetric blocks gated behind explicit branches so both callers can opt in:
+
+1. `globalConnPool.appendConnectionStats(&stats)`
+2. `numClientConnections` / `numAScopedConnections` (top-level)
+3. `ReplicationCoordinator::appendConnectionStats` — emit on both paths
+4. `Grid::getExecutorPool()->appendConnectionStats` — null-checked on both
+   paths (use the command's existing guard)
+5. `customConnPoolStatsFn`
+6. `stats.appendToBSON(builder, forFTDC)` — `forFTDC` controls the
+   `hosts` / aggregates fork; keeps existing FTDC schema invariant
+7. `ReplicaSetMonitorManager::report(&builder, forFTDC)`
+8. `appendDiagnosticInfo("mongot")` and `appendDiagnosticInfo("searchIndex")`
+   — emit on both paths
+
+After unification:
+
+- `PoolStats::run` calls `appendConnPoolStatsCommon(opCtx, result, false)`
+  and additionally retains the `ScopedAdmissionPriority(kExempt)` wrapper
+  that is command-specific.
+- `ConnPoolStatsCollector::collect` calls
+  `appendConnPoolStatsCommon(opCtx, builder, true)`.
+
+Net effect at the wire: `connPoolStats` command grows `mongot` /
+`searchIndex` subsections it was previously missing (additive); FTDC grows
+the replication-pool counters it was previously missing (additive). No field
+is removed from either surface. The `forFTDC=true` schema fork in
+`stats.appendToBSON` and `ReplicaSetMonitorManager::report` is preserved, so
+existing FTDC consumers see no schema break.
+
+## Rollback
+
+The unification is a refactor over identical helper calls; rollback is
+`git revert` of the single commit that introduces `appendConnPoolStatsCommon`
+plus restoration of the two original function bodies. No data migration, no
+catalog impact, no on-disk format change.
+
+## Test plan
+
+Two layers.
+
+1. **Existing tests must continue to pass**:
+   `jstests/sharding/conn_pool_stats.js` (command-side schema) and
+   `jstests/noPassthrough/ftdc/ftdc_connection_pool.js` (FTDC-side schema,
+   already pins the `hosts`-absent fork — see line 35 of that file).
+
+2. **New parity test**:
+   `jstests/noPassthrough/ftdc/ftdc_conn_pool_stats_parity.js` (added with
+   this design). Runs `connPoolStats` on a mongos, fetches the FTDC
+   `connPoolStats` subobject via `getDiagnosticData`, and asserts that the
+   set of top-level keys in each surface is equal modulo a known
+   intentional-fork list:
+
+   - `hosts` (command only — FTDC drops by design when `forFTDC=true`)
+   - `ok` / `$clusterTime` / `operationTime` (command envelope)
+
+   The test does **not** assert value equality — `numCreated` and friends
+   are point-in-time samples and will differ between the two reads — only
+   key-set equality. Key-set equality is what the bug is about.
+
+   The parity test also asserts that after this change, both surfaces
+   contain `mongot` and `searchIndex` subsections (additive parity), and
+   that both contain `pools` and `replicaSetMonitor` (existing parity that
+   should not regress).
+
+## Non-goals
+
+- Changing the FTDC schema for any field other than the two additive
+  subsections above (`mongot` / `searchIndex`) and the additive
+  replication-pool counters.
+- Touching `NetworkInterfaceStatsCollector` in the same file — it has no
+  command-side twin and is not part of this divergence.
+- Adding the `ScopedAdmissionPriority` priority wrapper to the FTDC path —
+  FTDC's controller already gates collection cadence and operates on its
+  own threads; admission priority is not a shared concern.


### PR DESCRIPTION
## Summary

jstest + design: FTDC connPoolStats parity.

**Jira:** https://jira.mongodb.org/browse/SERVER-126681
**Branch:** substrate-contrib/w3-110

## Files

```
  - .../ftdc/ftdc_conn_pool_stats_parity.js            |  88 ++++++++++++++
  - .../SERVER-126178-conn-pool-stats-unification.md   | 132 +++++++++++++++++++++
  - 2 files changed, 220 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
