### PR TITLE
SERVER-126385: Add jstest variants exercising WCE failpoint in index builds

### DIFF
--- a/jstests/noPassthrough/index_builds/index_build_write_conflict_collection_scan.js
+++ b/jstests/noPassthrough/index_builds/index_build_write_conflict_collection_scan.js
@@ -1,0 +1,58 @@
+/**
+ * SERVER-126385: Exercise the storage-engine-agnostic write conflict failpoint during the
+ * collection-scan phase of a hybrid index build, and verify the build retries through the
+ * injected conflicts and commits a queryable index.
+ *
+ * The failpoint name (WTWriteConflictException) is the runtime knob exported by the storage
+ * layer. SERVER-126328 generalised the C++ test-harness wiring; for jstests we still drive it
+ * via adminCommand. Keep `requires_wiredtiger` until the runtime failpoint is renamed to
+ * something storage-agnostic.
+ *
+ * @tags: [
+ *   requires_replication,
+ *   requires_wiredtiger,
+ * ]
+ */
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+import {IndexBuildTest} from "jstests/noPassthrough/libs/index_builds/index_build.js";
+
+const rst = new ReplSetTest({nodes: 1});
+rst.startSet();
+rst.initiate();
+
+const primary = rst.getPrimary();
+const primaryDB = primary.getDB(jsTestName());
+const coll = primaryDB.getCollection("coll");
+
+const numDocs = 200;
+{
+    const bulk = coll.initializeUnorderedBulkOp();
+    for (let i = 0; i < numDocs; i++) {
+        bulk.insert({_id: i, a: i, payload: "x".repeat(64)});
+    }
+    assert.commandWorked(bulk.execute());
+}
+
+// Force frequent yields so the collection-scan phase repeatedly re-acquires locks: each
+// re-acquisition path is a candidate site for the injected write conflict to fire.
+assert.commandWorked(primary.adminCommand({setParameter: 1, internalQueryExecYieldIterations: 4}));
+
+// Probabilistic injection across the entire build, exercising the retry loop in
+// IndexBuildsCoordinator without forcing a deterministic abort path.
+assert.commandWorked(
+    primary.adminCommand({
+        configureFailPoint: "WTWriteConflictException",
+        mode: {activationProbability: 0.05},
+    }),
+);
+
+try {
+    assert.commandWorked(coll.createIndex({a: 1}, {name: "a_1"}));
+} finally {
+    assert.commandWorked(primary.adminCommand({configureFailPoint: "WTWriteConflictException", mode: "off"}));
+}
+
+IndexBuildTest.assertIndexes(coll, 2, ["_id_", "a_1"]);
+assert.eq(numDocs, coll.find({a: {$gte: 0}}).hint({a: 1}).itcount());
+
+rst.stopSet();

--- a/jstests/noPassthrough/index_builds/index_build_write_conflict_side_writes_drain.js
+++ b/jstests/noPassthrough/index_builds/index_build_write_conflict_side_writes_drain.js
@@ -1,0 +1,76 @@
+/**
+ * SERVER-126385: Exercise the storage-engine-agnostic write conflict failpoint while the
+ * side-writes table is being drained, and verify the drain phase retries cleanly and the
+ * final index agrees with the collection.
+ *
+ * Pattern: pause the build after the initial collection scan, drive concurrent CRUD which
+ * lands in the side-writes table, then probabilistically inject write conflicts and resume
+ * the build so the drain path is what exercises the retry loop.
+ *
+ * @tags: [
+ *   requires_replication,
+ *   requires_wiredtiger,
+ * ]
+ */
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+import {IndexBuildTest} from "jstests/noPassthrough/libs/index_builds/index_build.js";
+
+const rst = new ReplSetTest({nodes: 1});
+rst.startSet();
+rst.initiate();
+
+const primary = rst.getPrimary();
+const primaryDB = primary.getDB(jsTestName());
+const coll = primaryDB.getCollection("coll");
+
+const initialDocs = 100;
+{
+    const bulk = coll.initializeUnorderedBulkOp();
+    for (let i = 0; i < initialDocs; i++) {
+        bulk.insert({_id: i, a: i});
+    }
+    assert.commandWorked(bulk.execute());
+}
+
+// Pause new index builds before the side-writes drain begins.
+IndexBuildTest.pauseIndexBuilds(primary);
+
+const awaitBuild = IndexBuildTest.startIndexBuild(primary, coll.getFullName(), {a: 1});
+const opId = IndexBuildTest.waitForIndexBuildToScanCollection(primaryDB, coll.getName(), "a_1");
+assert.gte(opId, 0, "expected an index build opId after the collection-scan phase");
+
+// Drive side-writes: inserts, updates, deletes that the drain phase will have to apply.
+const sideWriteOps = 60;
+for (let i = 0; i < sideWriteOps; i++) {
+    assert.commandWorked(coll.insert({_id: initialDocs + i, a: initialDocs + i}));
+    if (i % 3 === 0) {
+        assert.commandWorked(coll.update({_id: i}, {$set: {a: i + 10_000}}));
+    }
+    if (i % 5 === 0) {
+        assert.commandWorked(coll.remove({_id: i + 1}));
+    }
+}
+
+// Now activate the WCE failpoint, then unpause so the *drain* hits the retry loop.
+assert.commandWorked(
+    primary.adminCommand({
+        configureFailPoint: "WTWriteConflictException",
+        mode: {activationProbability: 0.1},
+    }),
+);
+
+try {
+    IndexBuildTest.resumeIndexBuilds(primary);
+    awaitBuild();
+} finally {
+    assert.commandWorked(primary.adminCommand({configureFailPoint: "WTWriteConflictException", mode: "off"}));
+}
+
+IndexBuildTest.waitForIndexBuildToStop(primaryDB, coll.getName(), "a_1");
+IndexBuildTest.assertIndexes(coll, 2, ["_id_", "a_1"]);
+
+// Collection-vs-index sanity: every doc must be indexed under the {a:1} entry.
+const indexedCount = coll.find({a: {$exists: true}}).hint({a: 1}).itcount();
+assert.eq(coll.count(), indexedCount, "drain phase under WCE retries dropped or duplicated keys");
+
+rst.stopSet();

--- a/jstests/noPassthrough/index_builds/index_build_write_conflict_unique_constraint.js
+++ b/jstests/noPassthrough/index_builds/index_build_write_conflict_unique_constraint.js
@@ -1,0 +1,63 @@
+/**
+ * SERVER-126385: Verify a unique-index build retries cleanly through injected write
+ * conflicts and does not surface a spurious DuplicateKey error when the conflicting
+ * document is rolled back and re-applied by the retry loop.
+ *
+ * Regression-shaped: a bug in the retry path could double-count an in-flight insert and
+ * fail the unique-constraint check on a key that is, in the end, unique.
+ *
+ * @tags: [
+ *   requires_replication,
+ *   requires_wiredtiger,
+ * ]
+ */
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+import {IndexBuildTest} from "jstests/noPassthrough/libs/index_builds/index_build.js";
+
+const rst = new ReplSetTest({nodes: 1});
+rst.startSet();
+rst.initiate();
+
+const primary = rst.getPrimary();
+const primaryDB = primary.getDB(jsTestName());
+const coll = primaryDB.getCollection("coll");
+
+// All-unique seed corpus. No two documents share `u`.
+const numDocs = 150;
+{
+    const bulk = coll.initializeUnorderedBulkOp();
+    for (let i = 0; i < numDocs; i++) {
+        bulk.insert({_id: i, u: i});
+    }
+    assert.commandWorked(bulk.execute());
+}
+
+// Yield often so the build re-enters the retry-eligible code path frequently.
+assert.commandWorked(primary.adminCommand({setParameter: 1, internalQueryExecYieldIterations: 8}));
+
+assert.commandWorked(
+    primary.adminCommand({
+        configureFailPoint: "WTWriteConflictException",
+        mode: {activationProbability: 0.08},
+    }),
+);
+
+let buildErr = null;
+try {
+    assert.commandWorked(coll.createIndex({u: 1}, {name: "u_1", unique: true}));
+} catch (e) {
+    buildErr = e;
+} finally {
+    assert.commandWorked(primary.adminCommand({configureFailPoint: "WTWriteConflictException", mode: "off"}));
+}
+
+assert.eq(null, buildErr, () => "unique index build failed under WCE retry: " + tojson(buildErr));
+IndexBuildTest.assertIndexes(coll, 2, ["_id_", "u_1"]);
+
+// All seeded values should be present under the unique index exactly once.
+assert.eq(numDocs, coll.find().hint({u: 1}).itcount());
+
+// And the unique constraint must actually be enforced post-build.
+assert.commandFailedWithCode(coll.insert({_id: numDocs, u: 0}), ErrorCodes.DuplicateKey);
+
+rst.stopSet();


### PR DESCRIPTION
## Summary

jstest variants exercising WCE failpoint in index builds.

**Jira:** https://jira.mongodb.org/browse/SERVER-126385 (existing upstream)
**Branch:** substrate-contrib/w3-67

## Files

```
  - .../index_build_write_conflict_collection_scan.js  | 58 +++++++++++++++++
  - ...index_build_write_conflict_side_writes_drain.js | 76 ++++++++++++++++++++++
  - ...index_build_write_conflict_unique_constraint.js | 63 ++++++++++++++++++
  - 3 files changed, 197 insertions(+)
```

## Verify

```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
