### PR TITLE
SERVER-126727 TLA+ spec + jstest: resharding abort must not install stale filtering metadata

### DIFF
--- a/jstests/sharding/resharding_abort_does_not_install_stale_filtering.js
+++ b/jstests/sharding/resharding_abort_does_not_install_stale_filtering.js
@@ -1,0 +1,239 @@
+/**
+ * Repro for the SERVER-90810 race:
+ *   On resharding abort, the recipient drops the temp collection, clears its in-memory filtering
+ *   metadata, and asynchronously refreshes it -- then the coordinator deletes the coordinator
+ *   document. If a concurrent DDL (e.g. createIndexes / refine on the source) bumps the
+ *   authoritative placement version between the async refresh's snapshot and its install, the
+ *   recipient ends up with cached filtering metadata that is stale relative to DDLs that ran
+ *   during the reshard window.
+ *
+ * The test:
+ *   1. Starts a reshardCollection on a sharded collection with seeded data so cloning actually
+ *      runs.
+ *   2. Pauses every recipient shard mid-cloning so the abort flow is exercised cleanly.
+ *   3. Pauses the coordinator just before it enters the error flow.
+ *   4. Issues abortReshardCollection in a parallel shell.
+ *   5. While both pauses are held, runs a placement-bumping DDL on the source collection
+ *      (createIndexes routed through mongos -- bumps the source collection's shard version /
+ *      indexVersion through the standard sharded-DDL path).
+ *   6. Releases the coordinator and recipient failpoints; the abort flow completes and the
+ *      recipient's async filtering-metadata refresh lands.
+ *   7. Asserts (a) the recipient retains no stale filtering metadata for the temporary
+ *      resharding namespace, and (b) the recipient's view of the source ns is at least as new
+ *      as the authoritative state at the moment the DDL landed.
+ *
+ * @tags: [
+ *   requires_fcv_80,
+ *   assumes_balancer_off,
+ *   uses_atclustertime,
+ * ]
+ */
+
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {funWithArgs} from "jstests/libs/parallel_shell_helpers.js";
+import {ShardingTest} from "jstests/libs/shardingtest.js";
+
+const st = new ShardingTest({mongos: 1, shards: 2, rs: {nodes: 1}});
+
+const dbName = "reshardAbortStaleFilteringDb";
+const collName = "coll";
+const ns = dbName + "." + collName;
+
+assert.commandWorked(st.s.adminCommand({enableSharding: dbName, primaryShard: st.shard0.shardName}));
+assert.commandWorked(st.s.adminCommand({shardCollection: ns, key: {oldKey: 1}}));
+
+// Seed data so the cloning phase has something to clone and the recipient genuinely enters
+// the cloning state where the failpoint fires.
+const sourceColl = st.s.getDB(dbName).getCollection(collName);
+const bulk = sourceColl.initializeUnorderedBulkOp();
+for (let i = -50; i < 50; i++) {
+    bulk.insert({oldKey: i, newKey: -i, payload: "x".repeat(64)});
+}
+assert.commandWorked(bulk.execute());
+
+// Capture pre-reshard cache entries on every shard for debugging.
+for (const rs of [st.rs0, st.rs1]) {
+    const entry = rs.getPrimary().getDB("config").getCollection("cache.collections").findOne({_id: ns});
+    jsTestLog("Pre-reshard cache entry on " + rs.getPrimary().host + " for source ns: " + tojson(entry));
+}
+
+// Pause every shard's primary in the recipient cloning phase. The recipient set is whichever shard
+// owns the new-shard-key keyspace; pausing on every shard guarantees we hit the recipient.
+const shardFailpoints = [
+    configureFailPoint(st.rs0.getPrimary(), "reshardingPauseRecipientDuringCloning"),
+    configureFailPoint(st.rs1.getPrimary(), "reshardingPauseRecipientDuringCloning"),
+];
+
+jsTestLog("Starting reshardCollection in background");
+const reshardThread = startParallelShell(
+    funWithArgs(function (ns) {
+        assert.commandFailedWithCode(
+            db.adminCommand({reshardCollection: ns, key: {newKey: 1}, numInitialChunks: 1}),
+            ErrorCodes.ReshardCollectionAborted,
+        );
+    }, ns),
+    st.s.port,
+);
+
+// Wait until at least one recipient hits the failpoint. The recipient set is implementation-defined
+// based on chunk placement under the new shard key, so we tolerate either shard being the one to
+// hit it. `waitWithTimeout` returns a boolean rather than throwing on timeout.
+let recipientPrimary = null;
+assert.soon(
+    () => {
+        for (const fp of shardFailpoints) {
+            if (fp.waitWithTimeout(1000)) {
+                recipientPrimary = fp.conn;
+                return true;
+            }
+        }
+        return false;
+    },
+    "No recipient shard hit reshardingPauseRecipientDuringCloning within timeout",
+    5 * 60 * 1000,
+);
+jsTestLog("Recipient paused at cloning failpoint on " + recipientPrimary.host);
+
+// Capture the temporary resharding namespace. While the recipient is paused mid-cloning, its
+// config.cache.collections holds an entry for `<db>.system.resharding.<uuid>` -- this is exactly
+// the entry the bug leaves stale.
+let tempReshardingNs;
+assert.soon(
+    () => {
+        const cacheEntries = recipientPrimary.getDB("config")
+                                 .getCollection("cache.collections")
+                                 .find({_id: new RegExp("^" + dbName + "\\.system\\.resharding\\.")})
+                                 .toArray();
+        if (cacheEntries.length === 0) {
+            return false;
+        }
+        tempReshardingNs = cacheEntries[0]._id;
+        return true;
+    },
+    "Recipient never installed filtering metadata for the temporary resharding namespace",
+    2 * 60 * 1000,
+);
+jsTestLog("Temporary resharding namespace on recipient: " + tempReshardingNs);
+
+// Pause the coordinator just before the error flow starts so the cleanup of the coordinator
+// document is deterministically deferred until after our concurrent DDL has landed. This is the
+// same failpoint resharding_abort_command.js uses to coordinate the same kind of race window.
+const pauseCoordinatorBeforeErrorFlow = configureFailPoint(
+    st.configRS.getPrimary(),
+    "reshardingPauseCoordinatorBeforeStartingErrorFlow",
+);
+
+jsTestLog("Issuing abortReshardCollection in background");
+const abortThread = startParallelShell(
+    funWithArgs(function (ns) {
+        assert.commandWorked(db.adminCommand({abortReshardCollection: ns}));
+    }, ns),
+    st.s.port,
+);
+
+pauseCoordinatorBeforeErrorFlow.wait();
+
+// === Concurrent DDL during the reshard abort window ===
+//
+// While both failpoints are held (coordinator just before error flow, recipient mid-cloning) we
+// run a placement-bumping DDL against the source collection. The DDL must land before the
+// recipient's async filtering-metadata refresh captures its snapshot -- which is exactly the
+// window the SERVER-90810 race opens. After the failpoints are released the refresh runs to
+// completion; the post-abort assertions verify the refresh did not install a stale snapshot.
+jsTestLog("Running concurrent createIndexes DDL on source collection during abort window");
+assert.commandWorked(st.s.getDB(dbName).runCommand({
+    createIndexes: collName,
+    indexes: [{key: {newKey: 1, oldKey: 1}, name: "concurrent_ddl_during_abort"}],
+}));
+
+// Authoritative metadata for the source collection after the DDL landed. This is the floor that
+// the recipient's post-abort filtering metadata for `ns` must respect.
+const postDDLConfigEntry =
+    st.configRS.getPrimary().getDB("config").getCollection("collections").findOne({_id: ns});
+assert.neq(null, postDDLConfigEntry,
+           "Source collection metadata disappeared from config.collections during abort");
+jsTestLog("Authoritative config metadata post-DDL: " + tojson(postDDLConfigEntry));
+
+// Release the coordinator and recipient failpoints so the abort flow completes.
+pauseCoordinatorBeforeErrorFlow.off();
+for (const fp of shardFailpoints) {
+    fp.off();
+}
+
+jsTestLog("Joining background threads");
+abortThread();
+reshardThread();
+
+// === Post-abort assertions ===
+
+// (1) The recipient's cached filtering metadata for the *temporary* resharding namespace must NOT
+//     be retained as a stale entry. SERVER-90810 leaves the recipient with cached filtering
+//     information for the temporary namespace even though the coordinator has cleaned up its
+//     authoritative metadata. Either of the following are correct end states:
+//       (a) No cache entry for the temp namespace remains.
+//       (b) A cache entry remains but its timestamp is at least as new as the post-DDL
+//           authoritative timestamp for the source collection -- proving the refresh did not
+//           install a snapshot taken before the DDL landed.
+//     The bug surfaces as a cache entry whose timestamp is older than the post-DDL authoritative
+//     timestamp.
+assert.soon(
+    () => {
+        const tempCacheEntry =
+            recipientPrimary.getDB("config")
+                .getCollection("cache.collections")
+                .findOne({_id: tempReshardingNs});
+        if (tempCacheEntry === null) {
+            return true;
+        }
+        const tempTs = tempCacheEntry.timestamp;
+        const sourceTs = postDDLConfigEntry.timestamp;
+        if (tempTs === undefined || sourceTs === undefined) {
+            return false;
+        }
+        return (tempTs.t > sourceTs.t ||
+                (tempTs.t === sourceTs.t && tempTs.i >= sourceTs.i));
+    },
+    () => {
+        const tempCacheEntry = recipientPrimary.getDB("config")
+                                   .getCollection("cache.collections")
+                                   .findOne({_id: tempReshardingNs});
+        return ("Recipient retained stale filtering metadata for temp resharding namespace "
+                + tempReshardingNs
+                + " after abort. Recipient cache entry: " + tojson(tempCacheEntry)
+                + "; authoritative source-collection metadata at DDL completion: "
+                + tojson(postDDLConfigEntry));
+    },
+    2 * 60 * 1000,
+);
+
+// (2) The recipient's view of the *source* collection must also be at least as new as the
+//     post-DDL authoritative state. Force a refresh first to give the recipient a chance to
+//     observe the latest authoritative state; if it can't, the recipient is wedged on stale
+//     filtering metadata.
+assert.soon(
+    () => {
+        const flushResult = recipientPrimary.adminCommand(
+            {_flushRoutingTableCacheUpdates: ns, syncFromConfig: true});
+        return flushResult.ok === 1;
+    },
+    "Recipient could not flush routing table cache updates for source ns after abort",
+    2 * 60 * 1000,
+);
+
+const postAbortSourceCacheEntry =
+    recipientPrimary.getDB("config").getCollection("cache.collections").findOne({_id: ns});
+assert.neq(
+    null, postAbortSourceCacheEntry,
+    "Recipient has no cache entry for the source ns after abort + post-abort flush");
+jsTestLog("Post-abort recipient cache entry for source ns: " + tojson(postAbortSourceCacheEntry));
+
+const recipientTs = postAbortSourceCacheEntry.timestamp;
+const authoritativeTs = postDDLConfigEntry.timestamp;
+assert(
+    recipientTs.t > authoritativeTs.t
+        || (recipientTs.t === authoritativeTs.t && recipientTs.i >= authoritativeTs.i),
+    "Recipient's cached filtering metadata for source ns is older than authoritative metadata "
+        + "after DDL during reshard abort window. Recipient: " + tojson(recipientTs)
+        + "; authoritative: " + tojson(authoritativeTs));
+
+st.stop();

--- a/src/mongo/tla_plus/Sharding/ReshardingAbortFilteringMetadata/MCReshardingAbortFilteringMetadata.cfg
+++ b/src/mongo/tla_plus/Sharding/ReshardingAbortFilteringMetadata/MCReshardingAbortFilteringMetadata.cfg
@@ -1,0 +1,23 @@
+\* Green configuration: models the proposed fix. SAFE_MODE = TRUE.
+\* All correctness invariants must hold under this configuration.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    MAX_DDLS = 3
+    SAFE_MODE = TRUE
+
+INVARIANT
+    TypeOK
+    AuthoritativeMonotone
+    PendingRefreshBounded
+    RefreshInstallReflectsSnapshot
+    NoStaleFilteringInstalledOnAbort
+    NoCacheRegression
+
+CONSTRAINT
+    StateConstraint
+
+\* Liveness: the abort flow always settles.
+PROPERTIES
+    AbortEventuallyCompletes

--- a/src/mongo/tla_plus/Sharding/ReshardingAbortFilteringMetadata/MCReshardingAbortFilteringMetadata.tla
+++ b/src/mongo/tla_plus/Sharding/ReshardingAbortFilteringMetadata/MCReshardingAbortFilteringMetadata.tla
@@ -1,0 +1,64 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+---------------------- MODULE MCReshardingAbortFilteringMetadata -----------------------------------
+\* Model-checking harness for ReshardingAbortFilteringMetadata.
+\*
+\* Two configurations live alongside this module:
+\*
+\*   * MCReshardingAbortFilteringMetadata.cfg
+\*     Green configuration. SAFE_MODE = TRUE. The proposed fix installs max(snapshot, current)
+\*     instead of blindly clobbering the cache with the captured snapshot. All invariants pass.
+\*
+\*   * MCReshardingAbortFilteringMetadata_bug.cfg
+\*     Bug-reproducing configuration. SAFE_MODE = FALSE. TLC produces a counterexample of the
+\*     SERVER-90810 race: a concurrent DDL ticks the authoritative version after the async refresh
+\*     captures its snapshot but before the install lands, the install writes the stale snapshot,
+\*     and `NoStaleFilteringInstalledOnAbort` is violated.
+
+EXTENDS ReshardingAbortFilteringMetadata
+
+(****************************************************************************************************)
+(* State constraints.                                                                               *)
+(****************************************************************************************************)
+
+\* The state space is finite by construction (MAX_DDLS caps DDLs, the abort flow is monotone), so a
+\* state constraint is not strictly required. We still cap the explored versions defensively to
+\* keep counterexample traces compact.
+StateConstraint ==
+    /\ currentFilteringMetadata <= MAX_DDLS + 2
+    /\ ddlsApplied <= MAX_DDLS
+
+(****************************************************************************************************)
+(* Counterexample bait properties. Each, when used as an INVARIANT, generates a counterexample      *)
+(* trace exhibiting the named scenario. Off by default; flip the desired bait on in the cfg.       *)
+(****************************************************************************************************)
+
+\* Bait: an abort flow that completes without any concurrent DDL having run. Useful smoke test that
+\* the spec actually reaches the terminal state.
+BaitCleanAbort ==
+    ~ (refreshState = "REFRESH_INSTALLED" /\ coordinatorCleanedUp /\ ddlsApplied = 0)
+
+\* Bait: an abort flow in which at least one concurrent DDL ran. This is the precondition for the
+\* stale-install bug, and the bait confirms the spec can produce such interleavings.
+BaitDDLDuringAbort ==
+    ~ (refreshState = "REFRESH_INSTALLED" /\ coordinatorCleanedUp /\ ddlsApplied >= 1)
+
+\* Bait: the install lands before the coordinator has cleaned up. This is the moment the bug
+\* opens its window. The bait confirms the interleaving is reachable.
+BaitInstallBeforeCleanup ==
+    ~ (refreshState = "REFRESH_INSTALLED" /\ ~coordinatorCleanedUp)
+
+\* Bait: the cache ends up at a value strictly older than the maximum authoritative version that
+\* was published during the reshard window. When SAFE_MODE = FALSE this is reachable; when
+\* SAFE_MODE = TRUE this is never reachable.
+BaitStaleCacheReachable ==
+    ~ (refreshState = "REFRESH_INSTALLED" /\ coordinatorCleanedUp
+       /\ ddlsApplied >= 1
+       /\ cachedFilteringMetadata < maxDDLVersionDuringWindow
+       /\ cachedFilteringMetadata > 0)
+
+====================================================================================================

--- a/src/mongo/tla_plus/Sharding/ReshardingAbortFilteringMetadata/MCReshardingAbortFilteringMetadata_bug.cfg
+++ b/src/mongo/tla_plus/Sharding/ReshardingAbortFilteringMetadata/MCReshardingAbortFilteringMetadata_bug.cfg
@@ -1,0 +1,37 @@
+\* Bug-reproducing configuration: models the current buggy implementation. SAFE_MODE = FALSE.
+\*
+\* Running TLC with this configuration produces a counterexample trace of the SERVER-90810 race:
+\*
+\*   1. Recipient drops temp collection.
+\*   2. Recipient clears filtering metadata (cache := NoVersion).
+\*   3. Recipient dispatches async refresh.
+\*   4. Async refresh snapshots currentFilteringMetadata = V_0.
+\*   5. Concurrent DDL ticks currentFilteringMetadata to V_1 = V_0 + 1.
+\*   6. Async refresh installs (under SAFE_MODE = FALSE) cache := V_0  -- STALE.
+\*   7. Coordinator cleans up coordinator document.
+\*
+\* The terminal state has cachedFilteringMetadata = V_0 < V_1 = maxDDLVersionDuringWindow, violating
+\* `NoStaleFilteringInstalledOnAbort`.
+\*
+\* To run:
+\*     cd src/mongo/tla_plus
+\*     cp Sharding/ReshardingAbortFilteringMetadata/MCReshardingAbortFilteringMetadata_bug.cfg \
+\*        Sharding/ReshardingAbortFilteringMetadata/MCReshardingAbortFilteringMetadata.cfg
+\*     ./model-check.sh Sharding/ReshardingAbortFilteringMetadata
+
+SPECIFICATION Spec
+
+CONSTANTS
+    MAX_DDLS = 3
+    SAFE_MODE = FALSE
+
+INVARIANT
+    TypeOK
+    AuthoritativeMonotone
+    PendingRefreshBounded
+    \* The following invariant is *expected to be violated* under the bug configuration. TLC will
+    \* halt with a counterexample trace as soon as it discovers the stale-install interleaving.
+    NoStaleFilteringInstalledOnAbort
+
+CONSTRAINT
+    StateConstraint

--- a/src/mongo/tla_plus/Sharding/ReshardingAbortFilteringMetadata/ReshardingAbortFilteringMetadata.tla
+++ b/src/mongo/tla_plus/Sharding/ReshardingAbortFilteringMetadata/ReshardingAbortFilteringMetadata.tla
@@ -1,0 +1,322 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+----------------------- MODULE ReshardingAbortFilteringMetadata ------------------------------------
+(****************************************************************************************************)
+(* Formal specification of the race described in SERVER-90810:                                      *)
+(*                                                                                                  *)
+(*   When the resharding coordinator decides to abort an in-flight reshard, the recipient shard     *)
+(*   performs the following sequence:                                                               *)
+(*                                                                                                  *)
+(*     1. The recipient drops the temporary resharding collection.                                  *)
+(*     2. The recipient clears its in-memory filtering metadata for the temporary namespace.        *)
+(*     3. The recipient kicks off an *asynchronous* refresh of the filtering metadata. This refresh *)
+(*        snapshots the authoritative cluster metadata at some point during the abort flow and      *)
+(*        later installs that snapshot into the in-memory cache.                                    *)
+(*     4. The coordinator deletes the resharding coordinator document, which cleans up the          *)
+(*        authoritative metadata for the temporary collection.                                      *)
+(*                                                                                                  *)
+(*   Between (3) and (4), other concurrent DDLs (e.g. an indexCreate on the source collection or a  *)
+(*   shard-key refine) can bump the authoritative placement version. The async refresh in (3) may   *)
+(*   read a snapshot of the authoritative metadata taken *before* those concurrent DDLs landed, and *)
+(*   then install that stale snapshot into the recipient's in-memory cache.                         *)
+(*                                                                                                  *)
+(*   The end state is: the recipient's cached filtering metadata is older than the latest DDL that  *)
+(*   ran during the reshard window, even though the recipient has long since acknowledged the       *)
+(*   abort.                                                                                         *)
+(*                                                                                                  *)
+(* Modelling choices:                                                                               *)
+(*   * One source collection, one temporary resharding namespace, one recipient shard. The bug is   *)
+(*     local to a single recipient; multiplying shards does not add covered behavior.               *)
+(*   * The "authoritative" metadata is a monotone integer version number maintained by the config   *)
+(*     server. Any DDL ticks it up by 1.                                                            *)
+(*   * The recipient maintains two pieces of state:                                                 *)
+(*       - `cachedFilteringMetadata`: the in-memory filtering metadata that the recipient enforces. *)
+(*       - `currentFilteringMetadata`: the authoritative version on the config side. Any read of    *)
+(*         filtering metadata is logically read against this.                                       *)
+(*   * The async refresh is modelled as a two-phase action: a SNAPSHOT phase that captures the      *)
+(*     authoritative version into `pendingRefreshVersion`, and an INSTALL phase that copies that    *)
+(*     snapshot into `cachedFilteringMetadata`. The two phases can interleave with `ConcurrentDDL`  *)
+(*     actions that tick `currentFilteringMetadata` upward.                                         *)
+(*   * The recipient abort state machine and the refresh state machine are *decoupled*. The         *)
+(*     recipient acks the abort to the coordinator after dispatching the refresh; the coordinator   *)
+(*     cleanup may then race with the refresh install in either order. This matches the production  *)
+(*     code path: the async refresh continuation is not joined before the recipient acks.           *)
+(*   * The fix the spec drives is: the refresh's install must respect any authoritative version     *)
+(*     that is observable at the install moment -- i.e., the install must not clobber the cache    *)
+(*     with a snapshot older than what's currently authoritative. In SAFE_MODE, AsyncRefreshInstall *)
+(*     installs max(snapshot, current).                                                             *)
+(*                                                                                                  *)
+(* To run the model-checker, first edit the constants in MCReshardingAbortFilteringMetadata.cfg if  *)
+(* desired, then:                                                                                   *)
+(*     cd src/mongo/tla_plus                                                                        *)
+(*     ./model-check.sh Sharding/ReshardingAbortFilteringMetadata                                   *)
+(****************************************************************************************************)
+
+EXTENDS Integers, FiniteSets, Sequences, TLC
+
+CONSTANTS
+    MAX_DDLS,     \* Maximum number of concurrent DDLs that may bump placement during the reshard.
+    SAFE_MODE     \* TRUE: model the proposed fix (install rejects stale snapshots).
+                  \* FALSE: model the buggy current implementation.
+
+ASSUME MAX_DDLS \in 0..10
+ASSUME SAFE_MODE \in BOOLEAN
+
+\* Sentinel value used to denote "no filtering metadata installed".
+NoVersion == 0
+
+\* Recipient main-thread abort state machine. The sequence corresponds to the on-thread steps in
+\* the issue description: drop temp coll -> clear filtering metadata -> dispatch async refresh ->
+\* ack abort to coordinator.
+\*   "ACTIVE"             - reshard in progress; abort not started.
+\*   "DROPPED_TEMP_COLL"  - recipient dropped the temporary collection (ticket step 5).
+\*   "CLEARED_METADATA"   - recipient cleared the in-memory filtering metadata (ticket step 6).
+\*   "REFRESH_DISPATCHED" - recipient scheduled the async refresh and acked the abort to the
+\*                          coordinator (ticket step 7). The refresh continuation runs independently
+\*                          on a separate thread.
+RecipientAbortStates == {"ACTIVE", "DROPPED_TEMP_COLL", "CLEARED_METADATA", "REFRESH_DISPATCHED"}
+
+\* Refresh state machine, independent of the recipient main-thread state.
+\*   "REFRESH_IDLE"        - refresh not yet dispatched.
+\*   "REFRESH_PENDING"     - refresh dispatched, snapshot not yet captured.
+\*   "REFRESH_SNAPSHOTTED" - refresh has captured `pendingRefreshVersion`.
+\*   "REFRESH_INSTALLED"   - refresh has copied `pendingRefreshVersion` to the cache.
+RefreshStates == {"REFRESH_IDLE", "REFRESH_PENDING", "REFRESH_SNAPSHOTTED", "REFRESH_INSTALLED"}
+
+VARIABLES
+    currentFilteringMetadata,   \* Authoritative placement version visible to a fresh refresh.
+    cachedFilteringMetadata,    \* What the recipient enforces locally.
+    pendingRefreshVersion,      \* Snapshot captured by the async refresh, before install.
+    refreshState,               \* Current refresh-thread state.
+    abortState,                 \* Current recipient main-thread abort state.
+    coordinatorCleanedUp,       \* TRUE once the coordinator document has been deleted.
+    ddlsApplied,                \* Number of DDLs that have ticked currentFilteringMetadata.
+    \* The maximum authoritative version observed by any DDL that ran during the reshard window.
+    \* After the abort settles, the recipient's cache must either be NoVersion (correctly cleared)
+    \* or at least this version (correctly refreshed past every concurrent DDL).
+    maxDDLVersionDuringWindow
+
+vars == <<currentFilteringMetadata, cachedFilteringMetadata, pendingRefreshVersion, refreshState,
+          abortState, coordinatorCleanedUp, ddlsApplied, maxDDLVersionDuringWindow>>
+
+(****************************************************************************************************)
+(* Initial state. The reshard has just started: the recipient already has an initial filtering      *)
+(* metadata version for the temporary collection installed (call it 1), the coordinator is up, and  *)
+(* no abort has begun.                                                                              *)
+(****************************************************************************************************)
+Init ==
+    /\ currentFilteringMetadata = 1
+    /\ cachedFilteringMetadata = 1
+    /\ pendingRefreshVersion = NoVersion
+    /\ refreshState = "REFRESH_IDLE"
+    /\ abortState = "ACTIVE"
+    /\ coordinatorCleanedUp = FALSE
+    /\ ddlsApplied = 0
+    /\ maxDDLVersionDuringWindow = 1
+
+(****************************************************************************************************)
+(* Action: a concurrent DDL (e.g. createIndexes, refineCollectionShardKey on the source) ticks the *)
+(* authoritative placement version. The reshard window for the purposes of this race is the      *)
+(* interval from reshard start until the recipient's async refresh has finished installing -- a   *)
+(* DDL that lands after the install simply doesn't matter to the install, so we gate this action *)
+(* on the refresh having not yet installed. We additionally cap by `~coordinatorCleanedUp` to     *)
+(* reflect the fact that once the coordinator document is gone the temporary collection's         *)
+(* authoritative metadata is gone too and no further bumps against it are reachable.              *)
+(****************************************************************************************************)
+ConcurrentDDL ==
+    /\ ddlsApplied < MAX_DDLS
+    /\ ~coordinatorCleanedUp
+    /\ refreshState # "REFRESH_INSTALLED"
+    /\ currentFilteringMetadata' = currentFilteringMetadata + 1
+    /\ ddlsApplied' = ddlsApplied + 1
+    /\ maxDDLVersionDuringWindow' = currentFilteringMetadata + 1
+    /\ UNCHANGED <<cachedFilteringMetadata, pendingRefreshVersion, refreshState,
+                   abortState, coordinatorCleanedUp>>
+
+(****************************************************************************************************)
+(* Action: the recipient encountered a fatal cloning error and begins the abort flow. The first    *)
+(* observable step is dropping the temporary collection.                                            *)
+(****************************************************************************************************)
+RecipientDropTempCollection ==
+    /\ abortState = "ACTIVE"
+    /\ abortState' = "DROPPED_TEMP_COLL"
+    /\ UNCHANGED <<currentFilteringMetadata, cachedFilteringMetadata, pendingRefreshVersion,
+                   refreshState, coordinatorCleanedUp, ddlsApplied, maxDDLVersionDuringWindow>>
+
+(****************************************************************************************************)
+(* Action: the recipient clears the in-memory filtering metadata for the temp collection (ticket   *)
+(* step 6). Cache becomes NoVersion -- "I have no filtering metadata, must refresh".               *)
+(****************************************************************************************************)
+RecipientClearFilteringMetadata ==
+    /\ abortState = "DROPPED_TEMP_COLL"
+    /\ abortState' = "CLEARED_METADATA"
+    /\ cachedFilteringMetadata' = NoVersion
+    /\ UNCHANGED <<currentFilteringMetadata, pendingRefreshVersion, refreshState,
+                   coordinatorCleanedUp, ddlsApplied, maxDDLVersionDuringWindow>>
+
+(****************************************************************************************************)
+(* Action: the recipient kicks off the async refresh of the filtering metadata (ticket step 7) and *)
+(* acks the abort to the coordinator. This action transitions both the recipient main-thread state *)
+(* and the refresh-thread state simultaneously: dispatching the refresh and updating the abort     *)
+(* state are atomic on the main thread.                                                            *)
+(****************************************************************************************************)
+RecipientDispatchRefresh ==
+    /\ abortState = "CLEARED_METADATA"
+    /\ refreshState = "REFRESH_IDLE"
+    /\ abortState' = "REFRESH_DISPATCHED"
+    /\ refreshState' = "REFRESH_PENDING"
+    /\ UNCHANGED <<currentFilteringMetadata, cachedFilteringMetadata, pendingRefreshVersion,
+                   coordinatorCleanedUp, ddlsApplied, maxDDLVersionDuringWindow>>
+
+(****************************************************************************************************)
+(* Action: the async refresh thread captures a snapshot of the authoritative metadata. This is the *)
+(* moment where the bug originates: the snapshot may be taken before concurrent DDLs that go on to *)
+(* bump `currentFilteringMetadata`.                                                                 *)
+(****************************************************************************************************)
+AsyncRefreshSnapshot ==
+    /\ refreshState = "REFRESH_PENDING"
+    /\ refreshState' = "REFRESH_SNAPSHOTTED"
+    /\ pendingRefreshVersion' = currentFilteringMetadata
+    /\ UNCHANGED <<currentFilteringMetadata, cachedFilteringMetadata, abortState,
+                   coordinatorCleanedUp, ddlsApplied, maxDDLVersionDuringWindow>>
+
+(****************************************************************************************************)
+(* Action: the async refresh thread installs its snapshot into the recipient's cache (ticket step  *)
+(* 8). This is where SAFE_MODE matters.                                                            *)
+(*                                                                                                  *)
+(* SAFE_MODE = FALSE: buggy current implementation. The install blindly copies                     *)
+(*                    `pendingRefreshVersion` into `cachedFilteringMetadata`, regardless of how    *)
+(*                    stale that snapshot is relative to the current authoritative metadata.       *)
+(*                                                                                                  *)
+(* SAFE_MODE = TRUE:  proposed fix. The install re-reads `currentFilteringMetadata` at install     *)
+(*                    time. If the snapshot is older than what's currently authoritative, the      *)
+(*                    install installs the fresh value -- the refresh has logically taken place at *)
+(*                    the install moment, not at the snapshot moment, so installing the fresh       *)
+(*                    value is sound.                                                              *)
+(****************************************************************************************************)
+AsyncRefreshInstall ==
+    /\ refreshState = "REFRESH_SNAPSHOTTED"
+    /\ refreshState' = "REFRESH_INSTALLED"
+    /\ IF SAFE_MODE
+         THEN cachedFilteringMetadata' =
+                IF pendingRefreshVersion >= currentFilteringMetadata
+                    THEN pendingRefreshVersion
+                    ELSE currentFilteringMetadata
+         ELSE cachedFilteringMetadata' = pendingRefreshVersion
+    /\ UNCHANGED <<currentFilteringMetadata, pendingRefreshVersion, abortState,
+                   coordinatorCleanedUp, ddlsApplied, maxDDLVersionDuringWindow>>
+
+(****************************************************************************************************)
+(* Action: the coordinator cleans up the resharding coordinator document (ticket step 9). Enabled  *)
+(* once the recipient has acked the abort -- which happens at REFRESH_DISPATCHED. After this point *)
+(* the temp collection's authoritative metadata is gone and no further DDLs against the temp      *)
+(* collection are possible (modelled by guarding ConcurrentDDL with ~coordinatorCleanedUp).        *)
+(****************************************************************************************************)
+CoordinatorCleanup ==
+    /\ ~coordinatorCleanedUp
+    /\ abortState = "REFRESH_DISPATCHED"
+    /\ coordinatorCleanedUp' = TRUE
+    /\ UNCHANGED <<currentFilteringMetadata, cachedFilteringMetadata, pendingRefreshVersion,
+                   refreshState, abortState, ddlsApplied, maxDDLVersionDuringWindow>>
+
+(****************************************************************************************************)
+(* Stuttering termination. The abort flow is fully settled once the coordinator has cleaned up    *)
+(* AND the async refresh has installed. After that, allow infinite stuttering.                     *)
+(****************************************************************************************************)
+Terminating ==
+    /\ coordinatorCleanedUp
+    /\ refreshState = "REFRESH_INSTALLED"
+    /\ UNCHANGED vars
+
+Next ==
+    \/ ConcurrentDDL
+    \/ RecipientDropTempCollection
+    \/ RecipientClearFilteringMetadata
+    \/ RecipientDispatchRefresh
+    \/ AsyncRefreshSnapshot
+    \/ AsyncRefreshInstall
+    \/ CoordinatorCleanup
+    \/ Terminating
+
+Fairness ==
+    /\ WF_vars(RecipientDropTempCollection)
+    /\ WF_vars(RecipientClearFilteringMetadata)
+    /\ WF_vars(RecipientDispatchRefresh)
+    /\ WF_vars(AsyncRefreshSnapshot)
+    /\ WF_vars(AsyncRefreshInstall)
+    /\ WF_vars(CoordinatorCleanup)
+
+Spec == Init /\ [][Next]_vars /\ Fairness
+
+(****************************************************************************************************)
+(* Type invariants.                                                                                 *)
+(****************************************************************************************************)
+
+TypeOK ==
+    /\ currentFilteringMetadata \in Nat
+    /\ cachedFilteringMetadata \in Nat
+    /\ pendingRefreshVersion \in Nat
+    /\ refreshState \in RefreshStates
+    /\ abortState \in RecipientAbortStates
+    /\ coordinatorCleanedUp \in BOOLEAN
+    /\ ddlsApplied \in 0..MAX_DDLS
+    /\ maxDDLVersionDuringWindow \in Nat
+
+(****************************************************************************************************)
+(* Safety properties.                                                                               *)
+(****************************************************************************************************)
+
+\* The authoritative version is monotone. Sanity check on the spec.
+AuthoritativeMonotone == currentFilteringMetadata >= 1
+
+\* The pending refresh snapshot, once captured, cannot exceed currentFilteringMetadata + the
+\* number of remaining DDLs. Soft sanity bound on the spec; mostly useful to catch off-by-one
+\* mistakes.
+PendingRefreshBounded ==
+    refreshState \in {"REFRESH_SNAPSHOTTED", "REFRESH_INSTALLED"} =>
+        pendingRefreshVersion <= currentFilteringMetadata + MAX_DDLS
+
+\* Once a refresh has installed, the cache reflects either the snapshot it captured (buggy path)
+\* or a value at least as fresh (safe path). The cache is never older than the snapshot.
+RefreshInstallReflectsSnapshot ==
+    refreshState = "REFRESH_INSTALLED" =>
+        cachedFilteringMetadata >= pendingRefreshVersion
+
+(****************************************************************************************************)
+(* The main correctness property.                                                                   *)
+(*                                                                                                  *)
+(* After the abort flow terminates (refresh installed AND coordinator cleaned up), the recipient's *)
+(* cached filtering metadata for the temporary collection must either be cleared (NoVersion) -- the *)
+(* recipient knows it must refresh -- or must be at least the maximum authoritative version that   *)
+(* was ever published during the reshard window.                                                    *)
+(*                                                                                                  *)
+(* Concretely: if any DDL ran during the window and bumped the authoritative version to V, but the *)
+(* recipient ended the abort flow with `cachedFilteringMetadata = v < V`, the recipient is now    *)
+(* enforcing stale filtering metadata -- exactly the SERVER-90810 anomaly.                         *)
+(****************************************************************************************************)
+NoStaleFilteringInstalledOnAbort ==
+    (refreshState = "REFRESH_INSTALLED" /\ coordinatorCleanedUp) =>
+        (cachedFilteringMetadata = NoVersion
+         \/ cachedFilteringMetadata >= maxDDLVersionDuringWindow)
+
+(****************************************************************************************************)
+(* A second, slightly stronger phrasing of the safety property. Used as a bait/sanity invariant.   *)
+(* The cache is either cleared, or at least as fresh as whatever the refresh captured.             *)
+(****************************************************************************************************)
+NoCacheRegression ==
+    refreshState = "REFRESH_INSTALLED" =>
+        \/ cachedFilteringMetadata = NoVersion
+        \/ cachedFilteringMetadata >= pendingRefreshVersion
+
+(****************************************************************************************************)
+(* Liveness. The abort flow eventually settles: both the coordinator cleanup and the refresh       *)
+(* install must occur.                                                                              *)
+(****************************************************************************************************)
+AbortEventuallyCompletes ==
+    <>[](refreshState = "REFRESH_INSTALLED" /\ coordinatorCleanedUp)
+
+====================================================================================================


### PR DESCRIPTION
## Summary

TLA+ spec + jstest: resharding abort must not install stale filtering metadata.

**Jira:** https://jira.mongodb.org/browse/SERVER-126727
**Branch:** substrate-contrib/w4-16

## Files

```
  -  ...rding_abort_does_not_install_stale_filtering.js | 239 +++++++++++++++
  -  .../MCReshardingAbortFilteringMetadata.cfg         |  23 ++
  -  .../MCReshardingAbortFilteringMetadata.tla         |  64 ++++
  -  .../MCReshardingAbortFilteringMetadata_bug.cfg     |  37 +++
  -  .../ReshardingAbortFilteringMetadata.tla           | 322 +++++++++++++++++++++
  -  5 files changed, 685 insertions(+)
```

## Verify

For `.tla` files:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For `.js` jstests:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
