### PR TITLE
SERVER-126721 TLA+ spec + jstest: standby loop must not race becomePrimary on step-up

### DIFF
--- a/jstests/replsets/standby_loop_does_not_race_become_primary.js
+++ b/jstests/replsets/standby_loop_does_not_race_become_primary.js
@@ -1,0 +1,157 @@
+/**
+ * Regression test for the standby-loop / becomePrimary() race in the disaggregated
+ * replication coordinator. During step-up, stepUpIfEligible() calls
+ * cancelStateMachine() + stateMachineJoin() *before* acquiring the RSTL, but then
+ * spends measurable time acquiring the RSTL and other locks before reaching
+ * accept(kStepUp) / becomePrimary(). A queued accept(kDisconnected) callback can
+ * fire on a different thread in that window, calling reconnectAsSecondary() and
+ * starting a fresh standby loop. When becomePrimary() subsequently tears down or
+ * rebinds the underlying gRPC stream, the racing standby loop's first
+ * ClientReader::Read() trips a fatal CallOpRecvInitialMetadata assertion inside
+ * gRPC.
+ *
+ * The TLA+ companion spec (src/mongo/tla_plus/Replication/StandbyStepUpRace)
+ * proves NoConcurrentStandbyAndBecomePrimary under the fix and exhibits a
+ * counter-example trace ending in grpcFatal = TRUE under the bug configuration.
+ *
+ * This test exercises the same window against a real mongod: it forces a step-up
+ * after slowing the standby exit path with a failpoint so that a Disconnected
+ * dispatch has the widest possible window to race becomePrimary(). The test then
+ * asserts that:
+ *   1) replSetStepUp succeeds and the target node ends up as primary,
+ *   2) no fatal gRPC assertion was logged on any node, and
+ *   3) no tassert / invariant failure was logged on any node.
+ *
+ * Tags: replica_sets only; the disagg failpoint is a non-fatal probe (the test
+ * still asserts the no-fatal contract on builds where the failpoint is absent,
+ * which is the safety guarantee SERVER-126278 fixes).
+ *
+ * @tags: [
+ *   requires_replication,
+ * ]
+ */
+
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+const kStandbySlowdownFailpoint = "hangBeforeStandbyExitDuringStepUp";
+
+const rst = new ReplSetTest({
+    name: jsTestName(),
+    nodes: 3,
+    settings: {chainingAllowed: false, catchUpTimeoutMillis: 0},
+});
+
+rst.startSet();
+rst.initiate();
+
+const originalPrimary = rst.getPrimary();
+const newPrimary = rst.getSecondaries()[0];
+const witness = rst.getSecondaries()[1];
+
+assert.commandWorked(
+    originalPrimary.getDB("test").runCommand({insert: "c", documents: [{_id: 0}], writeConcern: {w: "majority"}}),
+);
+rst.awaitReplication();
+
+// Try to install the slowdown failpoint on the prospective new primary so the
+// standby-loop exit path stalls during the step-up handler. If the build is
+// compiled without the disagg replication coordinator, this failpoint will not
+// exist; in that case we still proceed with the no-fatal assertion, which is
+// the load-bearing guarantee of the fix.
+let standbyFp = null;
+let standbyFpInstalled = false;
+try {
+    standbyFp = configureFailPoint(newPrimary, kStandbySlowdownFailpoint, {}, "alwaysOn");
+    standbyFpInstalled = true;
+    jsTestLog(`Installed ${kStandbySlowdownFailpoint} on ${newPrimary.host} to widen the race window.`);
+} catch (e) {
+    // Failpoint not registered in this build (disagg replication coordinator
+    // not compiled in). We continue: the post-step-up log assertions are still
+    // valid and would catch the race if it occurred.
+    jsTestLog(
+        `Failpoint ${kStandbySlowdownFailpoint} not available on ${newPrimary.host} ` +
+            `(likely not a disagg build). Proceeding without slowdown; log assertions still active. ` +
+            `Error: ${tojson(e)}`,
+    );
+}
+
+// Trigger a step-up. We retry because the original primary may step down and
+// briefly reject the request, mirroring the canonical jstests/replsets/stepup.js
+// pattern.
+let numStepUpCmds = 0;
+assert.soonNoExcept(function () {
+    numStepUpCmds++;
+    return newPrimary.adminCommand({replSetStepUp: 1}).ok;
+}, "replSetStepUp never succeeded against new primary");
+
+// If we installed the failpoint, let the standby exit unblock now -- the
+// race window has been opened wide enough that any Disconnected callback
+// queued during step-up has had a chance to interleave.
+if (standbyFpInstalled) {
+    try {
+        standbyFp.off();
+    } catch (e) {
+        // If the node was tassert'd, turning the failpoint off may fail. Let
+        // the log assertions below report the actual problem.
+        jsTestLog(`Failed to disable failpoint (node may already be down): ${tojson(e)}`);
+    }
+}
+
+// Confirm step-up succeeded.
+rst.awaitNodesAgreeOnPrimary(rst.timeoutMS, rst.nodes, newPrimary);
+assert.eq(newPrimary, rst.getPrimary(), "new primary did not win the step-up");
+
+// Drive a tiny write through the new primary to prove it can act as primary.
+assert.commandWorked(
+    newPrimary.getDB("test").runCommand({insert: "c", documents: [{_id: 1}], writeConcern: {w: "majority"}}),
+);
+rst.awaitReplication();
+
+// Inspect captured stdout/stderr for fatal gRPC assertions and tasserts. The
+// stack trace in SERVER-126278 contains both an absl log_internal::LogMessage
+// FailWithoutStackTrace frame and the grpc_core::FilterStackCall::ExternalUnref
+// teardown -- either signature is sufficient evidence of the race.
+const programOutput = rawMongoProgramOutput(".*");
+const fatalGrpcSignatures = [
+    "FilterStackCall::ExternalUnref",
+    "CallOpRecvInitialMetadata",
+    "log_internal::LogMessage::FailWithoutStackTrace",
+];
+for (const sig of fatalGrpcSignatures) {
+    assert.eq(
+        false,
+        programOutput.includes(sig),
+        `Found fatal gRPC signature '${sig}' in mongod output; ` +
+            `SERVER-126278 race may have triggered. Step-up retries=${numStepUpCmds}, ` +
+            `failpoint installed=${standbyFpInstalled}.`,
+    );
+}
+
+// Any tassert / invariant / fatal-assertion log on any node fails the test.
+// We scan rawMongoProgramOutput rather than each node's log file so we catch
+// crashes that happened before the test could even open a connection.
+const fatalTassertSignatures = ["Fatal assertion", "Invariant failure", "tassert"];
+for (const sig of fatalTassertSignatures) {
+    // tassert is a very common substring in healthy logs (e.g. "tasserted")
+    // only when followed by a numeric ID; tighten the match for that case.
+    const pattern = sig === "tassert" ? /tassert \d+/ : new RegExp(sig);
+    assert.eq(
+        false,
+        pattern.test(programOutput),
+        `Found '${sig}' in mongod output; step-up path tripped a fatal. ` +
+            `Step-up retries=${numStepUpCmds}, failpoint installed=${standbyFpInstalled}.`,
+    );
+}
+
+// Make sure the witness third node is still healthy and agrees on the primary.
+const witnessStatus = assert.commandWorked(witness.adminCommand({replSetGetStatus: 1}));
+const primaryMembers = witnessStatus.members.filter((m) => m.stateStr === "PRIMARY");
+assert.eq(1, primaryMembers.length, `Witness sees ${primaryMembers.length} primaries; expected exactly 1.`);
+assert.eq(
+    newPrimary.host,
+    primaryMembers[0].name,
+    `Witness primary is ${primaryMembers[0].name}; expected ${newPrimary.host}.`,
+);
+
+rst.stopSet();

--- a/src/mongo/tla_plus/Replication/StandbyStepUpRace/MCStandbyStepUpRace.cfg
+++ b/src/mongo/tla_plus/Replication/StandbyStepUpRace/MCStandbyStepUpRace.cfg
@@ -1,0 +1,31 @@
+\* Config file to run TLC on StandbyStepUpRace.tla with the FIX in place.
+\*
+\* fixEnabled is pinned TRUE by InitFix. All invariants must hold.
+\*
+\* To reproduce the bug instead, use MCStandbyStepUpRaceBug.cfg.
+
+SPECIFICATION SpecFix
+
+CONSTANTS
+    Workers = {w1, w2}
+    Secondary = Secondary
+    BecomingPrimary = BecomingPrimary
+    Primary = Primary
+    StandbyIdle = StandbyIdle
+    StandbyRunning = StandbyRunning
+    StandbyJoined = StandbyJoined
+    Disconnected = Disconnected
+    StepUp = StepUp
+
+CONSTRAINT
+    StateConstraint
+
+INVARIANT
+    TypeOK
+    HolderPhaseConsistent
+    NoConcurrentStandbyAndBecomePrimary
+    StandbyAndStepUpExclusive
+    NoGrpcFatal
+
+PROPERTY
+    StepUpEventuallyCompletes

--- a/src/mongo/tla_plus/Replication/StandbyStepUpRace/MCStandbyStepUpRace.tla
+++ b/src/mongo/tla_plus/Replication/StandbyStepUpRace/MCStandbyStepUpRace.tla
@@ -1,0 +1,72 @@
+------------------------------ MODULE MCStandbyStepUpRace --------------------------------
+\* Model-checking module for StandbyStepUpRace. See StandbyStepUpRace.tla.
+
+EXTENDS StandbyStepUpRace
+
+(**************************************************************************************************)
+(* Initial-state overrides.                                                                       *)
+(*                                                                                                *)
+(* The base Init lets fixEnabled range over BOOLEAN so a single spec admits     *)
+(* both worlds. The two MC cfgs use these initial predicates to pin the world    *)
+(* under test:                                                                  *)
+(*   - InitFix    : fixEnabled = TRUE  (the fix is in; invariants must hold)    *)
+(*   - InitBug    : fixEnabled = FALSE (the buggy world; counter-examples shown)*)
+(**************************************************************************************************)
+
+InitFix ==
+    /\ role = Secondary
+    /\ standby = StandbyRunning
+    /\ stepUpHolder = NONE
+    /\ stepUpPhase = "idle"
+    /\ callbackQueue = <<>>
+    /\ grpcFatal = FALSE
+    /\ fixEnabled = TRUE
+
+InitBug ==
+    /\ role = Secondary
+    /\ standby = StandbyRunning
+    /\ stepUpHolder = NONE
+    /\ stepUpPhase = "idle"
+    /\ callbackQueue = <<>>
+    /\ grpcFatal = FALSE
+    /\ fixEnabled = FALSE
+
+SpecFix == InitFix /\ [][Next]_vars
+    /\ \A w \in Workers : WF_vars(StepUpJoin(w))
+    /\ \A w \in Workers : WF_vars(StepUpAcquireRSTL(w))
+    /\ \A w \in Workers : WF_vars(StepUpBecomePrimary(w))
+    /\ \A w \in Workers : WF_vars(StepUpRelease(w))
+
+SpecBug == InitBug /\ [][Next]_vars
+    /\ \A w \in Workers : WF_vars(StepUpJoin(w))
+    /\ \A w \in Workers : WF_vars(StepUpAcquireRSTL(w))
+    /\ \A w \in Workers : WF_vars(StepUpBecomePrimary(w))
+    /\ \A w \in Workers : WF_vars(StepUpRelease(w))
+
+(**************************************************************************************************)
+(* State constraints to keep the model finite.                                                   *)
+(**************************************************************************************************)
+
+\* Hard bound on the callback queue (also enforced inline in the actions; this
+\* is the global state-space cap for the model checker).
+QueueLimit == Len(callbackQueue) <= 3
+
+\* Once a fatal has been reached we stop generating new events; the fatal
+\* state is absorbing in the bug cfg and we don't need TLC to explore beyond.
+NoMoreEventsAfterFatal == grpcFatal => callbackQueue = <<>>
+
+StateConstraint == QueueLimit /\ NoMoreEventsAfterFatal
+
+(**************************************************************************************************)
+(* Counterexamples / bait invariants.                                                            *)
+(*                                                                                                *)
+(* In the BUG cfg, BaitNoFatal is supplied as an invariant; TLC reports a       *)
+(* counter-example trace ending in grpcFatal = TRUE -- the standby/becomePrimary*)
+(* race materialised. Under the FIX cfg, BaitNoFatal is redundant with          *)
+(* NoGrpcFatal but kept here so the two cfgs differ only in which Init / Spec   *)
+(* they bind.                                                                   *)
+(**************************************************************************************************)
+
+BaitNoFatal == ~grpcFatal
+
+=================================================================================================

--- a/src/mongo/tla_plus/Replication/StandbyStepUpRace/MCStandbyStepUpRaceBug.cfg
+++ b/src/mongo/tla_plus/Replication/StandbyStepUpRace/MCStandbyStepUpRaceBug.cfg
@@ -1,0 +1,38 @@
+\* Config file that demonstrates the bug. fixEnabled is pinned FALSE.
+\*
+\* TLC should report a violation of NoConcurrentStandbyAndBecomePrimary
+\* (equivalently NoGrpcFatal). The counter-example trace shows:
+\*   1. Init: standby running, no step-up.
+\*   2. EnqueueStepUp.
+\*   3. StepUpJoin: standby joined, role -> BecomingPrimary.
+\*   4. EnqueueDisconnected.
+\*   5. DispatchDisconnected (without fix gate): standby restarts -> StandbyRunning
+\*      while role still = BecomingPrimary.
+\*   6. StepUpAcquireRSTL.
+\*   7. StepUpBecomePrimary: standby still Running AND role = BecomingPrimary,
+\*      so grpcFatal := TRUE -- the race window the ticket describes.
+\*
+\* This is the canonical reproduction the jstest exercises against a real
+\* mongod (see jstests/replsets/standby_loop_does_not_race_become_primary.js).
+
+SPECIFICATION SpecBug
+
+CONSTANTS
+    Workers = {w1, w2}
+    Secondary = Secondary
+    BecomingPrimary = BecomingPrimary
+    Primary = Primary
+    StandbyIdle = StandbyIdle
+    StandbyRunning = StandbyRunning
+    StandbyJoined = StandbyJoined
+    Disconnected = Disconnected
+    StepUp = StepUp
+
+CONSTRAINT
+    StateConstraint
+
+INVARIANT
+    TypeOK
+    HolderPhaseConsistent
+    NoGrpcFatal
+    NoConcurrentStandbyAndBecomePrimary

--- a/src/mongo/tla_plus/Replication/StandbyStepUpRace/OWNERS.yml
+++ b/src/mongo/tla_plus/Replication/StandbyStepUpRace/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-replication-reviewers

--- a/src/mongo/tla_plus/Replication/StandbyStepUpRace/StandbyStepUpRace.tla
+++ b/src/mongo/tla_plus/Replication/StandbyStepUpRace/StandbyStepUpRace.tla
@@ -1,0 +1,260 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+------------------------------- MODULE StandbyStepUpRace --------------------------------
+\* Models the standby loop / becomePrimary() race observed during step-up in the
+\* disaggregated replication coordinator. See SERVER-126278.
+\*
+\* The setup: stepUpIfEligible() runs the following sequence on a worker thread:
+\*
+\*   1. cancelStateMachine()        \* stop any active state-machine processing
+\*   2. stateMachineJoin()          \* drain pending state-machine work (joins active standby loop)
+\*   3. acquire RSTL (and others)   \* this can block / take measurable time
+\*   4. accept(kStepUp)             \* enqueue/process the StepUp transition
+\*   5. becomePrimary()             \* construct primary log writer, etc.
+\*
+\* Concurrently, a separate state-machine queue can deliver an
+\* accept(kDisconnected) callback on a *different* thread. That callback runs
+\* reconnectAsSecondary(), which starts a fresh standby loop. The bug is that
+\* step 2 only joins state-machine work that already exists; an accept(kDisconnected)
+\* enqueued AFTER stateMachineJoin() but BEFORE accept(kStepUp) reaches
+\* becomePrimary() will spin up a new standby loop that races with becomePrimary().
+\* When becomePrimary() tears down or rebinds the gRPC stream that the new
+\* standby loop holds, the standby loop's first ClientReader::Read() trips the
+\* fatal CallOpRecvInitialMetadata assertion inside gRPC.
+\*
+\* The fix being modelled: once stepUpIfEligible() has committed to performing
+\* a step-up, no accept(kDisconnected)/reconnectAsSecondary() may start a new
+\* standby loop until becomePrimary() has run to completion. Equivalently, an
+\* active standby loop and an in-flight becomePrimary() are mutually exclusive.
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+
+CONSTANTS Workers   \* Set of worker thread identifiers that can run callbacks.
+
+\* The substrate role on the node.
+CONSTANTS Secondary,        \* Node is acting as a secondary; standby loop runs.
+          BecomingPrimary,  \* Step-up sequence is mid-flight, between RSTL acquired and becomePrimary done.
+          Primary           \* Node is fully primary; no standby loop.
+
+\* The lifecycle of the standby loop itself.
+CONSTANTS StandbyIdle,      \* No standby loop is running.
+          StandbyRunning,   \* A standby loop has been started; its first ClientReader::Read() has not yet returned.
+          StandbyJoined     \* The standby loop has been cancelled and joined (terminal for that instance).
+
+\* Pending callbacks that the state machine can dispatch.
+CONSTANTS Disconnected, StepUp
+
+VARIABLES role,            \* element of {Secondary, BecomingPrimary, Primary}
+          standby,         \* element of {StandbyIdle, StandbyRunning, StandbyJoined}
+          stepUpHolder,    \* Worker currently driving stepUpIfEligible(), or NONE.
+          stepUpPhase,     \* "idle" | "joined" | "rstlHeld" | "primary"
+          callbackQueue,   \* Sequence of pending callbacks: each is [kind |-> Disconnected|StepUp, worker |-> w].
+          grpcFatal,       \* TRUE once the race has tripped the gRPC fatal assertion.
+          fixEnabled       \* TRUE = fix in place (standby loop creation gated on step-up); FALSE = bug cfg.
+
+vars == <<role, standby, stepUpHolder, stepUpPhase, callbackQueue, grpcFatal, fixEnabled>>
+
+NONE == "NONE"
+
+-----------------------------------------------------------------------------
+\* Helpers.
+-----------------------------------------------------------------------------
+
+\* TRUE if a worker is currently executing the step-up critical section that
+\* covers RSTL-acquisition through becomePrimary().
+StepUpInFlight ==
+    /\ stepUpHolder /= NONE
+    /\ stepUpPhase \in {"joined", "rstlHeld"}
+
+\* TRUE once becomePrimary() has run.
+BecomePrimaryDone == stepUpPhase = "primary"
+
+\* TRUE if the standby loop's gRPC stream is in a state where a concurrent
+\* becomePrimary() teardown will fatal it. In the real system, this is the
+\* window between starting the standby loop and the first Read() returning,
+\* during which CallOpRecvInitialMetadata is bound to the call. We model that
+\* as: standby is StandbyRunning AND becomePrimary() either has run or is
+\* running concurrently on another worker.
+StandbyExposedToFatal ==
+    /\ standby = StandbyRunning
+    /\ role = BecomingPrimary
+
+-----------------------------------------------------------------------------
+\* Initial state.
+-----------------------------------------------------------------------------
+
+Init ==
+    /\ role = Secondary
+    /\ standby = StandbyRunning      \* a standby loop is running on a secondary
+    /\ stepUpHolder = NONE
+    /\ stepUpPhase = "idle"
+    /\ callbackQueue = <<>>
+    /\ grpcFatal = FALSE
+    /\ fixEnabled \in BOOLEAN
+
+-----------------------------------------------------------------------------
+\* External events that enqueue state-machine callbacks.
+\*
+\* A network blip can enqueue accept(kDisconnected). A replSetStepUp command or
+\* election win can enqueue accept(kStepUp). Real subsystems can enqueue either
+\* at any moment; we permit interleavings inside fairness guards.
+-----------------------------------------------------------------------------
+
+EnqueueDisconnected(w) ==
+    /\ Len(callbackQueue) < 3   \* state-bound for the model checker
+    /\ callbackQueue' = Append(callbackQueue, [kind |-> Disconnected, worker |-> w])
+    /\ UNCHANGED <<role, standby, stepUpHolder, stepUpPhase, grpcFatal, fixEnabled>>
+
+EnqueueStepUp(w) ==
+    /\ Len(callbackQueue) < 3
+    /\ stepUpHolder = NONE
+    /\ callbackQueue' = Append(callbackQueue, [kind |-> StepUp, worker |-> w])
+    /\ UNCHANGED <<role, standby, stepUpHolder, stepUpPhase, grpcFatal, fixEnabled>>
+
+-----------------------------------------------------------------------------
+\* Step-up sequence on a worker thread, modelled in phases so that a separate
+\* worker can interleave a Disconnected dispatch between them.
+-----------------------------------------------------------------------------
+
+\* Phase 1: stepUpIfEligible() picks up the StepUp callback and runs
+\* cancelStateMachine()+stateMachineJoin(). Whatever standby loop existed at
+\* this moment is joined.
+StepUpJoin(w) ==
+    /\ stepUpHolder = NONE
+    /\ stepUpPhase = "idle"
+    /\ Len(callbackQueue) > 0
+    /\ Head(callbackQueue).kind = StepUp
+    /\ stepUpHolder' = w
+    /\ stepUpPhase' = "joined"
+    /\ callbackQueue' = Tail(callbackQueue)
+    /\ standby' = StandbyJoined
+    /\ role' = BecomingPrimary
+    /\ UNCHANGED <<grpcFatal, fixEnabled>>
+
+\* Phase 2: acquire RSTL (and any other locks). Nothing about the standby
+\* state changes here, but time passes during which other workers can run.
+StepUpAcquireRSTL(w) ==
+    /\ stepUpHolder = w
+    /\ stepUpPhase = "joined"
+    /\ stepUpPhase' = "rstlHeld"
+    /\ UNCHANGED <<role, standby, stepUpHolder, callbackQueue, grpcFatal, fixEnabled>>
+
+\* Phase 3: accept(kStepUp) reaches becomePrimary(). If the fix is enabled and
+\* a standby loop is running concurrently, this is the moment the contract
+\* says cannot happen; under the bug configuration we record the fatal.
+StepUpBecomePrimary(w) ==
+    /\ stepUpHolder = w
+    /\ stepUpPhase = "rstlHeld"
+    /\ stepUpPhase' = "primary"
+    /\ role' = Primary
+    /\ grpcFatal' = (grpcFatal \/ StandbyExposedToFatal)
+    /\ UNCHANGED <<standby, stepUpHolder, callbackQueue, fixEnabled>>
+
+\* Phase 4: step-up worker releases the role. Returning the holder to NONE
+\* makes the spec re-enterable for liveness checking.
+StepUpRelease(w) ==
+    /\ stepUpHolder = w
+    /\ stepUpPhase = "primary"
+    /\ stepUpHolder' = NONE
+    /\ stepUpPhase' = "idle"
+    /\ UNCHANGED <<role, standby, callbackQueue, grpcFatal, fixEnabled>>
+
+-----------------------------------------------------------------------------
+\* Disconnected callback: reconnectAsSecondary() starts a fresh standby loop.
+\*
+\* fixEnabled = FALSE  -- the buggy world: a Disconnected callback can fire
+\*                        even while StepUpInFlight, racing becomePrimary().
+\* fixEnabled = TRUE   -- the fix: while a step-up is in flight, a Disconnected
+\*                        callback either defers or runs only after becomePrimary()
+\*                        has returned (i.e. while role /= BecomingPrimary).
+-----------------------------------------------------------------------------
+
+DispatchDisconnected(w) ==
+    /\ Len(callbackQueue) > 0
+    /\ Head(callbackQueue).kind = Disconnected
+    /\ callbackQueue' = Tail(callbackQueue)
+    /\ IF fixEnabled
+       \* The fix gates Disconnected dispatch on "no in-flight step-up". The
+       \* gate is checked atomically with picking up the callback, modelled
+       \* here by tying the enabling clause to the role variable.
+       THEN /\ role /= BecomingPrimary
+            /\ standby' = StandbyRunning
+            /\ UNCHANGED <<role, stepUpHolder, stepUpPhase, grpcFatal, fixEnabled>>
+       \* No gate: a Disconnected callback can land mid-step-up.
+       ELSE /\ standby' = StandbyRunning
+            /\ UNCHANGED <<role, stepUpHolder, stepUpPhase, grpcFatal, fixEnabled>>
+
+-----------------------------------------------------------------------------
+\* Next state relation.
+-----------------------------------------------------------------------------
+
+Next ==
+    \/ \E w \in Workers : EnqueueStepUp(w)
+    \/ \E w \in Workers : EnqueueDisconnected(w)
+    \/ \E w \in Workers : StepUpJoin(w)
+    \/ \E w \in Workers : StepUpAcquireRSTL(w)
+    \/ \E w \in Workers : StepUpBecomePrimary(w)
+    \/ \E w \in Workers : StepUpRelease(w)
+    \/ \E w \in Workers : DispatchDisconnected(w)
+
+Spec ==
+    /\ Init
+    /\ [][Next]_vars
+    \* Weak fairness: any pending step-up phase eventually advances.
+    /\ \A w \in Workers : WF_vars(StepUpJoin(w))
+    /\ \A w \in Workers : WF_vars(StepUpAcquireRSTL(w))
+    /\ \A w \in Workers : WF_vars(StepUpBecomePrimary(w))
+    /\ \A w \in Workers : WF_vars(StepUpRelease(w))
+
+-----------------------------------------------------------------------------
+\* Type / sanity invariants.
+-----------------------------------------------------------------------------
+
+TypeOK ==
+    /\ role \in {Secondary, BecomingPrimary, Primary}
+    /\ standby \in {StandbyIdle, StandbyRunning, StandbyJoined}
+    /\ stepUpHolder \in (Workers \union {NONE})
+    /\ stepUpPhase \in {"idle", "joined", "rstlHeld", "primary"}
+    /\ grpcFatal \in BOOLEAN
+    /\ fixEnabled \in BOOLEAN
+    /\ \A i \in 1..Len(callbackQueue) :
+        /\ callbackQueue[i].kind \in {Disconnected, StepUp}
+        /\ callbackQueue[i].worker \in Workers
+
+\* If a step-up holder exists, the phase must be non-idle, and vice versa.
+HolderPhaseConsistent ==
+    (stepUpHolder = NONE) <=> (stepUpPhase = "idle")
+
+-----------------------------------------------------------------------------
+\* Safety: the core invariant the bug violates.
+\*
+\* While the step-up is in flight (between stateMachineJoin() and
+\* becomePrimary() returning), the standby loop must not be running.
+\* Equivalently: the standby-loop "running" predicate and the
+\* "becomePrimary in flight" predicate are mutually exclusive.
+-----------------------------------------------------------------------------
+
+NoConcurrentStandbyAndBecomePrimary ==
+    \* role = BecomingPrimary is exactly the window from joined-through-becomePrimary.
+    (role = BecomingPrimary) => (standby /= StandbyRunning)
+
+\* No fatal gRPC assertion ever fires.
+NoGrpcFatal == ~grpcFatal
+
+\* Strict form: at most one of {standby running, step-up in flight} at a time.
+StandbyAndStepUpExclusive ==
+    ~(standby = StandbyRunning /\ StepUpInFlight)
+
+-----------------------------------------------------------------------------
+\* Liveness: step-up always completes if requested.
+-----------------------------------------------------------------------------
+
+StepUpEventuallyCompletes ==
+    (\E i \in 1..Len(callbackQueue) : callbackQueue[i].kind = StepUp)
+        ~> (role = Primary)
+
+=================================================================================================


### PR DESCRIPTION
## Summary

TLA+ spec + jstest: standby loop must not race becomePrimary on step-up.

**Jira:** https://jira.mongodb.org/browse/SERVER-126721
**Branch:** substrate-contrib/w4-20

## Files

```
  -  .../standby_loop_does_not_race_become_primary.js   | 157 +++++++++++++
  -  .../StandbyStepUpRace/MCStandbyStepUpRace.cfg      |  31 +++
  -  .../StandbyStepUpRace/MCStandbyStepUpRace.tla      |  72 ++++++
  -  .../StandbyStepUpRace/MCStandbyStepUpRaceBug.cfg   |  38 +++
  -  .../Replication/StandbyStepUpRace/OWNERS.yml       |   5 +
  -  .../StandbyStepUpRace/StandbyStepUpRace.tla        | 260 +++++++++++++++++++++
  -  6 files changed, 563 insertions(+)
```

## Verify

For `.tla` files:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For `.js` jstests:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
