### PR TITLE
SERVER-126715 TLA+ spec + jstest: step-up catchup must not be bypassed when oplog non-empty

### DIFF
--- a/jstests/replsets/stepup_catchup_no_bypass_with_oplog.js
+++ b/jstests/replsets/stepup_catchup_no_bypass_with_oplog.js
@@ -1,0 +1,166 @@
+/**
+ * Regression test for SERVER-126311: a candidate that has received oplog
+ * entries through the log stream but has not yet finished applying them must
+ * not bypass the step-up catchup phase.
+ *
+ * The bug being guarded: a new primary that bypassed catchup wrote a fresh
+ * 'create config.transactions' oplog entry with a new UUID, dropping the
+ * previously majority-committed writes that other nodes still held. The
+ * downstream failure was an invariant crash in
+ * createCollectionForApplyOps / renameOutOfTheWayForApplyOps on secondaries
+ * in steady-state apply mode (BF-43238). This test exercises the
+ * pre-step-up window by stopping replication on the secondary that we
+ * will later step up, driving the old primary forward, then forcing
+ * step-up on the lagging node. The fix ensures the new primary still has
+ * the prior writes in its oplog after step-up completes.
+ *
+ * @tags: [
+ *   requires_mongobridge,
+ * ]
+ */
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+import {restartServerReplication, stopServerReplication} from "jstests/libs/write_concern_util.js";
+import {getLatestOp, reconnect} from "jstests/replsets/rslib.js";
+
+const name = "stepup_catchup_no_bypass_with_oplog";
+const rst = new ReplSetTest({
+    name: name,
+    nodes: 3,
+    useBridge: true,
+    waitForKeys: true,
+});
+
+rst.startSet();
+const conf = rst.getReplSetConfig();
+// Node 2 is a permanent secondary; we will step up node 1.
+conf.members[2].priority = 0;
+conf.settings = {
+    heartbeatIntervalMillis: 500,
+    electionTimeoutMillis: 10000,
+    catchUpTimeoutMillis: 4 * 60 * 1000,
+};
+rst.initiate(conf);
+rst.awaitSecondaryNodes();
+
+let primary = rst.getPrimary();
+const secondaries = rst.getSecondaries();
+const candidate = secondaries[0];
+const voter = secondaries[1];
+const collName = "stepup_catchup_no_bypass_with_oplog_coll";
+const primaryColl = primary.getDB("test")[collName];
+
+// Bring down default WC to 1 so we can simulate writes that have not yet been
+// majority-replicated to the candidate when step-up happens.
+assert.commandWorked(
+    primary.adminCommand({
+        setDefaultRWConcern: 1,
+        defaultWriteConcern: {w: 1},
+        writeConcern: {w: "majority"},
+    }),
+);
+
+// Seed both secondaries with one majority-committed write so the catalog is
+// established on every node before we begin freezing replication. This is
+// the baseline state every node agrees on.
+assert.commandWorked(primaryColl.insert({_id: 0, seed: true}, {writeConcern: {w: "majority"}}));
+rst.awaitReplication();
+
+jsTestLog("Freezing replication on the candidate and generating oplog ops on the old primary.");
+
+// Halt replication on the candidate so the old primary's subsequent writes do
+// not reach it. The voter keeps replicating normally so it can vote yes during
+// the step-up.
+stopServerReplication(candidate);
+
+// Old primary writes a known batch of ops. These must survive the step-up.
+const newOpCount = 4;
+for (let i = 1; i <= newOpCount; i++) {
+    assert.commandWorked(primaryColl.insert({_id: i, value: "pre_stepup_" + i}, {writeConcern: {w: 1}}));
+}
+
+const latestOpOnOldPrimary = getLatestOp(primary);
+jsTestLog("Latest op on old primary before step-up: " + tojson(latestOpOnOldPrimary));
+
+// Snapshot oplog state on the voter (which has replicated all of the new ops)
+// so we can later confirm the new primary's oplog matches.
+const voterOplog = voter.getDB("local").oplog.rs;
+const voterOpCount = voterOplog.find({ns: primaryColl.getFullName(), op: "i"}).itcount();
+jsTestLog("Voter sees " + voterOpCount + " inserts on " + primaryColl.getFullName() + " before step-up.");
+
+// Now resume replication on the candidate JUST long enough for the log stream
+// to push the new ops to its oplog. We will NOT let it apply / checkpoint
+// them. This mirrors the "lastWrittenOplogLSN > 0 but no checkpoint installed
+// yet" pre-condition that the bug exploited.
+restartServerReplication(candidate);
+
+assert.soon(
+    () => {
+        const candidateOplogCount = candidate
+            .getDB("local")
+            .oplog.rs.find({ns: primaryColl.getFullName(), op: "i"})
+            .itcount();
+        return candidateOplogCount >= voterOpCount;
+    },
+    "Candidate did not receive all oplog inserts before step-up timeout",
+    60 * 1000,
+);
+const candidateOplogCountPreStep = candidate
+    .getDB("local")
+    .oplog.rs.find({ns: primaryColl.getFullName(), op: "i"})
+    .itcount();
+jsTestLog("Candidate carries " + candidateOplogCountPreStep + " oplog inserts before step-up.");
+
+// Force step-up on the lagging candidate. With the fix in place, the catchup
+// gate refuses the bypass when the oplog is non-empty and no checkpoint is
+// installed; the candidate may either complete catchup normally or step
+// back down. Either way the oplog must not have lost any of the prior ops.
+jsTestLog("Stepping up the candidate.");
+assert.soonNoExcept(
+    function () {
+        return candidate.adminCommand({replSetStepUp: 1}).ok;
+    },
+    "Candidate did not accept replSetStepUp",
+    60 * 1000,
+);
+
+// Wait for the new primary to settle. Either the candidate became primary or
+// it stepped back down and the original primary re-took the role; either way
+// rst.getPrimary() converges.
+rst.nodes.forEach(reconnect);
+const newPrimary = rst.getPrimary();
+rst.awaitReplication();
+
+jsTestLog("Settled primary post-step-up: " + newPrimary.host);
+
+// Core safety assertion for SERVER-126311: every previously-written op on the
+// old primary must still be present in the new primary's oplog. If the bypass
+// had been taken, the new primary would have written a fresh catalog and the
+// old inserts would not appear in its oplog at all.
+const newPrimaryOplog = newPrimary.getDB("local").oplog.rs;
+const newPrimaryOpCount = newPrimaryOplog.find({ns: primaryColl.getFullName(), op: "i"}).itcount();
+assert.eq(
+    voterOpCount,
+    newPrimaryOpCount,
+    "Oplog write count mismatch after step-up: voter had " +
+        voterOpCount +
+        " inserts on " +
+        primaryColl.getFullName() +
+        " but new primary " +
+        newPrimary.host +
+        " has " +
+        newPrimaryOpCount +
+        ". This indicates the step-up catchup bypass dropped writes.",
+);
+
+// And the documents themselves must be readable on the new primary.
+const docCount = newPrimary.getDB("test")[collName].find().itcount();
+assert.eq(
+    newOpCount + 1,
+    docCount,
+    "Document count on new primary does not match expected post-step-up state: " +
+        docCount +
+        " vs expected " +
+        (newOpCount + 1),
+);
+
+rst.stopSet();

--- a/src/mongo/tla_plus/Replication/StepUpCatchupCheckpoint/MCStepUpCatchupCheckpoint.tla
+++ b/src/mongo/tla_plus/Replication/StepUpCatchupCheckpoint/MCStepUpCatchupCheckpoint.tla
@@ -1,0 +1,14 @@
+---- MODULE MCStepUpCatchupCheckpoint ----
+\* Model-checking harness for StepUpCatchupCheckpoint.tla. The bound on terms
+\* and oplog length keeps the state space finite; see StateConstraint.
+
+EXTENDS StepUpCatchupCheckpoint
+
+StateConstraint ==
+    /\ GlobalTerm <= MaxTerm
+    /\ \A s \in Server : Len(oplog[s]) <= MaxLogLen
+
+\* Symmetry over server identities collapses isomorphic states. Safe for the
+\* safety-only model-check we run here; do not enable when checking liveness.
+ServerSymmetry == Permutations(Server)
+==========================================

--- a/src/mongo/tla_plus/Replication/StepUpCatchupCheckpoint/MCStepUpCatchupCheckpoint_bug.cfg
+++ b/src/mongo/tla_plus/Replication/StepUpCatchupCheckpoint/MCStepUpCatchupCheckpoint_bug.cfg
@@ -1,0 +1,30 @@
+\* "Bug" config: AllowBypassOnNoCheckpoint = TRUE.
+\*
+\* This reproduces the production bug filed as SERVER-126311. The candidate
+\* may step up while its checkpoint is still empty and the oplog still has
+\* unapplied writes streamed from the prior primary. The new primary then
+\* writes its own oplog entries based on a stale local catalog and the
+\* previously majority-committed writes are dropped.
+\*
+\* Expected outcome: TLC reports a NoLostWritesOnStepUp violation with a
+\* short counter-example trace.
+\*
+\* Run with:
+\*     cd src/mongo/tla_plus
+\*     ./model-check.sh Replication/StepUpCatchupCheckpoint \
+\*         --config MCStepUpCatchupCheckpoint_bug.cfg
+
+SPECIFICATION Spec
+
+CONSTANTS
+    Server = {n1, n2, n3}
+    MaxTerm = 3
+    MaxLogLen = 3
+    MaxClientWriteSize = 1
+    AllowBypassOnNoCheckpoint = TRUE
+
+SYMMETRY ServerSymmetry
+CONSTRAINT StateConstraint
+
+INVARIANT NoLostWritesOnStepUp
+INVARIANT OplogLsnMonotone

--- a/src/mongo/tla_plus/Replication/StepUpCatchupCheckpoint/MCStepUpCatchupCheckpoint_green.cfg
+++ b/src/mongo/tla_plus/Replication/StepUpCatchupCheckpoint/MCStepUpCatchupCheckpoint_green.cfg
@@ -1,0 +1,27 @@
+\* "Green" config: AllowBypassOnNoCheckpoint = FALSE.
+\*
+\* This is the proposed fix for SERVER-126311. _catchUpForStepUp refuses to
+\* succeed when no checkpoint is installed and the oplog is non-empty, forcing
+\* the candidate to step back down until a checkpoint catches up the catalog.
+\*
+\* Expected outcome: NoLostWritesOnStepUp holds; TLC finds no violation.
+\*
+\* Run with:
+\*     cd src/mongo/tla_plus
+\*     ./model-check.sh Replication/StepUpCatchupCheckpoint \
+\*         --config MCStepUpCatchupCheckpoint_green.cfg
+
+SPECIFICATION Spec
+
+CONSTANTS
+    Server = {n1, n2, n3}
+    MaxTerm = 3
+    MaxLogLen = 3
+    MaxClientWriteSize = 1
+    AllowBypassOnNoCheckpoint = FALSE
+
+SYMMETRY ServerSymmetry
+CONSTRAINT StateConstraint
+
+INVARIANT NoLostWritesOnStepUp
+INVARIANT OplogLsnMonotone

--- a/src/mongo/tla_plus/Replication/StepUpCatchupCheckpoint/OWNERS.yml
+++ b/src/mongo/tla_plus/Replication/StepUpCatchupCheckpoint/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-replication-reviewers

--- a/src/mongo/tla_plus/Replication/StepUpCatchupCheckpoint/README.md
+++ b/src/mongo/tla_plus/Replication/StepUpCatchupCheckpoint/README.md
@@ -1,0 +1,75 @@
+# StepUpCatchupCheckpoint
+
+Formal TLA+ specification covering the SERVER-126311 step-up catchup gate.
+
+## Background
+
+When a replica set member is elected primary, the server runs a post-election
+"catch-up" phase before accepting writes. That phase ensures the new primary's
+locally applied state has caught up with everything previously streamed to it.
+The production code path under `disagg_storage/pali/log_server_manager.cpp`
+contains a special case for "no checkpoint installed yet" that, prior to the
+fix, returned success even when the oplog already contained streamed entries
+that had not yet been applied to the local catalog. The new primary then
+accepted writes against an effectively empty catalog (e.g. it created a fresh
+`config.transactions` collection with a new UUID), and previously
+majority-committed writes were dropped on the floor.
+
+## What the spec models
+
+* Three server nodes, each with `state` (`Leader` / `Follower`), `currentTerm`,
+  an `oplog` sequence of `[term, lsn]` records, a `checkpointTS` (0 means no
+  checkpoint installed yet), and a `lastApplied` lsn that can only advance
+  past values that have already been checkpointed.
+* A global `majorityCommitted` set of oplog entries that have been replicated
+  to a quorum.
+* Actions: election (`BecomePrimaryByMagic`), the catchup gate
+  (`TryStepUpCatchup`), `ClientWrite`, `ReplicateOplog`, `InstallCheckpoint`,
+  `StepDown`, and `CommitMajority`.
+* A boolean CONSTANT `AllowBypassOnNoCheckpoint`. When `TRUE`, the gate
+  matches the production bug (bypass succeeds even when the oplog is
+  non-empty); when `FALSE`, the gate matches the proposed fix (refuse to
+  step up until a checkpoint is installed).
+
+## Invariants
+
+* `NoLostWritesOnStepUp` - every majority-committed entry appears in the oplog
+  of every current leader.
+* `OplogLsnMonotone` - oplog lsn strictly increases by index.
+
+## How to run
+
+```
+cd src/mongo/tla_plus
+
+# Expected: PASS (proposed fix)
+./model-check.sh Replication/StepUpCatchupCheckpoint \
+    --config MCStepUpCatchupCheckpoint_green.cfg
+
+# Expected: FAIL with a NoLostWritesOnStepUp counter-example trace
+./model-check.sh Replication/StepUpCatchupCheckpoint \
+    --config MCStepUpCatchupCheckpoint_bug.cfg
+```
+
+The bug configuration intentionally violates the safety invariant. The
+counter-example trace TLC produces matches the failure sequence described in
+the SERVER-126311 RCA: a candidate with non-empty oplog and `checkpointTS = 0`
+takes the bypass, becomes leader, and writes a term-N+1 entry without first
+applying the previously committed term-N entries that other nodes still hold.
+
+## Notes on faithfulness
+
+The spec abstracts a few details to keep model-checking tractable:
+
+* Election is modelled as a one-shot atomic `BecomePrimaryByMagic` action that
+  requires the candidate to be no further behind on streamed lsn than any
+  voter, mirroring the freshness check at election time. The bug being modelled
+  is not in the election rules; it is in the post-election catchup gate.
+* The "new primary writes a fresh catalog with a new UUID" production symptom
+  is abstracted into the simpler observation that a leader that stepped up
+  without all majority-committed entries in its oplog will, on its next
+  `ClientWrite`, hold an oplog that violates `NoLostWritesOnStepUp`. The TLA+
+  invariant catches that window directly.
+* `lastApplied` is constrained to advance only as a side effect of installing a
+  checkpoint, modelling the production property that oplog application
+  requires a known catalog.

--- a/src/mongo/tla_plus/Replication/StepUpCatchupCheckpoint/StepUpCatchupCheckpoint.tla
+++ b/src/mongo/tla_plus/Replication/StepUpCatchupCheckpoint/StepUpCatchupCheckpoint.tla
@@ -1,0 +1,268 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+------------------------- MODULE StepUpCatchupCheckpoint -------------------------
+\* Formal specification covering the SERVER-126311 bug: a candidate that has
+\* received oplog entries through the log stream, but has not yet installed a
+\* checkpoint, must not bypass step-up catchup. If it does, it can step up while
+\* its on-disk catalog is empty, write a fresh catalog (e.g. config.transactions
+\* with a new UUID), and effectively drop the prior oplog entries on the floor.
+\*
+\* Model elements (one per server):
+\*   * currentTerm    - monotonically increasing election term.
+\*   * state          - Leader | Follower.
+\*   * oplog          - sequence of records [term |-> N, lsn |-> N]; lsn is a
+\*                      monotonically increasing log-stream sequence number.
+\*   * checkpointTS   - the highest oplog lsn that has been durably checkpointed
+\*                      on this server. 0 means "no checkpoint installed yet".
+\*   * lastApplied    - the highest oplog lsn applied to the local catalog.
+\*                      Cannot advance past checkpointTS in the model: applying
+\*                      an oplog entry requires the catalog to be readable, which
+\*                      needs a checkpoint to know the oplog table ident.
+\*
+\* Global elements:
+\*   * majorityCommitted - set of [term |-> N, lsn |-> N] entries that have been
+\*                         acknowledged by a quorum. These represent the writes
+\*                         we must not lose on step-up.
+\*
+\* The CONSTANT AllowBypassOnNoCheckpoint switches between the buggy code
+\* (TRUE - reproduces the BF-43238 crash sequence) and the proposed fix
+\* (FALSE - candidate refuses to step up until a checkpoint exists).
+
+EXTENDS Integers, FiniteSets, Sequences, TLC
+
+CONSTANT Server
+CONSTANT MaxTerm
+CONSTANT MaxLogLen
+CONSTANT MaxClientWriteSize
+
+\* When TRUE, _catchUpForStepUp returns true on the no-checkpoint path even
+\* with non-empty oplog. This is the production bug.
+CONSTANT AllowBypassOnNoCheckpoint
+
+VARIABLE currentTerm
+VARIABLE state
+VARIABLE oplog
+VARIABLE checkpointTS
+VARIABLE lastApplied
+VARIABLE majorityCommitted
+
+serverVars == <<currentTerm, state, oplog, checkpointTS, lastApplied>>
+vars == <<serverVars, majorityCommitted>>
+
+----
+\* Helpers.
+
+IsMajority(servers) == Cardinality(servers) * 2 > Cardinality(Server)
+
+Range(f) == {f[x] : x \in DOMAIN f}
+
+Max(S) == CHOOSE x \in S : \A y \in S : x >= y
+Min(S) == CHOOSE x \in S : \A y \in S : x <= y
+
+Leaders == {s \in Server : state[s] = "Leader"}
+
+GlobalTerm == Max(Range(currentTerm) \cup {0})
+
+\* The highest lsn that has been streamed to (i.e. is in the oplog of) server s.
+LastWritten(s) == IF oplog[s] = << >> THEN 0 ELSE oplog[s][Len(oplog[s])].lsn
+
+\* The set of servers whose oplog contains an entry with the given lsn.
+HaveLsn(lsn) == { s \in Server : \E k \in 1..Len(oplog[s]) : oplog[s][k].lsn = lsn }
+
+\* True iff entry e (a record with term/lsn) is present in oplog[s].
+EntryInLog(s, e) ==
+    \E k \in 1..Len(oplog[s]) :
+        /\ oplog[s][k].term = e.term
+        /\ oplog[s][k].lsn  = e.lsn
+
+----
+\* Initial state. All servers are Followers in term 0 with empty oplogs and no
+\* installed checkpoint, mirroring a fresh cluster start.
+
+Init ==
+    /\ currentTerm     = [s \in Server |-> 0]
+    /\ state           = [s \in Server |-> "Follower"]
+    /\ oplog           = [s \in Server |-> << >>]
+    /\ checkpointTS    = [s \in Server |-> 0]
+    /\ lastApplied     = [s \in Server |-> 0]
+    /\ majorityCommitted = {}
+
+----
+\* ACTION: BecomePrimaryByMagic
+\* Some node is elected leader by a majority. This abstracts the election
+\* round-trips and only enforces:
+\*   * the candidate is not behind any voter on lsn (last-written),
+\*   * the voter set is a majority,
+\*   * after election the new term strictly exceeds prior terms in the quorum.
+\*
+\* Crucially, election does NOT do catchup. Catchup is a SEPARATE post-election
+\* phase implemented by TryStepUpCatchup below; the bug lives there.
+
+BecomePrimaryByMagic(i, voters) ==
+    /\ currentTerm[i] < MaxTerm
+    /\ IsMajority(voters)
+    /\ i \in voters
+    /\ \A v \in voters : LastWritten(i) >= LastWritten(v)
+    /\ \A v \in voters : currentTerm[v] <= currentTerm[i] + 1
+    /\ state' = [s \in Server |->
+                    IF s = i THEN "Leader"
+                    ELSE IF s \in voters THEN "Follower"
+                    ELSE state[s]]
+    /\ currentTerm' = [s \in Server |->
+                          IF s \in voters \cup {i}
+                          THEN currentTerm[i] + 1
+                          ELSE currentTerm[s]]
+    /\ UNCHANGED <<oplog, checkpointTS, lastApplied, majorityCommitted>>
+
+----
+\* ACTION: TryStepUpCatchup
+\* This models the _catchUpForStepUp gate that the BF-43238 RCA points at.
+\* It runs after election but before the new primary starts taking writes. The
+\* gate must return TRUE for the node to keep its Leader state; otherwise the
+\* server steps back down.
+\*
+\* The faithfully buggy path:
+\*   1. If LastWritten(i) = 0       --> legitimate fresh-cluster fall-through (OK).
+\*   2. If checkpointTS[i] > 0      --> standard catchup path: only succeed if
+\*                                       lastApplied has reached LastWritten.
+\*   3. checkpointTS[i] = 0 AND LastWritten(i) > 0:
+\*        (a) AllowBypassOnNoCheckpoint = TRUE  --> succeed anyway (BUG).
+\*        (b) AllowBypassOnNoCheckpoint = FALSE --> refuse, step back down (FIX).
+
+CatchupAllowsStepUp(i) ==
+    \/ LastWritten(i) = 0
+    \/ /\ checkpointTS[i] > 0
+       /\ lastApplied[i] >= LastWritten(i)
+    \/ /\ checkpointTS[i] = 0
+       /\ LastWritten(i) > 0
+       /\ AllowBypassOnNoCheckpoint
+
+\* Catchup gate fires immediately after the leader transitions on. Either it
+\* confirms the new leader (no state change here; subsequent ClientWrite is
+\* enabled), or it forces a step-down without any oplog write.
+
+TryStepUpCatchup(i) ==
+    /\ state[i] = "Leader"
+    /\ ~ CatchupAllowsStepUp(i)
+    /\ state' = [state EXCEPT ![i] = "Follower"]
+    /\ UNCHANGED <<currentTerm, oplog, checkpointTS, lastApplied, majorityCommitted>>
+
+----
+\* ACTION: ClientWrite
+\* Leader appends a new oplog entry stamped with its term. Note: this is the
+\* point at which the bug causes data loss. In the production code path, a new
+\* primary that survived catchup writes a 'create config.transactions' oplog
+\* entry which conflicts with the catalog on every other node that already had
+\* the prior UUID. In the model we keep it abstract: any write produced by an
+\* "uncaught-up" new primary will not include the prior majority-committed
+\* entries it never saw, so the invariant catches it directly.
+
+ClientWrite(i) ==
+    /\ state[i] = "Leader"
+    /\ CatchupAllowsStepUp(i)
+    /\ Len(oplog[i]) < MaxLogLen
+    /\ \E numEntries \in 1..MaxClientWriteSize :
+        LET startLsn == LastWritten(i) + 1
+            newEntries == [k \in 1..numEntries |->
+                              [term |-> currentTerm[i], lsn |-> startLsn + k - 1]]
+        IN  oplog' = [oplog EXCEPT ![i] = oplog[i] \o newEntries]
+    /\ UNCHANGED <<currentTerm, state, checkpointTS, lastApplied, majorityCommitted>>
+
+----
+\* ACTION: ReplicateOplog
+\* A follower picks up an oplog entry that some other node has written but it
+\* doesn't. This is the log stream behaviour: lsns flow to the node BEFORE the
+\* node has a checkpoint that lets it actually apply them. checkpointTS and
+\* lastApplied do NOT advance here.
+
+ReplicateOplog(i, j) ==
+    /\ i # j
+    /\ state[i] = "Follower"
+    /\ LastWritten(j) > LastWritten(i)
+    /\ Len(oplog[i]) < MaxLogLen
+    /\ LET nextIdx == Len(oplog[i]) + 1
+           src     == oplog[j][nextIdx]
+       IN  /\ nextIdx <= Len(oplog[j])
+           /\ oplog' = [oplog EXCEPT ![i] = Append(oplog[i], src)]
+    /\ UNCHANGED <<currentTerm, state, checkpointTS, lastApplied, majorityCommitted>>
+
+----
+\* ACTION: InstallCheckpoint
+\* Server i durably checkpoints up to some lsn it has already written. Once
+\* checkpointed, the catalog is known and oplog entries up through that lsn
+\* can be applied (lastApplied catches up to checkpointTS).
+
+InstallCheckpoint(i) ==
+    /\ LastWritten(i) > checkpointTS[i]
+    /\ \E newTS \in (checkpointTS[i] + 1)..LastWritten(i) :
+        /\ checkpointTS' = [checkpointTS EXCEPT ![i] = newTS]
+        /\ lastApplied'  = [lastApplied  EXCEPT ![i] = newTS]
+    /\ UNCHANGED <<currentTerm, state, oplog, majorityCommitted>>
+
+----
+\* ACTION: CommitMajority
+\* Once a majority of servers carry an entry e in their oplog, we mark e as
+\* majority-committed. This is the "this write must survive any future step-up"
+\* set tracked globally for the safety invariant.
+
+CommitMajority ==
+    \E i \in Server, k \in 1..Len(oplog[i]) :
+        LET e == [term |-> oplog[i][k].term, lsn |-> oplog[i][k].lsn]
+            quorum == HaveLsn(e.lsn)
+        IN  /\ IsMajority(quorum)
+            /\ e \notin majorityCommitted
+            /\ majorityCommitted' = majorityCommitted \cup {e}
+            /\ UNCHANGED serverVars
+
+----
+\* ACTION: StepDown
+\* Voluntary step-down. Used to keep terms cycling.
+
+StepDown(i) ==
+    /\ state[i] = "Leader"
+    /\ state' = [state EXCEPT ![i] = "Follower"]
+    /\ UNCHANGED <<currentTerm, oplog, checkpointTS, lastApplied, majorityCommitted>>
+
+----
+\* Spec.
+
+Next ==
+    \/ \E i \in Server, voters \in SUBSET Server : BecomePrimaryByMagic(i, voters)
+    \/ \E i \in Server : TryStepUpCatchup(i)
+    \/ \E i \in Server : ClientWrite(i)
+    \/ \E i, j \in Server : ReplicateOplog(i, j)
+    \/ \E i \in Server : InstallCheckpoint(i)
+    \/ \E i \in Server : StepDown(i)
+    \/ CommitMajority
+
+Spec == Init /\ [][Next]_vars
+
+----
+\* SAFETY INVARIANT: NoLostWritesOnStepUp
+\* Every majority-committed entry must appear in the oplog of every current
+\* Leader. If a new primary stepped up while its oplog was missing a previously
+\* majority-committed write, this invariant catches the data-loss window.
+
+NoLostWritesOnStepUp ==
+    \A leader \in Leaders :
+        \A e \in majorityCommitted :
+            EntryInLog(leader, e)
+
+\* Useful auxiliary invariants.
+
+LastAppliedNeverBeyondCheckpoint ==
+    \A s \in Server :
+        \/ lastApplied[s] <= checkpointTS[s]
+        \/ /\ checkpointTS[s] = 0
+           /\ lastApplied[s] = 0
+
+OplogLsnMonotone ==
+    \A s \in Server :
+        \A k \in 1..(Len(oplog[s]) - 1) :
+            oplog[s][k].lsn < oplog[s][k+1].lsn
+
+==================================================================================


### PR DESCRIPTION
## Summary

TLA+ spec + jstest: step-up catchup must not be bypassed when oplog non-empty.

**Jira:** https://jira.mongodb.org/browse/SERVER-126715
**Branch:** substrate-contrib/w4-12

## Files

```
  -  .../stepup_catchup_no_bypass_with_oplog.js         | 166 +++++++++++++
  -  .../MCStepUpCatchupCheckpoint.tla                  |  14 ++
  -  .../MCStepUpCatchupCheckpoint_bug.cfg              |  30 +++
  -  .../MCStepUpCatchupCheckpoint_green.cfg            |  27 +++
  -  .../Replication/StepUpCatchupCheckpoint/OWNERS.yml |   5 +
  -  .../Replication/StepUpCatchupCheckpoint/README.md  |  75 ++++++
  -  .../StepUpCatchupCheckpoint.tla                    | 268 +++++++++++++++++++++
  -  7 files changed, 585 insertions(+)
```

## Verify

For `.tla` files:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For `.js` jstests:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
