### PR TITLE
SERVER-126722 jstest + design: heartbeat thread accounting must be bounded under asymmetric partition

### DIFF
--- a/jstests/replsets/heartbeat_thread_no_leak_under_asymmetric_partition.js
+++ b/jstests/replsets/heartbeat_thread_no_leak_under_asymmetric_partition.js
@@ -1,0 +1,137 @@
+/**
+ * Regression test for the leaking-heartbeat-threads bug under an asymmetric network partition.
+ *
+ * Topology:
+ *   3-node replica set behind mongobridge. Node 0 is the primary. We pick node 1 as the
+ *   victim and configure an asymmetric partition: nodes 0 and 2 can still reach node 1
+ *   (so node 1 keeps receiving incoming heartbeats from them), but node 1 can no longer
+ *   reach nodes 0 and 2 (so its outgoing heartbeat replies and follow-up config-fetch
+ *   heartbeats time out).
+ *
+ *   The buggy code path is: when node 1 receives a heartbeat from a peer whose config
+ *   version it does not recognise, it schedules a follow-up heartbeat to fetch that
+ *   peer's config. Under the asymmetric partition that follow-up never completes; the
+ *   handle stays tracked and a new handle is scheduled on every heartbeat interval,
+ *   so the heartbeat-handle queue grows without bound.
+ *
+ *   We sustain the partition long enough for the leak to manifest if present, then
+ *   assert that the per-node heartbeat-handle queue size and the maximum-seen queue
+ *   size both stay below a sane bound. We also sanity-check the live thread count.
+ *
+ * @tags: [
+ *   requires_mongobridge,
+ *   requires_replication,
+ * ]
+ */
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+const kHeartbeatIntervalMs = 2000;
+// Sustain the partition long enough that, if the bug were live, ~30 follow-up
+// heartbeat handles would have piled up on the victim (60s / 2s = 30 intervals).
+const kPartitionSustainMs = 60 * 1000;
+// Generous upper bound for the heartbeat-handle queue on a healthy 3-node set.
+// In steady state we expect O(replicaSetSize) outstanding handles per node; we
+// add a wide margin so this test stays robust against unrelated scheduling jitter.
+const kMaxAllowedHeartbeatHandleQueue = 16;
+
+const replTest = new ReplSetTest({
+    name: jsTestName(),
+    nodes: 3,
+    useBridge: true,
+    settings: {heartbeatIntervalMillis: kHeartbeatIntervalMs},
+    nodeOptions: {
+        setParameter: {
+            logComponentVerbosity: tojsononeline({replication: {heartbeats: 2}}),
+        },
+    },
+});
+
+const nodes = replTest.startSet();
+replTest.initiate();
+replTest.awaitSecondaryNodes();
+
+const primary = replTest.getPrimary();
+assert.eq(primary.host, nodes[0].host, "expected node 0 to be primary at start of test");
+
+const victim = nodes[1];
+const peerA = nodes[0];
+const peerB = nodes[2];
+
+jsTestLog("Baseline: capture heartbeat-handle queue size on the victim before partitioning.");
+const baseline = assert.commandWorked(victim.adminCommand({serverStatus: 1}));
+const baselineMaxSeen =
+    (((baseline.metrics || {}).repl || {}).heartBeat || {}).maxSeenHandleQueueSize || 0;
+jsTestLog("Baseline maxSeenHandleQueueSize on victim: " + tojson(baselineMaxSeen));
+
+jsTestLog("Installing asymmetric partition: peers can reach victim, victim cannot reply.");
+// Block the victim's outgoing direction to both peers. Incoming heartbeats from the
+// peers still arrive at the victim, so the victim will keep trying to schedule
+// follow-up "fetch config" heartbeats outbound — which is exactly the leak path
+// described in SERVER-122751.
+victim.acceptConnectionsFrom(peerA);
+victim.acceptConnectionsFrom(peerB);
+peerA.acceptConnectionsFrom(victim, false);
+peerB.acceptConnectionsFrom(victim, false);
+
+jsTestLog("Sustaining partition for " + kPartitionSustainMs + "ms.");
+sleep(kPartitionSustainMs);
+
+jsTestLog("Sampling heartbeat metrics on the victim while partition is still active.");
+const duringPartition = assert.commandWorked(victim.adminCommand({serverStatus: 1}));
+const heartBeat = (((duringPartition.metrics || {}).repl || {}).heartBeat || {});
+const maxSeen = heartBeat.maxSeenHandleQueueSize || 0;
+// The cumulative Counter64 of scheduled handles. Allowed to grow; we only assert on
+// the live-queue ceiling (maxSeen) which is what indicates a leak.
+const cumulativeScheduled = heartBeat.handleQueueSize || 0;
+
+jsTestLog("During partition: maxSeenHandleQueueSize=" + tojson(maxSeen) +
+          " cumulativeScheduled=" + tojson(cumulativeScheduled));
+
+assert.lte(
+    maxSeen,
+    kMaxAllowedHeartbeatHandleQueue,
+    "Heartbeat handle queue grew unbounded under asymmetric partition. " +
+        "maxSeenHandleQueueSize=" + maxSeen + " baseline=" + baselineMaxSeen +
+        " bound=" + kMaxAllowedHeartbeatHandleQueue +
+        ". This is the SERVER-122751 leak signature.",
+);
+
+jsTestLog("Sanity-check the live thread inventory via currentOp on the victim.");
+const currentOp = assert.commandWorked(
+    victim.getDB("admin").runCommand({currentOp: 1, $all: true, idleConnections: true}),
+);
+// Heartbeat callbacks run on the ReplCoordExtern task executor. Count threads whose
+// description names that executor — under the leak we'd see one extra per interval.
+const replThreadCount = (currentOp.inprog || []).filter(function (op) {
+    const desc = op.desc || "";
+    return desc.indexOf("ReplCoord") === 0 || desc.indexOf("ReplNetwork") === 0;
+}).length;
+jsTestLog("Repl-coord-related threads on victim: " + replThreadCount);
+assert.lte(
+    replThreadCount,
+    64,
+    "Repl-coord thread inventory on the victim looks unbounded (" + replThreadCount +
+        " threads). Expected O(replicaSetSize) steady-state — possible regression " +
+        "of the SERVER-122751 leak path.",
+);
+
+jsTestLog("Healing partition and confirming queue drains.");
+peerA.acceptConnectionsFrom(victim);
+peerB.acceptConnectionsFrom(victim);
+
+// Allow a few heartbeat intervals for the executor to drain.
+assert.soon(
+    function () {
+        const ss = victim.adminCommand({serverStatus: 1});
+        if (!ss.ok) {
+            return false;
+        }
+        const hb = (((ss.metrics || {}).repl || {}).heartBeat || {});
+        // Once healed, even the max-seen high-water mark should remain bounded.
+        return (hb.maxSeenHandleQueueSize || 0) <= kMaxAllowedHeartbeatHandleQueue;
+    },
+    "Heartbeat handle queue did not stay bounded after partition healed.",
+    5 * kHeartbeatIntervalMs,
+);
+
+replTest.stopSet();

--- a/src/mongo/db/repl/SERVER-122751-design.md
+++ b/src/mongo/db/repl/SERVER-122751-design.md
@@ -1,0 +1,79 @@
+# SERVER-122751 design — heartbeat thread accounting must be bounded under asymmetric partition
+
+## Root cause
+
+`ReplicationCoordinatorImpl::_doMemberHeartbeat` schedules an outbound heartbeat
+RemoteCommandRequest for every (target, interval) tuple without consulting how many
+heartbeats to that same target are already in flight. The handle is added to
+`_heartbeatHandles` and only removed when the callback fires — success, failure, or
+cancellation. When the callback path also detects an unknown config version for the
+target, `_scheduleHeartbeatReconfigResponse` schedules an *additional* follow-up
+heartbeat to fetch that target's config.
+
+Under an asymmetric partition (A can reach B; B cannot reply to A) the victim node
+keeps *receiving* incoming heartbeats from the peers — so it keeps observing a
+config-version mismatch on every interval — but its *outgoing* follow-up heartbeats
+never complete: they sit at the executor until they time out, and the timeout itself
+is bounded only by `electionTimeoutMillis`. Each interval therefore enqueues one new
+handle while the previous interval's handle is still tracked. `_heartbeatHandles`
+grows monotonically, `_maxSeenHeartbeatQSize` climbs without bound, and every
+operation that has to walk `_heartbeatHandles` (which today is bounded only by the
+size of that map) starts paying O(n) under `_mutex`. The same `_mutex` is taken on
+the oplog-fetcher hot path; replication lag follows.
+
+## Fix sketch
+
+Introduce a per-target outstanding-heartbeat cap, enforced inside `_doMemberHeartbeat`
+before `scheduleRemoteCommand`:
+
+```
+constexpr size_t kMaxOutstandingHeartbeatsPerTarget = 2;
+
+// Under _mutex, counted via _heartbeatHandles values.
+size_t outstanding = countHandlesForTarget(lk, target);
+if (outstanding >= kMaxOutstandingHeartbeatsPerTarget) {
+    // Drop the oldest in-flight handle to that target, or coalesce by skipping
+    // this scheduling cycle entirely. Cancellation is preferred because it
+    // returns the executor slot promptly and lets the next interval restart
+    // from a clean state.
+    cancelOldestHandleForTarget(lk, target);
+}
+```
+
+The cap of 2 (one "in flight" + one "scheduled for the next tick") preserves the
+existing semantics of overlapping a follow-up config-fetch heartbeat with the
+periodic interval heartbeat, while making it structurally impossible for the queue
+on any one target to grow past a small constant.
+
+Two operational concerns:
+
+1. **Drop vs coalesce.** Dropping the oldest cancels the executor handle and emits
+   a `replSetHeartbeat.cancelled` log line; coalescing simply skips scheduling and
+   leaves the existing handle to time out. Drop-oldest is preferred because the
+   pending follow-up under partition is *known to be doomed* — its timeout would
+   only delay recovery once the partition heals.
+2. **`_maxSeenHeartbeatQSize` interpretation.** The metric already exists at
+   `metrics.repl.heartBeat.maxSeenHandleQueueSize`. Post-fix it must stay bounded
+   by `kMaxOutstandingHeartbeatsPerTarget * replicaSetSize`. This is what the
+   new `heartbeat_thread_no_leak_under_asymmetric_partition.js` jstest asserts.
+
+## Why not de-dupe by target alone
+
+The question raised on the ticket is "why not one heartbeat thread per target with
+a de-dupe check?". One-per-target is correct in steady state but fragile during
+reconfig: a config-fetch heartbeat and an interval heartbeat to the same target
+carry different timeouts and different response handlers; collapsing them into a
+single in-flight slot would mean the reconfig path waits behind the interval
+timeout. The proposed cap of 2 preserves the two semantic slots while still
+bounding the queue.
+
+## Spec / test surface
+
+- jstest: `jstests/replsets/heartbeat_thread_no_leak_under_asymmetric_partition.js`
+  — bridge-injected one-way partition, 60s sustain, asserts
+  `metrics.repl.heartBeat.maxSeenHandleQueueSize` stays bounded and that the
+  repl-coord thread inventory is O(replicaSetSize).
+- Unit test surface (follow-up): extend
+  `replication_coordinator_impl_heartbeat_v1_test.cpp` with a fixture that
+  scripts repeated `_doMemberHeartbeat` calls without firing their callbacks,
+  asserting that `_heartbeatHandles.size()` plateaus at the cap.


### PR DESCRIPTION
## Summary

jstest + design: heartbeat thread accounting must be bounded under asymmetric partition.

**Jira:** https://jira.mongodb.org/browse/SERVER-126722
**Branch:** substrate-contrib/w4-21

## Files

```
  -  ...at_thread_no_leak_under_asymmetric_partition.js | 137 +++++++++++++++++++++
  -  src/mongo/db/repl/SERVER-122751-design.md          |  79 ++++++++++++
  -  2 files changed, 216 insertions(+)
```

## Verify

For `.tla` files:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For `.js` jstests:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
