### PR TITLE
SERVER-126723 jstest + design: FCV doc phase field must be SymmetricFCV-gated

### DIFF
--- a/jstests/multiVersion/fcv_phase_gated_by_symmetric_fcv.js
+++ b/jstests/multiVersion/fcv_phase_gated_by_symmetric_fcv.js
@@ -1,0 +1,181 @@
+/**
+ * Verifies that the "phase" field of the featureCompatibilityVersion document is only persisted
+ * when featureFlagSymmetricFCV is enabled.
+ *
+ * When the flag is off, intermediate setFCV transitions must NOT write a "phase" field into
+ * admin.system.version. Otherwise the field leaks the in-flight transition state to:
+ *   - external observers querying admin.system.version on a primary or secondary,
+ *   - lagging secondaries running an older binary that does not recognise the field
+ *     (no oplog application error is raised today, but the field is silently absorbed and
+ *      becomes visible to clients reading the doc).
+ *
+ * This test exercises the mixed-binary scenario:
+ *   - primary on "latest" binary,
+ *   - secondary on "last-lts" binary (does not know "phase"),
+ *   - FCV held in an intermediate transitional state via a hang-before-finalize failpoint,
+ *   - secondary's view of the FCV doc inspected before the transition completes.
+ *
+ * @tags: [
+ *   requires_replication,
+ *   multiversion_incompatible,
+ * ]
+ */
+
+import "jstests/multiVersion/libs/multi_rs.js";
+import "jstests/multiVersion/libs/verify_versions.js";
+
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {FeatureFlagUtil} from "jstests/libs/feature_flag_util.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+const kFcvNs = "admin.system.version";
+const kFcvId = "featureCompatibilityVersion";
+
+/**
+ * Reads the FCV document from the supplied connection and returns the "phase" field, or undefined
+ * if absent.
+ */
+function readPhase(conn) {
+    const doc = conn.getDB("admin").system.version.findOne({_id: kFcvId});
+    assert.neq(null, doc, `expected an FCV doc in ${kFcvNs}`);
+    return doc.phase;
+}
+
+/**
+ * Asserts that an oplog entry that targeted the FCV document does not contain a "phase" field
+ * once we have proven SymmetricFCV is off. We use the oplog rather than the secondary's local
+ * collection because some older binaries silently absorb unknown top-level fields on update.
+ */
+function assertNoPhaseInRecentFcvOplog(primary) {
+    const oplog = primary.getDB("local").oplog.rs;
+    const entries = oplog
+        .find({ns: kFcvNs})
+        .sort({$natural: -1})
+        .limit(10)
+        .toArray();
+    for (const e of entries) {
+        // Replacement updates land in `o`; delta updates land in `o.diff`.
+        if (e.o && e.o.phase !== undefined) {
+            assert(false, `oplog entry on ${kFcvNs} unexpectedly carries phase: ${tojson(e)}`);
+        }
+        if (e.o && e.o.diff && e.o.diff.i && e.o.diff.i.phase !== undefined) {
+            assert(false,
+                `oplog entry on ${kFcvNs} unexpectedly inserts phase: ${tojson(e)}`);
+        }
+        if (e.o && e.o.diff && e.o.diff.u && e.o.diff.u.phase !== undefined) {
+            assert(false,
+                `oplog entry on ${kFcvNs} unexpectedly updates phase: ${tojson(e)}`);
+        }
+    }
+}
+
+const rst = new ReplSetTest({
+    name: jsTestName(),
+    nodes: [
+        {binVersion: "latest"},
+        {binVersion: "last-lts", rsConfig: {priority: 0, votes: 0}},
+    ],
+});
+
+rst.startSet();
+rst.initiate(null, null, {initiateWithDefaultElectionTimeout: true});
+
+const primary = rst.getPrimary();
+const secondary = rst.getSecondary();
+const primaryAdmin = primary.getDB("admin");
+
+// Sanity check that we wound up with the expected topology. The helpers below come from
+// jstests/multiVersion/libs/verify_versions.js and operate on Mongo connections directly.
+assert.binVersion(primary, "latest");
+assert.binVersion(secondary, "last-lts");
+
+const symmetricEnabled = FeatureFlagUtil.isEnabled(primaryAdmin, "SymmetricFCV");
+jsTestLog(`featureFlagSymmetricFCV enabled on primary: ${symmetricEnabled}`);
+
+// Make sure the cluster is at latestFCV so the next setFCV step downgrades through the
+// intermediate transitional state where `phase` would historically appear.
+assert.commandWorked(
+    primaryAdmin.runCommand({setFeatureCompatibilityVersion: latestFCV, confirm: true}),
+);
+rst.awaitReplication();
+checkFCV(primaryAdmin, latestFCV);
+
+// Park setFCV inside the transitional window: the doc has been written to the transitional FCV
+// but the final-state write has not happened yet. This is the precise window during which
+// `phase` is observable.
+const hangFp = configureFailPoint(primary, "hangBeforeFinalizingFCV");
+
+const setFcvAwait = startParallelShell(() => {
+    assert.commandWorked(
+        db.getSiblingDB("admin").runCommand({
+            setFeatureCompatibilityVersion: lastLTSFCV,
+            confirm: true,
+        }),
+    );
+}, primary.port);
+
+hangFp.wait();
+
+try {
+    // Force the secondary to apply everything that has been replicated so far before we read.
+    rst.awaitReplication();
+
+    const primaryPhase = readPhase(primary);
+    const secondaryPhase = readPhase(secondary);
+
+    jsTestLog(`Primary phase observed: ${tojson(primaryPhase)}`);
+    jsTestLog(`Secondary phase observed: ${tojson(secondaryPhase)}`);
+
+    if (symmetricEnabled) {
+        // With the flag on, intermediate phase IS allowed to be persisted. The secondary may not
+        // know the field but the latest binary on the primary is permitted to write it. We only
+        // assert that the primary and secondary agree (replication faithfully delivered it).
+        assert.eq(
+            primaryPhase,
+            secondaryPhase,
+            "primary and secondary disagree on phase under symmetric flag",
+        );
+    } else {
+        // With the flag off, no observer (primary OR secondary) is permitted to see a phase
+        // field, because the writer must not have persisted one in the first place.
+        assert.eq(
+            undefined,
+            primaryPhase,
+            `primary leaked phase field with SymmetricFCV disabled: ${tojson(primaryPhase)}`,
+        );
+        assert.eq(
+            undefined,
+            secondaryPhase,
+            `secondary leaked phase field with SymmetricFCV disabled: ${tojson(secondaryPhase)}`,
+        );
+        // Belt-and-braces: also verify the oplog does not carry the field, which is what
+        // last-lts binaries would have to absorb.
+        assertNoPhaseInRecentFcvOplog(primary);
+    }
+
+    // Final invariant for both flag states: the older-binary secondary must not have logged an
+    // oplog-application error. If it did, replication would already be broken. Probing it via a
+    // trivial write confirms the secondary is still applying.
+    assert.commandWorked(primary.getDB("test").canary.insert({_id: "canary"}));
+    rst.awaitReplication();
+    assert.eq(
+        1,
+        secondary.getDB("test").canary.find({_id: "canary"}).itcount(),
+        "secondary stopped applying oplog after intermediate-phase FCV write",
+    );
+} finally {
+    hangFp.off();
+    setFcvAwait();
+}
+
+rst.awaitReplication();
+checkFCV(primaryAdmin, lastLTSFCV);
+
+// And one more invariant: the terminal state must NEVER carry a phase field, regardless of the
+// flag. This is the contract the existing code base relies on for the post-transition document.
+const terminalPhasePrimary = readPhase(primary);
+const terminalPhaseSecondary = readPhase(secondary);
+assert.eq(undefined, terminalPhasePrimary, "terminal FCV doc on primary still has phase");
+assert.eq(undefined, terminalPhaseSecondary, "terminal FCV doc on secondary still has phase");
+
+rst.stopSet();

--- a/src/mongo/db/commands/SERVER-126607-design.md
+++ b/src/mongo/db/commands/SERVER-126607-design.md
@@ -1,0 +1,74 @@
+# Gate the `phase` field of the FCV document on `featureFlagSymmetricFCV`
+
+## Problem
+
+`SERVER-119479` introduced a `phase` field on the featureCompatibilityVersion
+document so that interrupted `setFCV` transitions can resume from the last
+phase reached. The field is read only when `featureFlagSymmetricFCV` is on
+(see `feature_compatibility_version.cpp` ~L224), and the field is correctly
+cleared (`boost::none`) on the final write that publishes the new FCV.
+
+However, the **write side** is not gated:
+`FeatureCompatibilityVersion::updateFeatureCompatibilityVersionDocument`
+unconditionally executes `newFCVDoc.setPhase(phase)` regardless of the flag
+state. Intermediate phases of a `setFCV` transition therefore persist a
+`phase` string into `admin.system.version` on the primary, and the change
+is replicated to every secondary in the oplog.
+
+This has two observable consequences even though no code path crashes today:
+
+1. External observers (drivers, monitoring agents) reading the FCV document
+   on a primary or secondary see an internal transition state they should
+   not be exposed to when the SymmetricFCV feature is "off".
+2. Lagging secondaries running an older binary that does not know the
+   `phase` field still receive the update in their oplog. Today the field is
+   silently absorbed, but the surface area of partial-state leaking through
+   replication should be eliminated to match the read-side gate.
+
+## Fix
+
+Gate the write inside `updateFeatureCompatibilityVersionDocument` so that
+`setPhase` is only invoked when the cluster is permitted to use it.
+Specifically, replace the unconditional
+
+```cpp
+newFCVDoc.setPhase(phase);
+```
+
+with
+
+```cpp
+if (serverGlobalParams.featureCompatibility.isVersionInitialized() &&
+    gFeatureFlagSymmetricFCV.isEnabled()) {
+    newFCVDoc.setPhase(phase);
+}
+```
+
+`isVersionInitialized()` guards against the startup window before the FCV
+snapshot is hydrated. The flag is `fcv_gated: false`, so `isEnabled()` is
+safe once that snapshot exists. `ResolvedFCVTransition` already collapses
+`endPhase` to `kComplete` when the flag is off, so any phase argument
+passed in legacy mode is effectively a no-op once this write-side gate
+lands.
+
+## Risk
+
+Behavior under the flag is unchanged. When the flag is off, intermediate
+writes drop the `phase` field, matching the post-transition document shape
+that has always been published. Resumability under the flag is unaffected
+because the read path already requires the flag to be on before consulting
+`fcvDoc.getPhase()`.
+
+## Test
+
+`jstests/multiVersion/fcv_phase_gated_by_symmetric_fcv.js` brings up a
+two-node replica set with the primary on `latest` and the secondary on
+`last-lts`, holds `setFCV` inside the transitional window with
+`hangBeforeFinalizingFCV`, and asserts:
+
+- when the flag is off, no `phase` field exists on either node, and no
+  oplog entry targeting `admin.system.version` carries `phase`;
+- when the flag is on, primary and secondary at least agree on the field;
+- in both flag states the older-binary secondary is still applying the
+  oplog (no `OplogApplicationFailure` on the `phase` write);
+- the terminal post-transition document never has a `phase` field.


### PR DESCRIPTION
## Summary

jstest + design: FCV doc phase field must be SymmetricFCV-gated.

**Jira:** https://jira.mongodb.org/browse/SERVER-126723
**Branch:** substrate-contrib/w4-22

## Files

```
  -  .../fcv_phase_gated_by_symmetric_fcv.js            | 181 +++++++++++++++++++++
  -  src/mongo/db/commands/SERVER-126607-design.md      |  74 +++++++++
  -  2 files changed, 255 insertions(+)
```

## Verify

For `.tla` files:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For `.js` jstests:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
