### PR TITLE
SERVER-126720 TLA+ spec + jstest: OplogProvider shutdown must not deadlock

### DIFF
--- a/jstests/noPassthrough/oplog/oplog_provider_shutdown_no_hang.js
+++ b/jstests/noPassthrough/oplog/oplog_provider_shutdown_no_hang.js
@@ -1,0 +1,99 @@
+/**
+ * Regression test for SERVER-125455: "Hang stopping OplogProvider and subsequent total mongod hang".
+ *
+ * The bug: OplogProvider::stop() invokes scopedExecutor->shutdown() followed by
+ * scopedExecutor->join(), then destructs the held OperationContext. If a consumer task
+ * scheduled on that executor is parked in an uninterruptible resource wait (the original
+ * report points at WT eviction under WiredTigerRecoveryUnit::_txnOpen), the only thing that
+ * could unblock it is marking its OperationContext as killed -- and that doesn't happen
+ * until after the join returns. join() waits forever, the OplogProvider thread never
+ * exits, and any subsequent shutdown command on mongod hangs in turn.
+ *
+ * This test:
+ *   1. Starts a single-node replica set so the oplog and any oplog-provider machinery
+ *      are exercised end-to-end.
+ *   2. Drives enough oplog activity to keep the provider's consumer paths warm during
+ *      the shutdown window.
+ *   3. Sends SIGTERM (MongoRunner.stopMongod's default) and asserts the process exits
+ *      within 30 seconds with a clean exit code. A hang would either blow past the
+ *      bound or escalate to SIGKILL and produce a non-zero exit code.
+ *
+ * The bound matches the timeout downstream operators use when triaging a stuck node;
+ * anything north of 30s is the failure mode SERVER-125455 describes.
+ *
+ * @tags: [
+ *   requires_replication,
+ *   requires_persistence,
+ * ]
+ */
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+const SHUTDOWN_BUDGET_MS = 30 * 1000;
+const SIGTERM = 15;
+
+const rst = new ReplSetTest({nodes: 1});
+rst.startSet();
+rst.initiate();
+
+const primary = rst.getPrimary();
+const db = primary.getDB("oplog_provider_shutdown_no_hang");
+const coll = db.getCollection("c");
+
+// Seed the oplog so any provider-side warm-up paths have material to operate on.
+const seedBulk = coll.initializeUnorderedBulkOp();
+for (let i = 0; i < 200; i++) {
+    seedBulk.insert({_id: i, payload: "x".repeat(64)});
+}
+assert.commandWorked(seedBulk.execute());
+
+// Background writers keep oplog activity flowing right up until shutdown. They're best
+// effort: the parallel shell will fail at shutdown time, which is expected.
+const writers = [];
+for (let w = 0; w < 4; w++) {
+    writers.push(
+        startParallelShell(
+            `
+            const db = db.getSiblingDB("oplog_provider_shutdown_no_hang");
+            const coll = db.getCollection("c");
+            let i = 1000 + ${w} * 100000;
+            try {
+                while (true) {
+                    assert.commandWorked(coll.insert({_id: i++, w: ${w}, payload: "y".repeat(96)}));
+                }
+            } catch (e) {
+                // The mongod is shutting down. Swallow the connection error and exit.
+            }
+        `,
+            primary.port,
+        ),
+    );
+}
+
+// Give the writers a moment to actually take effect.
+sleep(2000);
+
+jsTest.log.info("Sending SIGTERM to primary; expecting a clean exit within " + SHUTDOWN_BUDGET_MS + "ms.");
+const startMs = Date.now();
+const exitCode = MongoRunner.stopMongod(primary, SIGTERM, {waitpid: true});
+const elapsedMs = Date.now() - startMs;
+jsTest.log.info("mongod exited with code " + exitCode + " after " + elapsedMs + "ms.");
+
+assert.eq(
+    MongoRunner.EXIT_CLEAN,
+    exitCode,
+    "mongod did not shut down cleanly on SIGTERM (got " + exitCode + "); SERVER-125455 regression",
+);
+assert.lt(
+    elapsedMs,
+    SHUTDOWN_BUDGET_MS,
+    "mongod took " + elapsedMs + "ms to shut down on SIGTERM, exceeding the " + SHUTDOWN_BUDGET_MS +
+        "ms budget; SERVER-125455 regression (OplogProvider::stop deadlock)",
+);
+
+// Let the parallel shells unwind. They are expected to fail because the server is gone.
+for (const awaitWriter of writers) {
+    awaitWriter({checkExitSuccess: false});
+}
+
+// stopSet here is a no-op for the already-stopped node but keeps the harness happy.
+rst.stopSet();

--- a/src/mongo/tla_plus/Replication/OplogProviderShutdownLiveness/MCOplogProviderShutdownLiveness.cfg
+++ b/src/mongo/tla_plus/Replication/OplogProviderShutdownLiveness/MCOplogProviderShutdownLiveness.cfg
@@ -1,0 +1,19 @@
+\* Fix-ordering configuration: stop() kills consumer opCtxs *before* joining.
+\* The resource wait is uninterruptible-by-design (WT-eviction trap), so the
+\* only way liveness can hold is by killing the opCtx first.
+SPECIFICATION Spec
+
+CONSTANTS
+    Consumers = {c1, c2}
+    KillOpCtxBeforeJoin = TRUE
+    InterruptibleResource = FALSE
+
+INVARIANT
+    TypeOK
+    NoExitWhileBusy
+    KillOrderingHonored
+
+PROPERTY
+    ShutdownEventuallyExits
+    ConsumersEventuallyDone
+    JoinEventuallyReturns

--- a/src/mongo/tla_plus/Replication/OplogProviderShutdownLiveness/MCOplogProviderShutdownLiveness.tla
+++ b/src/mongo/tla_plus/Replication/OplogProviderShutdownLiveness/MCOplogProviderShutdownLiveness.tla
@@ -1,0 +1,19 @@
+------------------ MODULE MCOplogProviderShutdownLiveness ------------------
+\* Model-checking module for OplogProviderShutdownLiveness.
+
+EXTENDS OplogProviderShutdownLiveness
+
+(**************************************************************************************************)
+(* State constraints. None needed; the state space is already tiny.                                *)
+(**************************************************************************************************)
+
+(**************************************************************************************************)
+(* Counterexample baits, useful when toggling the configuration to the bug ordering.               *)
+(**************************************************************************************************)
+
+\* In the buggy ordering with an uninterruptible resource wait we expect
+\* ShutdownEventuallyExits to be falsified. Negating it as a bait invariant
+\* gives an explicit trace.
+BaitProviderEventuallyExits == providerState # "exited"
+
+============================================================================

--- a/src/mongo/tla_plus/Replication/OplogProviderShutdownLiveness/MCOplogProviderShutdownLiveness_bug.cfg
+++ b/src/mongo/tla_plus/Replication/OplogProviderShutdownLiveness/MCOplogProviderShutdownLiveness_bug.cfg
@@ -1,0 +1,29 @@
+\* Bug-ordering configuration: stop() joins *before* killing opCtxs, and the
+\* resource wait is uninterruptible-by-design. Reproduces SERVER-125455:
+\* TLC will report a liveness violation on ShutdownEventuallyExits with a
+\* trace where a consumer parks in the resource wait, the provider enters
+\* join(), and the only thing that could unblock the consumer (an opCtx
+\* kill) is gated until after exit -- a deadlock.
+\*
+\* Run with:
+\*   cp MCOplogProviderShutdownLiveness_bug.cfg MCOplogProviderShutdownLiveness.cfg
+\*   ../../model-check.sh Replication/OplogProviderShutdownLiveness
+\* or invoke TLC directly with this cfg.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    Consumers = {c1, c2}
+    KillOpCtxBeforeJoin = FALSE
+    InterruptibleResource = FALSE
+
+INVARIANT
+    TypeOK
+    NoExitWhileBusy
+    KillOrderingHonored
+    \* BaitProviderEventuallyExits  \* uncomment to surface trace as an invariant violation
+
+PROPERTY
+    ShutdownEventuallyExits
+    ConsumersEventuallyDone
+    JoinEventuallyReturns

--- a/src/mongo/tla_plus/Replication/OplogProviderShutdownLiveness/OWNERS.yml
+++ b/src/mongo/tla_plus/Replication/OplogProviderShutdownLiveness/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-storage-engine-integration

--- a/src/mongo/tla_plus/Replication/OplogProviderShutdownLiveness/OplogProviderShutdownLiveness.tla
+++ b/src/mongo/tla_plus/Replication/OplogProviderShutdownLiveness/OplogProviderShutdownLiveness.tla
@@ -1,0 +1,253 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+------------------------ MODULE OplogProviderShutdownLiveness ------------------------
+\* Models OplogProvider::stop() and a pool of consumer tasks scheduled on the
+\* provider's scoped executor. Captures the deadlock reported in SERVER-125455:
+\* the stop path performs
+\*
+\*   scopedExecutor->shutdown();
+\*   scopedExecutor->join();          // <-- waits forever
+\*   _state = nullptr;
+\*   _opCtxHolder = {};               // <-- destructed too late
+\*
+\* If a consumer task is blocked in an uninterruptible resource wait (e.g. WT
+\* eviction inside WiredTigerRecoveryUnit::_txnOpen), the only way to unblock
+\* it is to mark its OperationContext killed. The bug ordering kills the
+\* OperationContext only after the join returns -- which it never does -- so
+\* mongod hangs forever.
+\*
+\* The model has two switches:
+\*   * KillOpCtxBeforeJoin   = TRUE  -- the fix; stop() marks every consumer's
+\*                                      opCtx killed before waiting on join().
+\*                            FALSE -- the buggy ordering shipped today.
+\*   * InterruptibleResource = TRUE  -- the resource wait already polls
+\*                                      opCtx->checkForInterrupt(); models a
+\*                                      world without the eviction trap.
+\*                            FALSE -- the wait is uninterruptible until the
+\*                                      consumer's opCtx is killed; matches
+\*                                      the WT-eviction trap from the ticket.
+\*
+\* The two BAIT configs (MCOplogProviderShutdownLiveness_bug.cfg) flip these
+\* to the worst-case combination and let TLC produce the counterexample
+\* trace that hangs mongod.
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+
+CONSTANTS Consumers,             \* Set of consumer task identities.
+          KillOpCtxBeforeJoin,   \* TRUE = fix ordering; FALSE = current ordering.
+          InterruptibleResource  \* TRUE = resource wait honours opCtx; FALSE = WT trap.
+
+\* Provider thread (the one that runs OplogProvider::stop()).
+ProviderThread == "Provider"
+
+\* Provider state machine.
+\*   "idle"          steady state, consumers free to run.
+\*   "signalled"     stop() called, executor->shutdown() done; no new tasks accepted.
+\*   "joining"       blocked in executor->join() until every consumer is done.
+\*   "exited"        join returned and OplogProvider thread has exited.
+ProviderStates == {"idle", "signalled", "joining", "exited"}
+
+\* Consumer task state machine.
+\*   "running"       executing on the scoped executor, not currently blocked.
+\*   "blocked"       parked in a resource wait (e.g. WT eviction); only an
+\*                   interrupt or the resource freeing unblocks it.
+\*   "interrupted"   opCtx has been marked killed; consumer will unwind.
+\*   "done"          task finished and released its executor slot.
+ConsumerStates == {"running", "blocked", "interrupted", "done"}
+
+VARIABLES
+    providerState,   \* element of ProviderStates.
+    consumerState,   \* [Consumers -> ConsumerStates].
+    opCtxKilled,     \* [Consumers -> BOOLEAN]; TRUE once opCtx marked killed.
+    resourceFree     \* BOOLEAN; TRUE once the resource the consumer is parked on releases.
+
+vars == <<providerState, consumerState, opCtxKilled, resourceFree>>
+
+-----------------------------------------------------------------------------
+
+AllDone == \A c \in Consumers : consumerState[c] = "done"
+
+AnyBlocked == \E c \in Consumers : consumerState[c] = "blocked"
+
+\* In the buggy ordering, opCtxs are destructed (and therefore can't be killed
+\* in time) until *after* join() returns. We model that by gating the opCtx
+\* kill action on either the fix being enabled, or the provider having reached
+\* "exited" -- which it never does while a consumer is still blocked, so the
+\* condition reduces to "fix enabled" for the deadlock scenarios we care about.
+CanKillOpCtx ==
+    \/ KillOpCtxBeforeJoin
+    \/ providerState = "exited"
+
+-----------------------------------------------------------------------------
+
+Init ==
+    /\ providerState = "idle"
+    /\ consumerState = [c \in Consumers |-> "running"]
+    /\ opCtxKilled = [c \in Consumers |-> FALSE]
+    /\ resourceFree = FALSE
+
+\* A running consumer parks on an external resource (models WT eviction etc.).
+ConsumerBlocksOnResource(c) ==
+    /\ consumerState[c] = "running"
+    /\ consumerState' = [consumerState EXCEPT ![c] = "blocked"]
+    /\ UNCHANGED <<providerState, opCtxKilled, resourceFree>>
+
+\* The external resource finishes on its own (the eviction front clears).
+ResourceReleases ==
+    /\ ~resourceFree
+    /\ resourceFree' = TRUE
+    /\ UNCHANGED <<providerState, consumerState, opCtxKilled>>
+
+\* A blocked consumer wakes because the resource finally released. Only valid
+\* when the wait is interruptible-by-resource OR the resource has freed.
+ConsumerWakesOnResource(c) ==
+    /\ consumerState[c] = "blocked"
+    /\ resourceFree
+    /\ consumerState' = [consumerState EXCEPT ![c] = "running"]
+    /\ UNCHANGED <<providerState, opCtxKilled, resourceFree>>
+
+\* The provider thread observes a shutdown request and calls
+\* scopedExecutor->shutdown(). No new tasks are accepted after this; live
+\* tasks keep running until they reach a yield point.
+SignalShutdown ==
+    /\ providerState = "idle"
+    /\ providerState' = "signalled"
+    /\ UNCHANGED <<consumerState, opCtxKilled, resourceFree>>
+
+\* The fix: mark every consumer's opCtx killed before entering join().
+\* Idempotent; running this once is enough but the spec allows re-firing.
+KillAllConsumerOpCtxs ==
+    /\ providerState = "signalled"
+    /\ KillOpCtxBeforeJoin
+    /\ opCtxKilled' = [c \in Consumers |-> TRUE]
+    /\ UNCHANGED <<providerState, consumerState, resourceFree>>
+
+\* Provider enters executor->join(); it will not progress until every
+\* consumer is in "done". With the fix ordering, the provider is required
+\* to mark every consumer's opCtx killed *before* entering join() -- that's
+\* the whole point of the patch. Without the fix, EnterJoin is free to fire
+\* immediately after SignalShutdown, modelling today's broken ordering.
+EnterJoin ==
+    /\ providerState = "signalled"
+    /\ KillOpCtxBeforeJoin => \A c \in Consumers : opCtxKilled[c]
+    /\ providerState' = "joining"
+    /\ UNCHANGED <<consumerState, opCtxKilled, resourceFree>>
+
+\* A consumer notices its opCtx has been killed and unwinds out of the
+\* resource wait. If the wait is uninterruptible-by-design (WT trap),
+\* the opCtx kill is the only thing that can unblock it.
+ConsumerObservesKill(c) ==
+    /\ consumerState[c] \in {"running", "blocked"}
+    /\ opCtxKilled[c]
+    /\ consumerState' = [consumerState EXCEPT ![c] = "interrupted"]
+    /\ UNCHANGED <<providerState, opCtxKilled, resourceFree>>
+
+\* An interrupted (or running, if it cooperatively yielded) consumer finishes
+\* its task and releases its executor slot.
+ConsumerFinishes(c) ==
+    /\ consumerState[c] \in {"running", "interrupted"}
+    /\ \/ consumerState[c] = "interrupted"
+       \/ providerState \in {"signalled", "joining"}
+    /\ consumerState' = [consumerState EXCEPT ![c] = "done"]
+    /\ UNCHANGED <<providerState, opCtxKilled, resourceFree>>
+
+\* Optional: a blocked consumer whose resource wait is interruptible can self
+\* unblock once the resource releases without an opCtx kill. Models the
+\* "no WT trap" branch.
+ConsumerSelfUnblocks(c) ==
+    /\ InterruptibleResource
+    /\ consumerState[c] = "blocked"
+    /\ resourceFree
+    /\ consumerState' = [consumerState EXCEPT ![c] = "running"]
+    /\ UNCHANGED <<providerState, opCtxKilled, resourceFree>>
+
+\* join() returns once every consumer is done; the OplogProvider thread exits.
+JoinReturnsAndExit ==
+    /\ providerState = "joining"
+    /\ AllDone
+    /\ providerState' = "exited"
+    /\ UNCHANGED <<consumerState, opCtxKilled, resourceFree>>
+
+\* After exit the buggy ordering destructs _opCtxHolder. We model that by
+\* allowing opCtx kill to fire post-exit -- it is harmless because every
+\* consumer is already "done" -- and it preserves the (TLA) invariant that
+\* opCtxKilled is monotone.
+LateOpCtxKill ==
+    /\ providerState = "exited"
+    /\ ~KillOpCtxBeforeJoin
+    /\ opCtxKilled' = [c \in Consumers |-> TRUE]
+    /\ UNCHANGED <<providerState, consumerState, resourceFree>>
+
+-----------------------------------------------------------------------------
+
+Next ==
+    \/ \E c \in Consumers : ConsumerBlocksOnResource(c)
+    \/ ResourceReleases
+    \/ \E c \in Consumers : ConsumerWakesOnResource(c)
+    \/ SignalShutdown
+    \/ KillAllConsumerOpCtxs
+    \/ EnterJoin
+    \/ \E c \in Consumers : ConsumerObservesKill(c)
+    \/ \E c \in Consumers : ConsumerFinishes(c)
+    \/ \E c \in Consumers : ConsumerSelfUnblocks(c)
+    \/ JoinReturnsAndExit
+    \/ LateOpCtxKill
+
+\* Fairness:
+\*  - The provider thread itself is fair (must eventually signal, kill, join, exit).
+\*  - Every consumer must eventually finish if it can.
+\*  - The resource is *not* assumed to release on its own; that's the whole point
+\*    of the WT-eviction trap. Liveness has to come from the opCtx-kill path.
+Spec ==
+    /\ Init
+    /\ [][Next]_vars
+    /\ WF_vars(SignalShutdown)
+    /\ WF_vars(KillAllConsumerOpCtxs)
+    /\ WF_vars(EnterJoin)
+    /\ WF_vars(JoinReturnsAndExit)
+    /\ \A c \in Consumers : /\ WF_vars(ConsumerObservesKill(c))
+                            /\ WF_vars(ConsumerFinishes(c))
+
+-----------------------------------------------------------------------------
+\* Invariants
+-----------------------------------------------------------------------------
+
+TypeOK ==
+    /\ providerState \in ProviderStates
+    /\ consumerState \in [Consumers -> ConsumerStates]
+    /\ opCtxKilled \in [Consumers -> BOOLEAN]
+    /\ resourceFree \in BOOLEAN
+
+\* The provider must not advance to "exited" while any consumer task is still
+\* live -- that would be an executor bug (join returned with tasks running).
+NoExitWhileBusy ==
+    providerState = "exited" => AllDone
+
+\* Buggy ordering invariant: in the broken world we never kill opCtxs before
+\* join. This is a sanity guard, not a correctness property.
+KillOrderingHonored ==
+    (~KillOpCtxBeforeJoin /\ providerState \in {"idle", "signalled", "joining"})
+        => \A c \in Consumers : ~opCtxKilled[c]
+
+-----------------------------------------------------------------------------
+\* Liveness
+-----------------------------------------------------------------------------
+
+\* Headline property: a stop signal eventually unwinds every consumer and the
+\* OplogProvider thread reaches "exited". This is what SERVER-125455 violates.
+ShutdownEventuallyExits ==
+    (providerState = "signalled") ~> (providerState = "exited")
+
+\* Every consumer eventually reaches "done" once shutdown is signalled.
+ConsumersEventuallyDone ==
+    \A c \in Consumers :
+        (providerState = "signalled") ~> (consumerState[c] = "done")
+
+\* If we ever enter join(), we eventually leave it.
+JoinEventuallyReturns ==
+    (providerState = "joining") ~> (providerState = "exited")
+=====================================================================================


### PR DESCRIPTION
## Summary

TLA+ spec + jstest: OplogProvider shutdown must not deadlock.

**Jira:** https://jira.mongodb.org/browse/SERVER-126720
**Branch:** substrate-contrib/w4-19

## Files

```
  -  .../oplog/oplog_provider_shutdown_no_hang.js       |  99 ++++++++
  -  .../MCOplogProviderShutdownLiveness.cfg            |  19 ++
  -  .../MCOplogProviderShutdownLiveness.tla            |  19 ++
  -  .../MCOplogProviderShutdownLiveness_bug.cfg        |  29 +++
  -  .../OplogProviderShutdownLiveness/OWNERS.yml       |   5 +
  -  .../OplogProviderShutdownLiveness.tla              | 253 +++++++++++++++++++++
  -  6 files changed, 424 insertions(+)
```

## Verify

For `.tla` files:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For `.js` jstests:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
