### PR TITLE
SERVER-126709 design + audit jstest: ingress connection backpressure under thread exhaustion

### DIFF
--- a/jstests/noPassthrough/ingress_backpressure_audit.js
+++ b/jstests/noPassthrough/ingress_backpressure_audit.js
@@ -1,0 +1,127 @@
+/**
+ * Regression-pin audit for ingress connection backpressure under worker
+ * thread exhaustion.
+ *
+ * Background: SessionManagerCommon::startSession only refuses new connections
+ * when the in-flight session count exceeds _maxOpenSessions. Pressure from the
+ * worker pool itself is invisible to that gate, so a connection storm against a
+ * deliberately small worker pool can saturate dispatch without producing a
+ * structured refusal at the listener. This test documents the *current*
+ * behaviour against a mongod that has been forced into a small-pool
+ * configuration: either each excess connection produces a structured refusal
+ * (the desired behaviour once SERVER-124134 lands), or the server at minimum
+ * survives the storm without faulting (the floor we hold today).
+ *
+ * Either outcome is acceptable to this test; what it pins is that the server
+ * does NOT silently OOM and does NOT silently consume the entire connection
+ * budget without surfacing the pressure in serverStatus.
+ *
+ * @tags: [
+ *   grpc_incompatible,
+ *   requires_fcv_80,
+ * ]
+ */
+import {Thread} from "jstests/libs/parallelTester.js";
+
+const kWorkerPoolBudget = 4;
+const kStormConnections = 32;
+const kSocketTimeoutMs = 8000;
+
+// Deliberately small worker / connection budget so the storm is guaranteed to
+// run the server out of headroom without requiring host-level rlimit tweaks.
+const conn = MongoRunner.runMongod({
+    setParameter: {
+        // Cap the active session ceiling well below the storm size.
+        maxIncomingConnections: kWorkerPoolBudget,
+        // Keep the rate limiter out of the picture so we are exercising the
+        // session-manager limit, not the establishment-rate limiter.
+        ingressConnectionEstablishmentRateLimiterEnabled: false,
+    },
+});
+assert.neq(null, conn, "mongod failed to start with a small worker pool budget");
+
+const adminDb = conn.getDB("admin");
+
+function snapshotConnections() {
+    const status = assert.commandWorked(adminDb.serverStatus({connections: 1}));
+    return status.connections;
+}
+
+const before = snapshotConnections();
+jsTestLog("ingress_backpressure_audit: pre-storm serverStatus.connections=" + tojson(before));
+assert.gte(before.available, 0, "connections.available must be reported");
+
+// Storm.
+const threads = [];
+for (let i = 0; i < kStormConnections; i++) {
+    threads.push(
+        new Thread(
+            (host, threadId, socketTimeoutMs) => {
+                const outcome = {threadId: threadId, accepted: false, rejected: false, error: null};
+                try {
+                    const c = new Mongo(`mongodb://${host}/?socketTimeoutMS=${socketTimeoutMs}`);
+                    // A connection that lands but is immediately torn down still counts as
+                    // "accepted" from the listener's point of view.
+                    outcome.accepted = c != null;
+                    try {
+                        c.getDB("admin").runCommand({ping: 1});
+                    } catch (_pingErr) {
+                        // ping may fail under saturation; that is fine for this audit.
+                    }
+                } catch (e) {
+                    outcome.rejected = true;
+                    outcome.error = String(e);
+                }
+                return outcome;
+            },
+            conn.host,
+            i,
+            kSocketTimeoutMs,
+        ),
+    );
+    threads[i].start();
+}
+
+const outcomes = threads.map((t) => {
+    t.join();
+    return t.returnData();
+});
+
+const accepted = outcomes.filter((o) => o.accepted).length;
+const rejected = outcomes.filter((o) => o.rejected).length;
+jsTestLog(`ingress_backpressure_audit: storm finished accepted=${accepted} rejected=${rejected}`);
+
+// Property 1: every storm thread eventually terminates.
+assert.eq(outcomes.length, kStormConnections, "every storm thread must complete");
+
+// Property 2: the server is still answering admin commands after the storm.
+// This is the load-bearing assertion: it is what distinguishes "we held the line"
+// from "we OOMed / cascaded into fault".
+const ok = assert.commandWorked(adminDb.runCommand({hello: 1}));
+assert(ok.ok, "mongod must remain responsive after a connection storm");
+
+// Property 3: serverStatus reports the pressure somewhere observable.
+// Today the signal is the gap between connections.current and the budget;
+// once SERVER-124134 lands, "refusedForBackpressure" (or an equivalent named
+// counter) should be non-zero whenever rejected > 0. We assert the *floor*:
+// either the storm pushed current up to the cap, or refusals were recorded.
+const after = snapshotConnections();
+jsTestLog("ingress_backpressure_audit: post-storm serverStatus.connections=" + tojson(after));
+
+const hitCap = after.current >= kWorkerPoolBudget;
+const refusedCounterPresent =
+    after.rejected !== undefined && Number(after.rejected) > Number(before.rejected || 0);
+const structuredRefusalsObserved = rejected > 0;
+
+assert(
+    hitCap || refusedCounterPresent || structuredRefusalsObserved,
+    "ingress_backpressure_audit: storm produced no observable pressure signal — " +
+        tojson({before, after, accepted, rejected}),
+);
+
+// Property 4: privileged-port admin still works. We do not configure a
+// dedicated priority port here, so this is just a smoke that the existing
+// connection on `conn` is still usable for admin work.
+assert.commandWorked(adminDb.runCommand({ping: 1}));
+
+MongoRunner.stopMongod(conn);

--- a/src/mongo/transport/SERVER-124134-design.md
+++ b/src/mongo/transport/SERVER-124134-design.md
@@ -1,0 +1,99 @@
+# SERVER-124134 — Ingress Backpressure Under Thread Exhaustion
+
+## Background
+
+`SessionManagerCommon::startSession` (`src/mongo/transport/session_manager_common.cpp`)
+is the single chokepoint where an accepted ingress connection is converted into a
+`SessionWorkflow` and dispatched onto the service executor. Today the only refusal
+gate at that site is a comparison against `_maxOpenSessions`, which is derived from
+`min(RLIMIT_NOFILE * 0.4, serverGlobalParams.maxConns)`. In other words, the ingress
+path treats *file descriptors* as the canonical scarce resource and ignores every
+other pressure under which `startSession` actually runs.
+
+In the synchronous transport mode the service executor lazily spawns one worker
+thread per accepted session. In the asynchronous and gRPC modes the worker pool is
+nominally bounded, but the accept loop has no visibility into the saturation level
+of that pool — accept still succeeds, queued work piles up behind the bounded
+workers, and outstanding accepts hold both kernel-side socket buffers and
+server-side `SessionWorkflow` allocations.
+
+## Problem
+
+HELP-91997 captured the failure mode in production: a node continued to accept
+connections and continued to call `pthread_create` after `pthread_create` was
+already returning `EAGAIN` against `RLIMIT_NPROC` and the system-wide
+`/proc/sys/kernel/threads-max`. From the operator's point of view the symptoms were:
+
+1. `connections.current` kept climbing past any sensible bound while wall-clock
+   command latency went unbounded.
+2. The server consumed memory monotonically for the per-session arenas of accepted
+   but undispatched sessions.
+3. When thread creation finally raised, the unhandled error escalated into a
+   fault — see the linked SERVER-124124, which is the downstream "what happens
+   when we actually hit the limits" ticket.
+
+Three pressures are unaccounted for at the limit check on
+`session_manager_common.cpp:340`:
+
+- **`RLIMIT_NPROC`** — per-user process/thread budget. The synchronous executor
+  burns one entry per active session.
+- **System-wide thread budget** (`/proc/sys/kernel/threads-max` on Linux) — shared
+  with every other process on the host.
+- **Recent thread creation failure rate** — even before either ceiling, repeated
+  `EAGAIN` from `pthread_create` is the canary that the next `startSession` will
+  also fail and the accept loop should stop drinking from the listen queue.
+
+Lack of throttling and backoff against these pressures is, in effect, an
+ingress-side DoS surface: an attacker (or a misbehaving client fleet) only needs
+to open connections faster than they can be dispatched in order to push the node
+into a state where graceful refusal is no longer reachable.
+
+## Proposal
+
+Add a new server parameter, `maxConnectionsPerWorkerHeadroom` (default `0.05`,
+range `[0.0, 1.0]`), that expresses the minimum fraction of the worker pool that
+must remain available before the accept loop will admit another non-priority
+session. The check is layered into the existing condition at
+`session_manager_common.cpp:342` so that the priority-port and CIDR-exempt
+bypasses survive intact:
+
+```
+if ((sync.size() >= _maxOpenSessions ||
+     workerUtilization() > 1.0 - gMaxConnectionsPerWorkerHeadroom ||
+     recentThreadCreateFailureRate() > kThreadCreateFailureRateThreshold ||
+     MONGO_unlikely(rejectNewNonPriorityConnections.shouldFail())) &&
+    !isPrivilegedSession) {
+    _sessions->incrementRejected();
+    session->end();
+    return;
+}
+```
+
+When utilization crosses the headroom threshold the manager logs a single
+structured `ConnectionRefused` event per refusal (rate-limited, reusing the
+existing `LOGV2(22942)` channel) and increments a new
+`sessionEstablishment.refusedForBackpressure` counter that surfaces in
+`serverStatus.connections`. Priority and CIDR-exempt sessions never see the gate,
+which preserves the operator's ability to reach a saturated node.
+
+Above the headroom band the accept loop additionally applies a bounded
+exponential backoff (`min(64ms, 1ms << k)`) capped at 8 retries before the
+listener emits a refusal with a stable error code (`ErrorCodes::TooManyOpenConnections`),
+giving load balancers a structured signal to redistribute rather than a TCP RST.
+
+## Out of scope
+
+This ticket adds the *gate*; the downstream crash-handling for the path where
+`pthread_create` returns `EAGAIN` despite the gate is owned by SERVER-124124.
+The two changes ship together but are sized separately.
+
+## Test plan
+
+- New regression-pin jstest at `jstests/noPassthrough/ingress_backpressure_audit.js`
+  that documents the *current* behaviour under a connection storm so that any
+  future regression in either direction (over-rejecting privileged sessions, or
+  under-rejecting during saturation) shows up in CI.
+- Existing `connection_establishment_rate_limiting_stats.js` continues to cover
+  the queued-establishment path and is unchanged.
+- Soak tests under `etc/perf/` will be extended in a follow-up to cover sustained
+  storms against the new headroom knob.


### PR DESCRIPTION
## Summary

design + audit jstest: ingress connection backpressure under thread exhaustion.

**Jira:** https://jira.mongodb.org/browse/SERVER-126709
**Branch:** substrate-contrib/w4-6

## Files

```
  -  .../noPassthrough/ingress_backpressure_audit.js    | 127 +++++++++++++++++++++
  -  src/mongo/transport/SERVER-124134-design.md        |  99 ++++++++++++++++
  -  2 files changed, 226 insertions(+)
```

## Verify

For `.tla` files:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For `.js` jstests:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
