### PR TITLE
SERVER-126725 jstest + design: moveChunk after convertToCapped must not hang

### DIFF
--- a/jstests/sharding/movechunk_after_converttocapped_no_hang.js
+++ b/jstests/sharding/movechunk_after_converttocapped_no_hang.js
@@ -1,0 +1,100 @@
+/**
+ * Regression test for the moveChunk hang observed after a convertToCapped operation on a sharded
+ * collection.
+ *
+ * Background: when convertToCapped runs against a sharded collection, the post-step on the data
+ * shard previously left the collection's filtering metadata and migration coordinator state in an
+ * inconsistent shape. A subsequent moveChunk would then never make progress on the source shard:
+ * the session-migration scan over kGroupForPossiblyRetryableOperations would loop forever (the
+ * surface symptom users see is repeated "moveChunk data transfer progress" log lines with no
+ * completion).
+ *
+ * This test exercises the user-visible path:
+ *
+ *   1. Create a sharded collection with a single chunk on the primary shard.
+ *   2. Run convertToCapped on the collection.
+ *   3. Run moveChunk with a bounded maxTimeMS so the test cannot hang the suite even on
+ *      unpatched binaries.
+ *   4. Assert moveChunk completes successfully and the chunk count on each shard reflects the
+ *      migration.
+ *
+ * On unpatched code paths this test times out at moveChunk and fails with MaxTimeMSExpired (or the
+ * chunk-location assertion below, depending on which side wins the race). On a patched build the
+ * moveChunk completes well under the bounded timeout.
+ *
+ * @tags: [
+ *  requires_sharding,
+ *  requires_fcv_90,
+ * ]
+ */
+
+import {ShardingTest} from "jstests/libs/shardingtest.js";
+import {findChunksUtil} from "jstests/sharding/libs/find_chunks_util.js";
+
+const st = new ShardingTest({
+    mongos: 1,
+    shards: 2,
+    rs: {nodes: 1},
+});
+
+const dbName = jsTestName();
+const collName = "convertToCappedThenMove";
+const ns = dbName + "." + collName;
+
+const testDB = st.s.getDB(dbName);
+const coll = testDB.getCollection(collName);
+
+// Pin the database's primary shard so we know which side owns the only chunk before the move.
+assert.commandWorked(st.s.adminCommand({enableSharding: dbName, primaryShard: st.shard0.shardName}));
+assert.commandWorked(st.s.adminCommand({shardCollection: ns, key: {_id: 1}}));
+
+// Seed a small amount of data so the convertToCapped path has documents to copy and the
+// subsequent moveChunk actually transfers a non-empty chunk.
+const seedBatch = [];
+for (let i = 0; i < 64; ++i) {
+    seedBatch.push({_id: i, payload: "x".repeat(32)});
+}
+assert.commandWorked(coll.insert(seedBatch));
+
+assert.eq(64, coll.countDocuments({}));
+assert(!coll.isCapped(), "collection should not be capped prior to convertToCapped");
+
+jsTestLog("Running convertToCapped on the sharded collection.");
+assert.commandWorked(testDB.runCommand({convertToCapped: collName, size: 1024 * 1024}));
+assert(coll.isCapped(), "convertToCapped did not capped the collection");
+
+// Sanity check that one chunk exists on the primary shard before the move.
+const initialChunks = findChunksUtil.findChunksByNs(st.config, ns).toArray();
+assert.eq(1, initialChunks.length, "expected exactly one chunk before moveChunk");
+assert.eq(st.shard0.shardName, initialChunks[0].shard);
+
+// Bounded timeout. On unpatched code moveChunk never makes progress past session migration; the
+// bound below ensures the test fails loudly instead of hanging the suite. 60s is generous enough
+// that a healthy moveChunk on a tiny chunk in a two-node ShardingTest completes comfortably.
+const moveChunkTimeoutMs = 60 * 1000;
+
+jsTestLog("Running moveChunk with bounded maxTimeMS=" + moveChunkTimeoutMs);
+const moveChunkResult = st.s.adminCommand({
+    moveChunk: ns,
+    find: {_id: 0},
+    to: st.shard1.shardName,
+    maxTimeMS: moveChunkTimeoutMs,
+});
+
+// On unpatched binaries this assertion fails with MaxTimeMSExpired. On a patched build, the
+// migration completes well within the bounded timeout.
+assert.commandWorked(
+    moveChunkResult,
+    "moveChunk after convertToCapped did not complete within " + moveChunkTimeoutMs + "ms;" +
+        " this is the SERVER-126352 hang signature.",
+);
+
+// Verify the chunk actually moved.
+const numChunksOnShard0 =
+    findChunksUtil.findChunksByNs(st.config, ns, {shard: st.shard0.shardName}).itcount();
+const numChunksOnShard1 =
+    findChunksUtil.findChunksByNs(st.config, ns, {shard: st.shard1.shardName}).itcount();
+assert.eq(0, numChunksOnShard0, "expected zero chunks on shard0 after move");
+assert.eq(1, numChunksOnShard1, "expected one chunk on shard1 after move");
+
+st.stop();

--- a/src/mongo/db/global_catalog/SERVER-126352-design.md
+++ b/src/mongo/db/global_catalog/SERVER-126352-design.md
@@ -1,0 +1,90 @@
+# SERVER-126352 — moveChunk hang after convertToCapped
+
+## Symptom
+
+After `convertToCapped` is executed against a sharded collection, the next
+`moveChunk` against that namespace (or, in the originally-observed reproducer,
+against `config.system.sessions` while the
+`convert_to_capped_unsplittable_collections.js` DSC workload is running) never
+makes forward progress. The source shard's `MoveChunk` thread loops in the
+session-migration phase, repeatedly emitting `moveChunk data transfer progress`
+log lines (id 21993) with `sessionCatalogSourceInCatchupPhase: false`. The
+client side blocks on the moveChunk admin command until either a `maxTimeMS`
+deadline fires or the operation is killed manually.
+
+The underlying parse failure surfaces as a `FailedToParse` from
+`_getNextSessionMods`:
+
+```
+Missing prevOpTime field on oplog entry of previous write in transaction
+```
+
+This happens because `convertToCapped`, when batched under
+`kGroupForPossiblyRetryableOperations`, can emit oplog entries inside a
+batched-write block whose `prevOpTime` chain has already been cleared by
+`setInitializedStatementIds` — and the session-migration scanner expects a
+clean per-session `prevOpTime` chain.
+
+The user-visible effect, regardless of the deeper batched-write cause, is a
+chunk migration that never returns and a shard whose filtering-metadata view
+of the namespace and whose migration-coordinator state are observably stale
+relative to the rest of the cluster.
+
+## Root cause hypothesis
+
+The hang is a downstream consequence of the convertToCapped post-step not
+fully resettling the per-collection sharding state on the data shard:
+
+1. `convertToCapped` rewrites the collection's catalog entry and changes its
+   UUID. The cached filtering metadata on the data shard still references the
+   pre-conversion UUID and chunk distribution at the point control returns to
+   the coordinator.
+2. Any migration-coordinator document or in-progress decision artifact left
+   over from a prior aborted move (or implicitly produced by the batched
+   convertToCapped path) is not cleared. A subsequent `moveChunk` sees that
+   document and waits for it to drain before starting its own work.
+3. Because the session-migration phase of moveChunk reads through the
+   leftover oplog entries produced under
+   `kGroupForPossiblyRetryableOperations` — which lack a usable `prevOpTime`
+   chain after the statement-id list was cleared — the source shard's
+   `_getNextSessionMods` loop never advances. From the coordinator's
+   perspective the migration has entered the `steady` phase and is waiting
+   for the catchup queue to drain; from the source's perspective the queue
+   never empties.
+
+The net effect is that filtering metadata and migration-coordinator state are
+both stale, and the moveChunk hang is the visible joint signature.
+
+## Proposed fix
+
+In the convertToCapped coordinator's post-step on each data shard
+(`convert_to_capped_coordinator.cpp`, after the local capping operation
+completes successfully):
+
+1. **Refresh filtering metadata.** Force a `forceShardFilteringMetadataRefresh`
+   against the new UUID before the coordinator releases the DDL lock. This
+   ensures the next moveChunk sees a current chunk view and a current UUID,
+   and that the source shard's range-deletion processor and migration source
+   manager are operating against the post-conversion catalog.
+
+2. **Abort any in-progress migration coordinator state** for the namespace.
+   Reuse the existing `migrationutil::recoverMigrationCoordinations` /
+   `abortAndForgetOngoingMigrations` paths that DDL coordinators already
+   invoke before taking exclusive locks (e.g. drop, renameCollection). On a
+   freshly-capped collection there should be no live migration, so aborting
+   is either a no-op or correctly cancels a leftover coordinator document
+   that would otherwise stall the next moveChunk.
+
+3. **Drain residual session-migration artifacts.** Either skip the
+   problematic insert in `OpObserverImpl::onWriteOpCompleted` when the
+   statement-id list has been cleared (the narrow fix the ticket describes),
+   or re-initialize the list with a single `kUninitializedStmtId` so the
+   `prevOpTime` chain remains parseable. The exact shape of this change must
+   go through the RSS team — the ticket's own proposal flags that an
+   over-eager fix breaks unit tests in adjacent batched-write paths.
+
+The jstest in this PR (`movechunk_after_converttocapped_no_hang.js`) is the
+regression gate: it shards a collection, runs convertToCapped, then runs
+moveChunk with a 60-second bounded `maxTimeMS`. On unpatched binaries it
+fails with `MaxTimeMSExpired`; on a patched build it completes in under a
+second.


### PR DESCRIPTION
## Summary

jstest + design: moveChunk after convertToCapped must not hang.

**Jira:** https://jira.mongodb.org/browse/SERVER-126725
**Branch:** substrate-contrib/w4-24

## Files

```
  -  .../movechunk_after_converttocapped_no_hang.js     | 100 +++++++++++++++++++++
  -  .../db/global_catalog/SERVER-126352-design.md      |  90 +++++++++++++++++++
  -  2 files changed, 190 insertions(+)
```

## Verify

For `.tla` files:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For `.js` jstests:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
