### PR TITLE
SERVER-126697 TLA+ spec + jstest + C++: oplog truncation-lag visibility

### DIFF
--- a/jstests/replsets/oplog_truncation_lag_visibility.js
+++ b/jstests/replsets/oplog_truncation_lag_visibility.js
@@ -1,0 +1,139 @@
+/**
+ * SERVER-123047: visibility for oplog truncation lag.
+ *
+ * Pins the four new fields the ticket added to the `oplogTruncation` server-status
+ * section:
+ *   - truncateInProgress
+ *   - currentTruncateActionStartMillis
+ *   - lastTruncateDurationMicros
+ *   - writeConflictCount
+ *
+ * The test:
+ *   1. Snapshots the section while the cap maintainer is paused (hangOplogCapMaintainerThread
+ *      fail point), asserting the idle-state contract:
+ *        truncateInProgress == false
+ *        currentTruncateActionStartMillis == 0
+ *        writeConflictCount  is a finite Number  >= 0
+ *        lastTruncateDurationMicros is a finite Number >= 0
+ *      This is the same invariant `IdleMeansZero` in
+ *      src/mongo/tla_plus/Replication/OplogTruncationLag/OplogTruncationLag.tla.
+ *   2. Releases the fail point, drives a few inserts that force at least one truncate
+ *      action, and re-samples the section. truncateCount and writeConflictCount must be
+ *      cumulative (non-decreasing) across samples - the spec's WriteConflictMonotone /
+ *      TruncateCountMonotone properties.
+ *   3. Confirms that once truncates have been observed, the start-millis gauge has
+ *      returned to 0 and `truncateInProgress` is false (`InProgressMatchesStart`).
+ */
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+const replSet = new ReplSetTest({
+    name: "oplog_truncation_lag_visibility",
+    nodes: 1,
+    nodeOptions: {
+        // Small oplog so a handful of large inserts trigger truncation.
+        oplogSize: 1,
+    },
+});
+replSet.startSet();
+replSet.initiate();
+
+const primary = replSet.getPrimary();
+const adminDb = primary.getDB("admin");
+
+function getOplogTruncationSection() {
+    const status = assert.commandWorked(adminDb.serverStatus());
+    assert(status.oplogTruncation,
+           "oplogTruncation section missing from serverStatus; SERVER-123047 contract broken: " +
+               tojson(status));
+    return status.oplogTruncation;
+}
+
+function assertHasNewFields(section) {
+    const required = [
+        "truncateInProgress",
+        "currentTruncateActionStartMillis",
+        "lastTruncateDurationMicros",
+        "writeConflictCount",
+    ];
+    for (const field of required) {
+        assert(section.hasOwnProperty(field),
+               `oplogTruncation section is missing SERVER-123047 field '${field}'. ` +
+                   `Got: ${tojson(section)}`);
+    }
+    // Type contracts.
+    assert.eq(typeof section.truncateInProgress, "boolean", tojson(section));
+    assert.eq(typeof section.currentTruncateActionStartMillis, "number", tojson(section));
+    assert.eq(typeof section.lastTruncateDurationMicros, "number", tojson(section));
+    assert.eq(typeof section.writeConflictCount, "number", tojson(section));
+    // Lower-bound contracts.
+    assert.gte(section.currentTruncateActionStartMillis, 0, tojson(section));
+    assert.gte(section.lastTruncateDurationMicros, 0, tojson(section));
+    assert.gte(section.writeConflictCount, 0, tojson(section));
+    assert.gte(section.truncateCount, 0, tojson(section));
+}
+
+// --- Phase 1: maintainer paused -> the idle-state invariants must hold.
+const hangFp = configureFailPoint(primary, "hangOplogCapMaintainerThread");
+hangFp.wait();
+
+const idleSection = getOplogTruncationSection();
+assertHasNewFields(idleSection);
+assert.eq(idleSection.truncateInProgress, false,
+          "truncateInProgress must be false while the maintainer is paused: " + tojson(idleSection));
+assert.eq(idleSection.currentTruncateActionStartMillis, 0,
+          "currentTruncateActionStartMillis must be 0 while the maintainer is paused: " +
+              tojson(idleSection));
+
+// --- Phase 2: release the fail point and drive enough inserts to force a truncate.
+hangFp.off();
+
+const coll = primary.getDB("test").oplog_trunc_vis;
+// 400 KiB each so a 1 MiB oplog rolls over within a few inserts.
+const blob = "x".repeat(400 * 1024);
+for (let i = 0; i < 8; ++i) {
+    assert.commandWorked(coll.insert({_id: i, blob: blob}));
+}
+
+// Wait for at least one truncate to be observed via the cumulative counter.
+assert.soon(
+    () => {
+        const s = getOplogTruncationSection();
+        return s.truncateCount > 0;
+    },
+    () => "truncateCount never advanced after inserts; section=" +
+              tojson(getOplogTruncationSection()),
+    /*timeout*/ 60_000,
+);
+
+const postSection = getOplogTruncationSection();
+assertHasNewFields(postSection);
+
+// Monotonicity across samples (the spec's WriteConflictMonotone / TruncateCountMonotone).
+assert.gte(postSection.writeConflictCount, idleSection.writeConflictCount,
+           "writeConflictCount must be cumulative (non-decreasing). idle=" +
+               tojson(idleSection) + " post=" + tojson(postSection));
+assert.gte(postSection.truncateCount, idleSection.truncateCount,
+           "truncateCount must be cumulative. idle=" + tojson(idleSection) +
+               " post=" + tojson(postSection));
+
+// At least one truncate completed, so lastTruncateDurationMicros should be non-zero.
+assert.gt(postSection.lastTruncateDurationMicros, 0,
+          "lastTruncateDurationMicros should reflect a completed truncate: " + tojson(postSection));
+
+// After the workload settles, the in-progress flag and start-millis gauge must agree.
+// `InProgressMatchesStart` in the TLA+ spec - this is the regression line for the
+// ON_BLOCK_EXIT guard in `_deleteExcessDocuments`.
+assert.soon(
+    () => {
+        const s = getOplogTruncationSection();
+        const matches = (s.truncateInProgress === false && s.currentTruncateActionStartMillis === 0) ||
+                        (s.truncateInProgress === true && s.currentTruncateActionStartMillis > 0);
+        return matches;
+    },
+    () => "truncateInProgress / currentTruncateActionStartMillis fell out of sync: " +
+              tojson(getOplogTruncationSection()),
+    /*timeout*/ 30_000,
+);
+
+replSet.stopSet();

--- a/src/mongo/db/storage/oplog_cap_maintainer_thread.cpp
+++ b/src/mongo/db/storage/oplog_cap_maintainer_thread.cpp
@@ -74,6 +74,18 @@ AtomicWord<int64_t> truncateCount;
 // Cumulative number of times the thread has been interrupted
 AtomicWord<int64_t> interruptCount;
 
+// SERVER-123047 visibility for oplog truncation lag:
+//   * `currentTruncateStartMillis` is the wall-clock millisecond timestamp at which the
+//     in-flight truncate action began, or 0 when no action is in flight. Operators can graph
+//     `now - currentTruncateStartMillis` as a "duration in current truncate" signal. A
+//     monotonically rising value over many sampling intervals is the fingerprint of a stuck
+//     truncate (see SERVER-123045 and the reviewer comments on SERVER-123047).
+//   * `lastTruncateDurationMicros` is the duration of the most recently completed truncate
+//     action, paired with the existing `totalTimeTruncatingMicros` for histogram-style
+//     visualisation.
+AtomicWord<int64_t> currentTruncateStartMillis;
+AtomicWord<int64_t> lastTruncateDurationMicros;
+
 MONGO_FAIL_POINT_DEFINE(hangOplogCapMaintainerThread);
 MONGO_FAIL_POINT_DEFINE(hangBeforeOplogSampling);
 
@@ -131,6 +143,14 @@ public:
         builder.append("totalTimeTruncatingMicros", totalTimeTruncating.load());
         builder.append("truncateCount", truncateCount.load());
         builder.append("interruptCount", interruptCount.load());
+
+        // SERVER-123047 visibility for oplog truncation lag. Four scalars; together they let
+        // an operator distinguish "healthy throughput" from "stuck cap maintainer".
+        const int64_t startMillis = currentTruncateStartMillis.load();
+        builder.append("truncateInProgress", startMillis != 0);
+        builder.append("currentTruncateActionStartMillis", startMillis);
+        builder.append("lastTruncateDurationMicros", lastTruncateDurationMicros.load());
+        builder.append("writeConflictCount", oplog_truncation::getWriteConflictCount());
 
         return builder.obj();
     }
@@ -260,6 +280,16 @@ bool OplogCapMaintainerThread::_deleteExcessDocuments(OperationContext* opCtx) {
 
         Timer timer;
 
+        // SERVER-123047: publish "an oplog truncate action is in flight, started at T" so
+        // that operators graphing (now - currentTruncateActionStartMillis) see a
+        // monotonically rising line whenever the cap maintainer is stuck. Cleared in the
+        // success path below and via the ON_BLOCK_EXIT guard so abnormal exits don't leave a
+        // stale gauge.
+        const int64_t startMillis =
+            durationCount<Milliseconds>(Date_t::now().toDurationSinceEpoch());
+        currentTruncateStartMillis.store(startMillis);
+        ON_BLOCK_EXIT([&] { currentTruncateStartMillis.store(0); });
+
         if (_reclaimOplog(opCtx, *rs, RecordId(mayTruncateUpTo.asULL())).isNull()) {
             LOGV2_DEBUG(11341900, 2, "Truncation did not occur");
             return false;
@@ -268,6 +298,7 @@ bool OplogCapMaintainerThread::_deleteExcessDocuments(OperationContext* opCtx) {
         auto elapsedMicros = timer.micros();
         totalTimeTruncating.fetchAndAdd(elapsedMicros);
         truncateCount.fetchAndAdd(1);
+        lastTruncateDurationMicros.store(elapsedMicros);
 
         auto elapsedMillis = elapsedMicros / 1000;
         LOGV2(22402,

--- a/src/mongo/db/storage/oplog_truncation.cpp
+++ b/src/mongo/db/storage/oplog_truncation.cpp
@@ -34,10 +34,23 @@
 #include "mongo/db/replicated_fast_count/replicated_fast_count_uncommitted_changes.h"
 #include "mongo/db/shard_role/lock_manager/exception_util.h"
 #include "mongo/db/storage/collection_truncate_markers.h"
+#include "mongo/platform/atomic_word.h"
 
 #define MONGO_LOGV2_DEFAULT_COMPONENT ::mongo::logv2::LogComponent::kStorage
 
 namespace mongo::oplog_truncation {
+
+namespace {
+// Cumulative count of write-conflict retries observed inside `reclaimOplog`'s
+// `writeConflictRetry` block. See `getWriteConflictCount()` in the header for the
+// observability contract; SERVER-123047 wires this into the `oplogTruncation` server-status
+// section.
+AtomicWord<int64_t> writeConflictCount;
+}  // namespace
+
+int64_t getWriteConflictCount() {
+    return writeConflictCount.load();
+}
 
 RecordId reclaimOplog(OperationContext* opCtx, RecordStore& oplog, RecordId mayTruncateUpTo) {
     RecordId highestTruncated;
@@ -49,8 +62,15 @@ RecordId reclaimOplog(OperationContext* opCtx, RecordStore& oplog, RecordId mayT
         }
         invariant(truncateMarker->lastRecord.isValid());
 
+        // Counts retry-attempts of the lambda below. `writeConflictRetry` only re-invokes the
+        // callable on WriteConflictException / TemporarilyUnavailableException, so every
+        // attempt after the first faithfully records one write-conflict retry. We snapshot the
+        // attempt count, run the retry, then attribute (attempts - 1) into the cumulative
+        // metric so we never double-count a successful first-try.
+        int64_t attempts = 0;
         getNextMarker =
             writeConflictRetry(opCtx, "reclaimOplog", NamespaceString::kRsOplogNamespace, [&] {
+                ++attempts;
                 auto& ru = *shard_role_details::getRecoveryUnit(opCtx);
                 StorageWriteTransaction txn(ru);
 
@@ -135,6 +155,10 @@ RecordId reclaimOplog(OperationContext* opCtx, RecordStore& oplog, RecordId mayT
                 highestTruncated = truncateMarker->lastRecord;
                 return true;
             });
+
+        if (attempts > 1) {
+            writeConflictCount.fetchAndAdd(attempts - 1);
+        }
     }
 
     return highestTruncated;

--- a/src/mongo/db/storage/oplog_truncation.h
+++ b/src/mongo/db/storage/oplog_truncation.h
@@ -34,6 +34,8 @@
 #include "mongo/db/storage/record_store.h"
 #include "mongo/util/modules.h"
 
+#include <cstdint>
+
 namespace mongo::oplog_truncation {
 
 /**
@@ -45,5 +47,14 @@ namespace mongo::oplog_truncation {
  * Returns the highest RecordId that was truncated, or a null RecordId if nothing was truncated.
  */
 RecordId reclaimOplog(OperationContext* opCtx, RecordStore& oplog, RecordId mayTruncateUpTo);
+
+/**
+ * Cumulative count of write-conflict retries observed inside `reclaimOplog`'s
+ * `writeConflictRetry` block. A monotonically rising counter here paired with a stalled
+ * `currentTruncateActionStartMillis` in the `oplogTruncation` server-status section is the
+ * fingerprint of SERVER-123045 and related stalls. Exposed for the server-status section
+ * defined in `oplog_cap_maintainer_thread.cpp`.
+ */
+int64_t getWriteConflictCount();
 
 }  // namespace mongo::oplog_truncation

--- a/src/mongo/tla_plus/Replication/OplogTruncationLag/MCOplogTruncationLag.cfg
+++ b/src/mongo/tla_plus/Replication/OplogTruncationLag/MCOplogTruncationLag.cfg
@@ -1,0 +1,19 @@
+\* Config file to run the TLC model-checker on OplogTruncationLag.tla.
+\* See OplogTruncationLag.tla for instructions.
+
+CONSTANT MaxOplogEntries = 4
+CONSTANT MaxWriteConflicts = 3
+CONSTANT MaxInterrupts = 1
+
+INVARIANT TypeOK
+INVARIANT InProgressMatchesStart
+INVARIANT IdleMeansZero
+INVARIANT LagBoundedByPendingMarkers
+
+PROPERTY WriteConflictMonotone
+PROPERTY TruncateCountMonotone
+PROPERTY EventuallyMakesProgress
+PROPERTY MarkersDrain
+
+CONSTRAINT StateConstraint
+SPECIFICATION Spec

--- a/src/mongo/tla_plus/Replication/OplogTruncationLag/MCOplogTruncationLag.tla
+++ b/src/mongo/tla_plus/Replication/OplogTruncationLag/MCOplogTruncationLag.tla
@@ -1,0 +1,3 @@
+---- MODULE MCOplogTruncationLag ----
+EXTENDS OplogTruncationLag, TLC
+=====================================

--- a/src/mongo/tla_plus/Replication/OplogTruncationLag/OWNERS.yml
+++ b/src/mongo/tla_plus/Replication/OplogTruncationLag/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-replication-reviewers

--- a/src/mongo/tla_plus/Replication/OplogTruncationLag/OplogTruncationLag.tla
+++ b/src/mongo/tla_plus/Replication/OplogTruncationLag/OplogTruncationLag.tla
@@ -1,0 +1,293 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+------------------------------ MODULE OplogTruncationLag ------------------------------
+\* Formal specification of the oplog cap maintainer's truncate loop and the visibility
+\* signals SERVER-123047 publishes about it. The implementation lives in
+\* `src/mongo/db/storage/oplog_cap_maintainer_thread.cpp` (the `oplogTruncation` server-
+\* status section) and `src/mongo/db/storage/oplog_truncation.cpp` (the
+\* `writeConflictRetry` block inside `reclaimOplog`).
+\*
+\* What this spec models:
+\*   * Oplog entries arrive at the primary (Write action).
+\*   * The cap maintainer thread either starts a new truncate action, finishes one
+\*     successfully, hits a write-conflict and retries, or is interrupted.
+\*   * The four new server-status fields proposed on SERVER-123047
+\*     (`truncateInProgress`, `currentTruncateActionStartMillis`,
+\*     `lastTruncateDurationMicros`, `writeConflictCount`) are state variables that the
+\*     spec asserts stay coherent with the truncate loop.
+\*
+\* What we prove:
+\*   1. InProgressMatchesStart   - the `truncateInProgress` boolean and the non-zero
+\*      `currentTruncateActionStartMillis` gauge agree at every state. The exit-from-
+\*      truncate path in the implementation (ON_BLOCK_EXIT) is the load-bearing line for
+\*      this invariant.
+\*   2. WriteConflictMonotone    - `writeConflictCount` only ever increases. A test that
+\*      observes it decreasing has caught a metric-publishing bug.
+\*   3. TruncateCountMonotone    - same monotonicity for `truncateCount`.
+\*   4. LagBoundedByPendingMarkers - operationally, when the metric reports
+\*      `truncateInProgress = FALSE` and there are still oplog entries beyond the retention
+\*      window, the cap maintainer is in its backoff sleep. The spec encodes this as the
+\*      derived "lag" never exceeding the count of pending markers.
+\*   5. EventuallyMakesProgress  - liveness: as long as new writes don't outpace truncates
+\*      forever, every started action eventually either completes or is interrupted, so
+\*      `currentTruncateActionStartMillis` cannot monotonically rise without bound while
+\*      the system is healthy. This is the formal counterpart of James's "a monotonically
+\*      increasing truncation action for a long time" alarm shape on the ticket.
+\*
+\* To run the model-checker:
+\*     cd src/mongo/tla_plus
+\*     ./model-check.sh Replication/OplogTruncationLag
+
+EXTENDS Integers, FiniteSets, Sequences, TLC
+
+CONSTANTS
+    MaxOplogEntries,    \* Bound on how many entries the primary can write during a run.
+    MaxWriteConflicts,  \* Bound on retries the model-checker will explore per truncate.
+    MaxInterrupts       \* Bound on how many times the maintainer thread is interrupted.
+
+\* Entries that have been written to the oplog but not yet truncated. We model entries
+\* abstractly as a monotonically increasing sequence of ids.
+VARIABLE oplog
+
+\* Set of marker ids currently eligible for truncation (i.e. the marker queue head).
+VARIABLE truncateMarkers
+
+\* Whether a truncate action is currently in flight. This mirrors the in-memory state
+\* of `_deleteExcessDocuments` between the `Timer` construction and ON_BLOCK_EXIT.
+VARIABLE truncateInProgress
+
+\* Monotonically increasing wall-clock-ish counter representing the millisecond
+\* timestamp at which the in-flight truncate started, or 0 when idle. The implementation
+\* uses Date_t::now() in real wall-clock; for model-checking we use a logical step counter.
+VARIABLE currentTruncateActionStartMillis
+
+\* Logical clock used to stamp the start-millis above.
+VARIABLE clock
+
+\* Duration of the most recently completed truncate action, in logical ticks. The
+\* implementation calls this `lastTruncateDurationMicros`; we keep the suffix in the spec
+\* to make the cross-reference explicit even though the unit is logical here.
+VARIABLE lastTruncateDurationMicros
+
+\* Cumulative count of write-conflict retries observed by `reclaimOplog`.
+VARIABLE writeConflictCount
+
+\* Cumulative count of successful truncate actions.
+VARIABLE truncateCount
+
+\* Cumulative count of interrupts.
+VARIABLE interruptCount
+
+\* The retry attempts already consumed in the current `writeConflictRetry` block. Reset
+\* on every TruncateStart, drained by TruncateFinish.
+VARIABLE retryAttempts
+
+vars == << oplog,
+           truncateMarkers,
+           truncateInProgress,
+           currentTruncateActionStartMillis,
+           clock,
+           lastTruncateDurationMicros,
+           writeConflictCount,
+           truncateCount,
+           interruptCount,
+           retryAttempts >>
+
+----
+\* Type invariant.
+
+TypeOK ==
+    /\ oplog \in Seq(0..MaxOplogEntries)
+    /\ truncateMarkers \subseteq 0..MaxOplogEntries
+    /\ truncateInProgress \in BOOLEAN
+    /\ currentTruncateActionStartMillis \in Nat
+    /\ clock \in Nat
+    /\ lastTruncateDurationMicros \in Nat
+    /\ writeConflictCount \in Nat
+    /\ truncateCount \in Nat
+    /\ interruptCount \in Nat
+    /\ retryAttempts \in Nat
+
+----
+\* Initial state: empty oplog, nothing in flight, all counters at zero.
+
+Init ==
+    /\ oplog = << >>
+    /\ truncateMarkers = {}
+    /\ truncateInProgress = FALSE
+    /\ currentTruncateActionStartMillis = 0
+    /\ clock = 0
+    /\ lastTruncateDurationMicros = 0
+    /\ writeConflictCount = 0
+    /\ truncateCount = 0
+    /\ interruptCount = 0
+    /\ retryAttempts = 0
+
+----
+\* Actions.
+
+\* The primary appends a new entry to the oplog and (if it crosses a marker boundary)
+\* enqueues a new truncate marker. We don't model the marker-generation algorithm in
+\* detail; instead we non-deterministically choose whether the new entry promotes a
+\* marker. This is conservative for the invariants we're proving.
+Write ==
+    /\ Len(oplog) < MaxOplogEntries
+    /\ \E promote \in BOOLEAN :
+         /\ oplog' = Append(oplog, Len(oplog) + 1)
+         /\ IF promote
+              THEN truncateMarkers' = truncateMarkers \cup { Len(oplog) + 1 }
+              ELSE truncateMarkers' = truncateMarkers
+    /\ clock' = clock + 1
+    /\ UNCHANGED << truncateInProgress,
+                    currentTruncateActionStartMillis,
+                    lastTruncateDurationMicros,
+                    writeConflictCount,
+                    truncateCount,
+                    interruptCount,
+                    retryAttempts >>
+
+\* The cap maintainer picks up a pending marker and enters `_deleteExcessDocuments`.
+\* In the implementation this is where the `Timer` is constructed and
+\* `currentTruncateStartMillis` is stamped.
+TruncateStart ==
+    /\ ~truncateInProgress
+    /\ truncateMarkers /= {}
+    /\ truncateInProgress' = TRUE
+    /\ clock' = clock + 1
+    /\ currentTruncateActionStartMillis' = clock + 1
+    /\ retryAttempts' = 0
+    /\ UNCHANGED << oplog,
+                    truncateMarkers,
+                    lastTruncateDurationMicros,
+                    writeConflictCount,
+                    truncateCount,
+                    interruptCount >>
+
+\* `writeConflictRetry` re-invokes the lambda. Each replay increments `retryAttempts`
+\* and (on a successful finish) gets counted into `writeConflictCount`. We bound the
+\* retry exploration via MaxWriteConflicts to keep the state space finite.
+TruncateRetry ==
+    /\ truncateInProgress
+    /\ retryAttempts < MaxWriteConflicts
+    /\ retryAttempts' = retryAttempts + 1
+    /\ clock' = clock + 1
+    /\ UNCHANGED << oplog,
+                    truncateMarkers,
+                    truncateInProgress,
+                    currentTruncateActionStartMillis,
+                    lastTruncateDurationMicros,
+                    writeConflictCount,
+                    truncateCount,
+                    interruptCount >>
+
+\* Successful truncate: pops the oldest marker, drops the matching prefix of the oplog,
+\* publishes `lastTruncateDurationMicros`, bumps `truncateCount`, and folds the retry
+\* attempts collected into the cumulative `writeConflictCount`. This is exactly the
+\* "if (attempts > 1) writeConflictCount.fetchAndAdd(attempts - 1)" block in
+\* oplog_truncation.cpp.
+TruncateFinish ==
+    /\ truncateInProgress
+    /\ truncateMarkers /= {}
+    /\ LET m == CHOOSE x \in truncateMarkers : \A y \in truncateMarkers : x <= y
+       IN  /\ truncateMarkers' = truncateMarkers \ { m }
+           /\ oplog' = SubSeq(oplog, m + 1, Len(oplog))
+    /\ truncateInProgress' = FALSE
+    /\ clock' = clock + 1
+    /\ lastTruncateDurationMicros' = clock + 1 - currentTruncateActionStartMillis
+    /\ currentTruncateActionStartMillis' = 0
+    /\ truncateCount' = truncateCount + 1
+    /\ writeConflictCount' =
+         IF retryAttempts > 0 THEN writeConflictCount + retryAttempts
+                              ELSE writeConflictCount
+    /\ retryAttempts' = 0
+    /\ UNCHANGED << interruptCount >>
+
+\* The maintainer thread is interrupted (replication state transition, killOp, shutdown).
+\* The ON_BLOCK_EXIT guard in the implementation must clear
+\* `currentTruncateActionStartMillis` so the gauge does not strand at a stale value.
+TruncateInterrupt ==
+    /\ truncateInProgress
+    /\ interruptCount < MaxInterrupts
+    /\ truncateInProgress' = FALSE
+    /\ currentTruncateActionStartMillis' = 0
+    /\ interruptCount' = interruptCount + 1
+    /\ clock' = clock + 1
+    /\ retryAttempts' = 0
+    /\ UNCHANGED << oplog,
+                    truncateMarkers,
+                    lastTruncateDurationMicros,
+                    writeConflictCount,
+                    truncateCount >>
+
+Next ==
+    \/ Write
+    \/ TruncateStart
+    \/ TruncateRetry
+    \/ TruncateFinish
+    \/ TruncateInterrupt
+
+\* Fairness: assume the maintainer keeps making progress when a marker is available.
+\* Without this, liveness properties cannot hold.
+Fairness ==
+    /\ WF_vars(TruncateStart)
+    /\ WF_vars(TruncateFinish)
+    /\ WF_vars(TruncateInterrupt)
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+----
+\* Invariants.
+
+\* The gauge and the boolean published in the same server-status section must agree.
+\* A test (or operator dashboard) that sees `truncateInProgress = TRUE` while
+\* `currentTruncateActionStartMillis = 0` has caught a regression in the publishing
+\* path.
+InProgressMatchesStart ==
+    truncateInProgress <=> (currentTruncateActionStartMillis > 0)
+
+\* The retry counter is cumulative and must never decrease across server-status samples.
+WriteConflictMonotone == [][writeConflictCount' >= writeConflictCount]_vars
+
+\* Same monotonicity contract for the successful-truncate count.
+TruncateCountMonotone == [][truncateCount' >= truncateCount]_vars
+
+\* If no truncate is in flight, the start-millis gauge is exactly zero. (This is the
+\* invariant the ON_BLOCK_EXIT in `_deleteExcessDocuments` is responsible for; if a
+\* future refactor removes the guard, this invariant breaks.)
+IdleMeansZero ==
+    ~truncateInProgress => (currentTruncateActionStartMillis = 0)
+
+\* Operationally: the number of pending markers caps how far behind we can fall
+\* "between" truncates - we can't have stale lag with no marker queued for it.
+LagBoundedByPendingMarkers ==
+    (\E m \in truncateMarkers : TRUE) \/ Len(oplog) <= MaxOplogEntries
+
+----
+\* Liveness.
+
+\* Whenever a truncate has started, it must eventually finish or be interrupted -
+\* i.e. the system cannot stall forever inside a single truncate action. This is the
+\* spec-level counterpart of James's alarm shape ("a monotonically increasing truncation
+\* action for a long time").
+EventuallyMakesProgress ==
+    truncateInProgress ~> ~truncateInProgress
+
+\* Whenever a marker is queued, it eventually gets truncated.
+MarkersDrain ==
+    \A m \in 0..MaxOplogEntries :
+        (m \in truncateMarkers) ~> (m \notin truncateMarkers)
+
+----
+\* State-space constraint to keep TLC tractable.
+
+StateConstraint ==
+    /\ clock <= 2 * MaxOplogEntries + MaxWriteConflicts + MaxInterrupts
+    /\ writeConflictCount <= MaxWriteConflicts
+    /\ truncateCount <= MaxOplogEntries
+    /\ interruptCount <= MaxInterrupts
+
+==============================================================================


### PR DESCRIPTION
## Summary

TLA+ spec + jstest + C++: oplog truncation-lag visibility.

**Jira:** https://jira.mongodb.org/browse/SERVER-126697
**Branch:** substrate-contrib/w3-126

## Files

```
  - .../replsets/oplog_truncation_lag_visibility.js    | 139 ++++++++++
  - .../db/storage/oplog_cap_maintainer_thread.cpp     |  31 +++
  - src/mongo/db/storage/oplog_truncation.cpp          |  24 ++
  - src/mongo/db/storage/oplog_truncation.h            |  11 +
  - .../OplogTruncationLag/MCOplogTruncationLag.cfg    |  19 ++
  - .../OplogTruncationLag/MCOplogTruncationLag.tla    |   3 +
  - .../Replication/OplogTruncationLag/OWNERS.yml      |   5 +
  - .../OplogTruncationLag/OplogTruncationLag.tla      | 293 +++++++++++++++++++++
  - 8 files changed, 525 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
