### PR TITLE
SERVER-126706 jstest + design: Express _id $eq DBRef-shaped crash repro

### DIFF
--- a/jstests/core/express/express_id_eq_dbref_crash.js
+++ b/jstests/core/express/express_id_eq_dbref_crash.js
@@ -1,0 +1,150 @@
+/**
+ * Deterministic repro for the Express write path crash that fires when the query
+ * filter is shaped {_id: {$eq: <object>}} and the wrapped object's first field
+ * name starts with '$' (the canonical example being a DBRef literal,
+ * {$ref: "foo", $id: <oid>}).
+ *
+ * Background:
+ *   - The Express write path is enabled by isSimpleIdQuery(), which permits
+ *     {_id: {$eq: <value>}} as an exact-_id query.
+ *   - On entry, makeExpressExecutorForUpdate / makeExpressExecutorForDelete
+ *     call getQueryFilterMaybeUnwrapEq() to flatten {_id: {$eq: <v>}} into
+ *     {_id: <v>}.
+ *   - The unwrapped filter is then re-validated by isExactMatchOnId(), which
+ *     rejects object values whose first sub-field begins with '$' on the
+ *     assumption that such a sub-field is an operator. A DBRef literal looks
+ *     exactly like that, but it is data, not an operator.
+ *   - The mismatch trips tassert(9248801) for update and tassert(9248804) for
+ *     delete, taking mongod down.
+ *
+ * This test pins the user-visible contract: an update or delete with such a
+ * filter must not crash. The server is permitted to either succeed with an
+ * empty match, succeed with a match on a document whose _id is the equivalent
+ * DBRef literal, or fail with a structured command error. What it must not do
+ * is tassert.
+ *
+ * @tags: [
+ *   assumes_unsharded_collection,
+ *   assumes_write_concern_unchanged,
+ *   requires_non_retryable_writes,
+ *   # Time-series collections have different _id properties and do not exercise
+ *   # the Express _id-equality fast path.
+ *   exclude_from_timeseries_crud_passthrough,
+ * ]
+ */
+
+const coll = db.getCollection("express_id_eq_dbref_crash");
+coll.drop();
+
+// Seed with a normal _id document so the collection is non-empty and the
+// Express path has a real index entry to compare against.
+assert.commandWorked(coll.insert({_id: 1, x: 0}));
+
+// Build the offending filter once. The literal DBRef shape is what trips the
+// Express re-validation: its first sub-field ('$ref') starts with '$' even
+// though it is plain data.
+const dbrefLiteral = {
+    $ref: "foo",
+    $id: 1,
+};
+const offendingFilter = {
+    _id: {$eq: dbrefLiteral},
+};
+
+// ---- Update path ----------------------------------------------------------
+// Pre-bug, this would tassert(9248801) and tear mongod down. Post-fix the
+// command may return a clean success with nMatched == 0, or a structured
+// write error. We accept either, but the server must remain alive.
+const updateRes = db.runCommand({
+    update: coll.getName(),
+    updates: [
+        {q: offendingFilter, u: {$set: {x: 1}}, multi: false, upsert: false},
+    ],
+});
+
+// If the command-level call itself returned ok:0, that is acceptable as long
+// as the structured response is well-formed (no crash). Inspect writeErrors
+// without asserting on a particular error code: the contract here is that the
+// server returns a response, not that it picks any specific shape.
+assert(typeof updateRes === "object" && updateRes !== null,
+       "update returned a non-object response: " + tojson(updateRes));
+
+if (updateRes.ok === 1) {
+    // Either nothing matched (DBRef literal does not equal _id: 1), or the
+    // server matched and modified a doc whose _id is a DBRef literal. Both
+    // are allowed; we only require nMatched to be a non-negative integer.
+    assert.eq(typeof updateRes.n, "number",
+              "update missing numeric n: " + tojson(updateRes));
+    assert.gte(updateRes.n, 0,
+               "update reported negative n: " + tojson(updateRes));
+} else {
+    // ok:0 path: expect a writeErrors array OR a top-level errmsg/code.
+    const hasStructuredError =
+        (Array.isArray(updateRes.writeErrors) && updateRes.writeErrors.length > 0) ||
+        (typeof updateRes.errmsg === "string" && typeof updateRes.code === "number");
+    assert(hasStructuredError,
+           "update returned ok:0 without a structured error: " + tojson(updateRes));
+}
+
+// The seed document must still be reachable after the update attempt. If the
+// server crashed earlier, this read would not return. If the update silently
+// corrupted state, the seed would be missing.
+assert.eq(coll.find({_id: 1}).itcount(), 1,
+          "seed document {_id: 1} disappeared after update attempt");
+
+// ---- Delete path ----------------------------------------------------------
+// Symmetric repro for tassert(9248804). Same allowance: clean success with
+// zero matches, clean success deleting a DBRef-_id document, or a structured
+// write error. No crash.
+const deleteRes = db.runCommand({
+    delete: coll.getName(),
+    deletes: [
+        {q: offendingFilter, limit: 1},
+    ],
+});
+
+assert(typeof deleteRes === "object" && deleteRes !== null,
+       "delete returned a non-object response: " + tojson(deleteRes));
+
+if (deleteRes.ok === 1) {
+    assert.eq(typeof deleteRes.n, "number",
+              "delete missing numeric n: " + tojson(deleteRes));
+    assert.gte(deleteRes.n, 0,
+               "delete reported negative n: " + tojson(deleteRes));
+} else {
+    const hasStructuredError =
+        (Array.isArray(deleteRes.writeErrors) && deleteRes.writeErrors.length > 0) ||
+        (typeof deleteRes.errmsg === "string" && typeof deleteRes.code === "number");
+    assert(hasStructuredError,
+           "delete returned ok:0 without a structured error: " + tojson(deleteRes));
+}
+
+// Server liveness post-delete. A follow-up find round-trip is the cheapest
+// proof that the connection survived both write attempts.
+assert.eq(coll.find({_id: 1}).itcount(), 1,
+          "seed document {_id: 1} disappeared after delete attempt");
+
+// ---- findAndModify spot check --------------------------------------------
+// findAndModify also routes through the Express write path for exact-_id
+// updates/deletes. Cover both modes briefly. A crash here would manifest as
+// a missing response; correctness for the remove/update result itself is not
+// the point of this test, so we only require a well-formed command response.
+const famUpdateRes = db.runCommand({
+    findAndModify: coll.getName(),
+    query: offendingFilter,
+    update: {$set: {x: 2}},
+});
+assert(typeof famUpdateRes === "object" && famUpdateRes !== null,
+       "findAndModify(update) returned a non-object response: " + tojson(famUpdateRes));
+
+const famRemoveRes = db.runCommand({
+    findAndModify: coll.getName(),
+    query: offendingFilter,
+    remove: true,
+});
+assert(typeof famRemoveRes === "object" && famRemoveRes !== null,
+       "findAndModify(remove) returned a non-object response: " + tojson(famRemoveRes));
+
+// Final liveness probe.
+assert.eq(coll.find({_id: 1}).itcount(), 1,
+          "seed document {_id: 1} disappeared after findAndModify attempts");

--- a/src/mongo/db/exec/express/SERVER-126499-design.md
+++ b/src/mongo/db/exec/express/SERVER-126499-design.md
@@ -1,0 +1,79 @@
+# SERVER-126499 — Design: Express write path on DBRef-shaped `_id` literals
+
+## Problem
+
+The Express update/delete fast path tasserts when given an exact-`_id` query
+whose value is an object literal whose first field name begins with `$`. The
+canonical example is a DBRef literal: `{_id: {$eq: {$ref: "foo", $id: <oid>}}}`.
+
+- Update site: `plan_executor_express.cpp` ~line 714, `tassert(9248801)`.
+- Delete site: `plan_executor_express.cpp` ~line 780, `tassert(9248804)`.
+
+## Root cause
+
+Two checks disagree about what counts as an "exact match on `_id`":
+
+1. `isSimpleIdQuery()` (eligibility check) accepts `{_id: {$eq: <object>}}` as
+   an exact-`_id` query regardless of the inner object's shape.
+2. `getQueryFilterMaybeUnwrapEq()` flattens `{_id: {$eq: <v>}}` into
+   `{_id: <v>}` before re-validating with `isExactMatchOnId()`.
+3. `isExactMatchOnId()` rejects an `_id` value whose first sub-field name
+   starts with `$`, on the assumption that such a name is an operator. A
+   literal DBRef value satisfies that pattern but is plain data, so the second
+   check fires a `tassert` instead of a user-visible error.
+
+The eligibility check (1) is the authoritative one for the write fast path —
+parsing has already classified the query as an exact match. The re-check (3)
+exists to protect against unexpected shapes reaching the executor after the
+`$eq` unwrap, but it is too coarse: it conflates "first sub-field starts with
+`$`" with "this is operator syntax", when in fact the unwrapped value is a
+literal that was already validated upstream.
+
+## Proposed fix
+
+Two ordered options, each minimally invasive:
+
+### Option A — relax `isExactMatchOnId` for already-unwrapped values
+
+Tighten `isExactMatchOnId()` so it accepts DBRef-shaped literals. Concretely:
+when the `_id` value is an object whose first sub-field name starts with `$`,
+inspect the full sub-field set. If every sub-field name begins with `$` and
+none of them is a known MatchExpression operator (`$eq`, `$gt`, `$in`, …), the
+value is a literal and the function returns `true`. This preserves the
+existing rejection of `{_id: {$gt: 1}}` while admitting `{$ref, $id, $db}` and
+similar BSON-encoded literal shapes (`$date`, `$oid`, `$numberLong` when used
+as data, etc.).
+
+Pros: localized, no change to call sites. Cons: requires maintaining the list
+of known operators near `isExactMatchOnId`, which couples it to
+`MatchExpressionParser`. Mitigation: pull the operator set from
+`MatchExpressionParser`'s public registry rather than hard-coding.
+
+### Option B — bypass the post-unwrap `tassert` and fall back to the classic path
+
+Replace the two `tassert` sites with an `if (!isExactMatchOnId(queryFilter))`
+that returns `nullptr` from `makeExpressExecutorFor{Update,Delete}`. The
+caller in `get_executor.cpp` already has a fallback for "Express declines";
+it will rebuild the query through the classic update/delete executor stack,
+which handles literal objects correctly.
+
+Pros: zero behavior change for queries Express already accepts; no operator
+registry coupling. Cons: silently widens the set of inputs Express rejects,
+which may mask future eligibility bugs.
+
+### Recommendation
+
+Ship Option A. Option B is the safety net if A turns up additional
+literal shapes during review. Both options leave `isSimpleIdQuery()` (the
+eligibility gate) untouched — the bug is in the re-validation, not in
+eligibility.
+
+## Test plan
+
+- `jstests/core/express/express_id_eq_dbref_crash.js` (this changeset) pins
+  the crash-free contract for update, delete, and findAndModify with a
+  DBRef-shaped `_id` literal.
+- Extend `plan_executor_express_test.cpp` with a unit case feeding the
+  DBRef literal directly into `isExactMatchOnId` once the fix lands.
+- No replication or sharding-specific behavior is exercised; the existing
+  `assumes_unsharded_collection` tag on the jstest is sufficient.


### PR DESCRIPTION
## Summary

jstest + design: Express _id $eq DBRef-shaped crash repro.

**Jira:** https://jira.mongodb.org/browse/SERVER-126706
**Branch:** substrate-contrib/w4-3

## Files

```
  -  jstests/core/express/express_id_eq_dbref_crash.js | 150 ++++++++++++++++++++++
  -  src/mongo/db/exec/express/SERVER-126499-design.md |  79 ++++++++++++
  -  2 files changed, 229 insertions(+)
```

## Verify

For `.tla` files:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For `.js` jstests:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
