### PR TITLE
SERVER-126699 jstest + suite: oplog truncation chaos stepup

### DIFF
--- a/buildscripts/resmokeconfig/suites/replica_sets_chaos_stepup.yml
+++ b/buildscripts/resmokeconfig/suites/replica_sets_chaos_stepup.yml
@@ -1,0 +1,58 @@
+# Chaos suite for SERVER-126514: exercises oplog truncation edge cases under repeated step-ups.
+#
+# The driver test (jstests/replsets/oplog_truncation_chaos_stepup.js) drives explicit replSetStepUp
+# commands at every secondary while a steady majority-write workload runs. The ContinuousStepdown
+# hook below is configured with randomize_kill=true so that the chaos surface also includes
+# graceful stepdowns, SIGTERM, and SIGKILL between rounds — together this stresses every code path
+# the oplog truncator may hit when a new primary takes over (e.g. truncating back to the stable
+# timestamp, redriving applied-through, recovering from an unclean shutdown).
+test_kind: js_test
+
+selector:
+  roots:
+    - jstests/replsets/oplog_truncation_chaos_stepup.js
+
+executor:
+  archive:
+    hooks:
+      - CheckReplDBHash
+      - CheckReplOplogs
+      - ValidateCollections
+  config:
+    shell_options:
+      eval: >-
+        globalThis.testingReplication = true;
+        await import('jstests/libs/override_methods/network_error_and_txn_override.js');
+      global_vars:
+        TestData:
+          alwaysInjectTransactionNumber: true
+          logRetryAttempts: true
+          networkErrorAndTxnOverrideConfig:
+            retryOnNetworkErrors: true
+          overrideRetryAttempts: 6
+          runningWithStepdowns: true
+  hooks:
+    # Layer chaos on top of the explicit step-ups the driver test issues. randomize_kill picks
+    # between clean stepdown, SIGTERM, and SIGKILL with equal probability — the full surface area
+    # the oplog truncation code path needs to survive.
+    - class: ContinuousStepdown
+      stepdown_interval_ms: 4000
+      randomize_kill: true
+    - class: CheckReplOplogs
+    - class: CheckReplDBHash
+    - class: ValidateCollections
+    - class: CleanEveryN
+      n: 1
+  fixture:
+    class: ReplicaSetFixture
+    mongod_options:
+      set_parameters:
+        enableTestCommands: 1
+        # Surface enough replication detail to debug failures from the archived logs.
+        logComponentVerbosity:
+          replication:
+            heartbeats: 2
+            election: 2
+            rollback: 2
+    all_nodes_electable: true
+    num_nodes: 3

--- a/jstests/replsets/oplog_truncation_chaos_stepup.js
+++ b/jstests/replsets/oplog_truncation_chaos_stepup.js
@@ -1,0 +1,190 @@
+/**
+ * Chaos test for oplog truncation under repeated step-ups.
+ *
+ * Many edge cases in the oplog truncation code path are only exercised on failover (e.g. truncating
+ * the oplog back to the stable timestamp after a new primary is elected). This driver test runs a
+ * steady write workload against a 3-node replica set while issuing a random sequence of explicit
+ * replSetStepUp commands against the current secondaries. The ContinuousStepdown hook configured
+ * by the surrounding suite (replica_sets_chaos_stepup.yml) is layered on top to add randomized
+ * stepdown / terminate / kill chaos between iterations.
+ *
+ * Invariants asserted after each round:
+ *   1. A primary is reachable (the set can always elect one).
+ *   2. The oplog truncation point (replSetGetStatus.lastStableRecoveryTimestamp) is non-decreasing
+ *      across rounds on every reachable node — truncation must never advance past stable.
+ *   3. Every applied write that majority-committed before the round is still visible on the new
+ *      primary (oplog truncation must not drop committed history).
+ *
+ * @tags: [
+ *   requires_replication,
+ *   requires_majority_read_concern,
+ *   resource_intensive,
+ *   incompatible_with_macos,
+ *   incompatible_with_windows_tls,
+ * ]
+ */
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+const kRounds = 12;
+const kWritesPerRound = 50;
+const kDbName = "oplog_chaos";
+const kCollName = "writes";
+
+const rst = new ReplSetTest({
+    name: "oplog_truncation_chaos_stepup",
+    nodes: 3,
+    nodeOptions: {
+        setParameter: {
+            // Tighten checkpoint cadence so the stable timestamp moves often enough that
+            // step-ups land in interesting truncation states.
+            syncdelay: 5,
+            logComponentVerbosity: tojson({replication: {heartbeats: 1, election: 2}}),
+        },
+    },
+});
+rst.startSet();
+rst.initiate();
+rst.awaitReplication();
+
+// Seed the collection with a known prefix so we can detect lost history later.
+{
+    const primary = rst.getPrimary();
+    const seedDocs = [];
+    for (let i = 0; i < 100; ++i) {
+        seedDocs.push({_id: `seed-${i}`, round: -1, payload: "seed"});
+    }
+    assert.commandWorked(
+        primary.getDB(kDbName).getCollection(kCollName).insert(seedDocs, {writeConcern: {w: "majority"}}),
+    );
+}
+
+// Track the highest oplog truncation point we have observed on any node. Per-node truncation must
+// be non-decreasing across rounds (a primary that re-elects from behind would violate this).
+const lastTruncationByNode = {};
+for (const node of rst.nodes) {
+    lastTruncationByNode[node.host] = Timestamp(0, 0);
+}
+
+let nextWriteId = 0;
+let committedThroughRound = -1;
+
+function pickStepUpTarget(currentPrimary) {
+    const secondaries = rst.getSecondaries().filter((node) => node.host !== currentPrimary.host);
+    assert.gt(secondaries.length, 0, "expected at least one secondary candidate for stepUp");
+    return secondaries[Math.floor(Math.random() * secondaries.length)];
+}
+
+function readTruncationPoint(node) {
+    try {
+        const status = node.adminCommand({replSetGetStatus: 1});
+        if (!status.ok || !status.lastStableRecoveryTimestamp) {
+            return null;
+        }
+        return status.lastStableRecoveryTimestamp;
+    } catch (e) {
+        // Node may be transiently unreachable due to chaos; surface to caller.
+        return null;
+    }
+}
+
+function timestampLessThan(a, b) {
+    if (a.getTime() !== b.getTime()) {
+        return a.getTime() < b.getTime();
+    }
+    return a.getInc() < b.getInc();
+}
+
+for (let round = 0; round < kRounds; ++round) {
+    jsTestLog(`oplog_truncation_chaos_stepup: round ${round} starting`);
+
+    // 1. Drive writes against the current primary at majority write concern. Retry on stepdown
+    //    so the round can complete even if the ContinuousStepdown hook fires mid-batch.
+    const primary = rst.getPrimary();
+    const coll = primary.getDB(kDbName).getCollection(kCollName);
+    for (let i = 0; i < kWritesPerRound; ++i) {
+        const doc = {_id: `r${round}-w${nextWriteId++}`, round: round, payload: "x".repeat(64)};
+        assert.soon(
+            function () {
+                try {
+                    assert.commandWorked(coll.insert(doc, {writeConcern: {w: "majority", wtimeout: 30000}}));
+                    return true;
+                } catch (e) {
+                    if (
+                        e.code === ErrorCodes.NotWritablePrimary ||
+                        e.code === ErrorCodes.InterruptedDueToReplStateChange ||
+                        e.code === ErrorCodes.PrimarySteppedDown
+                    ) {
+                        // Refresh primary and retry on transient stepdowns.
+                        rst.getPrimary();
+                        return false;
+                    }
+                    throw e;
+                }
+            },
+            `failed to insert ${tojson(doc)} after chaos retries`,
+            60 * 1000,
+        );
+    }
+    committedThroughRound = round;
+
+    // 2. Pick a random secondary and issue replSetStepUp. The current primary may already have
+    //    been stepped down by the chaos hook — in that case getPrimary() will pick a fresh one and
+    //    pickStepUpTarget will excludes that host.
+    const currentPrimary = rst.getPrimary();
+    const target = pickStepUpTarget(currentPrimary);
+    jsTestLog(`oplog_truncation_chaos_stepup: round ${round} stepping up ${target.host}`);
+    assert.soon(
+        function () {
+            const res = target.adminCommand({replSetStepUp: 1});
+            if (res.ok === 1) {
+                return true;
+            }
+            // Transient failures expected while the set is rebalancing under chaos.
+            if (
+                res.code === ErrorCodes.CommandFailed ||
+                res.code === ErrorCodes.NotYetInitialized ||
+                res.code === ErrorCodes.InterruptedDueToReplStateChange
+            ) {
+                return false;
+            }
+            doassert(`unexpected replSetStepUp failure: ${tojson(res)}`);
+        },
+        `target ${target.host} never accepted replSetStepUp`,
+        60 * 1000,
+    );
+
+    // 3. Wait for the cluster to settle on a single primary, then assert truncation invariants on
+    //    every reachable node.
+    rst.getPrimary();
+    for (const node of rst.nodes) {
+        const point = readTruncationPoint(node);
+        if (point === null) {
+            jsTestLog(`oplog_truncation_chaos_stepup: ${node.host} not reachable for status this round`);
+            continue;
+        }
+        const prev = lastTruncationByNode[node.host];
+        assert(
+            !timestampLessThan(point, prev),
+            `oplog truncation point regressed on ${node.host}: ${tojson(prev)} -> ${tojson(point)} in round ${round}`,
+        );
+        lastTruncationByNode[node.host] = point;
+    }
+
+    // 4. Verify that every majority-committed write from every prior round is still visible from
+    //    the post-stepup primary. This is the load-bearing oplog-truncation correctness check.
+    const newPrimary = rst.getPrimary();
+    const newColl = newPrimary.getDB(kDbName).getCollection(kCollName);
+    const expectedCount = 100 /* seed */ + (committedThroughRound + 1) * kWritesPerRound;
+    assert.eq(
+        newColl.find().readConcern("majority").itcount(),
+        expectedCount,
+        `lost committed writes after stepup in round ${round}; new primary=${newPrimary.host}`,
+    );
+}
+
+// Final consistency check before teardown — the CheckReplDBHash hook will repeat this across the
+// whole set, but verifying here surfaces a tighter blame for the truncation path specifically.
+rst.awaitReplication();
+rst.checkOplogs();
+
+rst.stopSet();


### PR DESCRIPTION
## Summary

jstest + suite: oplog truncation chaos stepup.

**Jira:** https://jira.mongodb.org/browse/SERVER-126699
**Branch:** substrate-contrib/w3-128

## Files

```
  - .../suites/replica_sets_chaos_stepup.yml           |  58 +++++++
  - jstests/replsets/oplog_truncation_chaos_stepup.js  | 190 +++++++++++++++++++++
  - 2 files changed, 248 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
