### PR TITLE
SERVER-126694 jstest + design: write-conflict storm early-reject

### DIFF
--- a/jstests/noPassthrough/query/write_conflict_storm_early_reject.js
+++ b/jstests/noPassthrough/query/write_conflict_storm_early_reject.js
@@ -1,0 +1,131 @@
+/**
+ * SERVER-126462: pins the storm-prevention behavior of the proposed
+ * early-reject backoff algorithm in PlanExecutorImpl::_handleNeedYield.
+ *
+ * With low thresholds (releaseBackoff=2, maxRetry=5) and K parallel ops
+ * contending on a hot document held by an open transaction, the test
+ * asserts:
+ *   - at least one client observes TemporarilyUnavailable (Phase-C shed);
+ *   - the server-side writeConflicts metric grew but stayed below the
+ *     unlimited-retry upper bound (K * maxRetry), proving the cap is
+ *     active rather than a coincidental success;
+ *   - after the holder commits, surviving ops complete within a bounded
+ *     retry budget.
+ *
+ * This test will FAIL on a build that has not landed the early-reject
+ * branch — by design. It is the regression-pin half of the design doc.
+ *
+ * @tags: [
+ *   requires_replication,
+ *   requires_persistence,
+ *   uses_transactions,
+ *   featureFlagWriteConflictStormEarlyReject,
+ * ]
+ */
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+import {Thread} from "jstests/libs/parallelTester.js";
+
+const kReleaseBackoff = 2;
+const kMaxRetry = 5;
+const kStormParallelism = kMaxRetry * 3;  // 15 contenders, well over the cap.
+
+const rst = new ReplSetTest({
+    nodes: 1,
+    nodeOptions: {
+        setParameter: {
+            internalQueryWriteConflictReleaseBackoff: kReleaseBackoff,
+            internalQueryWriteConflictMaxRetry: kMaxRetry,
+            // Keep the legacy alias coherent for the rollout window.
+            internalQueryEnableWriteConflictBackoffWithoutTicket: true,
+        },
+    },
+});
+rst.startSet();
+rst.initiate();
+
+const primary = rst.getPrimary();
+const dbName = "test";
+const collName = jsTestName();
+const testDB = primary.getDB(dbName);
+const testColl = testDB.getCollection(collName);
+
+assert.commandWorked(testColl.insert({_id: 0, counter: 0}));
+
+// Snapshot the writeConflicts metric so we can bound growth at the end.
+const beforeStatus = assert.commandWorked(testDB.adminCommand({serverStatus: 1}));
+const wcBefore = beforeStatus.metrics.operation.writeConflicts || 0;
+
+// Hold a write on _id:0 inside a transaction. Every contender will
+// fail with WriteConflict until this session commits.
+const holderSession = primary.startSession({causalConsistency: false});
+const holderColl = holderSession.getDatabase(dbName).getCollection(collName);
+holderSession.startTransaction();
+assert.commandWorked(holderColl.update({_id: 0}, {$inc: {counter: 1}}));
+
+// Worker body: try the same findAndModify and report the terminal status.
+// We deliberately use a generous maxTimeMS so the server-side cap (not
+// the client deadline) is what shapes the outcome.
+function stormWorker(host, dbName, collName) {
+    const conn = new Mongo(host);
+    const coll = conn.getDB(dbName).getCollection(collName);
+    const result = coll.runCommand({
+        findAndModify: collName,
+        query: {_id: 0},
+        update: {$inc: {counter: 1}},
+        maxTimeMS: 30 * 1000,
+    });
+    return {ok: result.ok, code: result.code, codeName: result.codeName};
+}
+
+const threads = [];
+for (let i = 0; i < kStormParallelism; i++) {
+    const t = new Thread(stormWorker, primary.host, dbName, collName);
+    t.start();
+    threads.push(t);
+}
+
+// Let the storm reach steady state before releasing the holder.
+sleep(2 * 1000);
+assert.commandWorked(holderSession.commitTransaction_forTesting());
+
+// Drain.
+const outcomes = threads.map((t) => {
+    t.join();
+    return t.returnData();
+});
+
+// Phase-C assertion: at least one contender saw the cap fire.
+const tempUnavail = outcomes.filter(
+    (o) => o.code === ErrorCodes.TemporarilyUnavailable);
+assert.gte(
+    tempUnavail.length,
+    1,
+    `expected at least one TemporarilyUnavailable shed; outcomes=${tojson(outcomes)}`);
+
+// Bound assertion: total observed writeConflicts grew, but stayed below
+// the unlimited-retry ceiling (K contenders * maxRetry retries each).
+const afterStatus = assert.commandWorked(testDB.adminCommand({serverStatus: 1}));
+const wcAfter = afterStatus.metrics.operation.writeConflicts || 0;
+const wcGrowth = wcAfter - wcBefore;
+assert.gt(wcGrowth, 0, "writeConflicts metric did not grow — storm did not engage");
+assert.lte(
+    wcGrowth,
+    kStormParallelism * kMaxRetry,
+    `writeConflicts growth ${wcGrowth} exceeded the K*maxRetry ceiling ` +
+        `${kStormParallelism * kMaxRetry} — cap did not fire`);
+
+// Recovery assertion: post-commit, the successful contenders together
+// advanced the counter without anyone getting stuck.
+const successCount = outcomes.filter((o) => o.ok === 1).length;
+assert.gte(
+    successCount,
+    1,
+    `expected at least one success after holder committed; outcomes=${tojson(outcomes)}`);
+const finalDoc = testColl.findOne({_id: 0});
+assert.eq(
+    finalDoc.counter,
+    1 + successCount,
+    `counter should equal holder + successes; finalDoc=${tojson(finalDoc)} ` +
+        `successes=${successCount}`);
+
+rst.stopSet();

--- a/src/mongo/db/query/design/SERVER-126462-write-conflict-storm-early-reject.md
+++ b/src/mongo/db/query/design/SERVER-126462-write-conflict-storm-early-reject.md
@@ -1,0 +1,160 @@
+# SERVER-126462: Early-reject backoff for write-conflict storms
+
+Status: design proposal (prototype)
+Owner: Query Execution
+Epic: SPM-4627
+Related: SERVER-65418 (release-ticket-before-backoff)
+
+## Problem
+
+When N concurrent ops contend on a hot document, the release-ticket path
+(`internalQueryEnableWriteConflictBackoffWithoutTicket=true`) creates a
+positive-feedback storm: a sleeping op drops its write ticket, the
+dynamic concurrency controller observes free capacity, admits the next
+queued writer, that writer also conflicts on the same document, and the
+pool refills with non-productive ops. CPU is burned on admission,
+scheduling, and WT transaction setup for ops guaranteed to retry.
+
+The Jira investigation comment (2026-05-12) rules out two prior
+candidates:
+
+1. **Pool-size circuit breaker.** Threshold scales with pool size; under
+   storm load the controller expands the pool faster than the breaker
+   can fire. Measured: pool 95-128, breaker requires 47-64 concurrent
+   waiters, workload produces at most 21. Never fires.
+2. **Queue-depth activation gate.** Release-ticket drops queue depth to
+   zero during sleeps, so the gate stays false through a severe storm.
+
+What survives empirically: a two-layer defense at different points in
+the retry lifecycle — `releaseBackoff` (mode switch) then `maxRetry`
+(hard shed).
+
+## Proposal
+
+Replace the singleton `internalQueryEnableWriteConflictBackoffWithoutTicket`
+boolean with a two-threshold escalation on per-op consecutive WCE count
+(`writeConflictsInARow`, already tracked in `PlanExecutorImpl`):
+
+| Phase | `writeConflictsInARow` range | Behavior            | Rationale                                          |
+|-------|------------------------------|---------------------|----------------------------------------------------|
+| A     | `[0, releaseBackoff)`        | release-ticket      | Isolated transient conflict; donate slot.          |
+| B     | `[releaseBackoff, maxRetry)` | hold-ticket         | Storm regime; occupy slot to throttle admission.   |
+| C     | `>= maxRetry`                | shed (TempUnavail)  | Stuck op; free slot, push retry to client.         |
+
+Both thresholds become query knobs. Defaults proposed:
+
+- `internalQueryWriteConflictReleaseBackoff` = 4
+- `internalQueryWriteConflictMaxRetry` = 50
+
+`INT_MAX` for `releaseBackoff` reproduces the current release-everywhere
+default; `0` reproduces the legacy hold-everywhere path. Existing
+boolean is kept as a deprecated alias that forces `releaseBackoff` to
+0 or `INT_MAX` for one release cycle.
+
+### Integration point
+
+`PlanExecutorImpl::_handleNeedYield` (`plan_executor_impl.cpp:500`),
+the existing branch that reads
+`internalQueryEnableWriteConflictBackoffWithoutTicket.load()`. Replace
+the boolean check with:
+
+```cpp
+const auto releaseBackoff = internalQueryWriteConflictReleaseBackoff.load();
+const auto maxRetry       = internalQueryWriteConflictMaxRetry.load();
+
+if (writeConflictsInARow >= static_cast<size_t>(maxRetry)) {
+    // Phase C: shed.
+    throwTemporarilyUnavailableException(
+        "Write-conflict retry cap reached (maxRetry={})", maxRetry);
+}
+
+if (writeConflictsInARow < static_cast<size_t>(releaseBackoff)) {
+    // Phase A: defer log+backoff to the yield handler (release-ticket).
+    _writeConflictsInARowToLog = writeConflictsInARow;
+} else {
+    // Phase B: log+backoff now, while holding the ticket.
+    logWriteConflictAndBackoff(writeConflictsInARow);
+}
+```
+
+User-facing only — `_yieldPolicy->canAutoYield()` already gates this
+code path; internal ops and secondaries that disable auto-yield bypass
+the cap.
+
+### Error code
+
+Reuse `ErrorCodes::TemporarilyUnavailable`. Drivers already treat it as
+retryable with backoff, which is exactly the client-side behavior we
+want for an op the server has declined to keep retrying. A dedicated
+`WriteConflictStorm` code was considered and rejected: it requires
+driver work and breaks proxy clients that whitelist retryable codes.
+
+### What this does NOT change
+
+- Internal ops, secondaries, applyOps, replication oplog tailing — none
+  of these flow through `PlanExecutorImpl::_handleNeedYield`.
+- Multi-statement transactions: the cap fires per statement; the
+  transaction itself follows the existing `TransientTransactionError`
+  contract.
+- Per-collection scoping (Option 3 in the Jira). Deferred to v2.
+
+## Why this resolves the storm
+
+Phase B is the load-bearing change. Under release-ticket, a sleeping
+op vacates its slot for the next queued writer, which is statistically
+also storm-bound on the same document. Under hold-ticket, the slot
+stays occupied, the concurrency controller observes high utilization,
+admission slows, and each retry sees fewer competitors. The
+self-throttling is automatic — no global state, no breaker that needs
+to detect the storm explicitly.
+
+Phase C is the backstop. A permanently-hot document (e.g. queue-head
+pattern) would otherwise pin Phase-B ops indefinitely, holding their
+tickets forever. Shedding at `maxRetry` returns the slot to the pool
+and pushes the retry decision to the client, which has a wider
+backoff budget than the server.
+
+## Test plan
+
+A jstest at
+`jstests/noPassthrough/query/write_conflict_storm_early_reject.js`
+pins the storm-prevention behavior end-to-end:
+
+1. Launch a single-node replset with knobs set to small thresholds
+   (`releaseBackoff=2`, `maxRetry=5`).
+2. Open a multi-statement transaction holding a write on `{_id: 0}`.
+3. From `K = maxRetry * 3` parallel shell connections, issue
+   `findAndModify` updates on `{_id: 0}` with `maxTimeMS` large enough
+   that the server-side cap fires before the deadline.
+4. Assert:
+   - At least one connection observes
+     `ErrorCodes.TemporarilyUnavailable` (the cap fired).
+   - The serverStatus `metrics.operation.writeConflicts` counter
+     grew but did not exceed `K * maxRetry` (each op shed at the cap,
+     not at the legacy unlimited retry).
+   - After the holder commits, all surviving connections succeed
+     within a bounded retry window.
+
+Unit-test seam (follow-up): `PlanExecutorImpl::_handleNeedYield` is
+not currently exposed for direct unit testing — the prototype CL will
+add a friend-test shim so the three-phase branch decision can be
+exercised without a live storage engine.
+
+## Rollout
+
+1. Land knobs + branch logic with `releaseBackoff = INT_MAX`,
+   `maxRetry = INT_MAX`. No behavior change; surface area opens.
+2. Bench `high_cpu_degradation` workload at
+   `releaseBackoff ∈ {2, 4, 8}` × `maxRetry ∈ {20, 50, 100}`. Pick the
+   combination that recovers the ~40-50% throughput regression
+   without inflating p99 on isolated-conflict microbenchmarks.
+3. Flip defaults in a separate PR with the perf numbers attached.
+
+## Open questions
+
+- Should `maxRetry` shedding emit a structured log event distinct from
+  the existing `logWriteConflictAndBackoff` cadence, so SREs can
+  alert on shed rate per replica set?
+- Interaction with prepared transactions: `_handleNeedYield` runs
+  before the yield, but `kPrepareConflict` flows through a different
+  branch. Confirm no double-counting against `writeConflictsInARow`.


### PR DESCRIPTION
## Summary

jstest + design: write-conflict storm early-reject.

**Jira:** https://jira.mongodb.org/browse/SERVER-126694
**Branch:** substrate-contrib/w3-123

## Files

```
  - .../query/write_conflict_storm_early_reject.js     | 131 +++++++++++++++++
  - ...VER-126462-write-conflict-storm-early-reject.md | 160 +++++++++++++++++++++
  - 2 files changed, 291 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
