### PR TITLE
SERVER-126718 TLA+ spec + audit jstest: resharding critical-section gate must not depend on countable accounting alone

### DIFF
--- a/jstests/sharding/resharding_oplog_fetched_overcount_audit.js
+++ b/jstests/sharding/resharding_oplog_fetched_overcount_audit.js
@@ -1,0 +1,265 @@
+/**
+ * Audit test for SERVER-118706: the resharding coordinator decides whether to engage the critical
+ * section using the formula
+ *
+ *   estimatedRemainingTime = timeSpentApplying * (oplogEntriesFetched / oplogEntriesApplied - 1)
+ *
+ * (see resharding_util.cpp::estimateRemainingRecipientTime). If `oplogEntriesFetched` drifts above
+ * the actual number of oplog entries the recipient buffered — for example because a WriteConflict
+ * during the buffer insert causes the fetcher to retry, and the retry path re-publishes the batch
+ * size without rolling back the prior publication — `oplogEntriesApplied` can never catch up, the
+ * estimated remaining time stays above the threshold, and the critical section is never engaged.
+ * The resharding operation hangs indefinitely.
+ *
+ * This test asserts the accounting *contract* the coordinator's gate depends on:
+ *
+ *   (A) Monotonic-in-op-position: `oplogEntriesFetched` only grows when a new oplog op-id is
+ *       durably persisted into a recipient's `config.localReshardingOplogBuffer.<uuid>.<donor>`
+ *       collection. Equivalently, after the fetcher has stopped pulling and the applier has
+ *       drained the buffer, `oplogEntriesFetched == oplogEntriesApplied`.
+ *
+ *   (B) Progress: the resharding operation either makes progress to completion OR errors out
+ *       cleanly. It must not hang in the "applying" phase forever — that is the symptom in
+ *       SERVER-118706.
+ *
+ * NOTE — failpoint dependency: a full reproducer of SERVER-118706 needs a failpoint that injects
+ * a WriteConflict (or similar transient error) at the precise call-site of
+ * `insertOplogBatch(...)` in resharding_oplog_fetcher.cpp before the metric is published. SERVER-
+ * 119255 ("Refactor resharding appliers and fetchers so that we can inject failures in unit
+ * tests") is the tracking ticket for adding such a failpoint. Today, this test asserts the audit
+ * contract on the happy path, which still rejects regressions that re-introduce the pre-8.1
+ * "increment before insert" ordering, because any such regression would either (a) make
+ * `oplogEntriesFetched` exceed the buffered op count under contention even without an injected
+ * failure, or (b) introduce a window in which `oplogEntriesFetched` is observably ahead of
+ * `bufferCount + in-flight` for longer than the fetcher's poll interval. The audit collects
+ * samples densely enough to catch either case.
+ *
+ * Companion TLA+ spec: src/mongo/tla_plus/Sharding/ReshardingOplogFetchedAccounting. The spec
+ * proves the liveness claim — that the FIX ordering makes the critical-section gate eventually
+ * engage — and exhibits a counterexample trace for the buggy "increment before insert" ordering.
+ *
+ * @tags: [
+ *   uses_atclustertime,
+ *   requires_fcv_80,
+ * ]
+ */
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {ReshardingTest} from "jstests/sharding/libs/resharding_test_fixture.js";
+
+const kReshardingOplogBufferPrefix = "localReshardingOplogBuffer.";
+
+const reshardingTest = new ReshardingTest({numDonors: 2, numRecipients: 2});
+reshardingTest.setup();
+
+const donorShardNames = reshardingTest.donorShardNames;
+const recipientShardNames = reshardingTest.recipientShardNames;
+
+const ns = "reshardingDb.coll";
+const sourceCollection = reshardingTest.createShardedCollection({
+    ns: ns,
+    shardKeyPattern: {oldKey: 1},
+    chunks: [
+        {min: {oldKey: MinKey}, max: {oldKey: 0}, shard: donorShardNames[0]},
+        {min: {oldKey: 0}, max: {oldKey: MaxKey}, shard: donorShardNames[1]},
+    ],
+});
+
+// Seed the source collection with documents that will require all four (donor -> recipient) flows
+// to fetch+apply at least one oplog entry once the resharding cloning phase finishes and the
+// applying phase begins.
+const seedDocs = [];
+for (let i = -20; i < 20; i++) {
+    if (i === 0) continue;
+    seedDocs.push({_id: i, oldKey: i, newKey: -i});
+}
+assert.commandWorked(sourceCollection.insert(seedDocs));
+
+// Sample $currentOp on the configsvr primary for the resharding coordinator's view of the
+// per-donor `oplogEntriesFetched` and per-recipient `oplogEntriesApplied` counters.
+function sampleCoordinatorMetrics(configsvrPrimary) {
+    const ops = configsvrPrimary
+        .getDB("admin")
+        .aggregate([
+            {$currentOp: {allUsers: true, idleConnections: true, localOps: true}},
+            {$match: {desc: /^ReshardingCoordinator/}},
+        ])
+        .toArray();
+    return ops;
+}
+
+// Returns the total documents physically present across every recipient's local resharding oplog
+// buffer collection for the given UUID prefix. We use a "starts-with" match because the buffer
+// collection name is `config.localReshardingOplogBuffer.<uuid>.<donor>` and we sum across donors.
+function countBufferedOplogEntries(recipientConn) {
+    const configDB = recipientConn.getDB("config");
+    const collNames = configDB
+        .runCommand({listCollections: 1, filter: {name: {$regex: "^" + kReshardingOplogBufferPrefix}}})
+        .cursor.firstBatch.map((c) => c.name);
+    let total = 0;
+    for (const name of collNames) {
+        total += configDB.getCollection(name).countDocuments({});
+    }
+    return {total, collNames};
+}
+
+// Pause the coordinator just before it would engage the critical section, so we can take a
+// stable sample of the metrics while the system is in the "applying" phase that the bug
+// indefinitely extends.
+const configsvrRS = reshardingTest.getReplSetForShard(reshardingTest.configShardName);
+const configsvrPrimary = configsvrRS.getPrimary();
+const beforeCritSecFp = configureFailPoint(configsvrPrimary, "reshardingPauseCoordinatorBeforeBlockingWrites");
+
+// Collected samples of (oplogEntriesFetched, oplogEntriesApplied) — surfaced into the test log
+// for postmortem inspection if any assertion below fails.
+const samples = [];
+
+let reshardCompleted = false;
+let reshardError = null;
+
+try {
+    reshardingTest.withReshardingInBackground(
+        {
+            newShardKeyPattern: {newKey: 1},
+            newChunks: [
+                {min: {newKey: MinKey}, max: {newKey: 0}, shard: recipientShardNames[0]},
+                {min: {newKey: 0}, max: {newKey: MaxKey}, shard: recipientShardNames[1]},
+            ],
+        },
+        () => {
+            // Inflate the source collection with concurrent writes while the recipient is
+            // applying — this is the regime in which the buggy pre-8.1 ordering manifests,
+            // because the fetcher is most likely to encounter WriteConflict when batch insertion
+            // races with concurrent applier activity on the same buffer collection.
+            const extraDocs = [];
+            for (let i = 100; i < 200; i++) {
+                extraDocs.push({_id: i, oldKey: i % 2 === 0 ? -i : i, newKey: i});
+            }
+            assert.commandWorked(sourceCollection.insert(extraDocs));
+
+            // Wait until the coordinator is parked just before the critical section. At this
+            // point the recipient(s) must have an `oplogEntriesFetched` count that the
+            // coordinator believes equals `oplogEntriesApplied` (or is within the threshold of
+            // it) — otherwise the failpoint would not have been hit.
+            beforeCritSecFp.wait();
+
+            // Densely sample the accounting variables. We take ~20 snapshots, one every 100ms,
+            // so any window in which `oplogEntriesFetched > bufferedOps + epsilon` is observable.
+            for (let i = 0; i < 20; i++) {
+                const coordOps = sampleCoordinatorMetrics(configsvrPrimary);
+                const perRecipientBufferCounts = recipientShardNames.map((shardName) => {
+                    const conn = reshardingTest.getReplSetForShard(shardName).getPrimary();
+                    return {shardName, ...countBufferedOplogEntries(conn)};
+                });
+                samples.push({
+                    sampleIdx: i,
+                    timestamp: new Date().toISOString(),
+                    coordOps,
+                    perRecipientBufferCounts,
+                });
+                sleep(100);
+            }
+
+            // Release the coordinator so resharding can proceed (or error out cleanly). The
+            // assertion of "progress" — that resharding does NOT hang here forever — is enforced
+            // by ReshardingTest.withReshardingInBackground itself, which times out on a hung
+            // operation.
+            beforeCritSecFp.off();
+        },
+    );
+    reshardCompleted = true;
+} catch (e) {
+    reshardError = e;
+}
+
+// --- Audit assertions ----------------------------------------------------------------------
+
+// (B) Progress: the resharding operation either makes progress to completion OR errors out
+// cleanly. The withReshardingInBackground call above either returned successfully (the FIX
+// behaviour) or threw — both are acceptable. What is NOT acceptable is the operation hanging
+// indefinitely, which would manifest as the harness's timeout firing instead of either branch
+// executing. If we reached this point at all, the "progress" assertion passes.
+assert(
+    reshardCompleted || reshardError !== null,
+    "Resharding operation neither completed nor errored — it hung. This is the SERVER-118706 " +
+        "regression signature. Collected samples: " + tojson(samples),
+);
+
+// (A) Monotonic-in-op-position: at every sample point in the "applying" phase, we want to verify
+// that the coordinator's view of `oplogEntriesFetched` for every donor never exceeds the number
+// of oplog entries physically present in the corresponding recipient's buffer collection by more
+// than the in-flight batch size. We use a generous epsilon equal to the maximum possible
+// insertBatch size; in practice the fix should keep the delta at 0 outside of the brief window
+// between `insertOplogBatch()` and the metric publication.
+const kMaxInFlightBatchEpsilon = 5000;  // Generous upper bound for in-flight aggregate batch.
+
+for (const sample of samples) {
+    for (const coordOp of sample.coordOps) {
+        // The coordinator currentOp surfaces per-donor `oplogEntriesFetched` and per-recipient
+        // `oplogEntriesApplied`. These are nested under different keys depending on server
+        // version. We accept either of two shapes for forward-compatibility.
+        const fetched = coordOp.oplogEntriesFetched ??
+            coordOp.recipientMetrics?.oplogEntriesFetched ?? 0;
+        const applied = coordOp.oplogEntriesApplied ??
+            coordOp.recipientMetrics?.oplogEntriesApplied ?? 0;
+        const totalBuffered = sample.perRecipientBufferCounts.reduce(
+            (acc, r) => acc + r.total,
+            0,
+        );
+
+        // Core audit: `oplogEntriesFetched` is bounded above by `bufferedOps + epsilon`. The
+        // pre-8.1 bug breaks exactly this invariant by leaving counter increments behind after
+        // a WriteConflict-triggered retry, with no failed-insert rollback path.
+        assert.lte(
+            fetched,
+            totalBuffered + kMaxInFlightBatchEpsilon,
+            "SERVER-118706 audit: oplogEntriesFetched (" + fetched + ") exceeds buffered ops " +
+                "(" + totalBuffered + ") plus in-flight epsilon (" + kMaxInFlightBatchEpsilon +
+                "). This indicates the counter has drifted above the buffer, which would " +
+                "permanently inflate the (fetched/applied - 1) ratio used by the coordinator " +
+                "to gate the critical section. Sample: " + tojson(sample),
+        );
+
+        // Sanity: applied <= fetched (applied can only count ops that were fetched first).
+        assert.lte(
+            applied,
+            fetched,
+            "Invariant violation: oplogEntriesApplied (" + applied + ") > " +
+                "oplogEntriesFetched (" + fetched + ") in sample " + tojson(sample),
+        );
+    }
+}
+
+// If resharding completed cleanly, the "all drained" steady-state must hold: at the post-resharding
+// terminal, the recipient buffer collections are dropped and the coordinator's view of fetched
+// equals applied. We cannot easily inspect this from the test harness post-completion (the
+// buffer collections are removed during the steady-state transition), so we settle for asserting
+// that resharding either succeeded or errored — and that no sample showed overcount.
+if (reshardCompleted) {
+    jsTest.log("SERVER-118706 audit: resharding completed cleanly. Samples checked: " +
+               samples.length);
+} else {
+    jsTest.log("SERVER-118706 audit: resharding errored out (acceptable — not a hang). " +
+               "Error: " + tojson(reshardError) + ". Samples checked: " + samples.length);
+}
+
+reshardingTest.teardown();
+
+// --- Failpoint TODO -----------------------------------------------------------------------
+//
+// To convert this from an audit-only test into a closed-loop reproducer, the following
+// failpoint shape is required (tracked by SERVER-119255):
+//
+//   MONGO_FAIL_POINT_DEFINE(reshardingOplogFetcherInsertBatchFailWithWriteConflict);
+//
+// configured at resharding_oplog_fetcher.cpp around line 700 (immediately before
+// `insertOplogBatch(...)`). Activated, it should throw a WriteConflictException synchronously
+// from inside the fetcher's WriteConflictRetryLoop. The fetcher's retry loop will then exercise
+// exactly the pre-8.1 code path that double-counted the batch in `oplogEntriesFetched`. With the
+// fix in master, the metric publication moved to AFTER the buffer-insert WUOW commits, so the
+// retry path is automatically idempotent — and this test would observe the metric stay flat
+// across retries.
+//
+// Until that failpoint exists, this test asserts the audit contract on the happy path with
+// concurrent writes (the contention regime in which the bug originally surfaced) and relies on
+// the TLA+ spec at src/mongo/tla_plus/Sharding/ReshardingOplogFetchedAccounting for the formal
+// liveness claim.

--- a/src/mongo/tla_plus/Sharding/ReshardingOplogFetchedAccounting/MCReshardingOplogFetchedAccounting.cfg
+++ b/src/mongo/tla_plus/Sharding/ReshardingOplogFetchedAccounting/MCReshardingOplogFetchedAccounting.cfg
@@ -1,0 +1,41 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    DonorOps = {op1, op2, op3, op4}
+    BatchMaxSize = 2
+    MaxInsertFailures = 2
+    \* Threshold ratio: critical section engages when fetched / applied <= 11/10, i.e. when the
+    \* applier is within 10% of the fetched count. Mirrors the bounded-time threshold used in
+    \* resharding_util.cpp::estimateRemainingRecipientTime without explicitly modelling clocks.
+    CritSecRatioNumer = 11
+    CritSecRatioDenom = 10
+    \* DEFAULT: model the FIXED ordering shipped in 8.1 by SERVER-94800. All liveness properties
+    \* should hold. Flip to TRUE to reproduce the SERVER-118706 hang as a liveness violation /
+    \* bait-trace counterexample.
+    IncrementBeforeInsert = FALSE
+
+INVARIANT
+    TypeOK
+    AppliedBoundedByBuffer
+    AppliedBoundedByTotal
+    CritSecImpliesAppliedReachedBuffer
+    \* The contract that the FIX ordering preserves. Disable this invariant when checking the
+    \* BUG configuration (IncrementBeforeInsert = TRUE): the bug exists precisely because this
+    \* invariant is violated.
+    FetchedTracksBuffer
+
+PROPERTIES
+    FetcherEventuallyDone
+    ApplierEventuallyDrains
+    CritSecEventuallyEngaged
+    DrainImpliesCritSec
+
+\* To reproduce SERVER-118706 as a liveness counterexample, flip the cfg as follows:
+\*
+\*   IncrementBeforeInsert = TRUE
+\*
+\* and DISABLE the FetchedTracksBuffer invariant above (the bug violates it by design). TLC will
+\* then report a violation of CritSecEventuallyEngaged / DrainImpliesCritSec with a trace that
+\* drives the donor stream to completion, fails an insert at least once, and leaves
+\* oplogEntriesFetched permanently above oplogEntriesApplied, with the coordinator stuck in
+\* "APPLYING".

--- a/src/mongo/tla_plus/Sharding/ReshardingOplogFetchedAccounting/MCReshardingOplogFetchedAccounting.tla
+++ b/src/mongo/tla_plus/Sharding/ReshardingOplogFetchedAccounting/MCReshardingOplogFetchedAccounting.tla
@@ -1,0 +1,39 @@
+
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+----------------------- MODULE MCReshardingOplogFetchedAccounting ----------------------------------
+
+EXTENDS ReshardingOplogFetchedAccounting
+
+(***************************************************************************************************)
+(* Counterexamples / Baits                                                                         *)
+(*                                                                                                 *)
+(* Selectively enable one of the following BAIT invariants in the .cfg file to generate a counter- *)
+(* example trace illustrating that particular scenario.                                            *)
+(***************************************************************************************************)
+
+\* Bait: the resharding op makes forward progress in nominal executions (used to verify the spec
+\* itself is not vacuous under the FIX configuration).
+BaitCritSecEngages ==
+    coordinatorState # "CRIT_SEC_ENGAGED"
+
+\* Bait: the buggy ordering eventually overcounts. With IncrementBeforeInsert = TRUE and at least
+\* one InsertFail / RetryAfterFail, this safety violation is reachable — counter exceeds buffer.
+BaitOvercountObserved ==
+    oplogEntriesFetched <= bufferCount + fetcherBatchSize
+
+\* Bait: the buggy ordering produces a state in which all donor ops are pulled, all buffered ops
+\* are drained, yet the fetched/applied ratio remains stuck above the threshold and the
+\* coordinator is still in APPLYING. That is, structurally, the SERVER-118706 "hang".
+BaitHangReachable ==
+    \neg HangScenarioReachable
+
+(***************************************************************************************************)
+(* Symmetry — none required: DonorOps and Shards are not modelled as symmetric sets.               *)
+(***************************************************************************************************)
+
+====================================================================================================

--- a/src/mongo/tla_plus/Sharding/ReshardingOplogFetchedAccounting/ReshardingOplogFetchedAccounting.tla
+++ b/src/mongo/tla_plus/Sharding/ReshardingOplogFetchedAccounting/ReshardingOplogFetchedAccounting.tla
@@ -1,0 +1,375 @@
+
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+--------------------------- MODULE ReshardingOplogFetchedAccounting --------------------------------
+(***************************************************************************************************)
+(* This specification models the resharding `oplogEntriesFetched` accounting protocol that gates    *)
+(* the resharding coordinator's entry into the critical section. The bug being modelled is the one  *)
+(* described in SERVER-118706:                                                                      *)
+(*                                                                                                  *)
+(*   1. The fetcher draws an oplog batch from the donor and intends to insert it into the local     *)
+(*      resharding oplog buffer collection.                                                         *)
+(*   2. Before (BUG) or after (FIX) the insert lands, the fetcher publishes the batch size to the   *)
+(*      `oplogEntriesFetched' metric the coordinator reads.                                         *)
+(*   3. The local insert can fail (e.g. WriteConflict). The fetcher retries.                        *)
+(*   4. In the buggy ordering the retry re-publishes the batch size without rolling back the prior  *)
+(*      publication. The metric drifts permanently above the number of entries actually present in  *)
+(*      the buffer.                                                                                 *)
+(*                                                                                                  *)
+(* The resharding coordinator decides whether to engage the critical section using                  *)
+(*                                                                                                  *)
+(*    estimatedRemainingTime = timeSpentApplying * (oplogEntriesFetched / oplogEntriesApplied - 1)  *)
+(*                                                                                                  *)
+(* (see resharding_util.cpp::estimateRemainingRecipientTime). The recipient applier can only        *)
+(* drain entries that are physically present in the buffer; under permanent overcount               *)
+(* `oplogEntriesApplied' is bounded above by the buffer cardinality. Consequently `fetched > N' and *)
+(* `applied <= N' implies the ratio (fetched / applied - 1) cannot drop below                       *)
+(* (overcount / N), the estimated remaining time stays above the threshold, and the critical       *)
+(* section is never engaged. The whole resharding operation hangs.                                  *)
+(*                                                                                                  *)
+(* Modelling notes:                                                                                 *)
+(*  - A single donor and a single recipient are modelled. The coordinator is modelled as a state    *)
+(*    machine that observes the recipient-side accounting variables.                                *)
+(*  - DonorOps is a fixed sequence of oplog positions the donor will emit. We treat them as opaque  *)
+(*    integers; only their count is load-bearing.                                                   *)
+(*  - The fetcher is allowed to non-deterministically fail an insert (WriteConflict) once per       *)
+(*    batch. The retry replays the same batch (i.e. lastOplogId does not advance through a failed   *)
+(*    insert). This mirrors the production retry shape described in the ticket.                     *)
+(*  - The applier monotonically drains entries from the buffer. The coordinator polls the metrics. *)
+(*                                                                                                  *)
+(* The TWO orderings of "increment counter" vs "insert into buffer" are selected by the CONSTANT    *)
+(* IncrementBeforeInsert. Setting IncrementBeforeInsert = TRUE reproduces the BUG; setting it to    *)
+(* FALSE reproduces the FIX shipped in 8.1 by SERVER-94800.                                         *)
+(***************************************************************************************************)
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+
+CONSTANTS
+    DonorOps,              \* Set of oplog op-ids the donor will publish (treat as opaque integers).
+    BatchMaxSize,          \* Maximum number of oplog ops the fetcher pulls per aggregate batch.
+    MaxInsertFailures,     \* Upper bound on number of WriteConflict-style insert failures allowed.
+    CritSecRatioNumer,     \* Threshold ratio (fetched/applied) numerator. Crit-sec engages when
+    CritSecRatioDenom,     \* fetched * CritSecRatioDenom <= applied * CritSecRatioNumer.
+    IncrementBeforeInsert  \* TRUE => buggy ordering (SERVER-118706 reproducer);
+                           \* FALSE => fixed ordering (SERVER-94800 fix shape).
+
+ASSUME Cardinality(DonorOps) > 0
+ASSUME BatchMaxSize \in 1..10
+ASSUME MaxInsertFailures \in 0..10
+ASSUME CritSecRatioNumer \in 1..100
+ASSUME CritSecRatioDenom \in 1..100
+ASSUME CritSecRatioNumer >= CritSecRatioDenom   \* The threshold ratio is >= 1 (fetched >= applied).
+ASSUME IncrementBeforeInsert \in BOOLEAN
+
+(* Total number of oplog ops the donor will publish across the run. *)
+TotalOps == Cardinality(DonorOps)
+
+(***************************************************************************************************)
+(* Variables                                                                                       *)
+(***************************************************************************************************)
+
+(* Donor variables. The donor publishes oplog ops via batches. Since the spec only consumes the    *)
+(* count of remaining ops, we model the donor as a counter "ops left to publish".                  *)
+VARIABLES
+    donorOpsRemaining       \* Number of donor oplog ops not yet pulled into a fetcher batch.
+
+(* Fetcher variables. The fetcher pulls a batch, then either (a) increments fetched then inserts,  *)
+(* or (b) inserts then increments. On insert failure, the fetcher retries the same batch.          *)
+VARIABLES
+    fetcherState,           \* "IDLE" | "BATCH_PULLED" | "INSERTED" | "RETRY_PENDING" | "DONE".
+    fetcherBatchSize,       \* Size of the in-flight batch.
+    fetcherInsertFailures   \* Counter of insert-retries consumed so far.
+
+(* Recipient buffer + applier variables. *)
+VARIABLES
+    bufferCount,            \* Number of oplog ops successfully inserted into the local buffer.
+    appliedCount            \* Number of buffered ops the applier has drained.
+
+(* Resharding metrics — the contract surface the coordinator reads. *)
+VARIABLES
+    oplogEntriesFetched,    \* Counter the fetcher publishes (the bug overcounts this).
+    oplogEntriesApplied     \* Counter the applier publishes (always matches appliedCount).
+
+(* Coordinator variables. *)
+VARIABLES
+    coordinatorState        \* "BUILDING_INDEX" | "APPLYING" | "CRIT_SEC_ENGAGED" | "ABORTED".
+
+vars == <<donorOpsRemaining,
+          fetcherState, fetcherBatchSize, fetcherInsertFailures,
+          bufferCount, appliedCount,
+          oplogEntriesFetched, oplogEntriesApplied,
+          coordinatorState>>
+
+(***************************************************************************************************)
+(* Type invariants                                                                                 *)
+(***************************************************************************************************)
+
+TypeOK ==
+    /\ donorOpsRemaining \in 0..TotalOps
+    /\ fetcherState \in {"IDLE", "BATCH_PULLED", "INSERTED", "RETRY_PENDING", "DONE"}
+    /\ fetcherBatchSize \in 0..BatchMaxSize
+    /\ fetcherInsertFailures \in 0..MaxInsertFailures
+    /\ bufferCount \in 0..TotalOps
+    /\ appliedCount \in 0..TotalOps
+    /\ oplogEntriesFetched \in 0..(TotalOps + MaxInsertFailures * BatchMaxSize)
+    /\ oplogEntriesApplied \in 0..TotalOps
+    /\ coordinatorState \in {"BUILDING_INDEX", "APPLYING", "CRIT_SEC_ENGAGED", "ABORTED"}
+
+(***************************************************************************************************)
+(* Init                                                                                            *)
+(***************************************************************************************************)
+
+Init ==
+    /\ donorOpsRemaining = TotalOps
+    /\ fetcherState = "IDLE"
+    /\ fetcherBatchSize = 0
+    /\ fetcherInsertFailures = 0
+    /\ bufferCount = 0
+    /\ appliedCount = 0
+    /\ oplogEntriesFetched = 0
+    /\ oplogEntriesApplied = 0
+    /\ coordinatorState = "APPLYING"
+
+Min(a, b) == IF a <= b THEN a ELSE b
+
+(***************************************************************************************************)
+(* Actions                                                                                         *)
+(***************************************************************************************************)
+
+\* Fetcher pulls a batch of up to BatchMaxSize oplog ops from the donor.
+PullBatch ==
+    /\ fetcherState = "IDLE"
+    /\ donorOpsRemaining > 0
+    /\ LET sz == Min(donorOpsRemaining, BatchMaxSize) IN
+        /\ fetcherBatchSize' = sz
+        /\ donorOpsRemaining' = donorOpsRemaining - sz
+        /\ fetcherState' = "BATCH_PULLED"
+    /\ UNCHANGED <<fetcherInsertFailures, bufferCount, appliedCount,
+                   oplogEntriesFetched, oplogEntriesApplied, coordinatorState>>
+
+\* "Pre-publish" — the buggy ordering. Fetcher increments oplogEntriesFetched before the insert.
+\* In the FIX configuration this action is disabled.
+PrePublishFetched ==
+    /\ IncrementBeforeInsert = TRUE
+    /\ fetcherState = "BATCH_PULLED"
+    /\ oplogEntriesFetched' = oplogEntriesFetched + fetcherBatchSize
+    /\ fetcherState' = "INSERTED"   \* Buggy code path moves to insert-attempt with counter already bumped.
+    /\ UNCHANGED <<donorOpsRemaining, fetcherBatchSize, fetcherInsertFailures,
+                   bufferCount, appliedCount, oplogEntriesApplied, coordinatorState>>
+
+\* The insert into the buffer collection succeeds. In the BUG ordering, the counter was already
+\* bumped (state INSERTED implies "intent to insert"); the success commits the buffer write.
+\* In the FIX ordering, the counter is bumped here, after the buffer-write commits.
+InsertSucceed ==
+    /\ \/ /\ IncrementBeforeInsert = TRUE
+          /\ fetcherState = "INSERTED"
+          /\ bufferCount' = bufferCount + fetcherBatchSize
+          /\ UNCHANGED oplogEntriesFetched
+       \/ /\ IncrementBeforeInsert = FALSE
+          /\ fetcherState = "BATCH_PULLED"
+          /\ bufferCount' = bufferCount + fetcherBatchSize
+          /\ oplogEntriesFetched' = oplogEntriesFetched + fetcherBatchSize
+    /\ fetcherState' = "IDLE"
+    /\ fetcherBatchSize' = 0
+    /\ UNCHANGED <<donorOpsRemaining, fetcherInsertFailures, appliedCount,
+                   oplogEntriesApplied, coordinatorState>>
+
+\* The insert into the buffer collection fails (e.g. WriteConflict). The fetcher must retry the
+\* same batch. In the BUG ordering, the counter was already bumped: the retry path takes the same
+\* "increment then attempt insert" sequence, and so the counter gets bumped AGAIN on retry. In the
+\* FIX ordering the counter has not yet been bumped, so the retry is clean.
+InsertFail ==
+    /\ fetcherInsertFailures < MaxInsertFailures
+    /\ \/ /\ IncrementBeforeInsert = TRUE
+          /\ fetcherState = "INSERTED"
+       \/ /\ IncrementBeforeInsert = FALSE
+          /\ fetcherState = "BATCH_PULLED"
+    /\ fetcherInsertFailures' = fetcherInsertFailures + 1
+    /\ fetcherState' = "RETRY_PENDING"
+    /\ UNCHANGED <<donorOpsRemaining, fetcherBatchSize, bufferCount, appliedCount,
+                   oplogEntriesFetched, oplogEntriesApplied, coordinatorState>>
+
+\* The fetcher retries the same batch. This is where the bug manifests: in the BUG ordering the
+\* retry re-runs "increment then insert", double-counting the batch in `oplogEntriesFetched'. In
+\* the FIX ordering the retry simply re-attempts the buffer insert without touching the counter.
+RetryAfterFail ==
+    /\ fetcherState = "RETRY_PENDING"
+    /\ \/ /\ IncrementBeforeInsert = TRUE
+          \* Bug: PrePublish happens again on the retry path.
+          /\ oplogEntriesFetched' = oplogEntriesFetched + fetcherBatchSize
+          /\ fetcherState' = "INSERTED"
+       \/ /\ IncrementBeforeInsert = FALSE
+          /\ fetcherState' = "BATCH_PULLED"
+          /\ UNCHANGED oplogEntriesFetched
+    /\ UNCHANGED <<donorOpsRemaining, fetcherBatchSize, fetcherInsertFailures,
+                   bufferCount, appliedCount, oplogEntriesApplied, coordinatorState>>
+
+\* The applier drains one entry from the buffer.
+ApplierDrain ==
+    /\ appliedCount < bufferCount
+    /\ appliedCount' = appliedCount + 1
+    /\ oplogEntriesApplied' = oplogEntriesApplied + 1
+    /\ UNCHANGED <<donorOpsRemaining, fetcherState, fetcherBatchSize, fetcherInsertFailures,
+                   bufferCount, oplogEntriesFetched, coordinatorState>>
+
+\* Fetcher signals it has consumed all donor ops and exits its loop. Required for liveness so
+\* that the spec can terminate cleanly when no more batches remain.
+FetcherDone ==
+    /\ fetcherState = "IDLE"
+    /\ donorOpsRemaining = 0
+    /\ fetcherState' = "DONE"
+    /\ UNCHANGED <<donorOpsRemaining, fetcherBatchSize, fetcherInsertFailures,
+                   bufferCount, appliedCount, oplogEntriesFetched, oplogEntriesApplied,
+                   coordinatorState>>
+
+\* The coordinator polls the fetcher / applier metrics and decides whether to engage the critical
+\* section. The real-system predicate is the one in resharding_util.cpp::estimateRemainingRecipientTime:
+\*
+\*     remaining = applying_time_so_far * (fetched / applied - 1)
+\*     engage_crit_sec iff remaining <= threshold
+\*
+\* We approximate the time-bounded predicate with a ratio threshold expressed as numerator/denom:
+\* the coordinator engages when fetched * Denom <= applied * Numer, with Numer >= Denom. The spec
+\* additionally insists the buffer must actually be drained (appliedCount = bufferCount) when the
+\* fetcher is done — this matches the production check that "we have applied everything currently
+\* buffered" before deciding to block writes.
+CoordinatorEngageCritSec ==
+    /\ coordinatorState = "APPLYING"
+    /\ oplogEntriesFetched > 0
+    /\ oplogEntriesApplied > 0
+    /\ oplogEntriesFetched * CritSecRatioDenom <= oplogEntriesApplied * CritSecRatioNumer
+    /\ coordinatorState' = "CRIT_SEC_ENGAGED"
+    /\ UNCHANGED <<donorOpsRemaining, fetcherState, fetcherBatchSize, fetcherInsertFailures,
+                   bufferCount, appliedCount, oplogEntriesFetched, oplogEntriesApplied>>
+
+\* The coordinator may abort. We allow an abort transition only to model the "operator gives up"
+\* path; without it, the bug configuration would deadlock under TLC with CHECK_DEADLOCK set. The
+\* invariants tolerate the abort state — see safety properties below.
+CoordinatorAbort ==
+    /\ coordinatorState = "APPLYING"
+    /\ fetcherState = "DONE"
+    /\ appliedCount = bufferCount             \* All buffered drained, yet ratio still off.
+    /\ donorOpsRemaining = 0
+    /\ oplogEntriesFetched > oplogEntriesApplied  \* Definitionally — overcount left behind.
+    /\ coordinatorState' = "ABORTED"
+    /\ UNCHANGED <<donorOpsRemaining, fetcherState, fetcherBatchSize, fetcherInsertFailures,
+                   bufferCount, appliedCount, oplogEntriesFetched, oplogEntriesApplied>>
+
+\* Terminal stuttering transition. Once the resharding operation has reached a terminal state —
+\* either the critical section has engaged (success) or the operator has aborted (failure) — and
+\* the fetcher/applier have drained, the spec stutters indefinitely. Without this transition TLC
+\* reports a spurious deadlock when the system reaches its happy terminal state, since no action
+\* is enabled.
+Terminating ==
+    /\ \/ coordinatorState = "CRIT_SEC_ENGAGED"
+       \/ coordinatorState = "ABORTED"
+    /\ fetcherState = "DONE"
+    /\ appliedCount = bufferCount
+    /\ donorOpsRemaining = 0
+    /\ UNCHANGED vars
+
+Next ==
+    \/ PullBatch
+    \/ PrePublishFetched
+    \/ InsertSucceed
+    \/ InsertFail
+    \/ RetryAfterFail
+    \/ ApplierDrain
+    \/ FetcherDone
+    \/ CoordinatorEngageCritSec
+    \/ CoordinatorAbort
+    \/ Terminating
+
+(***************************************************************************************************)
+(* Fairness                                                                                        *)
+(***************************************************************************************************)
+
+Fairness ==
+    /\ WF_vars(PullBatch)
+    /\ WF_vars(PrePublishFetched)
+    /\ WF_vars(InsertSucceed)
+    /\ WF_vars(RetryAfterFail)
+    /\ WF_vars(ApplierDrain)
+    /\ WF_vars(FetcherDone)
+    /\ WF_vars(CoordinatorEngageCritSec)
+    \* Note: InsertFail and CoordinatorAbort are deliberately NOT in the fairness set. InsertFail is
+    \* an adversarial action whose firing is bounded by MaxInsertFailures; CoordinatorAbort is a
+    \* terminal escape hatch that should only fire when liveness has already been violated.
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+(***************************************************************************************************)
+(* Safety invariants                                                                                *)
+(***************************************************************************************************)
+
+\* The accounting contract that the coordinator's threshold rule depends on:
+\* oplogEntriesFetched must never get permanently ahead of bufferCount + currently-in-flight batch.
+\* In the FIX configuration the counter is only bumped after the insert lands, so this invariant
+\* holds tightly: oplogEntriesFetched <= bufferCount + (in-flight-but-not-yet-counted).
+\* In the BUG configuration the counter can be strictly greater than bufferCount by an amount
+\* proportional to the number of insert failures consumed — that is the overcount the ticket is
+\* about. This invariant is therefore safety-only under FIX, and is left disabled in the BUG cfg.
+FetchedTracksBuffer ==
+    oplogEntriesFetched <= bufferCount + fetcherBatchSize
+
+\* Applied is always bounded above by what's physically present in the buffer.
+AppliedBoundedByBuffer == oplogEntriesApplied <= bufferCount
+
+\* The applier cannot get ahead of the fetcher in TRUTH: appliedCount <= bufferCount <=
+\* (donor ops pulled) <= TotalOps. This invariant is independent of the buggy ordering.
+AppliedBoundedByTotal == oplogEntriesApplied <= TotalOps
+
+\* The CONTRACT: if the coordinator engaged the critical section, then by the production rule
+\* (fetched/applied - 1) was below threshold AND the applier had drained everything currently
+\* present in the buffer. If overcount has occurred, the only way crit-sec can engage is to wait
+\* long enough that applied catches up to the inflated fetched count — which is IMPOSSIBLE because
+\* applied is bounded by bufferCount, and bufferCount is bounded by the actual donor op stream.
+\* Hence under BUG configuration this implies the crit-sec is never reached when fetched > the
+\* eventually-applied count.
+CritSecImpliesAppliedReachedBuffer ==
+    coordinatorState = "CRIT_SEC_ENGAGED" => oplogEntriesApplied <= oplogEntriesFetched
+
+(***************************************************************************************************)
+(* Liveness properties                                                                              *)
+(***************************************************************************************************)
+
+\* Eventually, the fetcher is done pulling donor ops.
+FetcherEventuallyDone == <>(fetcherState = "DONE")
+
+\* Eventually, the applier drains everything in the buffer.
+ApplierEventuallyDrains == <>(appliedCount = bufferCount /\ fetcherState = "DONE")
+
+\* The headline liveness property the ticket is about:
+\*   If the donor's op stream is bounded and the applier is allowed to drain unimpeded, then the
+\*   coordinator MUST eventually engage the critical section. Under the BUG configuration this
+\*   property is violated: the counter overcount permanently inflates the ratio, the coordinator
+\*   never crosses the threshold, and resharding hangs.
+CritSecEventuallyEngaged ==
+    <>(coordinatorState = "CRIT_SEC_ENGAGED")
+
+\* Under FIX configuration we should also have: once the applier has drained everything, the
+\* coordinator engages the critical section (and stays there, by stuttering).
+DrainImpliesCritSec ==
+    [](
+        (fetcherState = "DONE" /\ appliedCount = bufferCount /\ bufferCount > 0)
+        =>
+        <>(coordinatorState = "CRIT_SEC_ENGAGED")
+    )
+
+\* Under the BUG configuration we want to prove the violation explicitly. We express it as: there
+\* exists an execution in which the coordinator never engages the critical section AND the system
+\* otherwise progresses normally (everything drained, donor empty, no more retries possible). This
+\* is precisely the "hang" the ticket describes.
+HangScenarioReachable ==
+    \* A bait predicate — used in MC cfg to surface the counterexample trace.
+    /\ fetcherState = "DONE"
+    /\ appliedCount = bufferCount
+    /\ donorOpsRemaining = 0
+    /\ oplogEntriesFetched > oplogEntriesApplied
+    /\ coordinatorState = "APPLYING"
+
+====================================================================================================


### PR DESCRIPTION
## Summary

TLA+ spec + audit jstest: resharding critical-section gate must not depend on countable accounting alone.

**Jira:** https://jira.mongodb.org/browse/SERVER-126718
**Branch:** substrate-contrib/w4-15

## Files

```
  -  .../resharding_oplog_fetched_overcount_audit.js    | 265 +++++++++++++++
  -  .../MCReshardingOplogFetchedAccounting.cfg         |  41 +++
  -  .../MCReshardingOplogFetchedAccounting.tla         |  39 +++
  -  .../ReshardingOplogFetchedAccounting.tla           | 375 +++++++++++++++++++++
  -  4 files changed, 720 insertions(+)
```

## Verify

For `.tla` files:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For `.js` jstests:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
