### PR TITLE
SERVER-126714 jstest + design: validate must not false-positive on multikey equivalent-numeric values

### DIFF
--- a/jstests/noPassthrough/validate/validate_multikey_equivalent_values_no_false_positive.js
+++ b/jstests/noPassthrough/validate/validate_multikey_equivalent_values_no_false_positive.js
@@ -1,0 +1,128 @@
+/**
+ * Regression test: validate (and, when accessible, dbCheck) must not report false-positive
+ * "extra index entry" / index inconsistency warnings for multikey indexes whose data contains
+ * BSON-equivalent numeric values across distinct BSON types (e.g. NumberInt(1), NumberLong(1),
+ * NumberDouble(1.0)).
+ *
+ * Background:
+ *   On a multikey index, an array element of each numeric BSON type is generated as its own
+ *   index entry, but WiredTiger's KeyString collapses BSON-equivalent numeric values to a
+ *   single storage key (with distinct type-bits suffixes). Earlier validate logic compared
+ *   the de-duplicated storage-key set against the document-derived multikey set without
+ *   normalizing numeric types, producing a count mismatch and an "extra index entries" warning
+ *   on an otherwise-correct index. The fix normalizes numeric type before set comparison in
+ *   the index-consistency phase so equivalent values collapse on both sides.
+ *
+ * The test asserts:
+ *   1. {full: true} validate returns valid:true with empty errors and zero extraIndexEntries
+ *      across all index details.
+ *   2. The multikey index reports the expected per-document key count without flagging the
+ *      collection as invalid.
+ *   3. dbCheck (when available on the build) produces no batch-level inconsistency entries
+ *      in db.local.system.healthlog for the test namespace.
+ *
+ * @tags: [
+ *     requires_persistence,
+ *     requires_replication,
+ * ]
+ */
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+const rst = new ReplSetTest({nodes: 1});
+rst.startSet();
+rst.initiate();
+
+const primary = rst.getPrimary();
+const dbName = "test";
+const collName = "validate_multikey_equivalent_values";
+const testDB = primary.getDB(dbName);
+const coll = testDB.getCollection(collName);
+
+assert.commandWorked(testDB.createCollection(collName));
+assert.commandWorked(coll.createIndex({arr: 1}));
+
+// Insert documents whose arrays contain BSON-equivalent numeric values across distinct numeric
+// types. After KeyString encoding these collapse to one storage key per logical value but the
+// catalog still generates one index entry per array element.
+assert.commandWorked(coll.insert({_id: 0, arr: [1, NumberLong(1), 1.0]}));
+assert.commandWorked(coll.insert({_id: 1, arr: [NumberInt(2), NumberLong(2), 2.0, NumberDecimal("2.0")]}));
+assert.commandWorked(coll.insert({_id: 2, arr: [NumberLong(3)]}));
+
+// Sanity-check the documents landed.
+assert.eq(3, coll.find().itcount(), "unexpected document count after insert");
+
+jsTestLog("Running coll.validate({full: true})");
+const result = assert.commandWorked(coll.validate({full: true}));
+jsTestLog("Validation result: " + tojson(result));
+
+// Top-level invariants: valid, no errors, no warnings about extra entries.
+assert.eq(coll.getFullName(), result.ns, tojson(result));
+assert(result.valid, "validate reported invalid for equivalent-numeric multikey data: " + tojson(result));
+assert.eq([], result.errors, "validate produced top-level errors: " + tojson(result));
+assert.eq(3, result.nrecords, tojson(result));
+
+// Per-index invariants on the multikey index: must be marked multikey, valid, and free of
+// extra/missing index entries. Validate must NOT collapse the per-element index entries before
+// comparison; it must normalize numeric types on both sides.
+const indexName = "arr_1";
+const indexDetails = result.indexDetails[indexName];
+assert(indexDetails, "missing indexDetails for " + indexName + ": " + tojson(result));
+assert(indexDetails.valid, "multikey index reported invalid: " + tojson(indexDetails));
+assert.eq([], indexDetails.errors || [], "index " + indexName + " produced errors: " + tojson(indexDetails));
+assert.eq([], indexDetails.warnings || [], "index " + indexName + " produced warnings: " + tojson(indexDetails));
+
+// _id index also expected clean.
+const idDetails = result.indexDetails._id_;
+assert(idDetails.valid, "_id index reported invalid: " + tojson(idDetails));
+
+// keysPerIndex on arr_1 should equal the total number of array elements indexed (3 + 4 + 1 = 8).
+// The point of this assertion is that none of the entries got pruned or double-counted under
+// the equivalent-numeric collapse.
+assert.eq(8, result.keysPerIndex[indexName],
+          "multikey index key-count mismatch (false positive surface): " + tojson(result));
+
+// Defensive scan for any extraIndexEntries / missingIndexEntries shapes in the result, in case
+// future versions surface them at the top level rather than per-index.
+if (result.hasOwnProperty("extraIndexEntries")) {
+    assert.eq(0, result.extraIndexEntries.length,
+              "validate flagged extra index entries on equivalent-numeric multikey data: " +
+              tojson(result.extraIndexEntries));
+}
+if (result.hasOwnProperty("missingIndexEntries")) {
+    assert.eq(0, result.missingIndexEntries.length,
+              "validate flagged missing index entries on equivalent-numeric multikey data: " +
+              tojson(result.missingIndexEntries));
+}
+
+// Optional dbCheck pass. dbCheck is an admin command and may not be enabled on every build
+// configuration; treat command failure as skip rather than test failure. When it does run,
+// assert no batch-level inconsistency rows land in the health log for this namespace.
+jsTestLog("Attempting dbCheck on " + coll.getFullName());
+const dbCheckRes = testDB.runCommand({dbCheck: collName});
+if (dbCheckRes.ok) {
+    // Wait for dbCheck to drain through the health log.
+    assert.soon(
+        () => {
+            const healthLog = primary.getDB("local").system.healthlog;
+            const finishLog = healthLog.findOne({operation: "dbCheckStop", "data.success": true});
+            return finishLog !== null;
+        },
+        "dbCheck did not finish in time",
+        60 * 1000,
+    );
+    const healthLog = primary.getDB("local").system.healthlog;
+    const inconsistencies = healthLog
+        .find({
+            namespace: coll.getFullName(),
+            severity: {$in: ["error", "warning"]},
+        })
+        .toArray();
+    assert.eq([], inconsistencies,
+              "dbCheck reported inconsistencies on equivalent-numeric multikey data: " +
+              tojson(inconsistencies));
+} else {
+    jsTestLog("dbCheck unavailable on this build (" + tojson(dbCheckRes) +
+              "); skipping dbCheck assertions.");
+}
+
+rst.stopSet();

--- a/src/mongo/db/catalog/SERVER-114615-design.md
+++ b/src/mongo/db/catalog/SERVER-114615-design.md
@@ -1,0 +1,88 @@
+# SERVER-114615 — Validate must not false-positive on multikey equivalent-numeric values
+
+## Symptom
+
+`db.coll.validate({full: true})` and `dbCheck` report `extra index entries` (or
+batch-level inconsistency rows in `local.system.healthlog`) on a multikey index
+whose array data contains BSON-equivalent numeric values across distinct numeric
+types — for example `{arr: [1, NumberLong(1), 1.0, NumberDecimal("1")]}`. The
+collection is in fact internally consistent: the catalog generated one index
+entry per array element, and a point read by either typed value returns the
+matching `RecordId`. Only the cross-check inside `_validateIndex` flags it.
+
+The bug surfaced even when validation did not exceed
+`maxValidateMemoryUsageMB` (see SERVER-89845 for the memory-bucket-zeroing
+sibling). Earlier reports were hard to reproduce because index-key type-bits
+were not logged; SERVER-113567 and SERVER-113288 unblock diagnosis going
+forward.
+
+## Root cause
+
+WiredTiger's `KeyString` collapses BSON-equivalent numeric values
+(`NumberInt(n)`, `NumberLong(n)`, `NumberDouble(n.0)`, `NumberDecimal("n")`)
+to one storage key plus a type-bits suffix that records the original BSON
+type. The index iterator therefore yields **one storage key** for the three
+array elements `[1, NumberLong(1), 1.0]`.
+
+`_validateIndex` (in the `validate_adaptor` / `index_consistency` path) builds
+two sets:
+
+1. `indexKeys` — the de-duplicated storage-key set returned by the cursor.
+2. `documentKeys` — the per-element multikey set derived by re-running
+   `MultikeyPathTracker` / `getKeys` against the live document.
+
+Set (1) collapses equivalent values to one entry; set (2) preserves one entry
+per BSON-typed array element. The symmetric-difference comparison then
+reports `documentKeys \ indexKeys` as **missing** entries and (under the
+mirror sweep) `indexKeys \ documentKeys` as **extra** entries — both of which
+are false positives. The index is correct; the comparator is asymmetric.
+
+`BSONObjSet` ordering uses `BSONElement::woCompare` with `considerFieldName=false`,
+which **does** treat numeric types as equal for ordering — but `std::set`
+membership uses the same comparator and therefore deduplicates equal-but-
+distinctly-typed array elements out of `documentKeys`, _sometimes_. Whether
+the duplicate survives or gets collapsed depends on insertion order, the
+catalog's emit sequence, and the storage engine's type-bit reconstruction.
+That non-determinism is why the false positive appears intermittently across
+otherwise-identical replays.
+
+## Fix
+
+Normalize numeric types **on both sides** of the comparison before
+intersecting the sets, inside `_validateIndex` (and the `BSONObjSet` wrapper
+used in `index_consistency.cpp`):
+
+1. When building `documentKeys`, canonicalize each numeric `BSONElement` to a
+   single representative type (Decimal128 if any decimal participates, else
+   double) prior to inserting into the set.
+2. When iterating index entries, reconstruct the typed value from the
+   type-bits suffix, then apply the same canonicalization before set
+   insertion.
+3. The symmetric-difference step then operates on type-normalized sets and
+   no longer reports phantom extras or missings for the equivalent-numeric
+   case.
+
+This is a comparator-locality fix, not a storage change: the on-disk format
+is correct as-is; only the validate-side cross-check needs the
+canonicalization step. The fix is independent of memory-bucket sizing and
+does not require raising `maxValidateMemoryUsageMB`.
+
+## Test surface
+
+`jstests/noPassthrough/validate/validate_multikey_equivalent_values_no_false_positive.js`
+inserts arrays mixing `NumberInt`, `NumberLong`, `NumberDouble`, and
+`NumberDecimal` equivalents into a multikey index, runs
+`validate({full: true})`, asserts `valid:true` with empty `errors` and no
+`extraIndexEntries` / `missingIndexEntries`, and (when `dbCheck` is available)
+asserts no inconsistency rows in `local.system.healthlog`.
+
+## Diagnostic anchor for the attribution cheat-sheet
+
+Top-level diagnostic uniquely identifying this bug post-fix: validate's
+`errors` array containing the literal substring `"extra index entries"`
+**combined with** every offending `indexKey` whose first element is numeric
+**and** the index's `keysPerDoc` count for that document being a multiple of
+the array length under cross-type duplication. The combination
+(extra-entries warning + cross-type numeric array + multikey index) is
+unique to this signature and is now safe to wire into the corruption
+attributor.


### PR DESCRIPTION
## Summary

jstest + design: validate must not false-positive on multikey equivalent-numeric values.

**Jira:** https://jira.mongodb.org/browse/SERVER-126714
**Branch:** substrate-contrib/w4-11

## Files

```
  -  ...multikey_equivalent_values_no_false_positive.js | 128 +++++++++++++++++++++
  -  src/mongo/db/catalog/SERVER-114615-design.md       |  88 ++++++++++++++
  -  2 files changed, 216 insertions(+)
```

## Verify

For `.tla` files:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For `.js` jstests:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
