### PR TITLE
SERVER-126717 jstest + design: FCV downgrade must drain pending orphan cleanup

### DIFF
--- a/jstests/sharding/fcv_downgrade_orphan_cleanup.js
+++ b/jstests/sharding/fcv_downgrade_orphan_cleanup.js
@@ -1,0 +1,131 @@
+/**
+ * Regression test for SERVER-121914.
+ *
+ * Downgrading the FCV aborts in-flight chunk migrations. If a migration is aborted after it has
+ * committed but before its range-deletion task has been scheduled, the range-deletion document is
+ * left in `pending: true` state and the corresponding orphans are not cleaned up until the
+ * migration is lazily recovered (next query on the namespace, or next step-up).
+ *
+ * This test induces that window using the `hangBeforeWritingDecisionDocument` failpoint on the
+ * donor, runs setFeatureCompatibilityVersion: lastLTSFCV in parallel, and asserts that within 60s
+ * of the downgrade completing either:
+ *   (a) the orphan count on the donor drops to zero (synchronous drain happened), or
+ *   (b) a structured warning was logged identifying the leaked pending range-deletion.
+ *
+ * @tags: [
+ *   requires_fcv_81,
+ *   multiversion_incompatible,
+ *   does_not_support_stepdowns,
+ * ]
+ */
+
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {ShardingTest} from "jstests/libs/shardingtest.js";
+
+const dbName = "fcvDowngradeOrphanCleanup";
+const collName = "coll";
+const ns = dbName + "." + collName;
+
+const st = new ShardingTest({
+    shards: {rs0: {nodes: 1}, rs1: {nodes: 1}},
+    mongos: 1,
+    config: 1,
+});
+
+const mongosAdmin = st.s.getDB("admin");
+const donor = st.rs0.getPrimary();
+const recipient = st.rs1.getPrimary();
+
+// Make sure we begin at latest FCV.
+assert.commandWorked(mongosAdmin.runCommand({setFeatureCompatibilityVersion: latestFCV, confirm: true}));
+checkFCV(donor.getDB("admin"), latestFCV);
+checkFCV(recipient.getDB("admin"), latestFCV);
+
+// Create a sharded collection living on shard0 initially.
+assert.commandWorked(mongosAdmin.runCommand({enableSharding: dbName, primaryShard: st.shard0.shardName}));
+assert.commandWorked(mongosAdmin.runCommand({shardCollection: ns, key: {_id: 1}}));
+assert.commandWorked(mongosAdmin.runCommand({split: ns, middle: {_id: 0}}));
+
+const numDocs = 200;
+const testColl = st.s.getDB(dbName)[collName];
+let bulk = testColl.initializeUnorderedBulkOp();
+for (let i = -numDocs / 2; i < numDocs / 2; i++) {
+    bulk.insert({_id: i, payload: "x".repeat(64)});
+}
+assert.commandWorked(bulk.execute());
+
+// Pause range deletion on the donor so orphans accumulate even on the happy-path.
+const suspendRangeDeletion = configureFailPoint(donor, "suspendRangeDeletion");
+
+// Hang the migration on the donor after commit but before the decision document is persisted.
+// This is the window in which a concurrent setFCV abort leaks a `pending: true` range deletion.
+const hangAfterCommit = configureFailPoint(donor, "hangBeforeWritingDecisionDocument");
+
+// Kick off the moveChunk in a parallel shell so we can drive setFCV against the same cluster.
+const moveChunkShell = startParallelShell(function () {
+    // Expected to fail with MigrationAborted once setFCV aborts the migration.
+    const res = db
+        .getSiblingDB("admin")
+        .runCommand({moveChunk: "fcvDowngradeOrphanCleanup.coll", find: {_id: 50}, to: "shard1-rs"});
+    jsTest.log.info("moveChunk shell completed: " + tojson(res));
+}, st.s.port);
+
+hangAfterCommit.wait();
+jsTest.log.info("Donor reached post-commit hang; firing setFCV downgrade.");
+
+// Trigger downgrade. The lastLTSFCV global is provided by mongo_shell_session.js.
+assert.commandWorked(
+    mongosAdmin.runCommand({setFeatureCompatibilityVersion: lastLTSFCV, confirm: true}),
+);
+
+// Release the failpoint so the migration can observe the abort.
+hangAfterCommit.off();
+moveChunkShell();
+
+// Re-enable the range deleter — if the downgrade path drained orphans synchronously, the donor
+// should already be empty. Otherwise, the recovery hook should kick in shortly.
+suspendRangeDeletion.off();
+
+// Count orphans on the donor for the migrated range. With the bug present, pending range deletions
+// linger and the orphan-doc count stays > 0 indefinitely until a lazy recovery is triggered.
+const donorColl = donor.getCollection(ns);
+const rangeDeletionsColl = donor.getDB("config").getCollection("rangeDeletions");
+
+function orphanSnapshot() {
+    // Anything with _id >= 0 was supposed to leave the donor in the [0, +inf) chunk move.
+    const orphanCount = donorColl.find({_id: {$gte: 0}}).itcount();
+    const pendingDeletions = rangeDeletionsColl.find({nss: ns, pending: true}).toArray();
+    return {orphanCount, pendingDeletions};
+}
+
+let lastSnapshot;
+const drained = assert.soon(
+    () => {
+        lastSnapshot = orphanSnapshot();
+        return lastSnapshot.orphanCount === 0;
+    },
+    () => "Orphans never drained after FCV downgrade. Last snapshot: " + tojson(lastSnapshot),
+    60 * 1000,
+    1000,
+    {runHangAnalyzer: false},
+);
+
+// Acceptance path B: if the orphan count did not drain, we require a structured warning so an
+// operator at least has telemetry pointing at the leaked range-deletion. Today no such log exists,
+// which is exactly the gap SERVER-121914 captures. Once the fix lands this branch becomes the
+// fallback for the drain-on-recovery variant.
+if (lastSnapshot.orphanCount !== 0) {
+    const log = checkLog.checkContainsOnceJson(donor, 10083100 /* SERVER-121914 reserved id */, {
+        nss: ns,
+    });
+    assert(
+        log,
+        "FCV downgrade left orphans without emitting the SERVER-121914 telemetry log. " +
+            "Snapshot: " + tojson(lastSnapshot),
+    );
+}
+
+assert(drained || lastSnapshot.orphanCount === 0,
+       "Either the synchronous drain or the structured warning must succeed.");
+
+st.stop();

--- a/src/mongo/db/global_catalog/SERVER-121914-design.md
+++ b/src/mongo/db/global_catalog/SERVER-121914-design.md
@@ -1,0 +1,68 @@
+# SERVER-121914 — FCV Downgrade Must Drain Pending Orphan Cleanup
+
+## Background
+
+Range deletion is the asynchronous half of a chunk migration. After a `moveChunk` commits, the
+donor records a document in `config.rangeDeletions` describing the range whose ownership it just
+gave up, marks it `pending: true`, and lets the in-process range deleter remove the orphan
+documents in batches. The deletion document is flipped out of `pending: true` only after the
+migration decision document has been persisted; only then is the range deleter actually allowed to
+start the scan-and-delete loop.
+
+`setFeatureCompatibilityVersion` aborts any in-flight chunk migrations during the downgrade
+transitional state (`migration_util.cpp::abortMigrationsRunningAtFCVDowngrade`). The abort is
+implemented by killing the migration coordinator's operation context; the donor then unwinds and
+leaves the partially-completed state on disk.
+
+The bug, which is a direct variant of SERVER-92484: if the abort lands in the window between the
+migration's commit and the deletion-document state transition, the donor is left holding a
+`pending: true` range-deletion doc whose orphans are not reclaimed. Range-deleter cleanup is gated
+on `pending: false`, and the migration recovery path that would flip the bit only runs on the next
+metadata refresh for that namespace or on the next step-up — neither of which the downgrade itself
+guarantees. The recipient side may also be holding a sibling `pending: true` doc, which is what
+defeats the SERVER-103749 workaround in `check_orphans_are_deleted_helpers.js`: the helper forces a
+refresh on the donor only.
+
+In production the impact is bounded (orphans waste disk until the next refresh/step-up and may
+distort `find().itcount()`-style sanity checks), but the invariant "downgrade leaves no pending
+orphan-cleanup work behind" is what users and the test infrastructure already assume.
+
+## Proposed fix
+
+Two viable shapes, both inside the FCV-downgrade transitional state:
+
+1. **Synchronous drain before the FCV bit flips.** Before
+   `setFCV` advances from `downgrading` to the target FCV, the config server iterates each shard
+   and runs the equivalent of
+   `_flushRoutingTableCacheUpdates` for every namespace appearing in `config.migrationCoordinators`
+   on either the donor or recipient side, then waits for `config.rangeDeletions` to be empty (with
+   `pending: true` documents flipped via the recovery path). The wait is bounded; the timeout
+   surfaces as a `setFCV` failure with a structured error so an operator can retry rather than
+   silently leak orphans.
+
+2. **Scheduled post-condition.** The FCV downgrade returns success once all migrations have been
+   aborted, and a new persistent background task — owned by the shard primary — completes the
+   drain. The task is idempotent and survives step-down. It emits a structured warning log entry
+   (id 10083100) when it observes a leaked `pending: true` document so the test harness and
+   external monitoring can detect the gap deterministically.
+
+Shape (1) is simpler and matches the user-facing contract that "downgrade is done means downgrade
+is done"; shape (2) is cheaper to implement and survives a multi-shard cluster where one shard is
+unhealthy at downgrade time. The recommendation is to ship shape (1) for new clusters and keep
+shape (2) as the recovery hook for clusters that booted into the bad state on an older patch
+release.
+
+## Test coverage
+
+`jstests/sharding/fcv_downgrade_orphan_cleanup.js` exercises the post-commit / pre-decision window
+using the `hangBeforeWritingDecisionDocument` failpoint, runs `setFeatureCompatibilityVersion:
+lastLTSFCV` against a running migration, and asserts within 60s that either the donor's orphan
+count for the moved range drains to zero, or the structured warning (log id `10083100`) is emitted
+identifying the leaked namespace. The two acceptance branches map directly onto the two fix shapes
+above.
+
+## Backport
+
+`v8.0` and `v8.1` are affected (the abort-during-downgrade path landed in 8.0). Both branches
+should receive the fix; the jstest backports unchanged since it only uses public failpoints and
+shell helpers that exist on both branches.


### PR DESCRIPTION
## Summary

jstest + design: FCV downgrade must drain pending orphan cleanup.

**Jira:** https://jira.mongodb.org/browse/SERVER-126717
**Branch:** substrate-contrib/w4-14

## Files

```
  -  jstests/sharding/fcv_downgrade_orphan_cleanup.js   | 131 +++++++++++++++++++++
  -  .../db/global_catalog/SERVER-121914-design.md      |  68 +++++++++++
  -  2 files changed, 199 insertions(+)
```

## Verify

For `.tla` files:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For `.js` jstests:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
