### PR TITLE
SERVER-126705 TLA+ spec + jstest for oplog truncation liveness under cap pressure

### DIFF
--- a/jstests/replsets/oplog_cap_maintainer_truncation_liveness.js
+++ b/jstests/replsets/oplog_cap_maintainer_truncation_liveness.js
@@ -1,0 +1,173 @@
+/**
+ * Empirical companion to src/mongo/tla_plus/Replication/OplogTruncationLiveness.
+ *
+ * Reproduces the symptom shape from the production incident in which six
+ * fleet clusters stopped truncating oplog after time-based retention was
+ * enabled: the oplog cap maintainer thread is stalled, oplog accumulates
+ * beyond the retention cap, and (in the bug version) no progress is made;
+ * in the fixed version the maintainer eventually shrinks the oplog back
+ * below the cap.
+ *
+ * The hangOplogCapMaintainerThread failpoint is the documented runtime
+ * knob that reproduces the prod-scenario stall: while it is alwaysOn the
+ * maintainer is parked on a sync point and cannot process pending truncate
+ * markers, exactly matching the observed behavior in which the
+ * ReplicatedOplogTruncationThread was logging increasing attempts while
+ * the oplog continued to grow.
+ *
+ * Test outline:
+ *   1.  Start a 1-node replica set with a 1MB oplog and a 10-second
+ *       oplogMinRetentionHours (modeled as 0.002777 hours, matching the
+ *       pattern from jstests/noPassthrough/oplog/oplog_retention_hours.js).
+ *       The hangOplogCapMaintainerThread failpoint is alwaysOn at start.
+ *   2.  Write enough data to push the oplog well past both its byte cap
+ *       and its retention window, simulating the prod cluster state in
+ *       which "Replication Oplog Window was about a week when truncation
+ *       was enabled" (Jira description).
+ *   3.  Assert the oplog has NOT been truncated while the failpoint is
+ *       held (the symptom of the prod stall).
+ *   4.  Release the failpoint and assert the oplog shrinks back below
+ *       1.1x its configured cap within a bounded time (the liveness
+ *       obligation the maintainer is supposed to satisfy).
+ *   5.  Verify the serverStatus.oplogTruncation counters reflect that at
+ *       least one truncation actually completed.
+ *
+ * @tags: [
+ *   requires_persistence,
+ *   requires_replication,
+ *   requires_wiredtiger,
+ * ]
+ */
+import {kDefaultWaitForFailPointTimeout} from "jstests/libs/fail_point_util.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+const oplogSizeMB = 1;
+const oplogSizeBytes = oplogSizeMB * 1024 * 1024;
+const oplogSoftCapBytes = 1.1 * oplogSizeBytes; // OplogTruncateMarkers permits 10% overshoot.
+
+// Ten seconds, expressed in hours, mirroring the value used by
+// jstests/noPassthrough/oplog/oplog_retention_hours.js. The retention
+// window is intentionally short so the test does not wait minutes for
+// the maintainer to act on it.
+const oplogMinRetentionHours = 0.002777;
+const retentionSecondsApprox = oplogMinRetentionHours * 60 * 60;
+
+const tenKB = "a".repeat(10 * 1024);
+
+const replSet = new ReplSetTest({
+    name: "oplog_cap_maintainer_truncation_liveness",
+    oplogSize: oplogSizeMB,
+    nodes: 1,
+    nodeOptions: {
+        // syncdelay 1s so the checkpointer keeps up and we don't need to
+        // wait minutes for stable-timestamp to advance.
+        syncdelay: 1,
+        setParameter: {
+            logComponentVerbosity: tojson({storage: 1}),
+            // Park the cap maintainer at the failpoint. This simulates
+            // the prod stall: the thread is alive but not making
+            // progress on the truncate-marker queue.
+            "failpoint.hangOplogCapMaintainerThread": tojson({mode: "alwaysOn"}),
+        },
+    },
+});
+
+// oplogMinRetentionHours is a startup option, passed through to mongod's
+// CLI by startSet(); see jstests/noPassthrough/oplog/oplog_retention_hours.js
+// for the canonical pattern.
+replSet.startSet({oplogMinRetentionHours: oplogMinRetentionHours});
+replSet.initiate();
+
+const primary = replSet.getPrimary();
+const oplog = primary.getDB("local").oplog.rs;
+const coll = primary.getDB("oplog_cap_maintainer_truncation_liveness").coll;
+
+jsTestLog("Step 1: wait for the cap maintainer thread to park at hangOplogCapMaintainerThread.");
+assert.commandWorked(
+    primary.adminCommand({
+        waitForFailPoint: "hangOplogCapMaintainerThread",
+        timesEntered: 1,
+        maxTimeMS: kDefaultWaitForFailPointTimeout,
+    }),
+);
+
+jsTestLog("Step 2: write enough data to push the oplog past its retention window AND its byte cap.");
+// Aim well above the soft cap so the prod-style "way past retention" condition
+// is unambiguous. 20 inserts of 10KB = ~200KB of user data + oplog overhead;
+// loop until we are at least 2x oplogSize.
+const initialOplogSize = oplog.dataSize();
+let writeCount = 0;
+while (oplog.dataSize() < 2 * oplogSizeBytes) {
+    assert.commandWorked(coll.insert({tenKB: tenKB}));
+    writeCount++;
+    // Belt-and-braces guard so a misconfigured run can't loop forever.
+    assert.lt(writeCount, 5000, `Wrote ${writeCount} docs without crossing 2x oplog cap`);
+}
+jsTestLog(`Wrote ${writeCount} docs; oplog dataSize now ${oplog.dataSize()} (cap ${oplogSizeBytes}).`);
+
+// Hold past the retention window so the would-be-truncated entries are
+// definitely older than oplogMinRetentionHours. The maintainer is still
+// parked; this is the prod-shaped "stalled while retention violated" state.
+jsTestLog(`Step 3a: sleep ${retentionSecondsApprox * 2}s (2x retention window) with the maintainer parked.`);
+sleep((retentionSecondsApprox * 2) * 1000);
+
+jsTestLog("Step 3b: confirm the oplog has NOT shrunk while the failpoint holds the maintainer.");
+const stalledSize = oplog.dataSize();
+assert.gt(
+    stalledSize,
+    oplogSoftCapBytes,
+    `Oplog dataSize ${stalledSize} should still exceed soft cap ${oplogSoftCapBytes} ` +
+        `while hangOplogCapMaintainerThread is alwaysOn. If this fires, the failpoint may have been ` +
+        `relocated; see SERVER-121352.`,
+);
+
+// The bug version of the spec (BackoffOnConflict = FALSE in
+// MC_bug.cfg) corresponds to this state persisting forever. The fix
+// version corresponds to step 4 succeeding inside the assert.soon
+// budget.
+jsTestLog("Step 4: release the maintainer and assert it shrinks the oplog back below the soft cap.");
+assert.commandWorked(primary.adminCommand({configureFailPoint: "hangOplogCapMaintainerThread", mode: "off"}));
+
+// Encourage the maintainer to actually wake by writing a few more
+// entries (post-fix, the truncate-marker pipeline needs at least one
+// new marker creation to fire). The replicated_truncate path is
+// triggered on the next insertion after the marker queue advances.
+for (let i = 0; i < 5; i++) {
+    assert.commandWorked(coll.insert({tenKB: tenKB, postRelease: i}));
+}
+
+assert.soon(
+    () => {
+        const sizeNow = oplog.dataSize();
+        const truncationStatus = primary.getDB("admin").runCommand({serverStatus: 1}).oplogTruncation;
+        jsTestLog(
+            `  oplog dataSize=${sizeNow} cap=${oplogSizeBytes} soft=${oplogSoftCapBytes} ` +
+                `truncateCount=${truncationStatus.truncateCount} ` +
+                `totalTimeTruncatingMicros=${truncationStatus.totalTimeTruncatingMicros}`,
+        );
+        return sizeNow < oplogSoftCapBytes;
+    },
+    "Timed out waiting for the oplog cap maintainer thread to shrink the oplog below the soft cap. " +
+        "This is the symptom SERVER-121352 reported in production: maintainer is unblocked but " +
+        "still not making progress on the truncate-marker queue.",
+    ReplSetTest.kDefaultTimeoutMS,
+    1000 /* interval ms */,
+);
+
+jsTestLog("Step 5: verify serverStatus.oplogTruncation reflects at least one completed truncation.");
+const finalStatus = primary.getDB("admin").runCommand({serverStatus: 1});
+assert.commandWorked(finalStatus);
+const truncation = finalStatus.oplogTruncation;
+assert.gte(
+    truncation.truncateCount,
+    1,
+    `Expected at least one truncation to have completed; oplogTruncation=${tojson(truncation)}`,
+);
+assert.gt(
+    truncation.totalTimeTruncatingMicros,
+    0,
+    `Expected non-zero totalTimeTruncatingMicros; oplogTruncation=${tojson(truncation)}`,
+);
+
+jsTestLog("Done. The maintainer met its liveness obligation after the failpoint was released.");
+replSet.stopSet();

--- a/src/mongo/tla_plus/Replication/OplogTruncationLiveness/MCOplogTruncationLiveness.cfg
+++ b/src/mongo/tla_plus/Replication/OplogTruncationLiveness/MCOplogTruncationLiveness.cfg
@@ -1,0 +1,32 @@
+\* Green config for OplogTruncationLiveness.tla.
+\*
+\* Models the fixed cap-maintainer (size-based backoff on WCE). With these
+\* constants, TLC should report:
+\*     - Safety invariants TypeOK and NeverTruncateRetained hold.
+\*     - Liveness property EventuallyTruncates holds (no violation found).
+\*
+\* Run from src/mongo/tla_plus :
+\*     ./model-check.sh Replication/OplogTruncationLiveness
+\*
+\* See OplogTruncationLiveness.tla for full property descriptions and
+\* the corresponding bug configuration in MC_bug.cfg.
+
+CONSTANT MaxBurst         = 2
+CONSTANT CacheBudget      = 3
+CONSTANT RetentionCap     = 2
+CONSTANT MaxOplogSize     = 8
+CONSTANT BackoffOnConflict = TRUE
+
+INVARIANT TypeOK
+INVARIANT NeverTruncateRetained
+
+PROPERTY EventuallyTruncates
+
+\* Not configurable.
+CONSTRAINT StateConstraint
+SPECIFICATION Spec
+
+\* Once the workload has drained AND Excess = 0 there is nothing left for
+\* the spec to do; TLC would otherwise flag that as a deadlock. The
+\* liveness property still covers the "stuck with Excess > 0" case.
+CHECK_DEADLOCK FALSE

--- a/src/mongo/tla_plus/Replication/OplogTruncationLiveness/MCOplogTruncationLiveness.tla
+++ b/src/mongo/tla_plus/Replication/OplogTruncationLiveness/MCOplogTruncationLiveness.tla
@@ -1,0 +1,14 @@
+---- MODULE MCOplogTruncationLiveness ----
+\* This module defines OplogTruncationLiveness.tla constants/constraints
+\* for model-checking. See OplogTruncationLiveness.tla for instructions.
+
+EXTENDS OplogTruncationLiveness
+
+\* Keep the state space small. The bug manifests at any size where a
+\* single requested truncation exceeds CacheBudget, so we don't need
+\* large numeric ranges.
+StateConstraint ==
+    /\ oplogSize   <= MaxOplogSize
+    /\ attemptSize <= MaxOplogSize
+    /\ truncated   <= MaxOplogSize
+=============================================================================

--- a/src/mongo/tla_plus/Replication/OplogTruncationLiveness/MC_bug.cfg
+++ b/src/mongo/tla_plus/Replication/OplogTruncationLiveness/MC_bug.cfg
@@ -1,0 +1,39 @@
+\* Bug config for OplogTruncationLiveness.tla.
+\*
+\* Models the production cap-maintainer in March 2026: on WCE the
+\* maintainer retries the same oversize window every cycle (no size-based
+\* backoff). With these constants, TLC should report a Liveness violation
+\* on EventuallyTruncates - a counter-example trace showing the oplog
+\* growing past RetentionCap and the maintainer never managing to shrink
+\* it because attemptSize stays above CacheBudget forever.
+\*
+\* Run from src/mongo/tla_plus :
+\*     cd Replication/OplogTruncationLiveness
+\*     java -cp ../../tla2tools.jar tlc2.TLC -config MC_bug.cfg \
+\*          MCOplogTruncationLiveness
+\*
+\* The model-check.sh wrapper only invokes the default MC config, so this
+\* variant is run by hand to demonstrate the falsification.
+
+CONSTANT MaxBurst         = 2
+CONSTANT CacheBudget      = 3
+CONSTANT RetentionCap     = 2
+CONSTANT MaxOplogSize     = 8
+CONSTANT BackoffOnConflict = FALSE
+
+INVARIANT TypeOK
+INVARIANT NeverTruncateRetained
+
+\* Expected to fail under this config - this is the prod bug the ticket
+\* documents.
+PROPERTY EventuallyTruncates
+
+\* Not configurable.
+CONSTRAINT StateConstraint
+SPECIFICATION Spec
+
+\* In the bug config the stall state (drained, Excess > 0, attemptSize >
+\* CacheBudget) has no enabled action. CHECK_DEADLOCK FALSE lets TLC
+\* report the liveness violation rather than treating that state as a
+\* deadlock; the violation itself is exactly the production behavior.
+CHECK_DEADLOCK FALSE

--- a/src/mongo/tla_plus/Replication/OplogTruncationLiveness/OWNERS.yml
+++ b/src/mongo/tla_plus/Replication/OplogTruncationLiveness/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-replication-reviewers

--- a/src/mongo/tla_plus/Replication/OplogTruncationLiveness/OplogTruncationLiveness.tla
+++ b/src/mongo/tla_plus/Replication/OplogTruncationLiveness/OplogTruncationLiveness.tla
@@ -1,0 +1,264 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+----------------------- MODULE OplogTruncationLiveness -----------------------
+\* Models the oplog cap-maintainer thread's liveness obligation:
+\*
+\*   If MinRetentionHours > 0 and the oplog has grown beyond the retention cap,
+\*   the cap maintainer thread MUST eventually shrink the oplog back to the
+\*   retention cap.
+\*
+\* The production incident captured this property failing on six fleet
+\* clusters: oplog kept growing while the cap-maintainer thread repeatedly
+\* requested a truncation larger than the WiredTiger slow-truncate cache
+\* budget allowed, hit a WriteConflictException, and retried the same
+\* oversize window on the next tick (no size-based backoff). Per Jira
+\* comments dated 2026-03-10 / 2026-03-18, every cycle attempted to remove
+\* all excess oplog at once, so when one cycle was too big to fit in cache
+\* the next cycle was too big as well, and the cluster never made progress.
+\*
+\* The spec models two variants gated by the BackoffOnConflict constant:
+\*
+\*   BackoffOnConflict = TRUE  (the fixed path):
+\*       On WCE the maintainer drops the requested window to CacheBudget,
+\*       analogous to the per-cycle cap from SERVER-122519 which switched
+\*       the wake interval from 5 minutes to 30 seconds so each cycle's
+\*       requested truncation stays well below the cache budget. The
+\*       Liveness property holds.
+\*
+\*   BackoffOnConflict = FALSE (the bug path):
+\*       The MaintainerTruncateConflict action is disabled (the prod
+\*       maintainer had no working backoff path - on WCE it slept and
+\*       retried the same oversize window with no mutation of state).
+\*       Modeling this as a disabled action makes the stuck state a true
+\*       terminal node with no outgoing edges, and TLC reports a liveness
+\*       counter-example to Liveness: producer eventually drains, but the
+\*       maintainer is left stuck with attemptSize > CacheBudget forever.
+\*
+\* To run TLC:
+\*     cd src/mongo/tla_plus
+\*     ./download-tlc.sh
+\*     ./model-check.sh Replication/OplogTruncationLiveness
+\*
+\* The green config (MC.cfg) checks Liveness. The bug config (MC_bug.cfg)
+\* drops the CONSTRAINT bound to make the violation manifest more quickly
+\* and sets BackoffOnConflict = FALSE. See README.md for invocation notes.
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+
+\* ---------------------------------------------------------------------------
+\* Constants
+\* ---------------------------------------------------------------------------
+
+\* Maximum number of oplog entries that can be appended in one Producer step.
+\* "Bursty arrival" - matches the ticket's note that an affected cluster
+\* "accumulated oplog at a phenomenal rate, possibly as high as 24.5GB per
+\* hour for the first hour or two" (Jira comment, 2026-03-17).
+CONSTANT MaxBurst
+
+\* Per-cycle cache budget for slow truncate (WiredTiger ~3GB / 20% of cache
+\* limit referenced by Keith Smith in the ticket). The maintainer can shrink
+\* the oplog by at most CacheBudget entries in a single successful step.
+CONSTANT CacheBudget
+
+\* Number of oplog entries that constitute the retention window
+\* (a model-checking proxy for MinRetentionHours: the maintainer is
+\* obligated to keep at most RetentionCap entries on disk).
+CONSTANT RetentionCap
+
+\* Upper bound on log length for model-checking finiteness. The bug spec
+\* will saturate at MaxOplogSize and stutter; TLC then reports the
+\* liveness violation since the maintainer fails to shrink below
+\* RetentionCap eventually.
+CONSTANT MaxOplogSize
+
+\* TRUE  : on WCE the maintainer halves the requested truncation window
+\*         (the green / fixed model).
+\* FALSE : on WCE the maintainer retries the same oversize window forever
+\*         (the bug / production-incident model).
+CONSTANT BackoffOnConflict
+
+ASSUME MaxBurst       \in Nat \ {0}
+ASSUME CacheBudget    \in Nat \ {0}
+ASSUME RetentionCap   \in Nat \ {0}
+ASSUME MaxOplogSize   \in Nat \ {0}
+ASSUME RetentionCap < MaxOplogSize
+ASSUME BackoffOnConflict \in BOOLEAN
+
+\* ---------------------------------------------------------------------------
+\* Variables
+\* ---------------------------------------------------------------------------
+
+\* oplogSize  - number of entries currently in the oplog. The model abstracts
+\*              away byte size; one entry == one notional unit.
+\* attemptSize - the size of the truncation the maintainer is going to ask
+\*               for on its next attempt. Starts at RetentionCap (the
+\*               natural "shrink-to-cap" request).
+\* truncated  - cumulative count of entries successfully removed by the
+\*              maintainer. Used in safety invariants.
+\* phase      - workload phase, "running" or "drained". The producer fires
+\*              while phase = "running" and the workload eventually
+\*              transitions to "drained", after which only the maintainer
+\*              can act. This makes the liveness obligation concrete: the
+\*              maintainer must bring Excess back to 0 after the workload
+\*              stops pushing - any failure to do so is a permanent stall.
+
+VARIABLE oplogSize, attemptSize, truncated, phase
+
+vars == <<oplogSize, attemptSize, truncated, phase>>
+
+\* ---------------------------------------------------------------------------
+\* Helpers
+\* ---------------------------------------------------------------------------
+
+\* Excess over retention cap. The cap maintainer's job is to eventually
+\* drive this back to 0.
+Excess == IF oplogSize > RetentionCap THEN oplogSize - RetentionCap ELSE 0
+
+\* "Would this attempt fit in the cache budget?" Slow truncate fails when
+\* the requested window exceeds the WiredTiger-bounded cache.
+WouldFitCache(req) == req <= CacheBudget
+
+\* Cap an attempt at the actual excess - asking for more than the excess
+\* would mean truncating valid retention-window entries.
+EffectiveAttempt(req) == IF req > Excess THEN Excess ELSE req
+
+\* ---------------------------------------------------------------------------
+\* Initial state
+\* ---------------------------------------------------------------------------
+
+Init ==
+    /\ oplogSize    = 0
+    /\ attemptSize  = RetentionCap
+    /\ truncated    = 0
+    /\ phase        = "running"
+
+\* ---------------------------------------------------------------------------
+\* Actions
+\* ---------------------------------------------------------------------------
+
+\* Producer appends 1..MaxBurst entries to the oplog. Disabled once the
+\* workload has drained, and disabled when the model bound has been
+\* reached so TLC's state space is finite.
+ProducerAppend ==
+    /\ phase = "running"
+    /\ oplogSize < MaxOplogSize
+    /\ \E n \in 1..MaxBurst :
+         /\ oplogSize + n <= MaxOplogSize
+         /\ oplogSize' = oplogSize + n
+    /\ UNCHANGED <<attemptSize, truncated, phase>>
+
+\* The workload eventually stops generating new oplog entries (e.g. the
+\* application is taken down). After this point the maintainer is the
+\* only actor and is solely responsible for satisfying liveness.
+WorkloadDrains ==
+    /\ phase = "running"
+    /\ phase' = "drained"
+    /\ UNCHANGED <<oplogSize, attemptSize, truncated>>
+
+\* The maintainer wakes, sees excess > 0, and attempts to truncate.
+\* If the attempt fits in cache it succeeds. If not, it raises a WCE.
+\* The two cases are split into separate enabled actions so TLC can
+\* enumerate them.
+
+\* Success path: requested window fits the per-cycle cache budget.
+\* The oplog shrinks by EffectiveAttempt(attemptSize). The maintainer
+\* resets its next requested size to RetentionCap (so subsequent cycles
+\* request only the current excess).
+MaintainerTruncateSuccess ==
+    /\ Excess > 0
+    /\ WouldFitCache(attemptSize)
+    /\ LET delta == EffectiveAttempt(attemptSize)
+       IN  /\ delta > 0
+           /\ oplogSize'   = oplogSize - delta
+           /\ truncated'   = truncated + delta
+           /\ attemptSize' = RetentionCap
+    /\ UNCHANGED phase
+
+\* WCE path: requested window exceeds the cache budget. No bytes are
+\* truncated. The fix (SERVER-122519, "Change truncation thread interval
+\* to 30s when doing time-based truncation in disagg") is modeled here
+\* as: drop attemptSize to CacheBudget. That guarantees the next cycle
+\* fits the cache and makes progress. In the bug-config the action is
+\* disabled (BackoffOnConflict = FALSE) so the stuck state has no
+\* outgoing edge - which is what TLC will report as a liveness
+\* counter-example to EventuallyTruncates.
+MaintainerTruncateConflict ==
+    /\ BackoffOnConflict
+    /\ Excess > 0
+    /\ ~ WouldFitCache(attemptSize)
+    /\ oplogSize'   = oplogSize
+    /\ truncated'   = truncated
+    /\ attemptSize' = CacheBudget
+    /\ UNCHANGED phase
+
+\* On the very first wake-up after retention is enabled (or after a
+\* successful truncation), the maintainer asks for the full excess at
+\* once. This is the literal behavior described in Nick Shectman's
+\* 2026-03-10 comment: "the cap maintainer thread will attempt to
+\* truncate away all of the excess oplog at once". The pre-condition
+\* attemptSize <= RetentionCap ensures the action only fires from the
+\* "reset" state (start-up or post-success) - it does NOT overwrite a
+\* backed-off attemptSize, otherwise the spec would oscillate between
+\* backoff and re-inflation and never converge.
+MaintainerRecomputeWindow ==
+    /\ Excess > 0
+    /\ attemptSize <= RetentionCap
+    /\ Excess > RetentionCap
+    /\ attemptSize' = Excess
+    /\ UNCHANGED <<oplogSize, truncated, phase>>
+
+Next ==
+    \/ ProducerAppend
+    \/ WorkloadDrains
+    \/ MaintainerTruncateSuccess
+    \/ MaintainerTruncateConflict
+    \/ MaintainerRecomputeWindow
+
+\* Fairness:
+\*   - The workload must eventually drain (otherwise the producer could
+\*     refuse to stop and trivially keep Excess > 0 forever, but that's
+\*     not the bug we're modeling).
+\*   - The maintainer thread is required to run, by spec. Without WF on
+\*     the maintainer actions we'd get a trivial "scheduler never runs
+\*     the thread" counter-example, which also isn't the bug.
+Fairness ==
+    /\ WF_vars(WorkloadDrains)
+    /\ WF_vars(MaintainerTruncateSuccess)
+    /\ WF_vars(MaintainerTruncateConflict)
+    /\ WF_vars(MaintainerRecomputeWindow)
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+\* ---------------------------------------------------------------------------
+\* Safety invariants
+\* ---------------------------------------------------------------------------
+
+\* Type / bounds invariant.
+TypeOK ==
+    /\ oplogSize    \in 0..MaxOplogSize
+    /\ attemptSize  \in 1..MaxOplogSize
+    /\ truncated    \in Nat
+    /\ phase        \in {"running", "drained"}
+
+\* The maintainer never removes entries we must retain. (We model "must
+\* retain" as RetentionCap entries; in production those are the entries
+\* younger than MinRetentionHours.)
+NeverTruncateRetained ==
+    oplogSize >= 0 /\ (oplogSize >= RetentionCap \/ truncated = 0 \/ RetentionCap = 0)
+
+\* ---------------------------------------------------------------------------
+\* Liveness property - the obligation that the prod incident violated
+\* ---------------------------------------------------------------------------
+
+\* If the oplog ever exceeds the retention cap, eventually the maintainer
+\* shrinks it back. This is the patent claim of the cap-maintainer thread,
+\* and it's the property six clusters in the fleet were not meeting in
+\* March 2026.
+EventuallyTruncates ==
+    [](Excess > 0 ~> Excess = 0)
+
+===============================================================================

--- a/src/mongo/tla_plus/Replication/OplogTruncationLiveness/README.md
+++ b/src/mongo/tla_plus/Replication/OplogTruncationLiveness/README.md
@@ -1,0 +1,128 @@
+# OplogTruncationLiveness
+
+Formal model of the oplog cap-maintainer's liveness obligation, motivated by a
+production incident in which six fleet clusters stopped truncating oplog after
+time-based retention was enabled on March 6, 2026.
+
+## What the spec captures
+
+The cap-maintainer thread is required to satisfy:
+
+> If `MinRetentionHours > 0` and the oplog has grown beyond the retention
+> cap, the maintainer MUST eventually shrink the oplog back to the cap.
+
+Formally (in `OplogTruncationLiveness.tla`):
+
+    EventuallyTruncates == [](Excess > 0 ~> Excess = 0)
+
+The spec models four state variables:
+
+| Variable      | Meaning                                                       |
+|---------------|---------------------------------------------------------------|
+| `oplogSize`   | Number of entries currently in the oplog (abstract units).    |
+| `attemptSize` | Size of the truncation the maintainer will request next tick. |
+| `truncated`   | Cumulative entries successfully removed.                      |
+| `phase`       | `"running"` while the workload appends, `"drained"` after.    |
+
+And five actions:
+
+| Action                       | When it fires                                          |
+|------------------------------|--------------------------------------------------------|
+| `ProducerAppend`             | Workload appends 1..`MaxBurst` entries to the oplog.    |
+| `WorkloadDrains`             | Workload stops generating new entries.                  |
+| `MaintainerTruncateSuccess`  | Requested window fits the `CacheBudget`; shrink.        |
+| `MaintainerTruncateConflict` | Requested window exceeds `CacheBudget`; WCE. Only enabled when `BackoffOnConflict = TRUE`. |
+| `MaintainerRecomputeWindow`  | Maintainer is at its post-success reset and Excess exceeds the cap; raise the next request to Excess. |
+
+`MaintainerTruncateConflict` models the WCE path. In the green config it
+drops `attemptSize` to `CacheBudget` so the next cycle is guaranteed to
+fit. In the bug config the action is disabled entirely - the prod
+maintainer had no working backoff path, so we model that by removing
+the action's enabling clause. The stuck state (drained, Excess > 0,
+attemptSize > CacheBudget) then has no outgoing edge, which is exactly
+the production behavior and the basis of the liveness counter-example.
+
+## Why this maps to the prod incident
+
+`SERVER-121352` records that the affected clusters had `Replication Oplog
+Window` of roughly a week when time-based retention was first enabled.
+The cap-maintainer woke, computed the excess (the full backlog), asked
+WiredTiger to slow-truncate the entire backlog in one shot, hit the
+~3 GB / 20%-of-cache slow-truncate budget, raised a
+`WriteConflictException`, slept the retry interval, and asked for the
+same oversize window again. The ticket comment dated 2026-04-08 shows
+the `ReplicatedOplogTruncationThread` counter at `"attempts": 36` and
+still climbing - direct evidence that the maintainer was making zero
+progress.
+
+The mitigation that shipped (`SERVER-122519`) shortened the wake interval
+from 5 minutes to 30 seconds, so each cycle's requested truncation stays
+well below the cache budget. In the spec that corresponds to setting
+`BackoffOnConflict = TRUE`: each cycle requests a smaller window than
+the previous failing one, eventually fits the cache, and makes progress.
+
+## How to run
+
+From `src/mongo/tla_plus`:
+
+    ./download-tlc.sh             # one-time, requires network access
+    ./model-check.sh Replication/OplogTruncationLiveness
+
+That invokes the green config (`MCOplogTruncationLiveness.cfg`) which
+sets `BackoffOnConflict = TRUE`. Expected output: invariants
+`TypeOK` and `NeverTruncateRetained` hold, property
+`EventuallyTruncates` holds, no liveness violation.
+
+To exercise the bug config, run by hand from this directory after a
+`download-tlc.sh`:
+
+    java -cp ../../tla2tools.jar tlc2.TLC \
+        -config MC_bug.cfg MCOplogTruncationLiveness
+
+`MC_bug.cfg` sets `BackoffOnConflict = FALSE`. Expected output: TLC
+reports `Error: Temporal properties were violated.` and emits a
+counter-example trace ending in a stutter at a state with
+`phase = "drained"`, `oplogSize > RetentionCap`, and
+`attemptSize > CacheBudget`. From that state no action is enabled and
+the oplog never shrinks, exactly mirroring the production behavior
+reported on `sls-smoke-qa-aws-use1-restore-target` (Jira comment
+2026-04-08) where `ReplicatedOplogTruncationThread` was logging
+increasing `attempts` while the oplog continued to grow.
+
+If `tla2tools.jar` cannot be downloaded in the current environment,
+`./model-check.sh` returns with `No tla2tools.jar, run download-tlc.sh
+first`. The spec itself is self-contained and can be opened in any
+TLA+ Toolbox or TLC distribution that supports TLA+ 1.7 / Java 11+.
+
+## State space
+
+Both configs use:
+
+    MaxBurst       = 2
+    CacheBudget    = 3
+    RetentionCap   = 2
+    MaxOplogSize   = 8
+
+These bounds were chosen to make the bug manifest within a handful of
+states while keeping the green check tractable. The green check
+explores 310 distinct states (depth 16) and reports no liveness
+violation. The bug check explores the same state graph and reports
+the temporal-property violation at depth 16.
+
+Both configs set `CHECK_DEADLOCK FALSE`. Without that, TLC would
+flag the natural terminal state (Excess = 0, phase = "drained", no
+action enabled) as a deadlock in both configs and we'd lose the
+ability to distinguish "bug" from "green". The actual production
+issue surfaces purely as a liveness counter-example to
+`EventuallyTruncates`.
+
+## Paired empirical artifact
+
+A jstest that simulates the same condition lives at
+`jstests/replsets/oplog_cap_maintainer_truncation_liveness.js`. It
+uses the `hangOplogCapMaintainerThread` failpoint (also used by
+`jstests/replsets/libs/oplog_rollover_test.js`) to stall the
+maintainer, accumulate oplog beyond the retention cap, then unblock
+the thread and assert that within a bounded time the oplog shrinks
+back below the cap. The failpoint is the documented runtime knob that
+reproduces the prod scenario described in the ticket.


### PR DESCRIPTION
## Summary

TLA+ spec + jstest for oplog truncation liveness under cap pressure.

**Jira:** https://jira.mongodb.org/browse/SERVER-126705
**Branch:** substrate-contrib/w4-2

## Files

```
  -  .../oplog_cap_maintainer_truncation_liveness.js    | 173 ++++++++++++++
  -  .../MCOplogTruncationLiveness.cfg                  |  32 +++
  -  .../MCOplogTruncationLiveness.tla                  |  14 ++
  -  .../Replication/OplogTruncationLiveness/MC_bug.cfg |  39 +++
  -  .../Replication/OplogTruncationLiveness/OWNERS.yml |   5 +
  -  .../OplogTruncationLiveness.tla                    | 264 +++++++++++++++++++++
  -  .../Replication/OplogTruncationLiveness/README.md  | 128 ++++++++++
  -  7 files changed, 655 insertions(+)
```

## Verify

For `.tla` files:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For `.js` jstests:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
