### PR TITLE
SERVER-95283: Add jstest harness for injecting historical invalid catalog metadata

### DIFF
--- a/jstests/sharding/stale_catalog_injection_harness.js
+++ b/jstests/sharding/stale_catalog_injection_harness.js
@@ -1,0 +1,208 @@
+/**
+ * Harness for tests that inject previously-allowed but currently-disallowed catalog metadata
+ * and verify the server continues to behave correctly.
+ *
+ * This file is intentionally a *library* (no top-level test body) - example tests live in
+ * stale_catalog_injection_*.js next to it. The harness mediates two concerns:
+ *
+ *   1. Producing on-disk catalog rows that mirror what older versions of the server allowed
+ *      but which validation rejects today (SERVER-54712 weights on non-text indexes,
+ *      SERVER-68477 NaN expireAfterSeconds, SERVER-77828 float expireAfterSeconds,
+ *      SERVER-85837 obsolete feature_compatibility documents, SERVER-11064 pre-3.4 index
+ *      orderings of "" or 0).
+ *
+ *   2. Asserting server liveness afterwards - validate / collMod / restart should all stay
+ *      healthy, and known-good operations against the same collection should still succeed.
+ *
+ * Tests opt into the harness by calling runStaleCatalogInjectionScenario({...}) with a
+ * `setup` (mutate the catalog) and `verify` (assert behaviour) hook. The harness owns the
+ * ShardingTest / ReplSetTest lifecycle and the failpoint book-keeping.
+ *
+ * Follow-up to SERVER-94487, dependent on SERVER-99064. See SERVER-95283.
+ */
+
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+import {ShardingTest} from "jstests/libs/shardingtest.js";
+
+/**
+ * Failpoints that lift validation so we can persist catalog metadata in the same shape older
+ * server versions used to write. Each entry maps a friendly name onto the actual failpoint
+ * defined in src/mongo/db/index_key_validate.cpp (and adjacent files).
+ */
+export const StaleCatalogFailPoints = Object.freeze({
+    // Skips field-name validation on createIndex - allows unknown options like
+    // `weights` on a non-text index (SERVER-54712) and unknown fields in general.
+    skipIndexFieldNames: "skipIndexCreateFieldNameValidation",
+
+    // Skips TTL expireAfterSeconds validation - allows NaN (SERVER-68477) and float
+    // (SERVER-77828) values to be persisted in the catalog.
+    skipTtlExpireValidation: "skipTTLIndexExpireAfterSecondsValidation",
+});
+
+/**
+ * Default scenario shape. Tests override the `setup` and `verify` callbacks; everything
+ * else has a working default so a typical test is ~30 lines.
+ */
+const kDefaultOptions = {
+    // "replset" or "sharded"
+    topology: "replset",
+
+    // Topology sizing.
+    nodes: 2,
+    shards: 1,
+
+    // Failpoints to install on every data-bearing node before `setup` runs. Use the
+    // values from StaleCatalogFailPoints (e.g. [StaleCatalogFailPoints.skipTtlExpireValidation]).
+    failPoints: [],
+
+    // Whether to restart all data-bearing nodes after `setup` finishes. Many of the
+    // historical bugs only surface on a clean reload of the catalog from disk, so this
+    // defaults to true.
+    restartAfterSetup: true,
+
+    // (rst|st, primaryConn) => void. Runs while failpoints are active. Should write whatever
+    // legacy-shaped metadata the test wants to inject.
+    setup: () => {
+        throw new Error("stale-catalog injection scenario must define a `setup` callback");
+    },
+
+    // (rst|st, primaryConn) => void. Runs after failpoints are dropped (and after restart,
+    // if requested). Should make the actual liveness / repair / warning assertions.
+    verify: () => {
+        throw new Error("stale-catalog injection scenario must define a `verify` callback");
+    },
+});
+
+/**
+ * Returns the list of data-bearing connections we need to install failpoints on. For a
+ * replica set that's primary + secondaries; for a sharded cluster it's the primary of every
+ * shard. Config-server-side catalog injection is intentionally out-of-scope - those bugs
+ * are tracked separately.
+ */
+function dataBearingNodes(harness) {
+    if (harness.kind === "replset") {
+        return harness.rst.nodes;
+    }
+    const nodes = [];
+    for (const rs of harness.st._rs) {
+        for (const node of rs.test.nodes) {
+            nodes.push(node);
+        }
+    }
+    return nodes;
+}
+
+function startTopology(opts) {
+    if (opts.topology === "replset") {
+        const rst = new ReplSetTest({nodes: opts.nodes});
+        rst.startSet();
+        rst.initiate();
+        return {kind: "replset", rst, primary: () => rst.getPrimary()};
+    }
+    if (opts.topology === "sharded") {
+        const st = new ShardingTest({
+            shards: opts.shards,
+            rs: {nodes: opts.nodes},
+            initiateWithDefaultElectionTimeout: true,
+        });
+        return {kind: "sharded", st, primary: () => st.rs0.getPrimary()};
+    }
+    throw new Error("unknown topology: " + opts.topology);
+}
+
+function stopTopology(harness) {
+    if (harness.kind === "replset") {
+        harness.rst.stopSet();
+    } else {
+        harness.st.stop();
+    }
+}
+
+function installFailPoints(harness, names) {
+    const handles = [];
+    for (const node of dataBearingNodes(harness)) {
+        for (const name of names) {
+            handles.push(configureFailPoint(node.getDB("admin"), name));
+        }
+    }
+    return handles;
+}
+
+function dropFailPoints(handles) {
+    for (const fp of handles) {
+        try {
+            fp.off();
+        } catch (e) {
+            // Best-effort - the test may have already restarted the node the failpoint was on.
+        }
+    }
+}
+
+function restartAll(harness) {
+    if (harness.kind === "replset") {
+        const secondaries = harness.rst.getSecondaries();
+        for (const sec of secondaries) {
+            harness.rst.restart(sec);
+        }
+        harness.rst.awaitSecondaryNodes();
+        // Step the primary down + back up so its on-disk catalog is also re-read.
+        harness.rst.stepUp(harness.rst.getSecondary());
+        harness.rst.awaitNodesAgreeOnPrimary();
+        return;
+    }
+    for (const rs of harness.st._rs) {
+        const secondaries = rs.test.getSecondaries();
+        for (const sec of secondaries) {
+            rs.test.restart(sec);
+        }
+        rs.test.awaitSecondaryNodes();
+    }
+}
+
+/**
+ * Run a single stale-catalog injection scenario.
+ *
+ * @param {object} userOpts - see kDefaultOptions for the schema.
+ */
+export function runStaleCatalogInjectionScenario(userOpts) {
+    const opts = Object.assign({}, kDefaultOptions, userOpts);
+    const harness = startTopology(opts);
+
+    const failPointHandles = installFailPoints(harness, opts.failPoints);
+    try {
+        opts.setup(harness, harness.primary());
+    } finally {
+        dropFailPoints(failPointHandles);
+    }
+
+    // Persist on-disk before any restart so the secondaries see the legacy metadata.
+    if (harness.kind === "replset") {
+        harness.rst.awaitReplication();
+        assert.commandWorked(harness.primary().adminCommand({fsync: 1}));
+    } else {
+        for (const rs of harness.st._rs) {
+            rs.test.awaitReplication();
+            assert.commandWorked(rs.test.getPrimary().adminCommand({fsync: 1}));
+        }
+    }
+
+    if (opts.restartAfterSetup) {
+        restartAll(harness);
+    }
+
+    try {
+        opts.verify(harness, harness.primary());
+    } finally {
+        stopTopology(harness);
+    }
+}
+
+/**
+ * Convenience: create an index with otherwise-disallowed options. The relevant failpoints
+ * must already be installed by the caller (the harness does this automatically when the
+ * caller declares the failpoints in `opts.failPoints`).
+ */
+export function createIndexWithLegacyOptions(coll, keyPattern, options) {
+    return coll.createIndex(keyPattern, options);
+}

--- a/jstests/sharding/stale_catalog_injection_ttl_float.js
+++ b/jstests/sharding/stale_catalog_injection_ttl_float.js
@@ -1,0 +1,68 @@
+/**
+ * Inject a TTL index whose expireAfterSeconds is persisted as a float (a shape that the
+ * server accepted prior to SERVER-77828) and verify that the server starts cleanly, treats
+ * the value as a valid TTL expiry on the data path, and that collMod normalises it.
+ *
+ * Exercises the harness at jstests/sharding/stale_catalog_injection_harness.js.
+ *
+ * @tags: [
+ *     requires_persistence,
+ *     requires_replication,
+ * ]
+ */
+import {
+    runStaleCatalogInjectionScenario,
+    StaleCatalogFailPoints,
+} from "jstests/sharding/stale_catalog_injection_harness.js";
+
+const kDbName = "test";
+const kCollName = jsTestName();
+
+runStaleCatalogInjectionScenario({
+    topology: "replset",
+    nodes: 2,
+    failPoints: [
+        StaleCatalogFailPoints.skipIndexFieldNames,
+        StaleCatalogFailPoints.skipTtlExpireValidation,
+    ],
+    setup: (harness, primary) => {
+        const coll = primary.getDB(kDbName).getCollection(kCollName);
+        assert.commandWorked(coll.insert({_id: 0, t: ISODate()}));
+        // 3.14 instead of 3 - exactly the kind of float-typed expireAfterSeconds the
+        // pre-SERVER-77828 server would persist.
+        assert.commandWorked(
+            coll.createIndex({t: 1}, {expireAfterSeconds: 3.14}),
+        );
+    },
+    verify: (harness, primary) => {
+        const db = primary.getDB(kDbName);
+        const secondary = harness.rst.getSecondary();
+
+        // listIndexes should reflect the persisted float - the server is tolerant on read.
+        const indexes = db.getCollection(kCollName).getIndexes();
+        const ttl = indexes.find((idx) => idx.name !== "_id_");
+        assert(ttl !== undefined, indexes);
+        assert.eq(typeof ttl.expireAfterSeconds, "number", ttl);
+
+        // No startup error - the server keeps running. The collection accepts writes.
+        assert.commandWorked(
+            db.getCollection(kCollName).insert({_id: 1, t: ISODate()}),
+        );
+
+        // Validate succeeds on both nodes - float expireAfterSeconds is a soft repair target.
+        for (const conn of [db, secondary.getDB(kDbName)]) {
+            const res = assert.commandWorked(conn.runCommand({validate: kCollName}));
+            assert(res.valid, res);
+        }
+
+        // collMod with an explicit integer normalises the value.
+        assert.commandWorked(db.runCommand({
+            collMod: kCollName,
+            index: {name: ttl.name, expireAfterSeconds: NumberLong(4)},
+        }));
+        const normalised = db.getCollection(kCollName).getIndexes().find(
+            (idx) => idx.name === ttl.name,
+        );
+        assert.eq(normalised.expireAfterSeconds, 4, normalised);
+    },
+});

--- a/jstests/sharding/stale_catalog_injection_ttl_nan.js
+++ b/jstests/sharding/stale_catalog_injection_ttl_nan.js
@@ -1,0 +1,63 @@
+/**
+ * Inject a TTL index whose expireAfterSeconds is persisted as NaN (a shape that the server
+ * accepted prior to SERVER-68477) and verify:
+ *   - server startup logs the expected warning,
+ *   - validate() reports the collection as valid with a warning,
+ *   - collMod with the no-op spec coerces the NaN value back to a valid integer.
+ *
+ * Exercises the harness at jstests/sharding/stale_catalog_injection_harness.js.
+ *
+ * @tags: [
+ *     requires_persistence,
+ *     requires_replication,
+ * ]
+ */
+import {
+    runStaleCatalogInjectionScenario,
+    StaleCatalogFailPoints,
+} from "jstests/sharding/stale_catalog_injection_harness.js";
+
+const kDbName = "test";
+const kCollName = jsTestName();
+
+runStaleCatalogInjectionScenario({
+    topology: "replset",
+    nodes: 2,
+    failPoints: [
+        StaleCatalogFailPoints.skipIndexFieldNames,
+        StaleCatalogFailPoints.skipTtlExpireValidation,
+    ],
+    setup: (harness, primary) => {
+        const coll = primary.getDB(kDbName).getCollection(kCollName);
+        assert.commandWorked(coll.insert({_id: 0, t: ISODate()}));
+        // With the failpoints lifted, this createIndex call would have its NaN replaced by
+        // int32::max; under the failpoints the catalog row keeps the NaN exactly as a pre-
+        // SERVER-68477 mongod would have persisted it.
+        assert.commandWorked(coll.createIndex({t: 1}, {expireAfterSeconds: NaN}));
+    },
+    verify: (harness, primary) => {
+        const secondary = harness.rst.getSecondary();
+
+        // Startup warning fired on the restarted secondary (the harness restarts both nodes,
+        // so the previously-secondary node is the one carrying the freshly-replayed catalog).
+        checkLog.containsJson(secondary, 6852200, {
+            ns: `${kDbName}.${kCollName}`,
+            spec: (spec) => isNaN(spec.expireAfterSeconds),
+        });
+
+        const db = primary.getDB(kDbName);
+        const validateRes = assert.commandWorked(db.runCommand({validate: kCollName}));
+        assert(validateRes.valid, validateRes);
+        assert.gte(validateRes.warnings.length, 1, validateRes);
+
+        // collMod with no spec changes still walks the index list and is expected to fix up
+        // the NaN value in place.
+        assert.commandWorked(db.runCommand({collMod: kCollName}));
+
+        // Subsequent writes against the collection must still succeed - the whole point is
+        // that catalog repair does not break the data plane.
+        assert.commandWorked(
+            db.getCollection(kCollName).insert({_id: 1, t: ISODate()}),
+        );
+    },
+});

--- a/jstests/sharding/stale_catalog_injection_weights_on_non_text.js
+++ b/jstests/sharding/stale_catalog_injection_weights_on_non_text.js
@@ -1,0 +1,63 @@
+/**
+ * Inject a non-text index that carries a `weights` field (a shape that the server accepted
+ * prior to SERVER-54712) and verify that collMod can scrub the now-invalid option without
+ * data loss or replication divergence.
+ *
+ * Exercises the harness at jstests/sharding/stale_catalog_injection_harness.js.
+ *
+ * @tags: [
+ *     requires_persistence,
+ *     requires_replication,
+ * ]
+ */
+import {
+    runStaleCatalogInjectionScenario,
+    StaleCatalogFailPoints,
+} from "jstests/sharding/stale_catalog_injection_harness.js";
+
+const kDbName = "test";
+const kCollName = jsTestName();
+
+runStaleCatalogInjectionScenario({
+    topology: "replset",
+    nodes: 2,
+    failPoints: [StaleCatalogFailPoints.skipIndexFieldNames],
+    // The legacy options survive a clean shutdown only if the catalog row already reflects
+    // them, so we explicitly restart to confirm the catalog reloads cleanly.
+    restartAfterSetup: true,
+    setup: (harness, primary) => {
+        const coll = primary.getDB(kDbName).getCollection(kCollName);
+        assert.commandWorked(coll.insert({_id: 0, a: 1}));
+        // Non-text index with a `weights` field - illegal on master, legal pre-SERVER-54712.
+        assert.commandWorked(
+            coll.createIndex({a: 1}, {weights: {a: 5}, sparse: true}),
+        );
+        // And one extra unknown field to make sure scrub handles >1 stale option in a row.
+        assert.commandWorked(coll.createIndex({b: 1}, {legacy_unused_option: true}));
+    },
+    verify: (harness, primary) => {
+        const db = primary.getDB(kDbName);
+        const secondaryDb = harness.rst.getSecondary().getDB(kDbName);
+
+        for (const conn of [db, secondaryDb]) {
+            const validateRes = assert.commandWorked(conn.runCommand({validate: kCollName}));
+            assert(validateRes.valid, validateRes);
+            // One warning per index with a stale option.
+            assert.eq(validateRes.errors.length, 0, validateRes);
+            assert.gte(validateRes.warnings.length, 2, validateRes);
+        }
+
+        // collMod scrubs the invalid options on the primary and replicates the scrub.
+        assert.commandWorked(db.runCommand({collMod: kCollName}));
+
+        checkLog.containsJson(primary, 23878, {fieldName: "weights"});
+        checkLog.containsJson(primary, 23878, {fieldName: "legacy_unused_option"});
+        checkLog.containsJson(harness.rst.getSecondary(), 23878, {fieldName: "weights"});
+
+        for (const conn of [db, secondaryDb]) {
+            const validateRes = assert.commandWorked(conn.runCommand({validate: kCollName}));
+            assert(validateRes.valid, validateRes);
+            assert.eq(validateRes.warnings.length, 0, validateRes);
+        }
+    },
+});


### PR DESCRIPTION
## Summary

jstest harness for injecting historical invalid catalog metadata.

**Jira:** https://jira.mongodb.org/browse/SERVER-95283 (existing upstream)
**Branch:** substrate-contrib/w3-62

## Files

```
  - .../sharding/stale_catalog_injection_harness.js    | 208 +++++++++++++++++++++
  - .../sharding/stale_catalog_injection_ttl_float.js  |  68 +++++++
  - .../sharding/stale_catalog_injection_ttl_nan.js    |  63 +++++++
  - .../stale_catalog_injection_weights_on_non_text.js |  63 +++++++
  - 4 files changed, 402 insertions(+)
```

## Verify

```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
