### PR TITLE
SERVER-126683 jstest + lib: serverStatus metric-tree fixture

### DIFF
--- a/jstests/libs/server_status_metric_tree.js
+++ b/jstests/libs/server_status_metric_tree.js
@@ -1,0 +1,173 @@
+/**
+ * Test fixture for asserting on the serverStatus MetricTree.
+ *
+ * Motivation (SERVER-125804):
+ *   The C++ side of MetricTree+ServerStatus reads metrics through a static
+ *   `globalMetricTreeSet()` (see src/mongo/db/commands/server_status/server_status_command.cpp
+ *   `treeSet = globalMetricTreeSet()`). Even with the test-only `setTreeSet()` and
+ *   `removeForTests()` hooks on the C++ side, JS integration tests still rely on
+ *   ad-hoc walks like `ss.metrics.repl.network.oplogGetMoresProcessed.num` --
+ *   repetitive, easy to mis-spell, and silently degrade to `undefined` when a
+ *   metric path is renamed or guarded by a feature flag.
+ *
+ *   This module gives jstests a small, typed surface for reading the MetricTree
+ *   over the wire so the brittle bits live in one place. It does NOT mutate the
+ *   server's global tree; it only consumes the serverStatus payload.
+ *
+ * Usage:
+ *   import {
+ *       MetricTreeSnapshot,
+ *       getServerStatusMetric,
+ *       assertMetricPath,
+ *       diffMetricSnapshots,
+ *   } from "jstests/libs/server_status_metric_tree.js";
+ *
+ *   const before = MetricTreeSnapshot.capture(conn);
+ *   // ... drive workload ...
+ *   const after = MetricTreeSnapshot.capture(conn);
+ *   const delta = diffMetricSnapshots(before, after, ["network.numRequests"]);
+ *   assert.gt(delta["network.numRequests"], 0);
+ */
+
+/**
+ * Reads a dot-notation path out of an arbitrary BSON-shaped object. Returns
+ * `undefined` if any path component is missing -- callers decide whether that
+ * means "metric absent" (fine for feature-flagged paths) or "test bug".
+ */
+export function getPath(doc, path) {
+    if (doc === null || doc === undefined) return undefined;
+    let cur = doc;
+    for (const part of path.split(".")) {
+        if (cur === null || typeof cur !== "object" || !cur.hasOwnProperty(part)) {
+            return undefined;
+        }
+        cur = cur[part];
+    }
+    return cur;
+}
+
+/**
+ * Reads a single metric out of a fresh serverStatus call. Thin wrapper so callers
+ * don't repeat the assert.commandWorked + getPath dance.
+ *
+ *   const ops = getServerStatusMetric(conn, "network.numRequests");
+ *
+ * Passing a leading "." anchors the path at the serverStatus root; otherwise the
+ * path is implicitly resolved under "metrics." -- matching the C++ MetricTree
+ * convention documented in server_status_metric.h.
+ */
+export function getServerStatusMetric(conn, path) {
+    const status = assert.commandWorked(conn.adminCommand({serverStatus: 1}));
+    const resolved = path.startsWith(".") ? path.substring(1) : `metrics.${path}`;
+    return getPath(status, resolved);
+}
+
+/**
+ * Asserts that `path` resolves to a non-undefined leaf on the latest serverStatus.
+ * Optional `predicate(value)` lets callers add a shape check in the same call.
+ *
+ *   assertMetricPath(conn, ".network.numRequests", (v) => v >= 0);
+ */
+export function assertMetricPath(conn, path, predicate) {
+    const value = getServerStatusMetric(conn, path);
+    assert.neq(
+        value,
+        undefined,
+        `serverStatus metric "${path}" missing; full path resolution returned undefined`,
+    );
+    if (predicate) {
+        assert(
+            predicate(value),
+            `serverStatus metric "${path}" predicate failed; value=${tojson(value)}`,
+        );
+    }
+    return value;
+}
+
+/**
+ * Captured serverStatus payload + helpers for reading paths off it. The whole
+ * payload is retained so a single capture can answer many path queries without
+ * re-roundtripping to the server.
+ */
+export class MetricTreeSnapshot {
+    constructor(payload) {
+        this._payload = payload;
+    }
+
+    static capture(conn) {
+        return new MetricTreeSnapshot(assert.commandWorked(conn.adminCommand({serverStatus: 1})));
+    }
+
+    /** Returns the raw serverStatus document, for tests that need to escape the helper. */
+    raw() {
+        return this._payload;
+    }
+
+    /**
+     * Returns the value at the given path. Leading "." anchors at the root;
+     * otherwise resolved under "metrics." to mirror C++ MetricTree semantics.
+     */
+    get(path) {
+        const resolved = path.startsWith(".") ? path.substring(1) : `metrics.${path}`;
+        return getPath(this._payload, resolved);
+    }
+
+    /** True iff `path` resolves to a non-undefined value. */
+    has(path) {
+        return this.get(path) !== undefined;
+    }
+
+    /**
+     * Asserts every path in `paths` is present on this snapshot. Returns the map
+     * `{path: value}` for chained assertions.
+     */
+    assertPathsPresent(paths) {
+        const out = {};
+        for (const p of paths) {
+            const v = this.get(p);
+            assert.neq(v, undefined, `metric path "${p}" missing from serverStatus`);
+            out[p] = v;
+        }
+        return out;
+    }
+}
+
+/**
+ * Returns a `{path: after - before}` map over `paths`. Useful for asserting that
+ * a workload moved specific counters by an expected amount. Both endpoints must
+ * have numeric values at the path or the diff entry is `undefined`. Mirrors the
+ * shape of `diffHistogram` / `diffTop` in jstests/libs/stats.js.
+ */
+export function diffMetricSnapshots(before, after, paths) {
+    const out = {};
+    for (const p of paths) {
+        const b = before.get(p);
+        const a = after.get(p);
+        if (typeof b !== "number" || typeof a !== "number") {
+            out[p] = undefined;
+            continue;
+        }
+        out[p] = a - b;
+    }
+    return out;
+}
+
+/**
+ * Asserts that the delta at each path is at least `expectedMin[path]`. Counter
+ * metrics in serverStatus are monotonically non-decreasing; tests typically
+ * want "at least N more" rather than "exactly N more" because background
+ * traffic (TTL monitor, periodic noop writer, etc.) can perturb totals.
+ */
+export function assertMetricDeltaAtLeast(before, after, expectedMin) {
+    const paths = Object.keys(expectedMin);
+    const delta = diffMetricSnapshots(before, after, paths);
+    for (const p of paths) {
+        assert.neq(delta[p], undefined, `metric "${p}" not a numeric leaf in both snapshots`);
+        assert.gte(
+            delta[p],
+            expectedMin[p],
+            `metric "${p}" delta=${delta[p]} below expected min=${expectedMin[p]}`,
+        );
+    }
+    return delta;
+}

--- a/jstests/noPassthroughWithMongod/server_status_metric_tree_fixture_example.js
+++ b/jstests/noPassthroughWithMongod/server_status_metric_tree_fixture_example.js
@@ -1,0 +1,87 @@
+/**
+ * Example/demonstration test for jstests/libs/server_status_metric_tree.js.
+ *
+ * Companion fixture for SERVER-125804 (improve MetricTree + ServerStatus
+ * testability). The fixture itself lives in jstests/libs/; this file is the
+ * "show, don't tell" -- it walks through every helper against a real mongod
+ * so reviewers can see the surface shape without context-switching to a
+ * sharded/replset harness.
+ *
+ * Exercised helpers:
+ *   - MetricTreeSnapshot.capture / .get / .has / .assertPathsPresent
+ *   - getServerStatusMetric (one-shot path read)
+ *   - assertMetricPath (one-shot read + predicate)
+ *   - diffMetricSnapshots (counter delta over a workload)
+ *   - assertMetricDeltaAtLeast (min-delta assertion, background-traffic safe)
+ *
+ *  @tags: [requires_fcv_63]
+ */
+
+import {
+    MetricTreeSnapshot,
+    assertMetricDeltaAtLeast,
+    assertMetricPath,
+    diffMetricSnapshots,
+    getServerStatusMetric,
+} from "jstests/libs/server_status_metric_tree.js";
+
+const conn = db.getMongo();
+
+// ---- One-shot reads ---------------------------------------------------------
+
+// `network.numRequests` is a root-level (leading-dot) counter, present on every
+// mongod build. The fixture's leading-"." convention matches MetricTree's
+// "absolute path" semantics documented in server_status_metric.h.
+assertMetricPath(conn, ".network.numRequests", (v) => typeof v === "number" && v >= 0);
+
+// Paths without a leading dot are implicitly rooted under "metrics." -- the
+// MetricTree default. Pick a well-known counter that exists on standalone mongod.
+const cmdCount = getServerStatusMetric(conn, "commands.serverStatus.total");
+assert.neq(cmdCount, undefined, "metrics.commands.serverStatus.total missing");
+
+// ---- Snapshot + delta -------------------------------------------------------
+
+const before = MetricTreeSnapshot.capture(conn);
+assert(before.has(".network.numRequests"), "snapshot should expose .network paths");
+assert.eq(before.has("definitely.not.a.real.metric.path"), false);
+
+// Drive a small, deterministic workload: 5 explicit serverStatus calls. Each
+// one is itself a request, and each one increments commands.serverStatus.total.
+const workloadIterations = 5;
+for (let i = 0; i < workloadIterations; i++) {
+    assert.commandWorked(conn.adminCommand({serverStatus: 1}));
+}
+
+const after = MetricTreeSnapshot.capture(conn);
+
+// Raw diff -- handy when a test wants to log the deltas before asserting.
+const delta = diffMetricSnapshots(after, before, [
+    ".network.numRequests",
+    "commands.serverStatus.total",
+]);
+jsTest.log.info({"server_status_metric_tree_fixture_example deltas": delta});
+
+// `commands.serverStatus.total` should have grown by at least `workloadIterations`
+// (the 5 explicit calls). Background work may push it higher; the fixture's
+// `assertMetricDeltaAtLeast` is the right shape for that.
+assertMetricDeltaAtLeast(before, after, {
+    "commands.serverStatus.total": workloadIterations,
+});
+
+// `.network.numRequests` counts every command including the serverStatus calls
+// the fixture itself makes for capture(). It must have moved by at least the
+// workload count too.
+assertMetricDeltaAtLeast(before, after, {
+    ".network.numRequests": workloadIterations,
+});
+
+// ---- assertPathsPresent batch read ----------------------------------------
+
+// Lets a single test assert on many paths in one shot. The returned map is the
+// `{path: value}` slice of the snapshot, useful for chained range checks.
+const values = after.assertPathsPresent([
+    ".network.numRequests",
+    "commands.serverStatus.total",
+]);
+assert.gt(values[".network.numRequests"], 0);
+assert.gt(values["commands.serverStatus.total"], 0);


### PR DESCRIPTION
## Summary

jstest + lib: serverStatus metric-tree fixture.

**Jira:** https://jira.mongodb.org/browse/SERVER-126683
**Branch:** substrate-contrib/w3-112

## Files

```
  - jstests/libs/server_status_metric_tree.js          | 173 +++++++++++++++++++++
  - .../server_status_metric_tree_fixture_example.js   |  87 +++++++++++
  - 2 files changed, 260 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
