### PR TITLE
SERVER-126704 jstest + design: drop view over system.buckets must not drop underlying collection

### DIFF
--- a/jstests/sharding/timeseries/timeseries_drop_view_over_system_buckets.js
+++ b/jstests/sharding/timeseries/timeseries_drop_view_over_system_buckets.js
@@ -1,0 +1,159 @@
+/**
+ * Regression test for SERVER-125060.
+ *
+ * Reproduces the legacy (viewful) timeseries data-loss scenario where dropping a
+ * user-created view whose `viewOn` targets a `system.buckets.<name>` collection
+ * accidentally drops the underlying buckets collection on the shard. The shard
+ * catalog still has the buckets namespace registered, so the resulting state
+ * surfaces as a `MissingLocalCollection` inconsistency from
+ * `checkMetadataConsistency()` and the time-series collection becomes
+ * unreadable.
+ *
+ * On unpatched v8.0 binaries this test fails: after dropping the view,
+ *   - `system.buckets.<ts>` is missing from the shard, and
+ *   - `db.checkMetadataConsistency()` reports a `MissingLocalCollection` for it.
+ *
+ * The patched code path must:
+ *   (a) leave `system.buckets.<ts>` intact on the shard after dropping the
+ *       view, and
+ *   (b) keep `checkMetadataConsistency()` clean, and
+ *   (c) keep the time-series collection readable.
+ *
+ * The bug is impossible on viewless time-series, so we skip when those are
+ * enabled.
+ *
+ * @tags: [
+ *   requires_fcv_80,
+ *   requires_sharding,
+ *   requires_timeseries,
+ *   # The test exercises view DDL whose semantics differ when timeseries are
+ *   # viewless. The repro only applies to viewful timeseries.
+ *   assumes_no_implicit_collection_creation_after_drop,
+ * ]
+ */
+
+import {
+    areViewlessTimeseriesEnabled,
+    getTimeseriesBucketsColl,
+    skipTestIfViewlessTimeseriesEnabled,
+} from "jstests/core/timeseries/libs/viewless_timeseries_util.js";
+import {ShardingTest} from "jstests/libs/shardingtest.js";
+
+const dbName = "test";
+const tsCollName = "realts";
+const viewName = "fakets";
+const bucketsCollName = getTimeseriesBucketsColl(tsCollName);
+const timeField = "t";
+const metaField = "m";
+
+const st = new ShardingTest({shards: 2, rs: {nodes: 2}});
+const mongos = st.s0;
+const mainDB = mongos.getDB(dbName);
+
+try {
+    // The bug is only reproducible on viewful (legacy) timeseries. On viewless
+    // timeseries the user-visible namespace is the buckets collection itself
+    // and the view DDL path involved here does not exist.
+    skipTestIfViewlessTimeseriesEnabled(mainDB, () => st.stop());
+
+    assert.commandWorked(mongos.adminCommand({enableSharding: dbName}));
+
+    // Shard a time-series collection. ShardCollection auto-creates the
+    // backing `system.buckets.realts` collection on the primary shard and
+    // registers it in the sharding catalog.
+    assert.commandWorked(
+        mongos.adminCommand({
+            shardCollection: `${dbName}.${tsCollName}`,
+            timeseries: {timeField: timeField, metaField: metaField},
+            key: {[metaField]: 1},
+        }),
+    );
+
+    // Insert a sentinel document so we can later prove the time-series
+    // collection is still readable end-to-end.
+    assert.commandWorked(
+        mainDB.getCollection(tsCollName).insert({
+            [timeField]: ISODate("2026-01-01T00:00:00Z"),
+            [metaField]: "host-A",
+            value: 42,
+        }),
+    );
+
+    // Baseline metadata-consistency check: no inconsistencies after a clean
+    // shardCollection + insert.
+    let inconsistencies = mainDB.checkMetadataConsistency().toArray();
+    assert.eq(0, inconsistencies.length, tojson(inconsistencies));
+
+    // Create a user view whose `viewOn` points directly at the
+    // `system.buckets.realts` namespace. This is the trigger configuration
+    // from the ticket repro.
+    assert.commandWorked(mainDB.createView(viewName, bucketsCollName, []));
+
+    // Sanity: the view, the time-series collection, and the buckets
+    // collection all exist before the drop.
+    const collsBefore = new Set(mainDB.getCollectionNames());
+    assert(collsBefore.has(viewName), () => tojson([...collsBefore]));
+    assert(collsBefore.has(tsCollName), () => tojson([...collsBefore]));
+    assert(collsBefore.has(bucketsCollName), () => tojson([...collsBefore]));
+
+    // ---- The action under test ----
+    // Drop the user-created view. The drop must only remove view metadata.
+    // On unpatched v8.0 the code path interprets this as dropping a
+    // timeseries view and follows `coll->viewOn()` to drop
+    // `system.buckets.realts` from the local shard catalog. The sharding
+    // catalog still references the buckets namespace, so a
+    // `MissingLocalCollection` inconsistency appears.
+    assert.commandWorked(mainDB.runCommand({drop: viewName}));
+
+    // ---- Invariants the patched code must preserve ----
+
+    // (1) The view itself is gone from the mongos view of the database.
+    const collsAfter = new Set(mainDB.getCollectionNames());
+    assert(!collsAfter.has(viewName), () => tojson([...collsAfter]));
+
+    // (2) The time-series user namespace and its backing buckets collection
+    //     are both still present.
+    assert(
+        collsAfter.has(tsCollName),
+        `time-series collection ${tsCollName} was dropped as a side effect of dropping view ${viewName}: ` +
+            tojson([...collsAfter]),
+    );
+    assert(
+        collsAfter.has(bucketsCollName),
+        `backing buckets collection ${bucketsCollName} was dropped as a side effect of dropping view ${viewName}: ` +
+            tojson([...collsAfter]),
+    );
+
+    // (3) The buckets collection is still physically present on every shard
+    //     that owns chunks for it. We check the primary shard explicitly to
+    //     match the failure mode in the ticket repro.
+    for (const shard of [st.shard0, st.shard1]) {
+        const shardCollections = new Set(shard.getDB(dbName).getCollectionNames());
+        // Only assert presence on shards that may own data; shards with no
+        // chunks for the collection legitimately do not have a local copy.
+        if (shardCollections.has(bucketsCollName) || shard === st.getPrimaryShard(dbName)) {
+            assert(
+                shardCollections.has(bucketsCollName),
+                `${shard.shardName} is missing ${bucketsCollName} after dropping view ${viewName}: ` +
+                    tojson([...shardCollections]),
+            );
+        }
+    }
+
+    // (4) checkMetadataConsistency must remain clean. This is the primary
+    //     assertion the ticket asks for; on unpatched code it returns one
+    //     `MissingLocalCollection` entry for `test.system.buckets.realts`.
+    inconsistencies = mainDB.checkMetadataConsistency().toArray();
+    assert.eq(
+        0,
+        inconsistencies.length,
+        `dropping the view over ${bucketsCollName} introduced a metadata inconsistency: ` + tojson(inconsistencies),
+    );
+
+    // (5) The time-series collection remains readable end-to-end.
+    const docs = mainDB.getCollection(tsCollName).find({}).toArray();
+    assert.eq(1, docs.length, tojson(docs));
+    assert.eq(42, docs[0].value, tojson(docs));
+} finally {
+    st.stop();
+}

--- a/src/mongo/db/timeseries/SERVER-125060-design.md
+++ b/src/mongo/db/timeseries/SERVER-125060-design.md
@@ -1,0 +1,95 @@
+# Design: dropping a view over `system.buckets.*` must not drop the buckets collection
+
+## Symptom
+
+On v8.0 binaries the following sequence on a sharded cluster leaves the
+collection in a `MissingLocalCollection` state and silently destroys the
+underlying time-series data:
+
+```js
+db.adminCommand({shardCollection: "test.realts",
+                 timeseries: {timeField: 't', metaField: 'm'},
+                 key: {m: 1}});
+db.createView("fakets", "system.buckets.realts", []);
+db.fakets.drop();   // <-- also drops system.buckets.realts on the shard
+db.checkMetadataConsistency();
+// -> [{ type: 'MissingLocalCollection',
+//      details: { namespace: 'test.system.buckets.realts', ... } }]
+```
+
+The sharding catalog still has `system.buckets.realts` registered, but the
+local buckets collection on the primary shard is gone, so the time-series
+collection becomes unreadable. The companion jstest at
+`jstests/sharding/timeseries/timeseries_drop_view_over_system_buckets.js`
+reproduces this failure on unpatched code and pins the patched contract.
+
+## Root cause
+
+In `src/mongo/db/catalog/drop_collection.cpp` (v8.0 line range cited in the
+ticket, around L532-L535) the `drop` command for a view inspects the
+catalog `Collection` object and, when it appears to back a time-series
+namespace, also drops `coll->viewOn()`. That field is whatever
+namespace the user supplied to `createView`. For an arbitrary user view
+whose `viewOn` happens to be `system.buckets.<name>`, the local buckets
+collection is destroyed even though the view is not the canonical
+time-series view created by `createCollection({timeseries: ...})`.
+
+The sharding DDL coordinator side does the correct thing: it looks up
+`system.buckets.fakets`, finds nothing tracked, and does not touch the
+global catalog entry for `system.buckets.realts`. The local-shard drop
+runs independently and silently desynchronises the two catalogs.
+
+## Proposed fix
+
+Two complementary changes, both small and local to the view-drop path.
+
+1. **Scope the cascading drop to the canonical buckets namespace only.**
+   When dropping a view, if the code wants to also drop a buckets
+   collection it must use `coll->ns().makeTimeseriesBucketsNamespace()`
+   (i.e. `system.buckets.<view-name>`) rather than `coll->viewOn()`. The
+   buckets companion of a real time-series view is always
+   `system.buckets.<same-name>`; any other `viewOn` value identifies a
+   user-defined view that happens to read from a buckets namespace and
+   must not be cascaded.
+
+2. **Refuse, at create time, user views whose `viewOn` targets
+   `system.buckets.*`.** A view that reads from a buckets namespace is
+   a sharp edge with no legitimate user-facing use case in v8.0: the
+   buckets schema is internal, exposing it via a hand-rolled view does
+   not produce a usable time-series surface, and it is the exact
+   configuration that triggers the data-loss path. Returning
+   `IllegalOperation` on `createView` when `viewOn` matches
+   `system.buckets.*` removes the only known trigger. Existing legit
+   time-series views are created by `createCollection`, not
+   `createView`, so this change does not affect supported flows.
+
+Change (1) is the load-bearing correctness fix; change (2) is
+defense in depth and matches the spirit of the existing
+`IllegalOperation` guard against direct drops of
+`system.buckets.<name>`.
+
+`v8.1+` already fixes the local-drop branch as part of `SERVER-94829`,
+and viewless time-series make the entire class impossible, so the
+backport target is `v8.0` only.
+
+## Test plan
+
+* New jstest reproduces the data-loss state on unpatched v8.0 and pins
+  all four invariants on patched code: view is gone, buckets collection
+  survives on the owning shard, `checkMetadataConsistency()` stays
+  clean, and the time-series collection remains readable.
+* Existing `jstests/sharding/timeseries/timeseries_drop.js` continues to
+  exercise the legitimate buckets-drop path through `coll.drop()` on
+  the time-series collection itself; the proposed fix does not alter
+  that flow.
+* Add a unit-level guard in `drop_collection_test.cpp` if a fixture
+  exists for the view-drop path; otherwise the jstest is sufficient
+  for a v8.0 backport-only fix.
+
+## Out of scope
+
+* No change to `v8.1+` — already corrected by `SERVER-94829`.
+* No change to viewless time-series, which structurally cannot hit this
+  bug.
+* No change to the sharding DDL coordinator: it already does the right
+  thing.


### PR DESCRIPTION
## Summary

jstest + design: drop view over system.buckets must not drop underlying collection.

**Jira:** https://jira.mongodb.org/browse/SERVER-126704
**Branch:** substrate-contrib/w4-1

## Files

```
  -  .../timeseries_drop_view_over_system_buckets.js    | 159 +++++++++++++++++++++
  -  src/mongo/db/timeseries/SERVER-125060-design.md    |  95 ++++++++++++
  -  2 files changed, 254 insertions(+)
```

## Verify

For `.tla` files:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For `.js` jstests:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
