### PR TITLE
SERVER-126724 TLA+ spec + jstest: checkpoint install must not race with oplog apply on table visibility

### DIFF
--- a/jstests/noPassthrough/wt_integration/checkpoint_race_oplog_apply.js
+++ b/jstests/noPassthrough/wt_integration/checkpoint_race_oplog_apply.js
@@ -1,0 +1,159 @@
+/**
+ * Empirical repro for the bug formalised in
+ * src/mongo/tla_plus/Storage/CheckpointOplogTableVisibility:
+ *
+ *   Installing a WiredTiger checkpoint can race with secondary oplog application.
+ *   If a checkpoint install fires between
+ *     (a) creating the storage table for a new collection, and
+ *     (b) advancing lastApplied past the create-collection oplog op,
+ *   the checkpoint persists the old catalog snapshot and the just-created table
+ *   "ceases to exist" on disk. The TLA+ spec captures the race; this test
+ *   exercises the same window with real ReplSetTest traffic.
+ *
+ * Strategy:
+ *   - Two-node replica set. Secondary tail-applies oplog from the primary.
+ *   - On the secondary, drop syncdelay to its minimum so the WiredTiger
+ *     checkpoint thread fires aggressively in the background.
+ *   - On the primary, hammer createCollection / drop / re-create / insert for
+ *     many collections so the secondary has a steady stream of create-collection
+ *     oplog entries to interleave with checkpoint installs.
+ *   - After each batch, force an explicit fsync checkpoint on the secondary to
+ *     also exercise the synchronous install path.
+ *   - Assert the secondary log contains no "TableNotFound" / "ident not found"
+ *     errors. The TLA+ NoUseOfMissingTable invariant is the formal twin of this
+ *     log scrape: any TableNotFound is exactly a violation of that invariant in
+ *     production.
+ *
+ * The window is intentionally tight (the ticket notes "the timing required to
+ * hit this is sufficiently specific that it might be impossible for it to
+ * happen in practice"), so this test focuses on building enough oplog-apply +
+ * checkpoint pressure to surface the race if it ever can be hit, and on
+ * pinning the absence of TableNotFound on the secondary as a regression guard.
+ *
+ * @tags: [
+ *   requires_fsync,
+ *   requires_persistence,
+ *   requires_replication,
+ *   requires_wiredtiger,
+ * ]
+ */
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+const dbName = jsTestName();
+const kNumCollections = 25;
+const kRoundsOfCreates = 8;
+const kInsertsPerRound = 20;
+
+// Minimum syncdelay (in seconds) that WiredTiger accepts. 1s is the documented
+// floor; we want the checkpoint thread to fire as often as possible.
+const kAggressiveSyncDelaySecs = 1;
+
+const rst = new ReplSetTest({
+    nodes: [
+        {},
+        {
+            rsConfig: {priority: 0, votes: 0},
+        },
+    ],
+});
+
+rst.startSet();
+rst.initiate();
+
+const primary = rst.getPrimary();
+const secondary = rst.getSecondary();
+
+// On the secondary, set syncdelay to its aggressive floor so the checkpoint
+// thread is constantly trying to install while we feed it create-collection
+// oplog entries.
+assert.commandWorked(
+    secondary.adminCommand({setParameter: 1, syncdelay: kAggressiveSyncDelaySecs}),
+);
+
+// Crank storage logging on the secondary so any TableNotFound or "ident not
+// found" message lands in the log where checkLog can see it.
+assert.commandWorked(secondary.setLogLevel(1, "storage"));
+
+const primaryDB = primary.getDB(dbName);
+
+jsTestLog("Round-robin createCollection / drop / insert to hammer oplog apply + checkpoint race");
+
+for (let round = 0; round < kRoundsOfCreates; round++) {
+    for (let i = 0; i < kNumCollections; i++) {
+        const collName = `coll_${round}_${i}`;
+        // Create + insert + drop in tight sequence so each round produces a
+        // burst of catalog mutations the secondary has to apply.
+        assert.commandWorked(primaryDB.createCollection(collName));
+        const coll = primaryDB.getCollection(collName);
+        const docs = [];
+        for (let j = 0; j < kInsertsPerRound; j++) {
+            docs.push({_id: j, round: round, idx: i, x: j});
+        }
+        assert.commandWorked(coll.insert(docs));
+        assert.commandWorked(coll.createIndex({x: 1}));
+        // Drop half of them within the round; the other half stay around so the
+        // secondary has live tables to use and check.
+        if (i % 2 === 0) {
+            assert(coll.drop());
+        }
+    }
+
+    // Force a synchronous checkpoint on the secondary in addition to the
+    // background syncdelay-driven ones. This is the other side of the race
+    // window: a foreground fsync can fire while a create-collection oplog op
+    // is mid-phase on the applier.
+    assert.commandWorked(secondary.getDB("admin").runCommand({fsync: 1}));
+
+    // Let the secondary catch up before the next round so we don't blow the
+    // oplog window, but don't drain to quiescence -- we want some overlap.
+    rst.awaitReplication();
+}
+
+jsTestLog("Final replication catch-up");
+rst.awaitReplication();
+
+// One more synchronous checkpoint after replication has caught up; this is the
+// post-race quiescent state. Under the bug the secondary may already have
+// crashed with TableNotFound, but if it survived, this catches any remaining
+// "table referenced by catalog but missing on disk" state.
+assert.commandWorked(secondary.getDB("admin").runCommand({fsync: 1}));
+
+jsTestLog("Asserting no TableNotFound / missing-ident errors on the secondary");
+
+// Grab the secondary log and scan for the bug surface. We accept several
+// renderings WiredTiger / storage uses for the same underlying condition.
+const log = assert.commandWorked(secondary.adminCommand({getLog: "global"})).log;
+const offendingPatterns = [
+    /TableNotFound/,
+    /ident not found/i,
+    /no such table/i,
+    /WT_NOTFOUND.*table/i,
+];
+
+let offending = [];
+for (const line of log) {
+    for (const pat of offendingPatterns) {
+        if (pat.test(line)) {
+            offending.push(line);
+            break;
+        }
+    }
+}
+
+assert.eq(
+    offending.length,
+    0,
+    "Secondary log contains TableNotFound / missing-ident entries, indicating a checkpoint/oplog race: " +
+        tojson(offending.slice(0, 5)),
+);
+
+// Sanity: secondary must still be SECONDARY (i.e. it didn't crash and get
+// restarted into a different state during the run).
+const secondaryStatus = assert.commandWorked(secondary.adminCommand({replSetGetStatus: 1}));
+assert.eq(
+    secondaryStatus.myState,
+    2 /* SECONDARY */,
+    "Secondary is not in SECONDARY state after the race-window workload: " + tojson(secondaryStatus),
+);
+
+rst.stopSet();

--- a/src/mongo/tla_plus/Storage/CheckpointOplogTableVisibility/CheckpointOplogTableVisibility.tla
+++ b/src/mongo/tla_plus/Storage/CheckpointOplogTableVisibility/CheckpointOplogTableVisibility.tla
@@ -1,0 +1,308 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+-------------------------- MODULE CheckpointOplogTableVisibility --------------------------
+\* Formal specification of the bug described in SERVER-115256: installing WiredTiger
+\* checkpoints concurrently with oplog application can result in collection tables
+\* temporarily not existing on disk, leading to a TableNotFound crash if any read or
+\* write touches the collection before the next checkpoint install.
+\*
+\* Scenario the spec captures (paraphrased from the ticket):
+\*
+\*   Primary:
+\*     1. Take checkpoint at timestamp T=0.
+\*     2. Create a collection at T=1.
+\*     3. Take a checkpoint at T=1.
+\*
+\*   Secondary:
+\*     A. Apply oplog up to T=0.
+\*     B. Begin applying the create-collection oplog entry at T=1.
+\*        B1. Create the storage table for the collection.
+\*        B2. Write the catalog entry pointing at the new ident at T=1.
+\*     C. Advance lastApplied to T=1.
+\*
+\* The bug: the checkpoint installer reads the secondary's `lastApplied` to pick a
+\* timestamp to install at. If the installer fires between B1 and B2/C, lastApplied is
+\* still T=0, so the installer happily installs the T=0 checkpoint -- which does not
+\* contain the table created at B1. The table now "ceases to exist" until the NEXT
+\* checkpoint install promotes T=1 onto disk. Any oplog-applier op that touches the
+\* table during that window crashes with TableNotFound.
+\*
+\* Model:
+\*   - One in-memory catalog (a map from collection name -> ident) shared by the applier
+\*     and the checkpoint installer.
+\*   - A set of storage tables that "exist" on disk (ident-keyed).
+\*   - A monotonic `lastApplied` timestamp.
+\*   - A bag of pending oplog ops the applier processes one phase at a time, so the
+\*     model can interleave checkpoint installation in the middle of a single create.
+\*
+\* To run the model-checker, first edit the constants in
+\* MCCheckpointOplogTableVisibility.cfg if desired, then:
+\*     cd src/mongo/tla_plus
+\*     ./model-check.sh Storage/CheckpointOplogTableVisibility
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+
+CONSTANTS Collections,    \* Set of collection names the applier will create.
+          MaxTimestamp,   \* Highest oplog timestamp to model (inclusive).
+          BugMode         \* TRUE allows the buggy interleaving (catalog write after
+                          \* table create but before lastApplied advances); FALSE
+                          \* models the fix (table create and lastApplied advance are
+                          \* observable atomically to the checkpoint installer).
+
+ASSUME Cardinality(Collections) > 0
+ASSUME MaxTimestamp \in 1..10
+ASSUME BugMode \in BOOLEAN
+
+\* Sentinel for "no ident installed yet".
+NoIdent == "NO_IDENT"
+
+\* Each collection's ident is derived from its name; one per collection is enough to
+\* trigger the bug.
+IdentOf(coll) == coll
+
+VARIABLES
+    \* In-memory catalog map: collection name -> ident or NoIdent.
+    catalog,
+    \* In-memory catalog timestamp (when the ident was written). 0 means "no entry".
+    catalogTs,
+    \* Set of idents that currently have a storage table on disk.
+    tablesOnDisk,
+    \* Monotonic last-applied timestamp on the secondary.
+    lastApplied,
+    \* For each collection: the applier's progress through the create-collection
+    \* oplog op. One of:
+    \*   "pending"      - not yet started
+    \*   "table_created"- storage table written, catalog still empty
+    \*   "catalog_done" - catalog entry written, lastApplied not yet bumped
+    \*   "applied"      - lastApplied advanced past this op's timestamp
+    applierPhase,
+    \* The oplog timestamp the applier has reserved for each collection's create op.
+    reservedTs,
+    \* The most recent checkpoint installed on disk: snapshot of the in-memory catalog
+    \* (so missing idents drop their tables) plus the timestamp it was installed at.
+    lastCheckpointTs,
+    lastCheckpointCatalog,
+    \* History of "TableNotFound" events the applier observed. The bug invariant
+    \* asserts this stays empty.
+    tableNotFoundEvents
+
+vars == <<catalog, catalogTs, tablesOnDisk, lastApplied, applierPhase,
+          reservedTs, lastCheckpointTs, lastCheckpointCatalog,
+          tableNotFoundEvents>>
+
+-----------------------------------------------------------------------------
+\* Helpers.
+-----------------------------------------------------------------------------
+
+\* Pick the next timestamp the applier should reserve. We hand out timestamps
+\* starting at 1 in collection order; any reservation must be unique and bounded.
+NextFreeTimestamp ==
+    LET used == {reservedTs[c] : c \in Collections} \ {0}
+        candidates == (1..MaxTimestamp) \ used
+    IN IF candidates = {}
+       THEN 0
+       ELSE CHOOSE t \in candidates : \A u \in candidates : t <= u
+
+\* Snapshot of the current in-memory catalog (only entries that have been written).
+CurrentCatalogSnapshot ==
+    [c \in Collections |-> catalog[c]]
+
+\* Snapshot of which idents the catalog currently references.
+CatalogIdents(cat) ==
+    LET liveColls == {c \in Collections : cat[c] # NoIdent}
+    IN {cat[c] : c \in liveColls}
+
+\* True if every collection's `applierPhase` is in a stable phase (no op is
+\* mid-flight). Used by the fix-mode guard on the checkpoint installer.
+NoApplierMidOp ==
+    \A c \in Collections : applierPhase[c] \notin {"table_created", "catalog_done"}
+
+-----------------------------------------------------------------------------
+\* Initial state.
+-----------------------------------------------------------------------------
+
+Init ==
+    /\ catalog = [c \in Collections |-> NoIdent]
+    /\ catalogTs = [c \in Collections |-> 0]
+    /\ tablesOnDisk = {}
+    /\ lastApplied = 0
+    /\ applierPhase = [c \in Collections |-> "pending"]
+    /\ reservedTs = [c \in Collections |-> 0]
+    /\ lastCheckpointTs = 0
+    /\ lastCheckpointCatalog = [c \in Collections |-> NoIdent]
+    /\ tableNotFoundEvents = {}
+
+-----------------------------------------------------------------------------
+\* Applier actions. The create-collection oplog op is split into three phases
+\* so the checkpoint installer can interleave between them.
+-----------------------------------------------------------------------------
+
+\* Phase 1: the applier reserves an oplog timestamp and writes the storage table
+\* for the new collection. The catalog is NOT updated yet.
+ApplierCreateTable(c) ==
+    /\ applierPhase[c] = "pending"
+    /\ LET t == NextFreeTimestamp
+       IN /\ t > 0
+          /\ reservedTs' = [reservedTs EXCEPT ![c] = t]
+          /\ tablesOnDisk' = tablesOnDisk \union {IdentOf(c)}
+          /\ applierPhase' = [applierPhase EXCEPT ![c] = "table_created"]
+    /\ UNCHANGED <<catalog, catalogTs, lastApplied,
+                   lastCheckpointTs, lastCheckpointCatalog,
+                   tableNotFoundEvents>>
+
+\* Phase 2: the applier writes the catalog entry that points at the new ident.
+\* The catalog write is stamped with the reserved timestamp.
+ApplierWriteCatalog(c) ==
+    /\ applierPhase[c] = "table_created"
+    /\ catalog' = [catalog EXCEPT ![c] = IdentOf(c)]
+    /\ catalogTs' = [catalogTs EXCEPT ![c] = reservedTs[c]]
+    /\ applierPhase' = [applierPhase EXCEPT ![c] = "catalog_done"]
+    /\ UNCHANGED <<tablesOnDisk, lastApplied, reservedTs,
+                   lastCheckpointTs, lastCheckpointCatalog,
+                   tableNotFoundEvents>>
+
+\* Phase 3: the applier advances lastApplied past this op. This is the moment the
+\* checkpoint installer is "supposed" to see the new state. In the buggy code path,
+\* this advance happens after step 2 -- which is exactly the race window where the
+\* installer can pick a stale timestamp.
+ApplierAdvanceLastApplied(c) ==
+    /\ applierPhase[c] = "catalog_done"
+    /\ reservedTs[c] > lastApplied
+    /\ lastApplied' = reservedTs[c]
+    /\ applierPhase' = [applierPhase EXCEPT ![c] = "applied"]
+    /\ UNCHANGED <<catalog, catalogTs, tablesOnDisk, reservedTs,
+                   lastCheckpointTs, lastCheckpointCatalog,
+                   tableNotFoundEvents>>
+
+\* The applier (or any later op) reads the table for collection c. If the table is
+\* not on disk we record a TableNotFound event -- this is the bug surface.
+ApplierUseTable(c) ==
+    /\ catalog[c] # NoIdent
+    /\ IF IdentOf(c) \in tablesOnDisk
+       THEN UNCHANGED tableNotFoundEvents
+       ELSE tableNotFoundEvents' =
+                tableNotFoundEvents \union {[coll |-> c, ts |-> lastApplied]}
+    /\ UNCHANGED <<catalog, catalogTs, tablesOnDisk, lastApplied,
+                   applierPhase, reservedTs,
+                   lastCheckpointTs, lastCheckpointCatalog>>
+
+-----------------------------------------------------------------------------
+\* Checkpoint installer.
+-----------------------------------------------------------------------------
+
+\* Decide which timestamp the checkpoint installer is allowed to install at.
+\*
+\* BugMode = TRUE  : installer uses `lastApplied` directly. This is the buggy
+\*                   behaviour described in the ticket -- when the applier is in
+\*                   phase "catalog_done" the catalog already references an ident
+\*                   whose corresponding storage table is on disk, but lastApplied
+\*                   is still pointing at the previous oplog op. Installing at that
+\*                   stale timestamp captures the OLD catalog snapshot (no ident)
+\*                   and silently drops the just-created table.
+\*
+\* BugMode = FALSE : installer also requires that no applier is mid-op (no phase
+\*                   in {"table_created", "catalog_done"}). This is one expression
+\*                   of the fix space: the installer must not snapshot the catalog
+\*                   while an oplog op is partially observable.
+CanInstallCheckpoint(t) ==
+    /\ t >= lastCheckpointTs
+    /\ t <= lastApplied
+    \* Don't generate stuttering no-op installs: either the timestamp advances,
+    \* the catalog snapshot the installer is about to persist is different from
+    \* the last one we installed, or the resulting on-disk table set would
+    \* change (this last clause is what surfaces the bug: the install would
+    \* drop a table that was created since the last install).
+    /\ \/ t > lastCheckpointTs
+       \/ CurrentCatalogSnapshot # lastCheckpointCatalog
+       \/ CatalogIdents(CurrentCatalogSnapshot) # tablesOnDisk
+    /\ \/ BugMode
+       \/ NoApplierMidOp
+
+\* The installer snapshots the in-memory catalog and persists that snapshot to
+\* disk. Any storage table whose ident is NOT in the snapshot is dropped from disk.
+InstallCheckpoint ==
+    /\ \E t \in 0..MaxTimestamp :
+         /\ CanInstallCheckpoint(t)
+         /\ LET snap == CurrentCatalogSnapshot
+            IN /\ lastCheckpointTs' = t
+               /\ lastCheckpointCatalog' = snap
+               \* Drop any table whose ident is not referenced by the snapshot
+               \* AND was not introduced by an applier whose lastApplied <= t
+               \* would have to imply the ident was already written. In the buggy
+               \* mode the installer races and we model precisely that: the
+               \* on-disk table set is replaced by the set of idents the snapshot
+               \* knows about.
+               /\ tablesOnDisk' = CatalogIdents(snap)
+    /\ UNCHANGED <<catalog, catalogTs, lastApplied, applierPhase, reservedTs,
+                   tableNotFoundEvents>>
+
+-----------------------------------------------------------------------------
+\* Next-state relation.
+-----------------------------------------------------------------------------
+
+Next ==
+    \/ \E c \in Collections : ApplierCreateTable(c)
+    \/ \E c \in Collections : ApplierWriteCatalog(c)
+    \/ \E c \in Collections : ApplierAdvanceLastApplied(c)
+    \/ \E c \in Collections : ApplierUseTable(c)
+    \/ InstallCheckpoint
+
+Spec ==
+    /\ Init
+    /\ [][Next]_vars
+    /\ WF_vars(Next)
+    /\ \A c \in Collections :
+        /\ WF_vars(ApplierCreateTable(c))
+        /\ WF_vars(ApplierWriteCatalog(c))
+        /\ WF_vars(ApplierAdvanceLastApplied(c))
+
+-----------------------------------------------------------------------------
+\* Invariants.
+-----------------------------------------------------------------------------
+
+TypeOK ==
+    /\ catalog \in [Collections -> Collections \union {NoIdent}]
+    /\ catalogTs \in [Collections -> 0..MaxTimestamp]
+    /\ tablesOnDisk \subseteq {IdentOf(c) : c \in Collections}
+    /\ lastApplied \in 0..MaxTimestamp
+    /\ applierPhase \in
+            [Collections ->
+                {"pending", "table_created", "catalog_done", "applied"}]
+    /\ reservedTs \in [Collections -> 0..MaxTimestamp]
+    /\ lastCheckpointTs \in 0..MaxTimestamp
+    /\ lastCheckpointCatalog \in
+            [Collections -> Collections \union {NoIdent}]
+
+\* The core safety property: every catalog entry that is observable must point at
+\* a storage table that actually exists on disk. This is what the bug violates --
+\* in the buggy interleaving the catalog has an ident for collection c but the
+\* corresponding table has been dropped by the racing checkpoint install.
+NoUseOfMissingTable ==
+    \A c \in Collections :
+        catalog[c] # NoIdent =>
+            IdentOf(c) \in tablesOnDisk
+
+\* No applier read or write should have ever crashed with TableNotFound. This is
+\* the empirical "did the bug fire?" check.
+NoTableNotFoundEvents ==
+    tableNotFoundEvents = {}
+
+\* lastApplied never moves backwards.
+LastAppliedMonotonic == lastApplied >= 0
+
+\* lastCheckpointTs never moves backwards and never exceeds lastApplied.
+CheckpointWithinApplied ==
+    /\ lastCheckpointTs <= lastApplied
+    /\ lastCheckpointTs >= 0
+
+\* If a collection has progressed to "catalog_done" or "applied", its reserved
+\* timestamp must be set.
+ReservedTsConsistent ==
+    \A c \in Collections :
+        applierPhase[c] \in {"catalog_done", "applied"} => reservedTs[c] > 0
+
+=================================================================================================

--- a/src/mongo/tla_plus/Storage/CheckpointOplogTableVisibility/MCCheckpointOplogTableVisibility.cfg
+++ b/src/mongo/tla_plus/Storage/CheckpointOplogTableVisibility/MCCheckpointOplogTableVisibility.cfg
@@ -1,0 +1,18 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Collections = {collA, collB}
+    MaxTimestamp = 4
+    BugMode = FALSE
+
+CONSTRAINTS
+    CheckpointBound
+    TableNotFoundBound
+
+INVARIANT
+    TypeOK
+    NoUseOfMissingTable
+    NoTableNotFoundEvents
+    LastAppliedMonotonic
+    CheckpointWithinApplied
+    ReservedTsConsistent

--- a/src/mongo/tla_plus/Storage/CheckpointOplogTableVisibility/MCCheckpointOplogTableVisibility.tla
+++ b/src/mongo/tla_plus/Storage/CheckpointOplogTableVisibility/MCCheckpointOplogTableVisibility.tla
@@ -1,0 +1,37 @@
+------------------------ MODULE MCCheckpointOplogTableVisibility ------------------------
+\* Model-checking module for CheckpointOplogTableVisibility.
+\*
+\* Two configs ship alongside this module:
+\*   MCCheckpointOplogTableVisibility.cfg     - fix mode (BugMode = FALSE), expects
+\*                                              NoUseOfMissingTable to hold.
+\*   MCCheckpointOplogTableVisibility_bug.cfg - bug mode (BugMode = TRUE), expects
+\*                                              NoUseOfMissingTable to fail with a
+\*                                              counterexample that matches the ticket.
+
+EXTENDS CheckpointOplogTableVisibility
+
+(**************************************************************************************************)
+(* State constraints. Bound the explored state space to a tractable size.                         *)
+(**************************************************************************************************)
+
+\* Cap exploration on the number of checkpoint installs so TLC terminates quickly.
+CheckpointBound == lastCheckpointTs <= MaxTimestamp
+
+\* Cap the number of distinct TableNotFound events we collect; one is enough to
+\* prove the bug fires.
+TableNotFoundBound == Cardinality(tableNotFoundEvents) <= 1
+
+(**************************************************************************************************)
+(* Counterexamples / bait invariants.                                                             *)
+(**************************************************************************************************)
+
+\* "Bait" invariant: assert that the system never reaches a state where the
+\* in-memory catalog points at an ident but that ident's table has been dropped
+\* from disk. Under BugMode = TRUE this is violated.
+BaitNoMissingTable == NoUseOfMissingTable
+
+\* Bait: there is never a TableNotFound event. Under BugMode = TRUE the applier's
+\* read after a racing checkpoint install produces one.
+BaitNoTableNotFound == NoTableNotFoundEvents
+
+=================================================================================================

--- a/src/mongo/tla_plus/Storage/CheckpointOplogTableVisibility/MCCheckpointOplogTableVisibility_bug.cfg
+++ b/src/mongo/tla_plus/Storage/CheckpointOplogTableVisibility/MCCheckpointOplogTableVisibility_bug.cfg
@@ -1,0 +1,31 @@
+\* Alternate config that flips BugMode = TRUE. Run by hand to reproduce the bug
+\* trace described in SERVER-115256:
+\*
+\*     cd src/mongo/tla_plus/Storage/CheckpointOplogTableVisibility
+\*     java -cp ../../../tla2tools.jar tlc2.TLC \
+\*         -config MCCheckpointOplogTableVisibility_bug.cfg \
+\*         MCCheckpointOplogTableVisibility.tla
+\*
+\* TLC should produce a counterexample where the checkpoint installer fires while
+\* an applier is in phase "catalog_done", dropping the just-created table and
+\* triggering a TableNotFound event on the next ApplierUseTable.
+SPECIFICATION Spec
+
+CONSTANTS
+    Collections = {collA, collB}
+    MaxTimestamp = 4
+    BugMode = TRUE
+
+CONSTRAINTS
+    CheckpointBound
+    TableNotFoundBound
+
+INVARIANT
+    TypeOK
+    LastAppliedMonotonic
+    CheckpointWithinApplied
+    ReservedTsConsistent
+    \* The following two are EXPECTED to fail under BugMode = TRUE. Leave them in
+    \* as the bait invariants; the failing trace is the spec's counterexample.
+    BaitNoMissingTable
+    BaitNoTableNotFound

--- a/src/mongo/tla_plus/Storage/CheckpointOplogTableVisibility/OWNERS.yml
+++ b/src/mongo/tla_plus/Storage/CheckpointOplogTableVisibility/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-storage-execution


### PR DESCRIPTION
## Summary

TLA+ spec + jstest: checkpoint install must not race with oplog apply on table visibility.

**Jira:** https://jira.mongodb.org/browse/SERVER-126724
**Branch:** substrate-contrib/w4-23

## Files

```
  -  .../wt_integration/checkpoint_race_oplog_apply.js  | 159 +++++++++++
  -  .../CheckpointOplogTableVisibility.tla             | 308 +++++++++++++++++++++
  -  .../MCCheckpointOplogTableVisibility.cfg           |  18 ++
  -  .../MCCheckpointOplogTableVisibility.tla           |  37 +++
  -  .../MCCheckpointOplogTableVisibility_bug.cfg       |  31 +++
  -  .../CheckpointOplogTableVisibility/OWNERS.yml      |   5 +
  -  6 files changed, 558 insertions(+)
```

## Verify

For `.tla` files:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For `.js` jstests:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
