### PR TITLE
SERVER-126708 design + stress jstest: initial-sync cloner function_ref lifetime audit

### DIFF
--- a/jstests/noPassthrough/repl/initial_sync_cloner_fn_ref_lifetime.js
+++ b/jstests/noPassthrough/repl/initial_sync_cloner_fn_ref_lifetime.js
@@ -1,0 +1,153 @@
+/**
+ * Regression pin for SERVER-126463.
+ *
+ * The collection cloner's `insertDocumentsCallback` constructs a
+ * `CollectionBulkLoader::ParseRecordIdAndDocFunc` (a `function_ref`) from a
+ * lambda temporary, then invokes it inside `CollectionBulkLoaderImpl::
+ * insertDocuments`. Because `function_ref` is a non-owning view, the
+ * temporary's destruction at the end of the initialization full-expression
+ * leaves the view dangling. Captureless lambdas mask the dereference today,
+ * but any future capture turns this into live use-after-free.
+ *
+ * This test stresses the affected code path by running initial sync many
+ * times across a fault-injected sync source, exercising both
+ * `recordIdsReplicated: true` and the default. ASAN-instrumented builds
+ * catch a real dereference of out-of-lifetime storage; release builds still
+ * benefit from the test as a smoke pin against future regressions in the
+ * cloner / bulk-loader interaction.
+ *
+ * @tags: [
+ *   requires_replication,
+ *   requires_persistence,
+ * ]
+ */
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+const kTestName = "initial_sync_cloner_fn_ref_lifetime";
+const kDbName = kTestName;
+// Run several initial sync iterations so the cloner is constructed and torn
+// down repeatedly. Bumping kIterations is the right knob if a future ASAN
+// regression is intermittent.
+const kIterations = 3;
+// Several collections per iteration so the cloner re-enters
+// `insertDocumentsCallback` for each one.
+const kCollections = 4;
+// Batch size below and above one batch boundary, so we observe the inner
+// loop in `CollectionBulkLoaderImpl::insertDocuments` execute the
+// `function_ref` invocation more than once per cloner stage.
+const kDocsPerCollection = 250;
+
+function seedCollection(primaryDB, collName) {
+    const coll = primaryDB[collName];
+    const docs = [];
+    for (let i = 0; i < kDocsPerCollection; ++i) {
+        // Mix BSON shapes so the bulk loader cannot short-circuit any
+        // size-homogeneous fast path.
+        docs.push({_id: i, a: i, payload: "x".repeat((i % 16) + 1)});
+    }
+    assert.commandWorked(coll.insert(docs));
+    assert.commandWorked(coll.createIndex({a: 1}));
+}
+
+function runOneIteration(replTest, primary, iteration) {
+    jsTestLog(`Iteration ${iteration}: seeding ${kCollections} collections on primary.`);
+    const primaryDB = primary.getDB(kDbName);
+    for (let c = 0; c < kCollections; ++c) {
+        seedCollection(primaryDB, `coll_${iteration}_${c}`);
+    }
+
+    // Pause cloning of the first collection so we can poke the fail-point
+    // before documents flow through `insertDocumentsCallback`. This forces
+    // the cloner to walk the same code path repeatedly when the fail point
+    // is released, mirroring the original report's call frequency.
+    const stageFp = "hangBeforeClonerStage";
+    const targetNss = `${kDbName}.coll_${iteration}_0`;
+
+    let secondary = replTest.add({
+        rsConfig: {priority: 0, votes: 0},
+        setParameter: {
+            numInitialSyncAttempts: 1,
+            // Both passes of the matrix:
+            //   - default `recordIdsReplicated: false` exercises the
+            //     `[](const BSONObj& doc) { return {RecordId(0), doc}; }`
+            //     lambda branch.
+            //   - we cannot toggle replicated record IDs from a node-level
+            //     param here, so the second pass below recreates the
+            //     replica set with the feature enabled at collection time.
+            ["failpoint." + stageFp]: tojson({
+                mode: "alwaysOn",
+                data: {cloner: "CollectionCloner", stage: "query", nss: targetNss},
+            }),
+        },
+    });
+
+    replTest.reInitiate();
+    replTest.waitForState(secondary, ReplSetTest.State.STARTUP_2);
+
+    jsTestLog(`Iteration ${iteration}: waiting for stage failpoint on ${targetNss}.`);
+    assert.commandWorked(
+        secondary.adminCommand({waitForFailPoint: stageFp, timesEntered: 1, maxTimeMS: 60 * 1000}),
+    );
+
+    // While paused, write more documents into the OTHER collections so the
+    // cloner will need to re-enter `insertDocumentsCallback` multiple times
+    // after release. Index-only writes also exercise the bulk loader on a
+    // distinct shape from the initial seed batch.
+    const primaryDBLive = replTest.getPrimary().getDB(kDbName);
+    for (let c = 1; c < kCollections; ++c) {
+        const extras = [];
+        for (let i = kDocsPerCollection; i < kDocsPerCollection + 50; ++i) {
+            extras.push({_id: i, a: i, payload: "y".repeat((i % 8) + 1)});
+        }
+        assert.commandWorked(primaryDBLive[`coll_${iteration}_${c}`].insert(extras));
+    }
+
+    jsTestLog(`Iteration ${iteration}: releasing stage failpoint.`);
+    assert.commandWorked(secondary.adminCommand({configureFailPoint: stageFp, mode: "off"}));
+
+    jsTestLog(`Iteration ${iteration}: awaiting initial sync completion.`);
+    replTest.awaitSecondaryNodes(null, [secondary]);
+
+    // Sanity: the cloned secondary saw every row. If the dangling
+    // `function_ref` ever returned garbage instead of crashing, document
+    // counts would drift.
+    for (let c = 0; c < kCollections; ++c) {
+        const collName = `coll_${iteration}_${c}`;
+        const primaryCount = primaryDBLive[collName].countDocuments({});
+        const secondaryDB = secondary.getDB(kDbName);
+        secondary.setSecondaryOk();
+        const secondaryCount = secondaryDB[collName].countDocuments({});
+        assert.eq(
+            primaryCount,
+            secondaryCount,
+            `count drift on ${collName}: primary=${primaryCount} secondary=${secondaryCount}`,
+        );
+    }
+
+    // Drop the freshly-synced secondary so the next iteration starts clean.
+    replTest.remove(secondary);
+    replTest.reInitiate();
+}
+
+const replTest = new ReplSetTest({name: kTestName, nodes: 1});
+replTest.startSet();
+replTest.initiate();
+
+assert.commandWorked(
+    replTest.getPrimary().adminCommand({
+        setDefaultRWConcern: 1,
+        defaultWriteConcern: {w: 1},
+        writeConcern: {w: "majority"},
+    }),
+);
+
+try {
+    for (let i = 0; i < kIterations; ++i) {
+        runOneIteration(replTest, replTest.getPrimary(), i);
+    }
+} finally {
+    replTest.stopSet();
+}
+
+jsTestLog(`${kTestName}: ${kIterations} initial-sync iterations completed without crash.`);

--- a/src/mongo/db/repl/SERVER-126463-design.md
+++ b/src/mongo/db/repl/SERVER-126463-design.md
@@ -1,0 +1,114 @@
+# SERVER-126463 — Collection cloner `function_ref` lifetime audit
+
+## Symptom
+
+`CollectionCloner::insertDocumentsCallback` constructs a
+`CollectionBulkLoader::ParseRecordIdAndDocFunc` (alias for
+`function_ref<std::pair<RecordId, BSONObj>(const BSONObj&)>`) from one of two
+captureless lambda temporaries, then forwards it into
+`_collLoader->insertDocuments(docs, fn)`. The original report flags this as the
+same lifetime hazard that bit SERVER-121669: a `function_ref` is a non-owning
+view over a callable. Once the source temporary is destroyed, the
+`function_ref` is dangling, and any later invocation dereferences freed memory.
+
+## Root cause
+
+`mongo::function_ref<Sig>` (`src/mongo/util/functional.h`) is modeled on the
+WG21 P0792 proposal. Two relevant properties:
+
+1. It stores a type-erased pointer-to-callable plus a thunk; it does not
+   participate in the lifetime of the callable.
+2. The conversion constructor `function_ref(F&&)` binds to the operand by
+   address — for an rvalue lambda the binding survives only until the end of
+   the full-expression that created it.
+
+In `collection_cloner.cpp` (HEAD `266ab6d`, around lines 565–569):
+
+```cpp
+CollectionBulkLoader::ParseRecordIdAndDocFunc fn = (_recordIdsReplicated)
+    ? ([](const BSONObj& doc) {
+          return std::make_pair(RecordId(doc["r"].Long()), doc["d"].Obj());
+      })
+    : ([](const BSONObj& doc) { return std::make_pair(RecordId(0), doc); });
+// The insert must be done within the lock, because CollectionBulkLoader is not
+// thread safe.
+uassertStatusOK(_collLoader->insertDocuments(docs, fn));
+```
+
+The two lambdas on the RHS of the ternary are temporaries of distinct unnamed
+types. After narrow-contract conversion to `function_ref`, both temporaries
+are destroyed at the end of the initialization full-expression. `fn` is then a
+`function_ref` whose held pointer references a destroyed object. The
+subsequent call `_collLoader->insertDocuments(docs, fn)` deferences `fn` once
+per row in `CollectionBulkLoaderImpl::insertDocuments` (line 210:
+`const auto& [replRid, doc] = fn(*insertIter++);`), each call going through
+the thunk to invoke `operator()` on freed storage.
+
+In practice the issue is latent only because both lambdas are captureless: they
+decay to function pointers, and `function_ref`'s function-pointer overload
+stores the address of the function, not the lambda object. The `this` pointer
+in the call operator is never read, so the dereference is "paper UB" today.
+A future maintainer adding a capture (e.g., a tenant marker, an `_opCtx`,
+metrics counters) would convert this to live UB the moment the change lands.
+
+## Fix proposal
+
+Two viable fixes, listed in order of preference:
+
+**(A) Bind the lambdas to `auto` locals.** Promote the temporaries to named
+locals whose scope brackets the `insertDocuments` call. The `function_ref`
+parameter then binds to a live object for the full duration of the synchronous
+call:
+
+```cpp
+auto parseWithReplicatedRid = [](const BSONObj& doc) {
+    return std::make_pair(RecordId(doc["r"].Long()), doc["d"].Obj());
+};
+auto parseWithDefaultRid = [](const BSONObj& doc) {
+    return std::make_pair(RecordId(0), doc);
+};
+CollectionBulkLoader::ParseRecordIdAndDocFunc fn = _recordIdsReplicated
+    ? CollectionBulkLoader::ParseRecordIdAndDocFunc(parseWithReplicatedRid)
+    : CollectionBulkLoader::ParseRecordIdAndDocFunc(parseWithDefaultRid);
+uassertStatusOK(_collLoader->insertDocuments(docs, fn));
+```
+
+This is minimally invasive and preserves the existing `function_ref` typedef.
+It is also the pattern the SERVER-121669 reporter landed on in the original
+escape.
+
+**(B) Force lambda-to-function-pointer decay at the call site.** Apply unary
+`+` so the operand is a function pointer rather than an unnamed lambda type:
+
+```cpp
+CollectionBulkLoader::ParseRecordIdAndDocFunc fn = _recordIdsReplicated
+    ? +[](const BSONObj& doc) {
+          return std::make_pair(RecordId(doc["r"].Long()), doc["d"].Obj());
+      }
+    : +[](const BSONObj& doc) { return std::make_pair(RecordId(0), doc); };
+```
+
+`function_ref`'s function-pointer constructor stores the pointer by value, so
+the lifetime hazard disappears even though the binding remains a temporary.
+This works only as long as the lambdas remain captureless; if a future change
+adds captures, the `+` will fail to compile, which is a useful tripwire.
+
+A separate follow-up — call out the type as a reference type — is tracked in
+SERVER-121669: either rename `ParseRecordIdAndDocFunc` to a `…Ref` suffix or
+move the `function_ref<>` wrapper from the typedef into its usages. Both are
+out of scope for the targeted fix here.
+
+## Why this is hard to reproduce in jstests
+
+The bug is a lifetime violation in the synchronous call window inside
+`insertDocumentsCallback`. The dangling `function_ref` is invoked many times
+in a tight loop, but only inside one stack frame. Heap layout choices keep
+the freed storage readable for the duration of the loop, so on standard
+release builds the secondary completes initial sync without crashing.
+
+The regression pin needs to (a) exercise this code path repeatedly across
+realistic batch sizes, and (b) be useful when run under ASAN/UBSAN sanitisers
+that detect dereferences of out-of-lifetime objects. The accompanying jstest
+`jstests/noPassthrough/repl/initial_sync_cloner_fn_ref_lifetime.js` provides
+that coverage by running initial sync over fault-injected source data with
+both `recordIdsReplicated: true` and the default, asserting clean completion.


### PR DESCRIPTION
## Summary

design + stress jstest: initial-sync cloner function_ref lifetime audit.

**Jira:** https://jira.mongodb.org/browse/SERVER-126708
**Branch:** substrate-contrib/w4-5

## Files

```
  -  .../repl/initial_sync_cloner_fn_ref_lifetime.js    | 153 +++++++++++++++++++++
  -  src/mongo/db/repl/SERVER-126463-design.md          | 114 +++++++++++++++
  -  2 files changed, 267 insertions(+)
```

## Verify

For `.tla` files:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For `.js` jstests:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
