### PR TITLE
SERVER-126716 TLA+ spec + jstest: ShardRegistry refresh must not stick on stale config secondary

### DIFF
--- a/jstests/sharding/shard_registry_refresh_stuck_on_stale_replica.js
+++ b/jstests/sharding/shard_registry_refresh_stuck_on_stale_replica.js
@@ -1,0 +1,152 @@
+/**
+ * Regression test for the config server's ShardRegistry refresh blocking indefinitely against a
+ * stale config replica.
+ *
+ * Scenario reproduced:
+ *  - The config server replica set has three nodes.
+ *  - One secondary is artificially held back so its applied oplog does not catch up to the
+ *    primary's. This makes it unable to satisfy afterClusterTime recency requirements for any new
+ *    cluster time written by the primary.
+ *  - A shard-topology change (addShard) is performed on the primary. This bumps the cluster time
+ *    and, in the buggy build, causes a subsequent ShardRegistry refresh on mongos to read with
+ *    afterClusterTime > stale node's lastApplied.
+ *  - The refresh on mongos must still complete within a bounded time. With the fix, the refresh
+ *    re-routes away from the stale secondary; without the fix, the request stalls indefinitely.
+ *
+ * @tags: [
+ *   requires_sharding,
+ *   config_shard_incompatible,
+ *   does_not_support_stepdowns,
+ * ]
+ */
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+import {ShardingTest} from "jstests/libs/shardingtest.js";
+
+// The bug only reproduces when the config server is its own replica set, distinct from any data
+// shard. The 'config_shard_incompatible' tag above keeps the suite from co-locating the two.
+const st = new ShardingTest({
+    name: "shard_registry_refresh_stuck_on_stale_replica",
+    shards: 1,
+    rs: {nodes: 1},
+    config: 3,
+    other: {
+        // Lower heartbeat frequency so the replica-set monitor on mongos notices state changes
+        // promptly. Without this the test could falsely pass simply because the monitor would not
+        // even consider the stale secondary inside the bounded wait.
+        configOptions: {setParameter: {heartbeatIntervalMillis: 500}},
+    },
+});
+
+const configRS = st.configRS;
+const configPrimary = configRS.getPrimary();
+const configSecondaries = configRS.getSecondaries();
+assert.eq(2, configSecondaries.length, "expected exactly two config secondaries");
+
+// Pick one secondary to render stale. We freeze its oplog application via the stopReplProducer
+// failpoint, which is the same mechanism used by jstests/replsets/oplog_fetch_lag_metric.js to
+// induce replication lag deterministically.
+const staleSecondary = configSecondaries[0];
+const liveSecondary = configSecondaries[1];
+
+jsTestLog("Freezing oplog production on stale config secondary: " + staleSecondary.host);
+const stopProducerFp = configureFailPoint(staleSecondary, "stopReplProducer");
+stopProducerFp.wait({maxTimeMS: 60 * 1000});
+
+// Confirm the live secondary is still healthy before driving topology changes through. This
+// guarantees the primary can still commit writes with w:majority (primary + liveSecondary form a
+// majority), which is the realistic shape of the bug: the stale node is a minority drag, not a
+// quorum failure.
+configRS.awaitSecondaryNodes(60 * 1000, [liveSecondary]);
+
+// Force mongos to drop any cached shard registry state so the next routing operation has to issue
+// a fresh refresh against the config server.
+assert.commandWorked(st.s.adminCommand({flushRouterConfig: 1}));
+
+// Start a second replica set to be added as a new shard. The addShard write goes through the
+// config primary and bumps cluster time; this is the operation that, in the buggy build, causes a
+// subsequent ShardRegistry refresh to deadlock against the stale secondary's afterClusterTime
+// check.
+jsTestLog("Starting auxiliary replica set to addShard");
+const auxRS = new ReplSetTest({name: "shardRegistryRefreshAux", nodes: 1});
+auxRS.startSet({shardsvr: ""});
+auxRS.initiate();
+auxRS.getPrimary();
+
+const newShardName = "shardRegistryRefreshAuxShard";
+assert.commandWorked(st.s.adminCommand({addShard: auxRS.getURL(), name: newShardName}));
+
+// Sanity check: the primary's view of config.shards now contains the new shard.
+assert.neq(
+    null,
+    configPrimary.getDB("config").shards.findOne({_id: newShardName}),
+    "addShard did not commit on the config primary",
+);
+
+// The core assertion: a routing operation that requires the ShardRegistry to be refreshed must
+// return within a bounded time, even though one config secondary is unrecoverably stale.
+//
+// listShards is a thin wrapper around the ShardRegistry; if the registry refresh is stuck, this
+// command will block indefinitely. We wrap it in assert.soon with a 30s ceiling so a regression
+// shows up as a test timeout rather than a hanging suite.
+const refreshDeadlineMs = 30 * 1000;
+jsTestLog("Asserting ShardRegistry refresh on mongos completes within " + refreshDeadlineMs + "ms");
+
+let listShardsResult;
+const refreshStart = Date.now();
+assert.soon(
+    function () {
+        // flushRouterConfig forces the next routing operation through the ShardRegistry refresh
+        // path each iteration, so we are exercising the refresh code and not a cached response.
+        assert.commandWorked(st.s.adminCommand({flushRouterConfig: 1}));
+        try {
+            listShardsResult = st.s.adminCommand({listShards: 1});
+            return listShardsResult && listShardsResult.ok === 1;
+        } catch (e) {
+            jsTestLog("listShards iteration threw: " + tojson(e));
+            return false;
+        }
+    },
+    "ShardRegistry refresh on mongos did not complete within " + refreshDeadlineMs + "ms while one " +
+        "config secondary was held stale; the refresh appears stuck against the stale replica.",
+    refreshDeadlineMs,
+    1000,
+);
+const refreshElapsedMs = Date.now() - refreshStart;
+jsTestLog("ShardRegistry refresh completed in " + refreshElapsedMs + "ms");
+
+// The refresh must have produced a complete view that includes the newly-added shard, otherwise
+// the test would be unable to distinguish a real refresh from a cached stub.
+assert.eq(1, listShardsResult.ok, "listShards did not return ok");
+const observedShardIds = listShardsResult.shards.map((s) => s._id);
+assert.contains(
+    newShardName,
+    observedShardIds,
+    "ShardRegistry refresh returned but did not include the freshly-added shard; result was: " +
+        tojson(listShardsResult),
+);
+
+jsTestLog("Releasing stopReplProducer failpoint on stale secondary");
+stopProducerFp.off();
+
+// Wait for the previously-stale secondary to catch up so ShardingTest's teardown can perform its
+// usual majority-write health checks without timing out.
+configRS.awaitReplication(60 * 1000);
+
+// removeShard isn't strictly required for the regression check, but it keeps the cluster tidy
+// before stopping the auxiliary replica set.
+assert.soon(
+    function () {
+        const res = st.s.adminCommand({removeShard: newShardName});
+        if (!res.ok) {
+            return false;
+        }
+        return res.state === "completed";
+    },
+    "removeShard did not reach 'completed' state for " + newShardName,
+    5 * 60 * 1000,
+    1000,
+);
+
+auxRS.stopSet();
+st.stop();

--- a/src/mongo/tla_plus/Sharding/ShardRegistryRefreshLiveness/MCShardRegistryRefreshLiveness.cfg
+++ b/src/mongo/tla_plus/Sharding/ShardRegistryRefreshLiveness/MCShardRegistryRefreshLiveness.cfg
@@ -1,0 +1,24 @@
+\* Green configuration: HasPerAttemptDeadline = TRUE. The fixed implementation must satisfy
+\* RefreshLiveness regardless of which node the read-preference selector targets.
+SPECIFICATION Spec
+
+CONSTANTS
+    ConfigNodes = {n1, n2, n3}
+    StaleNode = n3
+    MaxRetries = 4
+    MaxClusterTime = 3
+    HasPerAttemptDeadline = TRUE
+
+INVARIANT
+    TypeOK
+    LastAppliedMonotone
+    StaleNodeNeverCatchesUp
+    DoneIsAbsorbing
+\*  -- Bait invariants. Enable one at a time to sanity-check coverage:
+\*  BaitClientTargetsStaleNode
+\*  BaitRefreshCompletes
+\*  BaitRetryFires
+
+PROPERTIES
+    RefreshEventuallyCompletes
+    RefreshLiveness

--- a/src/mongo/tla_plus/Sharding/ShardRegistryRefreshLiveness/MCShardRegistryRefreshLiveness.tla
+++ b/src/mongo/tla_plus/Sharding/ShardRegistryRefreshLiveness/MCShardRegistryRefreshLiveness.tla
@@ -1,0 +1,44 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+---------------------------- MODULE MCShardRegistryRefreshLiveness ---------------------------------
+\* This module is the model-checking entry point for ShardRegistryRefreshLiveness.tla. It binds
+\* the model's CONSTANTS and exposes a small handful of bait predicates that are convenient for
+\* eyeballing counter-example traces.
+\*
+\* Two .cfg files live in this directory:
+\*   - MCShardRegistryRefreshLiveness.cfg      (green: HasPerAttemptDeadline = TRUE, liveness must
+\*                                              hold). This is the file consumed by
+\*                                              ../../model-check.sh.
+\*   - MCShardRegistryRefreshLiveness_bug.cfg  (bug:  HasPerAttemptDeadline = FALSE, liveness must
+\*                                              fail). Run by hand with the .cfg argument flipped:
+\*       cd src/mongo/tla_plus/Sharding/ShardRegistryRefreshLiveness
+\*       java -cp ../../../tla2tools.jar tlc2.TLC -lncheck final \
+\*           -config MCShardRegistryRefreshLiveness_bug.cfg \
+\*           MCShardRegistryRefreshLiveness.tla
+
+EXTENDS ShardRegistryRefreshLiveness
+
+(**************************************************************************************************)
+(* Bait invariants. Enable in the .cfg to confirm the model can reach the named state.            *)
+(**************************************************************************************************)
+
+\* The refresh ever parks on the stale node. If this invariant is enabled and TLC reports no
+\* violation, the model is failing to cover the scenario being defended against.
+BaitClientTargetsStaleNode ==
+    /\ ~ ( refreshState = RefreshStateWaiting /\ targetNode = StaleNode )
+
+\* The refresh ever completes. Useful for confirming the green configuration produces happy
+\* terminating traces, not just ones that loop forever.
+BaitRefreshCompletes ==
+    /\ refreshState # RefreshStateDone
+
+\* A retry ever fires. Without this, the green configuration could be passing trivially because
+\* the model never even reached the stale node.
+BaitRetryFires ==
+    /\ ~ ( refreshState = RefreshStateSelecting /\ attemptResult = AttemptResultRetry )
+
+====================================================================================================

--- a/src/mongo/tla_plus/Sharding/ShardRegistryRefreshLiveness/MCShardRegistryRefreshLiveness_bug.cfg
+++ b/src/mongo/tla_plus/Sharding/ShardRegistryRefreshLiveness/MCShardRegistryRefreshLiveness_bug.cfg
@@ -1,0 +1,24 @@
+\* Bug configuration: HasPerAttemptDeadline = FALSE. The buggy build, in which the refresh has no
+\* per-attempt deadline, must violate RefreshLiveness on the trace where the client picks the
+\* stale node. TLC is expected to print a liveness counter-example.
+\*
+\* The safety invariants still hold in this configuration (nothing about the bug breaks
+\* monotonicity or makes 'done' non-absorbing) so they remain enabled.
+SPECIFICATION Spec
+
+CONSTANTS
+    ConfigNodes = {n1, n2, n3}
+    StaleNode = n3
+    MaxRetries = 4
+    MaxClusterTime = 3
+    HasPerAttemptDeadline = FALSE
+
+INVARIANT
+    TypeOK
+    LastAppliedMonotone
+    StaleNodeNeverCatchesUp
+    DoneIsAbsorbing
+
+PROPERTIES
+    RefreshEventuallyCompletes
+    RefreshLiveness

--- a/src/mongo/tla_plus/Sharding/ShardRegistryRefreshLiveness/OWNERS.yml
+++ b/src/mongo/tla_plus/Sharding/ShardRegistryRefreshLiveness/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-catalog-and-routing

--- a/src/mongo/tla_plus/Sharding/ShardRegistryRefreshLiveness/ShardRegistryRefreshLiveness.tla
+++ b/src/mongo/tla_plus/Sharding/ShardRegistryRefreshLiveness/ShardRegistryRefreshLiveness.tla
@@ -1,0 +1,291 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+------------------------------ MODULE ShardRegistryRefreshLiveness ---------------------------------
+\* This specification models the liveness of a ShardRegistry refresh against a config-server
+\* replica set in which one secondary is unrecoverably stale (its oplog applier has stalled and
+\* will never advance during the trace).
+\*
+\* The behaviour being modelled is the routing client's read against the config server's catalog
+\* with an afterClusterTime recency requirement. The refresh either:
+\*   - succeeds, because it reaches a node whose lastApplied satisfies the recency requirement, or
+\*   - returns a retryable error to the caller, which then re-targets to a different node.
+\*
+\* The bug being defended against is that, in the absence of a per-attempt deadline, the client
+\* can park on the stale secondary indefinitely waiting for its lastApplied to catch up. The
+\* refresh loop never advances because it keeps reading from the same lagging node.
+\*
+\* The model exposes a single boolean knob, HasPerAttemptDeadline, which switches the
+\* implementation between the buggy version (the wait is unbounded) and the fixed version (a
+\* per-attempt timeout fires, the response is treated as retryable, and the next attempt picks a
+\* different replica). The green configuration sets HasPerAttemptDeadline = TRUE and proves
+\* liveness; the bug configuration sets it to FALSE and is expected to violate liveness, which
+\* the MC bait observes.
+\*
+\* To run the model-checker, edit MCShardRegistryRefreshLiveness.cfg if desired, then:
+\*     cd src/mongo/tla_plus
+\*     ./model-check.sh ShardRegistryRefreshLiveness
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+
+CONSTANTS
+    ConfigNodes,            \* Set of replica-set member identifiers.
+    StaleNode,              \* The single member whose oplog applier has stalled. Element of
+                            \* ConfigNodes.
+    MaxRetries,             \* Bound on the number of retry attempts the refresh will make.
+                            \* Keeps the state space finite.
+    MaxClusterTime,         \* Bound on how far the primary will advance the cluster time. Keeps
+                            \* the state space finite.
+    HasPerAttemptDeadline   \* TRUE  => fixed implementation (refresh attempt times out, becomes
+                            \*           a retryable error).
+                            \* FALSE => buggy implementation (refresh attempt waits forever on
+                            \*           the stale node).
+
+ASSUME Cardinality(ConfigNodes) >= 3
+ASSUME StaleNode \in ConfigNodes
+ASSUME MaxRetries \in 1..20
+ASSUME MaxClusterTime \in 1..20
+ASSUME HasPerAttemptDeadline \in BOOLEAN
+
+(* Refresh client states.
+   - idle:       no refresh in flight.
+   - selecting:  picking which node to target next; reads the latest required cluster time.
+   - waiting:    request sent, awaiting a response from the targeted node.
+   - done:       refresh has completed successfully.
+*)
+RefreshStateIdle      == "idle"
+RefreshStateSelecting == "selecting"
+RefreshStateWaiting   == "waiting"
+RefreshStateDone      == "done"
+RefreshStates         == {RefreshStateIdle, RefreshStateSelecting, RefreshStateWaiting,
+                          RefreshStateDone}
+
+(* Per-target response state for the in-flight attempt.
+   - pending:   the targeted node has not responded yet.
+   - satisfied: the node's lastApplied is >= requiredClusterTime; the refresh succeeded.
+   - retry:     the node could not satisfy the recency requirement and produced a retryable error.
+   In the buggy build, the stale node never produces 'retry' because there is no per-attempt
+   deadline; the request just keeps waiting.
+*)
+AttemptResultPending   == "pending"
+AttemptResultSatisfied == "satisfied"
+AttemptResultRetry     == "retry"
+AttemptResults         == {AttemptResultPending, AttemptResultSatisfied, AttemptResultRetry}
+
+VARIABLES
+    refreshState,           \* Element of RefreshStates.
+    targetNode,              \* Currently targeted ConfigNode, or "-" when none.
+    requiredClusterTime,     \* The afterClusterTime carried by the in-flight attempt.
+    attemptResult,           \* Element of AttemptResults.
+    retriesLeft,             \* Decrements on each retry attempt.
+    lastApplied,             \* lastApplied[n]: monotone non-decreasing oplog position for n.
+    clusterTime              \* Latest cluster time written by the primary.
+
+NoTarget == "-"
+
+vars == << refreshState, targetNode, requiredClusterTime, attemptResult, retriesLeft,
+           lastApplied, clusterTime >>
+
+TypeOK ==
+    /\ refreshState \in RefreshStates
+    /\ targetNode \in ConfigNodes \cup {NoTarget}
+    /\ requiredClusterTime \in 0..MaxClusterTime
+    /\ attemptResult \in AttemptResults
+    /\ retriesLeft \in 0..MaxRetries
+    /\ lastApplied \in [ConfigNodes -> 0..MaxClusterTime]
+    /\ clusterTime \in 0..MaxClusterTime
+
+Init ==
+    /\ refreshState = RefreshStateIdle
+    /\ targetNode = NoTarget
+    /\ requiredClusterTime = 0
+    /\ attemptResult = AttemptResultPending
+    /\ retriesLeft = MaxRetries
+    /\ lastApplied = [n \in ConfigNodes |-> 0]
+    /\ clusterTime = 0
+
+(**************************************************************************************************)
+(* Helpers.                                                                                       *)
+(**************************************************************************************************)
+
+\* The set of non-stale nodes. These are the only ones whose lastApplied is allowed to advance,
+\* and they are the ones the refresh will eventually re-target to once a retry has fired.
+LiveNodes == ConfigNodes \ {StaleNode}
+
+(**************************************************************************************************)
+(* Cluster-progress actions.                                                                      *)
+(*                                                                                                *)
+(* These mirror the real cluster's behaviour outside of the refresh loop:                         *)
+(*  - The primary advances the cluster time (e.g. by accepting an addShard write).                *)
+(*  - Healthy secondaries eventually catch up.                                                    *)
+(*  - The stale secondary does not catch up.                                                      *)
+(**************************************************************************************************)
+
+\* The primary commits a write that advances the cluster time. The primary is modeled as any
+\* member of LiveNodes whose lastApplied was already at clusterTime (i.e. caught up).
+AdvanceClusterTime(n) ==
+    /\ n \in LiveNodes
+    /\ lastApplied[n] = clusterTime
+    /\ clusterTime < MaxClusterTime
+    /\ clusterTime' = clusterTime + 1
+    /\ lastApplied' = [lastApplied EXCEPT ![n] = clusterTime + 1]
+    /\ UNCHANGED << refreshState, targetNode, requiredClusterTime, attemptResult, retriesLeft >>
+
+\* A healthy secondary applies the next oplog entry, advancing its lastApplied toward clusterTime.
+HealthySecondaryCatchUp(n) ==
+    /\ n \in LiveNodes
+    /\ lastApplied[n] < clusterTime
+    /\ lastApplied' = [lastApplied EXCEPT ![n] = lastApplied[n] + 1]
+    /\ UNCHANGED << refreshState, targetNode, requiredClusterTime, attemptResult, retriesLeft,
+                    clusterTime >>
+
+\* StaleNode never advances. We explicitly do NOT include an action for the stale node to make
+\* progress; its lastApplied stays pinned at its Init value (0) for the whole trace.
+
+(**************************************************************************************************)
+(* Refresh client actions.                                                                        *)
+(*                                                                                                *)
+(* Mirrors the routing client driving a ShardRegistry refresh:                                    *)
+(*   idle --StartRefresh--> selecting --PickTarget--> waiting                                     *)
+(*   waiting --AttemptSucceeds--> done                                                            *)
+(*   waiting --AttemptTimesOutAndRetries--> selecting (only when HasPerAttemptDeadline is TRUE,   *)
+(*                                                     or when the target was a healthy node      *)
+(*                                                     that simply produced retry on its own)     *)
+(*                                                                                                *)
+(* The buggy variant (HasPerAttemptDeadline = FALSE) keeps the client in 'waiting' against the    *)
+(* stale node forever, because no timeout fires and the node never satisfies the request.        *)
+(**************************************************************************************************)
+
+\* A new refresh starts. It captures the current cluster time as its recency requirement.
+StartRefresh ==
+    /\ refreshState = RefreshStateIdle
+    /\ clusterTime > 0
+    /\ refreshState' = RefreshStateSelecting
+    /\ requiredClusterTime' = clusterTime
+    /\ attemptResult' = AttemptResultPending
+    /\ targetNode' = NoTarget
+    /\ UNCHANGED << retriesLeft, lastApplied, clusterTime >>
+
+\* The client picks any config node as the next target. This is intentionally non-deterministic
+\* to model the replica-set monitor's read-preference scheduling: under read pref 'nearest' or
+\* 'secondary', any node may be chosen, including the stale one.
+PickTarget(n) ==
+    /\ refreshState = RefreshStateSelecting
+    /\ n \in ConfigNodes
+    /\ retriesLeft > 0
+    /\ targetNode' = n
+    /\ refreshState' = RefreshStateWaiting
+    /\ attemptResult' = AttemptResultPending
+    /\ UNCHANGED << requiredClusterTime, retriesLeft, lastApplied, clusterTime >>
+
+\* The targeted node observes that its lastApplied meets the recency requirement and responds
+\* with satisfied. The refresh transitions to done.
+AttemptSucceeds ==
+    /\ refreshState = RefreshStateWaiting
+    /\ targetNode \in ConfigNodes
+    /\ lastApplied[targetNode] >= requiredClusterTime
+    /\ attemptResult' = AttemptResultSatisfied
+    /\ refreshState' = RefreshStateDone
+    /\ UNCHANGED << targetNode, requiredClusterTime, retriesLeft, lastApplied, clusterTime >>
+
+\* The targeted node cannot satisfy the recency requirement and produces a retryable error.
+\* For a healthy node, this can happen whenever its lastApplied is still behind clusterTime; the
+\* node will resolve naturally once it catches up. For the stale node, this transition only fires
+\* in the fixed build because that is the build where the per-attempt deadline lives. In the
+\* buggy build the stale node simply never responds, modelled by omitting this enabling clause.
+AttemptTimesOutAndRetries ==
+    /\ refreshState = RefreshStateWaiting
+    /\ targetNode \in ConfigNodes
+    /\ lastApplied[targetNode] < requiredClusterTime
+    /\ \/ targetNode \in LiveNodes
+       \/ /\ targetNode = StaleNode
+          /\ HasPerAttemptDeadline
+    /\ retriesLeft > 0
+    /\ attemptResult' = AttemptResultRetry
+    /\ refreshState' = RefreshStateSelecting
+    /\ retriesLeft' = retriesLeft - 1
+    /\ UNCHANGED << targetNode, requiredClusterTime, lastApplied, clusterTime >>
+
+(**************************************************************************************************)
+(* Refresh completion stutters once done so traces can stop without violating fairness.           *)
+(**************************************************************************************************)
+Terminated ==
+    /\ refreshState = RefreshStateDone
+    /\ UNCHANGED vars
+
+(**************************************************************************************************)
+(* Next-state relation and fairness.                                                              *)
+(**************************************************************************************************)
+
+Next ==
+    \/ StartRefresh
+    \/ \E n \in ConfigNodes : PickTarget(n)
+    \/ AttemptSucceeds
+    \/ AttemptTimesOutAndRetries
+    \/ \E n \in ConfigNodes : AdvanceClusterTime(n)
+    \/ \E n \in ConfigNodes : HealthySecondaryCatchUp(n)
+    \/ Terminated
+
+\* Fairness: every action that is continuously enabled must eventually fire. This is what makes
+\* the difference between the green and bug configurations observable.
+\*
+\*  - Weak fairness on AttemptTimesOutAndRetries: in the green config this action is enabled
+\*    whenever the client is parked on the stale node, so weak fairness forces a retry. In the
+\*    bug config the same action is disabled for the stale node, so the client gets stuck in
+\*    'waiting' and the liveness property fails.
+\*
+\*  - Strong fairness on PickTarget(liveNode): the replica-set monitor will not pin a sequence of
+\*    retries to the same stale node forever. Modelling this with strong fairness mirrors the
+\*    real RSM's behaviour of cycling through eligible hosts: as long as picking a live node is
+\*    enabled infinitely often (which it is whenever the client is in 'selecting' with retries
+\*    remaining), it eventually fires. Without this, the green model could pessimistically retry
+\*    onto the stale node until retriesLeft hit zero, which is not a faithful model of the
+\*    production RSM and would muddy the green-vs-bug signal.
+\*
+\*  - Strong fairness on AttemptSucceeds and on the cluster-progress actions ensures the system
+\*    cannot starve a healthy completion path forever.
+Fairness ==
+    /\ WF_vars(StartRefresh)
+    /\ WF_vars(\E n \in ConfigNodes : PickTarget(n))
+    /\ SF_vars(\E n \in LiveNodes  : PickTarget(n))
+    /\ SF_vars(AttemptSucceeds)
+    /\ WF_vars(AttemptTimesOutAndRetries)
+    /\ WF_vars(\E n \in ConfigNodes : AdvanceClusterTime(n))
+    /\ WF_vars(\E n \in ConfigNodes : HealthySecondaryCatchUp(n))
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+(**************************************************************************************************)
+(* Safety properties.                                                                             *)
+(**************************************************************************************************)
+
+\* lastApplied never moves backwards.
+LastAppliedMonotone == \A n \in ConfigNodes : lastApplied[n] <= clusterTime
+
+\* The stale node's lastApplied is pinned at 0 for the entire trace.
+StaleNodeNeverCatchesUp == lastApplied[StaleNode] = 0
+
+\* Once the refresh is done, it stays done.
+DoneIsAbsorbing == refreshState = RefreshStateDone =>
+                        attemptResult \in {AttemptResultSatisfied, AttemptResultRetry}
+
+(**************************************************************************************************)
+(* Liveness properties.                                                                           *)
+(*                                                                                                *)
+(* The key property of the fix is that a refresh started under a stale-replica situation must    *)
+(* eventually complete. In the green config this holds. In the bug config the property fails on  *)
+(* the trace where the client picks the stale node and HasPerAttemptDeadline is FALSE.            *)
+(**************************************************************************************************)
+
+\* Any refresh that starts eventually transitions to done.
+RefreshEventuallyCompletes ==
+    [] ( refreshState = RefreshStateSelecting => <> (refreshState = RefreshStateDone) )
+
+\* Even stronger: from any state, if the system has issued a refresh (we are no longer idle), the
+\* refresh eventually completes.
+RefreshLiveness == (refreshState # RefreshStateIdle) ~> (refreshState = RefreshStateDone)
+
+====================================================================================================


### PR DESCRIPTION
## Summary

TLA+ spec + jstest: ShardRegistry refresh must not stick on stale config secondary.

**Jira:** https://jira.mongodb.org/browse/SERVER-126716
**Branch:** substrate-contrib/w4-13

## Files

```
  -  ...hard_registry_refresh_stuck_on_stale_replica.js | 152 +++++++++++
  -  .../MCShardRegistryRefreshLiveness.cfg             |  24 ++
  -  .../MCShardRegistryRefreshLiveness.tla             |  44 ++++
  -  .../MCShardRegistryRefreshLiveness_bug.cfg         |  24 ++
  -  .../ShardRegistryRefreshLiveness/OWNERS.yml        |   5 +
  -  .../ShardRegistryRefreshLiveness.tla               | 291 +++++++++++++++++++++
  -  6 files changed, 540 insertions(+)
```

## Verify

For `.tla` files:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For `.js` jstests:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
