### PR TITLE
SERVER-126707 jstest + design: single-component system variable in $lookup join predicate crash

### DIFF
--- a/jstests/aggregation/sources/lookup/lookup_single_component_sysvar_predicate.js
+++ b/jstests/aggregation/sources/lookup/lookup_single_component_sysvar_predicate.js
@@ -1,0 +1,121 @@
+/**
+ * Regression: assertion when a single-component system variable (e.g. $$NOW, $$ROOT, $$CURRENT)
+ * is used inside a $lookup join predicate ($expr in the sub-pipeline's $match, or in a downstream
+ * $match between two $lookups that the join optimizer attempts to push down).
+ *
+ * Root cause: extractExpressionCompare() in predicate_extractor.cpp unconditionally calls
+ * ExpressionFieldPath::getFieldPathWithoutCurrentPrefix() on both sides of a $eq once they are
+ * confirmed to be ExpressionFieldPath pointers. That helper invokes FieldPath::tail(), which trips
+ * tassert(16409, "FieldPath::tail() called on single element path", getPathLength() > 1) when the
+ * referenced path has a single component. Bare system variables ($$NOW, $$ROOT, $$CURRENT) are
+ * stored as ExpressionFieldPath whose underlying _fieldPath is a single component ("NOW", "ROOT",
+ * "CURRENT"). $$NOW is preserved as an ExpressionFieldPath (not constant-folded) unless
+ * featureFlagSbeFull is enabled, so it reaches the join optimizer intact.
+ *
+ * The query should either return an expected (typically empty) result or be rejected with a clean
+ * error -- it must not crash the server with a tassert.
+ *
+ * @tags: [
+ *   requires_fcv_90,
+ * ]
+ */
+const testDB = db.getSiblingDB(jsTestName());
+const base = testDB.base;
+const left = testDB.left;
+const right = testDB.right;
+
+base.drop();
+left.drop();
+right.drop();
+
+assert.commandWorked(base.insert({_id: 0, lk: 1, rk: 1, ts: new Date(0)}));
+assert.commandWorked(base.insert({_id: 1, lk: 2, rk: 2, ts: new Date(0)}));
+assert.commandWorked(left.insert({_id: "left", lk: 1, a: 1}));
+assert.commandWorked(right.insert({_id: "right", rk: 1, b: 1, ts: new Date(0)}));
+
+assert.commandWorked(base.createIndex({lk: 1, rk: 1}));
+assert.commandWorked(left.createIndex({lk: 1}));
+assert.commandWorked(right.createIndex({rk: 1}));
+
+// Helper: a command either runs cleanly (returns its result array) or fails with a non-crash
+// error code. Either is acceptable; an unclean shutdown / tassert is not.
+function runOrAcceptError(coll, pipeline, label) {
+    const cmdRes = testDB.runCommand({aggregate: coll.getName(), pipeline: pipeline, cursor: {}});
+    if (cmdRes.ok === 1) {
+        jsTestLog(label + ": ok, cursor returned");
+        return new DBCommandCursor(testDB, cmdRes).toArray();
+    }
+    // Acceptable: any clean error code. Unacceptable: tassert / crash (caught by parallel suite).
+    jsTestLog(label + ": clean error, code=" + cmdRes.code + " errmsg=" + cmdRes.errmsg);
+    return null;
+}
+
+// Case 1: $$NOW in a join predicate between two $lookups. This reproduces the original ticket.
+// The $eq compares the single-component system variable $$NOW (a Date) against a scalar from the
+// upstream left $lookup -- the equality can never hold but the optimizer must not crash trying to
+// extract it as a join predicate.
+{
+    const pipeline = [
+        {$lookup: {from: left.getName(), localField: "lk", foreignField: "lk", as: "left"}},
+        {$unwind: "$left"},
+        {$lookup: {from: right.getName(), localField: "rk", foreignField: "rk", as: "right"}},
+        {$unwind: "$right"},
+        {$match: {$expr: {$eq: ["$$NOW", "$left.a"]}}},
+    ];
+    const out = runOrAcceptError(base, pipeline, "case1 $$NOW vs $left.a");
+    if (out !== null) {
+        assert.eq([], out, "Date ($$NOW) is never equal to scalar 1");
+    }
+}
+
+// Case 2: $$NOW inside a $lookup let + sub-pipeline. let binds $$now to a foreign timestamp; the
+// sub-pipeline predicate equates $$NOW (the bare system variable, single-component) against the
+// let-bound variable. The join optimizer should not attempt -- or, attempting, must not crash --
+// to push this down as an equijoin.
+{
+    const pipeline = [
+        {
+            $lookup: {
+                from: right.getName(),
+                let: {ts: "$ts"},
+                pipeline: [{$match: {$expr: {$eq: ["$$NOW", "$$ts"]}}}],
+                as: "matched",
+            },
+        },
+    ];
+    const out = runOrAcceptError(base, pipeline, "case2 $$NOW in let + sub-pipeline");
+    if (out !== null) {
+        // $$NOW is the wall-clock at query time; the seeded $ts is epoch. They never match, so the
+        // 'matched' array must be empty for every base doc.
+        for (const doc of out) {
+            assert.eq([], doc.matched, "matched array must be empty: " + tojson(doc));
+        }
+    }
+}
+
+// Case 3: $$ROOT used in a downstream $expr equality. $$ROOT is also single-component and exercises
+// the same code path.
+{
+    const pipeline = [
+        {$lookup: {from: left.getName(), localField: "lk", foreignField: "lk", as: "left"}},
+        {$unwind: "$left"},
+        {$match: {$expr: {$eq: ["$$ROOT", "$left"]}}},
+    ];
+    runOrAcceptError(base, pipeline, "case3 $$ROOT vs $left");
+}
+
+// Case 4: $$CURRENT mirror. By default $$CURRENT aliases $$ROOT, so the same single-component
+// path-tail code path is exercised.
+{
+    const pipeline = [
+        {$lookup: {from: left.getName(), localField: "lk", foreignField: "lk", as: "left"}},
+        {$unwind: "$left"},
+        {$match: {$expr: {$eq: ["$$CURRENT", "$left"]}}},
+    ];
+    runOrAcceptError(base, pipeline, "case4 $$CURRENT vs $left");
+}
+
+// Case 5: confirm the server is still healthy after running every pipeline above. If any of them
+// had crashed the server we would have failed before reaching this point; this is a belt-and-
+// braces final ping.
+assert.commandWorked(testDB.runCommand({ping: 1}));

--- a/src/mongo/db/pipeline/SERVER-126396-design.md
+++ b/src/mongo/db/pipeline/SERVER-126396-design.md
@@ -1,0 +1,72 @@
+# Design note: single-component system variable in $lookup join predicate
+
+## Symptom
+
+`tassert(16409, "FieldPath::tail() called on single element path")` (server abort) when a $lookup
+join predicate references a bare system variable -- `$$NOW`, `$$ROOT`, `$$CURRENT` -- inside a
+$expr equality. Repro is in the ticket and pinned by `lookup_single_component_sysvar_predicate.js`.
+
+## Root cause
+
+`PredicateExtractor::extractExpressionCompare()` in
+`src/mongo/db/query/compiler/optimizer/join/predicate_extractor.cpp` accepts any $eq whose two
+operands are `ExpressionFieldPath` and unconditionally calls
+`getFieldPathWithoutCurrentPrefix()` on each:
+
+```cpp
+auto leftPathId  = _pathResolver.resolve(left->getFieldPathWithoutCurrentPrefix());
+auto rightPathId = _pathResolver.resolve(right->getFieldPathWithoutCurrentPrefix());
+```
+
+`getFieldPathWithoutCurrentPrefix()` is defined as `return _fieldPath.tail();`
+(`src/mongo/db/pipeline/expression.h`). `FieldPath::tail()` tasserts (16409) when
+`getPathLength() <= 1`. Bare system-variable references (`$$NOW`, `$$ROOT`, `$$CURRENT`) are stored
+as `ExpressionFieldPath` whose `_fieldPath` is a single component ("NOW" / "ROOT" / "CURRENT"), so
+the call aborts.
+
+`$$NOW` reaches this site because it is preserved as an `ExpressionFieldPath` rather than being
+constant-folded unless `featureFlagSbeFull` is on. The same path is reached when the system
+variable appears in a $lookup `let` + sub-pipeline `$expr`, since the join optimizer walks both
+sides of any $eq inside `$expr`.
+
+## Fix sketch
+
+In `extractExpressionCompare()`, gate the `tail()` call on path length before resolving. A bare
+single-component `ExpressionFieldPath` is by definition either a system variable (`$$NOW`,
+`$$ROOT`, `$$CURRENT`) or an un-prefixed user variable, none of which is a valid equijoin
+candidate: there is no field path to push down. The proper behaviour is to mark the predicate
+non-extractable and let the planner fall back to evaluating the $expr at the executor layer.
+
+Concrete edit, in both surface sites that call `getFieldPathWithoutCurrentPrefix()` directly on a
+visitor-supplied `ExpressionFieldPath`:
+
+```cpp
+if (left->getFieldPath().getPathLength() <= 1 ||
+    right->getFieldPath().getPathLength() <= 1) {
+    _expressionIsFullyAbsorbed = false;
+    return;
+}
+```
+
+The same guard belongs in `JoinPredicateExpr::make()` and in the `localCollectionFieldPath()`
+helper (lines 359-367), both of which call `getFieldPathWithoutCurrentPrefix()` on caller-supplied
+`ExpressionFieldPath` pointers. A small `static bool isSingleComponentSysvar(const
+ExpressionFieldPath*)` helper (returns `expr->isVariableReference() &&
+expr->getFieldPath().getPathLength() <= 1`) keeps the three call sites uniform and aligns naming
+with the existing `isReferenceToLocalCollectionField()` / `isReferenceToForeignCollectionField()`
+predicates.
+
+## Verification
+
+- jstest `lookup_single_component_sysvar_predicate.js` runs four pipelines exercising `$$NOW`,
+  `$$ROOT`, `$$CURRENT` in both the downstream-$match shape and the `let` + sub-pipeline shape.
+  Each pipeline must complete cleanly or return a non-tassert error; the post-condition `{ping:
+  1}` confirms the server is still alive.
+- Unit coverage: extend `predicate_extractor_test.cpp` with an `ExpressionCompare` whose operand
+  is a single-component `ExpressionFieldPath` and assert the extractor leaves it un-absorbed.
+
+## Out of scope
+
+Constant-folding `$$NOW` ahead of the join optimizer (the `featureFlagSbeFull` path already does
+this) is a separate optimisation. The guard above is sufficient to eliminate the crash regardless
+of feature-flag state.


### PR DESCRIPTION
## Summary

jstest + design: single-component system variable in $lookup join predicate crash.

**Jira:** https://jira.mongodb.org/browse/SERVER-126707
**Branch:** substrate-contrib/w4-4

## Files

```
  -  .../lookup_single_component_sysvar_predicate.js    | 121 +++++++++++++++++++++
  -  src/mongo/db/pipeline/SERVER-126396-design.md      |  72 ++++++++++++
  -  2 files changed, 193 insertions(+)
```

## Verify

For `.tla` files:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For `.js` jstests:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
