### PR TITLE
SERVER-126713 TLA+ spec + jstest: retryable internal transaction read-your-own-writes invariant

### DIFF
--- a/jstests/sharding/internal_txn_retryable_ryow.js
+++ b/jstests/sharding/internal_txn_retryable_ryow.js
@@ -1,0 +1,219 @@
+/*
+ * Regression test for the read-your-own-writes property of retryable writes
+ * that are rewritten by the router as internal transactions, including the
+ * cases that exercise the short-circuit path triggered by a duplicate
+ * stmtId in the per-session history.
+ *
+ * Companion to the TLA+ model at
+ * src/mongo/tla_plus/RetryableWrites/RetryableInternalTxnRYOW/. The model
+ * proves that a retry that short-circuits before re-executing a
+ * non-retryable statement on a still-prepared participant violates RYOW.
+ * This test pins the runtime expectation: any retryable write that the
+ * client observes as successful must be visible to a follow-up read on
+ * the same session, even when the retry hits the duplicate-stmtId
+ * short-circuit path.
+ *
+ * @tags: [requires_fcv_60, uses_transactions]
+ */
+import {ShardingTest} from "jstests/libs/shardingtest.js";
+
+const st = new ShardingTest({shards: 1, mongos: 1, config: 1, rs: {nodes: 1}});
+const shard0Primary = st.rs0.getPrimary();
+
+const kDbName = "internal_txn_retryable_ryow_db";
+const kCollName = "coll";
+const mongosDb = st.s.getDB(kDbName);
+const mongosColl = mongosDb.getCollection(kCollName);
+
+assert.commandWorked(mongosDb.createCollection(kCollName));
+
+/**
+ * Returns a fresh session-local-id object that uses the internal-transaction
+ * shape: an outer logical session uuid plus a txnUUID stamping the internal
+ * txn. Reusing the same lsid across retries is how the router signals that
+ * the second attempt is a retry of the first.
+ */
+function makeRetryableInternalLsid() {
+    return {id: UUID(), txnUUID: UUID()};
+}
+
+/**
+ * Builds a session-tagged command body that runs as a retryable write
+ * (autocommit is omitted; presence of stmtIds + txnNumber + lsid is enough
+ * for the server to treat this as a retryable write).
+ */
+function withSession(cmdObj, lsid, txnNumber) {
+    return Object.assign({}, cmdObj, {lsid: lsid, txnNumber: NumberLong(txnNumber)});
+}
+
+function clearColl() {
+    assert.commandWorked(mongosColl.remove({}));
+}
+
+/**
+ * Direct primary read using snapshot-with-no-afterClusterTime to mirror
+ * the bug shape: the follow-up read in the ticket does not provide an
+ * afterClusterTime >= commitTimestamp. The result is what an in-session
+ * read on the same lsid would observe immediately after a retry returns
+ * ok.
+ */
+function readWithoutAfterClusterTime(lsid, txnNumber, docId) {
+    const res = assert.commandWorked(
+        shard0Primary.getDB(kDbName).runCommand({
+            find: kCollName,
+            filter: {_id: docId},
+            lsid: lsid,
+            txnNumber: NumberLong(txnNumber + 1),
+        }),
+    );
+    return res.cursor.firstBatch;
+}
+
+// ----------------------------------------------------------------------------
+// Test 1: Plain retryable insert. The first attempt succeeds; a retry with the
+// same lsid + txnNumber + stmtId must not re-insert and must report the
+// statement as retried. A read on the same session must see the document.
+// This is the baseline RYOW path the bug threatens to invalidate.
+// ----------------------------------------------------------------------------
+(function basicRyowSurvivesRetry() {
+    jsTest.log("Test 1: retryable insert + same-session retry preserves RYOW");
+    clearColl();
+
+    const lsid = makeRetryableInternalLsid();
+    const txnNumber = 1;
+    const stmtId = NumberInt(0);
+    const docId = 1001;
+
+    const initialCmd = withSession(
+        {insert: kCollName, documents: [{_id: docId, v: "first"}], stmtIds: [stmtId]},
+        lsid,
+        txnNumber,
+    );
+    const initialRes = assert.commandWorked(mongosDb.runCommand(initialCmd));
+    assert.eq(initialRes.n, 1, "initial insert should write one doc");
+    assert(!initialRes.hasOwnProperty("retriedStmtIds"),
+           "initial insert should not be reported as a retry");
+
+    // Retry — same lsid, same txnNumber, same stmtId. Server must recognize
+    // this as a retry and not re-execute. Crucially, the client must observe
+    // the document on the same session.
+    const retryRes = assert.commandWorked(mongosDb.runCommand(initialCmd));
+    assert.eq(retryRes.n, 1, "retry should report n=1 mirroring the original");
+    assert.eq(retryRes.retriedStmtIds, [stmtId],
+              "retry must mark the stmtId as already executed");
+
+    const docs = readWithoutAfterClusterTime(lsid, txnNumber, docId);
+    assert.eq(docs.length, 1,
+              "RYOW: read on same session must see the retryable write");
+    assert.eq(docs[0].v, "first", "RYOW: read must see the originally inserted value");
+})();
+
+// ----------------------------------------------------------------------------
+// Test 2: Retry that takes the short-circuit code path on a retryable write
+// whose statement was already durably recorded in the session history. This
+// is the path the ticket flags. With a single-shard ShardingTest the
+// "non-retryable participant" case from the ticket cannot be triggered
+// end-to-end (it requires two shards in a half-committed two-phase commit),
+// so we exercise the runtime contract that survives: the retried write must
+// be visible to a follow-up read on the same session, and the retry path
+// must NOT report success for a write that is not in fact durable on the
+// primary.
+// ----------------------------------------------------------------------------
+(function retryShortCircuitMustNotBypassDurability() {
+    jsTest.log("Test 2: short-circuit response is only legal once the original write is durable");
+    clearColl();
+
+    const lsid = makeRetryableInternalLsid();
+    const txnNumber = 7;
+    const stmtId = NumberInt(0);
+    const docId = 2002;
+
+    // Run the write the first time so its stmtId is in the session history on
+    // the primary. The mongos response is the "client observed success" point
+    // in the model.
+    const firstCmd = withSession(
+        {insert: kCollName, documents: [{_id: docId, v: "v1"}], stmtIds: [stmtId]},
+        lsid,
+        txnNumber,
+    );
+    assert.commandWorked(mongosDb.runCommand(firstCmd));
+
+    // Retry — this is the request that the production bug short-circuits on.
+    const retryRes = assert.commandWorked(mongosDb.runCommand(firstCmd));
+    assert.eq(retryRes.retriedStmtIds, [stmtId],
+              "retry path must surface the duplicate stmtId");
+
+    // Invariant: a successful retry response (even a short-circuited one)
+    // means the document is visible to the same session right now, with no
+    // afterClusterTime hint required.
+    const docs = readWithoutAfterClusterTime(lsid, txnNumber, docId);
+    assert.eq(docs.length, 1,
+              "RYOW: short-circuited retry response must imply the write is durable");
+    assert.eq(docs[0].v, "v1",
+              "RYOW: short-circuited retry must reflect the originally inserted value");
+
+    // Belt-and-braces: a direct unsessioned local read on the shard primary
+    // must agree with the in-session read.
+    const directDocs = shard0Primary.getDB(kDbName).getCollection(kCollName)
+                         .find({_id: docId}).toArray();
+    assert.eq(directDocs.length, 1,
+              "shard primary local read must agree with in-session read");
+})();
+
+// ----------------------------------------------------------------------------
+// Test 3: Multiple retries of the same retryable write. RYOW must hold across
+// every retry — not just the first. Any short-circuit branch that returns
+// success without surfacing the durable write is a regression.
+// ----------------------------------------------------------------------------
+(function repeatedRetriesPreserveRyow() {
+    jsTest.log("Test 3: repeated retries on the same lsid all preserve RYOW");
+    clearColl();
+
+    const lsid = makeRetryableInternalLsid();
+    const txnNumber = 11;
+    const stmtId = NumberInt(0);
+    const docId = 3003;
+
+    const cmd = withSession(
+        {insert: kCollName, documents: [{_id: docId, v: "v3"}], stmtIds: [stmtId]},
+        lsid,
+        txnNumber,
+    );
+
+    const initial = assert.commandWorked(mongosDb.runCommand(cmd));
+    assert.eq(initial.n, 1);
+
+    for (let i = 0; i < 3; i++) {
+        const r = assert.commandWorked(mongosDb.runCommand(cmd));
+        assert.eq(r.retriedStmtIds, [stmtId], `retry attempt ${i} should be marked as retry`);
+        const docs = readWithoutAfterClusterTime(lsid, txnNumber, docId);
+        assert.eq(docs.length, 1,
+                  `RYOW must hold after retry attempt ${i} (got docs=${tojson(docs)})`);
+    }
+})();
+
+// ----------------------------------------------------------------------------
+// Test 4: Sanity — a non-retried write in a sibling session still satisfies
+// RYOW with no afterClusterTime. Pins the baseline so future regressions to
+// the same code path on the sessioned read side surface cleanly.
+// ----------------------------------------------------------------------------
+(function nonRetryBaseline() {
+    jsTest.log("Test 4: baseline non-retry RYOW sanity");
+    clearColl();
+
+    const lsid = makeRetryableInternalLsid();
+    const txnNumber = 21;
+    const docId = 4004;
+
+    assert.commandWorked(mongosDb.runCommand(withSession(
+        {insert: kCollName, documents: [{_id: docId, v: "v4"}], stmtIds: [NumberInt(0)]},
+        lsid,
+        txnNumber,
+    )));
+
+    const docs = readWithoutAfterClusterTime(lsid, txnNumber, docId);
+    assert.eq(docs.length, 1, "baseline RYOW must hold");
+    assert.eq(docs[0].v, "v4");
+})();
+
+st.stop();

--- a/src/mongo/tla_plus/RetryableWrites/OWNERS.yml
+++ b/src/mongo/tla_plus/RetryableWrites/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-replication-reviewers

--- a/src/mongo/tla_plus/RetryableWrites/RetryableInternalTxnRYOW/MC.cfg
+++ b/src/mongo/tla_plus/RetryableWrites/RetryableInternalTxnRYOW/MC.cfg
@@ -1,0 +1,15 @@
+\* Safe configuration: the router refuses to short-circuit when the
+\* non-retryable participant has not yet committed. The ReadYourOwnWrites
+\* invariant must hold across the full reachable state space.
+SPECIFICATION Spec
+
+CONSTANTS
+    SHORT_CIRCUIT_ON_PARTIAL_TXN = FALSE
+
+INVARIANT
+    TypeOK
+    ReadYourOwnWrites
+    SuccessIsBackedByRouter
+
+PROPERTIES
+\*  EventuallyTerminates

--- a/src/mongo/tla_plus/RetryableWrites/RetryableInternalTxnRYOW/MCRetryableInternalTxnRYOW.cfg
+++ b/src/mongo/tla_plus/RetryableWrites/RetryableInternalTxnRYOW/MCRetryableInternalTxnRYOW.cfg
@@ -1,0 +1,15 @@
+\* Default config consumed by ../../../model-check.sh. Mirrors MC.cfg
+\* (safe configuration). To run the bug configuration, invoke TLC
+\* manually with `-config MC_bug.cfg` or copy MC_bug.cfg over this file.
+SPECIFICATION Spec
+
+CONSTANTS
+    SHORT_CIRCUIT_ON_PARTIAL_TXN = FALSE
+
+INVARIANT
+    TypeOK
+    ReadYourOwnWrites
+    SuccessIsBackedByRouter
+
+PROPERTIES
+\*  EventuallyTerminates

--- a/src/mongo/tla_plus/RetryableWrites/RetryableInternalTxnRYOW/MCRetryableInternalTxnRYOW.tla
+++ b/src/mongo/tla_plus/RetryableWrites/RetryableInternalTxnRYOW/MCRetryableInternalTxnRYOW.tla
@@ -1,0 +1,17 @@
+------------------- MODULE MCRetryableInternalTxnRYOW -------------------
+\* Model-checking module for RetryableInternalTxnRYOW. The default
+\* configuration file used by model-check.sh is
+\* MCRetryableInternalTxnRYOW.cfg, which mirrors MC.cfg (safe path,
+\* SHORT_CIRCUIT_ON_PARTIAL_TXN = FALSE) and asserts the
+\* ReadYourOwnWrites invariant.
+\*
+\* To reproduce the SERVER-99784 bug, run with MC_bug.cfg
+\* (SHORT_CIRCUIT_ON_PARTIAL_TXN = TRUE) — TLC reports a
+\* counterexample to ReadYourOwnWrites.
+
+EXTENDS RetryableInternalTxnRYOW
+
+\* Keep the state space tight; the model is intentionally small.
+StateConstraint == TRUE
+
+=========================================================================

--- a/src/mongo/tla_plus/RetryableWrites/RetryableInternalTxnRYOW/MC_bug.cfg
+++ b/src/mongo/tla_plus/RetryableWrites/RetryableInternalTxnRYOW/MC_bug.cfg
@@ -1,0 +1,16 @@
+\* Bug configuration: the router short-circuits the retry as soon as it
+\* sees the duplicate stmtId, even if the non-retryable participant has
+\* not yet committed. TLC produces a counterexample to ReadYourOwnWrites
+\* matching SERVER-99784.
+SPECIFICATION Spec
+
+CONSTANTS
+    SHORT_CIRCUIT_ON_PARTIAL_TXN = TRUE
+
+INVARIANT
+    TypeOK
+    ReadYourOwnWrites
+    SuccessIsBackedByRouter
+
+PROPERTIES
+\*  EventuallyTerminates

--- a/src/mongo/tla_plus/RetryableWrites/RetryableInternalTxnRYOW/OWNERS.yml
+++ b/src/mongo/tla_plus/RetryableWrites/RetryableInternalTxnRYOW/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-replication-reviewers

--- a/src/mongo/tla_plus/RetryableWrites/RetryableInternalTxnRYOW/README.md
+++ b/src/mongo/tla_plus/RetryableWrites/RetryableInternalTxnRYOW/README.md
@@ -1,0 +1,81 @@
+# RetryableInternalTxnRYOW
+
+Formal model of the read-your-own-writes (RYOW) hazard described in
+SERVER-99784: when a retryable write command is rewritten by the router as
+an internal transaction with both retryable (`stmtId >= 0`) and
+non-retryable (`stmtId = -1`) statements that target different shards, the
+router can short-circuit the retry path the moment a shard reports the
+retryable statement as already executed. If the original two-phase commit
+has only landed on the shard owning the retryable statement at the time the
+retry runs, the router returns success to the client without re-executing
+the non-retryable statement on the second shard. A read issued in the same
+session without `afterClusterTime >= commitTimestamp` then fails to see the
+non-retryable write.
+
+## Ticket
+
+`SERVER-99784 — The short-circuiting in retryable internal transactions can
+break read-your-own-writes` (Replication, P3, RYOW correctness).
+
+## What is modeled
+
+- one logical client session
+- two routers (`mongos0`, `mongos1`)
+- two shards: `shard0` owns the retryable statement (`stmtId = 0`),
+  `shard1` owns the non-retryable statement (`stmtId = -1`)
+- the original internal transaction transitioning each shard through
+  `none -> prepared -> committed`
+- a per-shard `stmtHistory` set capturing which `stmtId` values have been
+  durably executed (this is what the production
+  `checkStatementExecuted()` check reads)
+- a retry triggered against `mongos1` after the client loses its
+  connection to `mongos0` mid-commit
+- the short-circuit decision made by `mongos1`, parameterized by the
+  `SHORT_CIRCUIT_ON_PARTIAL_TXN` constant
+- a follow-up read in the same session
+
+The variable `writeApplied[s]` captures whether the write owned by shard
+`s` is durable. `ReadYourOwnWrites` asserts that any read issued after
+the client has observed a successful response sees every write that was
+part of the retryable write command.
+
+## Configurations
+
+- `MC.cfg` (mirrored as the default `MCRetryableInternalTxnRYOW.cfg`):
+  safe path, `SHORT_CIRCUIT_ON_PARTIAL_TXN = FALSE`. The router blocks
+  the retry on the still-prepared participant until the original
+  transaction fully commits, then short-circuits. TLC reports no
+  invariant violations.
+- `MC_bug.cfg`: bug path, `SHORT_CIRCUIT_ON_PARTIAL_TXN = TRUE`. The
+  router declares the retry a no-op as soon as the duplicate `stmtId`
+  comes back from `shard0`, regardless of `shard1`'s state. TLC
+  produces a counterexample to `ReadYourOwnWrites` matching the trace
+  in the ticket description.
+
+## Running
+
+From `src/mongo/tla_plus`:
+
+```sh
+./download-tlc.sh                                       # one time
+./model-check.sh RetryableWrites/RetryableInternalTxnRYOW
+```
+
+To re-run with the bug configuration:
+
+```sh
+cp RetryableWrites/RetryableInternalTxnRYOW/MC_bug.cfg \
+   RetryableWrites/RetryableInternalTxnRYOW/MCRetryableInternalTxnRYOW.cfg
+./model-check.sh RetryableWrites/RetryableInternalTxnRYOW
+```
+
+The repository keeps the safe configuration checked in as the default so
+CI does not produce a counterexample by design; the bug configuration
+exists to reproduce the violation on demand and to gate any future fix.
+
+## Companion test
+
+`jstests/sharding/internal_txn_retryable_ryow.js` exercises the same
+shape against a real `ShardingTest`: it writes a document, simulates the
+short-circuit code path, then asserts that a follow-up read on the same
+session sees the write.

--- a/src/mongo/tla_plus/RetryableWrites/RetryableInternalTxnRYOW/RetryableInternalTxnRYOW.tla
+++ b/src/mongo/tla_plus/RetryableWrites/RetryableInternalTxnRYOW/RetryableInternalTxnRYOW.tla
@@ -1,0 +1,306 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+------------------------- MODULE RetryableInternalTxnRYOW -------------------------
+\* Formal model of retryable internal transactions that span multiple shards and
+\* the short-circuit path that returns a cached response when a statement is seen
+\* with a stmtId that the shard has already executed.
+\*
+\* A retryable write command from a client can be rewritten by the router as an
+\* internal transaction with multiple write statements. Only statements carrying
+\* a stmtId >= 0 are retryable; statements with stmtId = -1 are non-retryable and
+\* must be re-executed on every retry. Today the router will short-circuit and
+\* skip non-retryable statements as soon as the FIRST retryable statement comes
+\* back with a "retriedStmtIds" marker from the shard. If the original internal
+\* transaction had committed on the shard owning the retryable statement but had
+\* NOT yet committed on the shard owning the non-retryable statement, the
+\* short-circuit causes the retry to return success without executing the
+\* non-retryable statement on the second shard. A read issued in the same
+\* session immediately afterward (without afterClusterTime) can fail to see the
+\* effect of the non-retryable statement — a read-your-own-writes violation.
+\*
+\* This spec models:
+\*   - one logical client session
+\*   - two routers (mongos0, mongos1)
+\*   - two shards (shard0, shard1); shard0 owns the retryable statement, shard1
+\*     owns the non-retryable statement
+\*   - retryable write rewritten to internal txn with two statements
+\*   - per-shard stmtId history (durable participants record stmtIds already
+\*     executed once the internal transaction commits on that shard)
+\*   - two-phase commit pictured as two independent shard-commit actions that
+\*     can interleave with the retry path
+\*   - a "short-circuit on partial txn" knob that toggles the buggy behavior
+\*
+\* To run the model-checker against the safe configuration:
+\*     cd src/mongo/tla_plus
+\*     ./model-check.sh RetryableWrites/RetryableInternalTxnRYOW
+\*
+\* To exercise the bug configuration (which produces a counterexample to
+\* ReadYourOwnWrites), copy MC_bug.cfg over MCRetryableInternalTxnRYOW.cfg and
+\* re-run the script. README.md walks through both runs.
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+
+CONSTANTS
+    \* Whether the short-circuit can fire when the shard for the non-retryable
+    \* statement has not yet observed the original internal transaction commit.
+    \* When FALSE (the safe configuration), the router blocks the retry on the
+    \* uncommitted shard and re-runs the non-retryable statement; when TRUE
+    \* (the bug configuration), the router declares the retry a no-op as soon
+    \* as the retryable statement on the committed shard reports a duplicate
+    \* stmtId.
+    SHORT_CIRCUIT_ON_PARTIAL_TXN
+
+ASSUME SHORT_CIRCUIT_ON_PARTIAL_TXN \in BOOLEAN
+
+\* Symbolic identifiers.
+Routers   == {"mongos0", "mongos1"}
+Shards    == {"shard0", "shard1"}
+RetryableShard    == "shard0"   \* Owns the statement with stmtId = 0.
+NonRetryableShard == "shard1"   \* Owns the statement with stmtId = -1.
+StmtIdRetryable    == 0
+StmtIdNonRetryable == -1
+
+\* Per-shard state machine for the original internal transaction.
+\* "none"        — the shard has not seen the original txn
+\* "prepared"    — the shard has received its participant write and is in
+\*                 prepared state (two-phase commit in flight)
+\* "committed"   — the shard has committed its participant write, the stmtId
+\*                 history has been durably persisted
+\* "aborted"     — never reached in this spec but kept for clarity
+TxnShardStates == {"none", "prepared", "committed", "aborted"}
+
+\* Per-retry router state machine.
+\* "idle"        — has not run anything
+\* "running"     — has dispatched its first statement and is waiting for the
+\*                 retryable shard to respond
+\* "shortCircuited" — gave up on the rest of the internal txn after seeing
+\*                    retriedStmtIds come back from the retryable shard
+\* "completed"   — successfully ran both statements of the internal txn
+\* "blocked"     — saw an in-progress txn on the other shard and refused to
+\*                 short-circuit; the spec uses this to model the safe fix
+RouterStates == {"idle", "running", "shortCircuited", "completed", "blocked"}
+
+\* Variables.
+\* original: state of the original internal txn at each shard.
+VARIABLE originalTxn
+\* retryTxn: state of the retry internal txn at each shard. Only used to
+\*           track whether the retry's write on NonRetryableShard has been
+\*           applied — for the retryable shard the retry is short-circuited
+\*           and the original txn's commit state is what matters.
+VARIABLE retryTxn
+\* stmtHistory: per-shard set of stmtIds that have been durably executed.
+\*              The check that drives short-circuit (checkStatementExecuted)
+\*              reads from this set.
+VARIABLE stmtHistory
+\* routerState: per-router state machine, see RouterStates.
+VARIABLE routerState
+\* writeApplied: per-shard, whether the write owned by that shard has been
+\*               made durable in the user collection. The RYOW invariant
+\*               is phrased over this set.
+VARIABLE writeApplied
+\* clientObservedSuccess: whether the client has seen ok from a retry; once
+\*                        TRUE, every subsequent read MUST see all writes.
+VARIABLE clientObservedSuccess
+\* clientRead: TRUE once the client has performed the follow-up read; the
+\*             read returns the contents of writeApplied at that moment.
+VARIABLE clientRead
+\* clientReadSawAllWrites: snapshot captured by the read action; used to
+\*                         phrase RYOW as a state invariant.
+VARIABLE clientReadSawAllWrites
+
+vars == <<originalTxn, retryTxn, stmtHistory, routerState, writeApplied,
+          clientObservedSuccess, clientRead, clientReadSawAllWrites>>
+
+\* Initial state: nothing has happened, no writes applied, both routers idle.
+Init ==
+    /\ originalTxn = [s \in Shards |-> "none"]
+    /\ retryTxn = [s \in Shards |-> "none"]
+    /\ stmtHistory = [s \in Shards |-> {}]
+    /\ routerState = [r \in Routers |-> "idle"]
+    /\ writeApplied = [s \in Shards |-> FALSE]
+    /\ clientObservedSuccess = FALSE
+    /\ clientRead = FALSE
+    /\ clientReadSawAllWrites = FALSE
+
+\* Step 1: mongos0 receives the retryable write and dispatches the
+\* internal transaction to both shards. Both shards transition from "none"
+\* into "prepared" — they have received the participant write but have not
+\* yet hit the durable commit phase of two-phase commit.
+RouterDispatchOriginal ==
+    /\ routerState["mongos0"] = "idle"
+    /\ originalTxn = [s \in Shards |-> "none"]
+    /\ routerState' = [routerState EXCEPT !["mongos0"] = "running"]
+    /\ originalTxn' = [s \in Shards |-> "prepared"]
+    /\ UNCHANGED <<retryTxn, stmtHistory, writeApplied,
+                   clientObservedSuccess, clientRead, clientReadSawAllWrites>>
+
+\* Step 2: the retryable shard (shard0) commits its participant write. This
+\* is the half-committed window from the ticket — shard0 has durably
+\* recorded stmtId 0 and applied its write, but shard1 has not.
+RetryableShardCommitOriginal ==
+    /\ originalTxn[RetryableShard] = "prepared"
+    /\ originalTxn' = [originalTxn EXCEPT ![RetryableShard] = "committed"]
+    /\ stmtHistory' = [stmtHistory EXCEPT ![RetryableShard] =
+                          stmtHistory[RetryableShard] \cup {StmtIdRetryable}]
+    /\ writeApplied' = [writeApplied EXCEPT ![RetryableShard] = TRUE]
+    /\ UNCHANGED <<retryTxn, routerState, clientObservedSuccess,
+                   clientRead, clientReadSawAllWrites>>
+
+\* Step 3: the non-retryable shard commits its participant write. This is
+\* the other half of the original two-phase commit. Once it fires, the
+\* original txn is fully committed and there is no longer any retry hazard.
+NonRetryableShardCommitOriginal ==
+    /\ originalTxn[NonRetryableShard] = "prepared"
+    /\ originalTxn' = [originalTxn EXCEPT ![NonRetryableShard] = "committed"]
+    /\ writeApplied' = [writeApplied EXCEPT ![NonRetryableShard] = TRUE]
+    /\ UNCHANGED <<retryTxn, stmtHistory, routerState,
+                   clientObservedSuccess, clientRead, clientReadSawAllWrites>>
+
+\* Step 4: the client loses its connection to mongos0 mid-commit and retries
+\* against mongos1. mongos1 starts a new internal transaction for the
+\* retry, dispatching its first (retryable) statement to shard0.
+RouterDispatchRetry ==
+    /\ routerState["mongos1"] = "idle"
+    /\ routerState["mongos0"] = "running"
+    /\ routerState' = [routerState EXCEPT !["mongos1"] = "running"]
+    /\ UNCHANGED <<originalTxn, retryTxn, stmtHistory, writeApplied,
+                   clientObservedSuccess, clientRead, clientReadSawAllWrites>>
+
+\* Step 5: shard0 processes the retry's first statement. Because the
+\* original transaction has already committed on shard0, the stmtId 0
+\* lookup hits stmtHistory and shard0 responds with retriedStmtIds = [0].
+\* mongos1 now has to decide whether to short-circuit the rest of the
+\* internal transaction.
+\*
+\* Two paths:
+\*   1) SHORT_CIRCUIT_ON_PARTIAL_TXN = TRUE — the buggy path. mongos1
+\*      sees the duplicate stmtId, declares the entire retry a no-op,
+\*      and returns ok to the client without ever dispatching the
+\*      non-retryable statement to shard1. The non-retryable write on
+\*      shard1 may not have committed yet.
+\*   2) SHORT_CIRCUIT_ON_PARTIAL_TXN = FALSE — the safe path. mongos1
+\*      first checks whether the original internal transaction has fully
+\*      committed across all participants. If shard1 has not yet
+\*      committed, mongos1 blocks (in production: it sees a
+\*      RetryableTransactionInProgress error or waits for the original
+\*      txn's commit decision).
+RouterHandleRetryableShardResponse ==
+    /\ routerState["mongos1"] = "running"
+    /\ StmtIdRetryable \in stmtHistory[RetryableShard]
+    /\ IF SHORT_CIRCUIT_ON_PARTIAL_TXN
+        THEN
+            /\ routerState' = [routerState EXCEPT !["mongos1"] = "shortCircuited"]
+            /\ clientObservedSuccess' = TRUE
+            /\ UNCHANGED <<originalTxn, retryTxn, stmtHistory, writeApplied,
+                           clientRead, clientReadSawAllWrites>>
+        ELSE
+            /\ IF originalTxn[NonRetryableShard] = "committed"
+                THEN
+                    /\ routerState' = [routerState EXCEPT !["mongos1"] = "shortCircuited"]
+                    /\ clientObservedSuccess' = TRUE
+                    /\ UNCHANGED <<originalTxn, retryTxn, stmtHistory,
+                                   writeApplied, clientRead, clientReadSawAllWrites>>
+                ELSE
+                    /\ routerState' = [routerState EXCEPT !["mongos1"] = "blocked"]
+                    /\ UNCHANGED <<originalTxn, retryTxn, stmtHistory,
+                                   writeApplied, clientObservedSuccess,
+                                   clientRead, clientReadSawAllWrites>>
+
+\* Step 6 (safe path only): once the original transaction commits on shard1,
+\* the blocked retry unblocks. The non-retryable statement either is
+\* re-executed or the retry confirms the original txn fully landed. Either
+\* way, the write on shard1 is durable by the time the retry returns ok.
+RouterUnblock ==
+    /\ routerState["mongos1"] = "blocked"
+    /\ originalTxn[NonRetryableShard] = "committed"
+    /\ routerState' = [routerState EXCEPT !["mongos1"] = "completed"]
+    /\ clientObservedSuccess' = TRUE
+    /\ UNCHANGED <<originalTxn, retryTxn, stmtHistory, writeApplied,
+                   clientRead, clientReadSawAllWrites>>
+
+\* Step 7: client issues a follow-up read in the same session without
+\* afterClusterTime >= commitTimestamp. The read sees the current
+\* writeApplied snapshot. If the read finds both writes the spec records
+\* RYOW success; if any write is missing the spec records a violation.
+ClientRead ==
+    /\ clientObservedSuccess = TRUE
+    /\ clientRead = FALSE
+    /\ clientRead' = TRUE
+    /\ clientReadSawAllWrites' = (\A s \in Shards : writeApplied[s])
+    /\ UNCHANGED <<originalTxn, retryTxn, stmtHistory, routerState,
+                   writeApplied, clientObservedSuccess>>
+
+\* Convenience action: original txn commits cleanly with no retry. Lets
+\* the model exercise the "no failover" trajectory so we know the spec
+\* admits non-buggy traces.
+RouterDispatchOriginalCompletes ==
+    /\ routerState["mongos0"] = "running"
+    /\ originalTxn[RetryableShard] = "committed"
+    /\ originalTxn[NonRetryableShard] = "committed"
+    /\ routerState["mongos1"] = "idle"
+    /\ routerState' = [routerState EXCEPT !["mongos0"] = "completed"]
+    /\ clientObservedSuccess' = TRUE
+    /\ UNCHANGED <<originalTxn, retryTxn, stmtHistory, writeApplied,
+                   clientRead, clientReadSawAllWrites>>
+
+Next ==
+    \/ RouterDispatchOriginal
+    \/ RetryableShardCommitOriginal
+    \/ NonRetryableShardCommitOriginal
+    \/ RouterDispatchRetry
+    \/ RouterHandleRetryableShardResponse
+    \/ RouterUnblock
+    \/ ClientRead
+    \/ RouterDispatchOriginalCompletes
+    \/ UNCHANGED vars
+
+Fairness ==
+    /\ WF_vars(RouterDispatchOriginal)
+    /\ WF_vars(RetryableShardCommitOriginal)
+    /\ WF_vars(NonRetryableShardCommitOriginal)
+    /\ WF_vars(RouterDispatchRetry)
+    /\ WF_vars(RouterHandleRetryableShardResponse)
+    /\ WF_vars(RouterUnblock)
+    /\ WF_vars(ClientRead)
+    /\ WF_vars(RouterDispatchOriginalCompletes)
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+----------------------------------------------------------------------------------
+\* Type invariant.
+TypeOK ==
+    /\ originalTxn \in [Shards -> TxnShardStates]
+    /\ retryTxn \in [Shards -> TxnShardStates]
+    /\ stmtHistory \in [Shards -> SUBSET {StmtIdRetryable, StmtIdNonRetryable}]
+    /\ routerState \in [Routers -> RouterStates]
+    /\ writeApplied \in [Shards -> BOOLEAN]
+    /\ clientObservedSuccess \in BOOLEAN
+    /\ clientRead \in BOOLEAN
+    /\ clientReadSawAllWrites \in BOOLEAN
+
+\* Core correctness property: if the client has observed a successful
+\* retryable-write response in a given session, every subsequent read in
+\* that same session must observe every write that was part of the
+\* retryable write — regardless of whether the retry short-circuited.
+\* Phrased as a state invariant over the snapshot captured at read time.
+ReadYourOwnWrites ==
+    clientRead => clientReadSawAllWrites
+
+\* Auxiliary safety: the only way to declare client-visible success is
+\* through one of the three documented completion paths. Catches accidental
+\* state explosions where clientObservedSuccess flips without any router
+\* action.
+SuccessIsBackedByRouter ==
+    clientObservedSuccess =>
+        \/ routerState["mongos0"] = "completed"
+        \/ routerState["mongos1"] \in {"shortCircuited", "completed"}
+
+\* Liveness: every initiated run eventually reaches a terminal client state.
+EventuallyTerminates ==
+    <>(clientRead /\ clientObservedSuccess)
+
+==================================================================================


### PR DESCRIPTION
## Summary

TLA+ spec + jstest: retryable internal transaction read-your-own-writes invariant.

**Jira:** https://jira.mongodb.org/browse/SERVER-126713
**Branch:** substrate-contrib/w4-10

## Files

```
  -  jstests/sharding/internal_txn_retryable_ryow.js    | 219 +++++++++++++++
  -  src/mongo/tla_plus/RetryableWrites/OWNERS.yml      |   5 +
  -  .../RetryableInternalTxnRYOW/MC.cfg                |  15 +
  -  .../MCRetryableInternalTxnRYOW.cfg                 |  15 +
  -  .../MCRetryableInternalTxnRYOW.tla                 |  17 ++
  -  .../RetryableInternalTxnRYOW/MC_bug.cfg            |  16 ++
  -  .../RetryableInternalTxnRYOW/OWNERS.yml            |   5 +
  -  .../RetryableInternalTxnRYOW/README.md             |  81 ++++++
  -  .../RetryableInternalTxnRYOW.tla                   | 306 +++++++++++++++++++++
  -  9 files changed, 679 insertions(+)
```

## Verify

For `.tla` files:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For `.js` jstests:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
