### PR TITLE
SERVER-126700 matrix-suite mappings: disagg max-mirroring opportunistic secondary targeting

### DIFF
--- a/buildscripts/resmokeconfig/matrix_suites/mappings/disagg_replica_sets_max_mirroring.yml
+++ b/buildscripts/resmokeconfig/matrix_suites/mappings/disagg_replica_sets_max_mirroring.yml
@@ -1,0 +1,7 @@
+base_suite: disagg_replica_sets
+description: >-
+  DSC variant of replica_sets_max_mirroring. Confirms mirrored reads work on disaggregated
+  replica-set deployments (SERVER-122158).
+overrides:
+  - "max_mirroring.enable"
+  - "replica_sets.non_enterprise_root"

--- a/buildscripts/resmokeconfig/matrix_suites/mappings/disagg_sharding_max_mirroring_opportunistic_secondary_targeting.yml
+++ b/buildscripts/resmokeconfig/matrix_suites/mappings/disagg_sharding_max_mirroring_opportunistic_secondary_targeting.yml
@@ -1,0 +1,12 @@
+base_suite: disagg_sharding
+description: >-
+  DSC variant of sharding_max_mirroring_opportunistic_secondary_targeting. Combines
+  disagg_sharding_max_mirroring and opportunistic secondary targeting so we can confirm that
+  mirrored reads work on disaggregated storage clusters (SERVER-122158). You can run any of
+  these tests individually to debug any issues that might arise.
+overrides:
+  - "archive.no_archive"
+  - "max_mirroring.enable"
+  - "opportunistic_secondary_targeting.enable"
+excludes:
+  - "max_mirroring.sharding_excluded_files"

--- a/buildscripts/resmokeconfig/matrix_suites/mappings/disagg_sharding_max_mirroring_opportunistic_secondary_targeting_ese.yml
+++ b/buildscripts/resmokeconfig/matrix_suites/mappings/disagg_sharding_max_mirroring_opportunistic_secondary_targeting_ese.yml
@@ -1,0 +1,16 @@
+# This suite should not be run in any other variants that include
+# disagg_sharding_max_mirroring_opportunistic_secondary_targeting_ese_gcm or
+# disagg_sharding_max_mirroring_opportunistic_secondary_targeting.
+# disagg_sharding_ese should be run in these cases instead.
+base_suite: disagg_sharding
+description: >-
+  DSC variant combining disagg_sharding_max_mirroring, disagg_sharding_ese, and
+  opportunistic secondary targeting (SERVER-122158). You can run any of these tests
+  individually to debug any issues that might arise.
+overrides:
+  - "max_mirroring.enable"
+  - "opportunistic_secondary_targeting.enable"
+  - "encryption.testdata_ese"
+excludes:
+  - "max_mirroring.sharding_excluded_files"
+  - "encryption.excluded_files"

--- a/buildscripts/resmokeconfig/matrix_suites/mappings/disagg_sharding_max_mirroring_opportunistic_secondary_targeting_ese_gcm.yml
+++ b/buildscripts/resmokeconfig/matrix_suites/mappings/disagg_sharding_max_mirroring_opportunistic_secondary_targeting_ese_gcm.yml
@@ -1,0 +1,13 @@
+base_suite: disagg_sharding
+description: >-
+  DSC variant combining disagg_sharding_max_mirroring, disagg_sharding_ese_gcm, and
+  opportunistic secondary targeting (SERVER-122158). You can run any of these tests
+  individually to debug any issues that might arise.
+overrides:
+  - "max_mirroring.enable"
+  - "opportunistic_secondary_targeting.enable"
+  - "encryption.testdata_ese"
+  - "encryption.testdata_gcm"
+excludes:
+  - "max_mirroring.sharding_excluded_files"
+  - "encryption.excluded_files"


### PR DESCRIPTION
## Summary

matrix-suite mappings: disagg max-mirroring opportunistic secondary targeting.

**Jira:** https://jira.mongodb.org/browse/SERVER-126700
**Branch:** substrate-contrib/w3-129

## Files

```
  - .../mappings/disagg_replica_sets_max_mirroring.yml       |  7 +++++++
  - ...g_max_mirroring_opportunistic_secondary_targeting.yml | 12 ++++++++++++
  - ...x_mirroring_opportunistic_secondary_targeting_ese.yml | 16 ++++++++++++++++
  - ...rroring_opportunistic_secondary_targeting_ese_gcm.yml | 13 +++++++++++++
  - 4 files changed, 48 insertions(+)
```

## Verify

For any `.tla` file:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For any `.js` jstest:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
