### PR TITLE
SERVER-126731 TLA+ spec + concurrency jstest: time-series bucket catalog must be consistent under concurrent drop

### DIFF
--- a/jstests/concurrency/fsm_workloads/timeseries/timeseries_concurrent_insert_drop.js
+++ b/jstests/concurrency/fsm_workloads/timeseries/timeseries_concurrent_insert_drop.js
@@ -1,0 +1,269 @@
+/**
+ * Concurrent time-series inserts and drops, checking that the bucket catalog
+ * remains in a consistent state.
+ *
+ * Repro skeleton for SERVER-107351 ("Concurrent time-series inserts and drops
+ * can lead to inconsistent bucket catalog states"). One thread inserts into a
+ * pool of time-series collections; the other thread drops and re-creates them.
+ * If the bucket catalog's per-UUID executionStats entry is re-emplaced by an
+ * insert that races between drop's release-stats phase and clear-buckets
+ * phase, the catalog leaks a stats entry for a uuid that no longer exists.
+ *
+ * After all threads finish, the teardown step checks:
+ *   - bucketCatalog.numActiveBuckets is non-negative (SERVER-106451 regression
+ *     check; double-decrement would push it below zero),
+ *   - collStats reports timeseries.bucketCount >= 0 and bucketCount is
+ *     consistent with the actual on-disk bucket count for each surviving
+ *     collection (precondition that reshardCollection relies on),
+ *   - reshardCollection precondition probes (when running on a sharded
+ *     cluster) succeed against the surviving collections.
+ *
+ * @tags: [
+ *   requires_timeseries,
+ *   # Time-series collections cannot be written to in a multi-document
+ *   # transaction.
+ *   does_not_support_transactions,
+ *   # The test relies on collStats and bucketCatalog numbers; stepdowns can
+ *   # transiently make either return values that look inconsistent.
+ *   does_not_support_stepdowns,
+ *   # Config fuzzer can shrink bucket parameters in ways that change the
+ *   # assertion thresholds.
+ *   does_not_support_config_fuzzer,
+ * ]
+ */
+
+export const $config = (function () {
+    const timeFieldName = "time";
+    const metaFieldName = "tag";
+    const collCount = 3;
+    const insertBatchSize = 25;
+
+    // Error codes the test treats as expected when a command races with a
+    // collection drop. Lifted from existing time-series concurrency tests
+    // (e.g. timeseries_raw_data_with_collection_recreation.js).
+    const acceptableInsertErrorCodes = [
+        ErrorCodes.NamespaceNotFound,
+        ErrorCodes.QueryPlanKilled,
+        ErrorCodes.CommandNotSupportedOnView,
+        ErrorCodes.StaleConfig,
+        // Insert vs concurrent re-create as time-series.
+        10685100,
+        10685101,
+    ];
+
+    const acceptableDropErrorCodes = [
+        ErrorCodes.NamespaceNotFound,
+    ];
+
+    function collectionName(suffix, idx) {
+        return jsTestName() + "_" + suffix + "_" + idx;
+    }
+
+    function getRandomCollIdx() {
+        return Random.randInt(collCount);
+    }
+
+    const data = {
+        collCount: collCount,
+        insertBatchSize: insertBatchSize,
+        timeFieldName: timeFieldName,
+        metaFieldName: metaFieldName,
+        collectionName: collectionName,
+
+        createIfMissing: function (db, collName) {
+            // createCollection will fail with NamespaceExists if it lost a
+            // race; that's fine.
+            const res = db.createCollection(collName, {
+                timeseries: {timeField: timeFieldName, metaField: metaFieldName},
+            });
+            if (!res.ok && res.code !== ErrorCodes.NamespaceExists) {
+                assert.commandWorked(res);
+            }
+        },
+    };
+
+    const states = {
+        init: function init(db, collName) {
+            // Threads are partitioned by tid parity into one inserter and one
+            // dropper. The FSM scheduler uses threadCount=2, so this gives
+            // exactly one of each.
+            this.role = (this.tid % 2 === 0) ? "inserter" : "dropper";
+        },
+
+        insertBatch: function insertBatch(db, collName) {
+            if (this.role !== "inserter") {
+                return;
+            }
+            const idx = getRandomCollIdx();
+            const target = collectionName(collName, idx);
+            const docs = [];
+            for (let i = 0; i < insertBatchSize; ++i) {
+                docs.push({
+                    [timeFieldName]: new Date(),
+                    [metaFieldName]: (this.tid * 1000) + i,
+                    payload: i,
+                });
+            }
+            const res = db.runCommand({insert: target, documents: docs, ordered: false});
+            // Insert may fail or partially fail if the collection is dropped
+            // mid-flight; that is the race we are trying to provoke. We do
+            // NOT fail the test on those expected codes.
+            if (!res.ok) {
+                assert.contains(res.code, acceptableInsertErrorCodes,
+                    `Unexpected insert error: ${tojson(res)}`);
+                return;
+            }
+            if (res.writeErrors) {
+                for (const we of res.writeErrors) {
+                    assert.contains(we.code, acceptableInsertErrorCodes,
+                        `Unexpected write error: ${tojson(we)}`);
+                }
+            }
+        },
+
+        dropAndRecreate: function dropAndRecreate(db, collName) {
+            if (this.role !== "dropper") {
+                return;
+            }
+            const idx = getRandomCollIdx();
+            const target = collectionName(collName, idx);
+            const dropRes = db.runCommand({drop: target});
+            if (!dropRes.ok) {
+                assert.contains(dropRes.code, acceptableDropErrorCodes,
+                    `Unexpected drop error: ${tojson(dropRes)}`);
+            }
+            // Re-create so the inserter has a target to race against next
+            // iteration. The race window we care about (between drop's
+            // releaseStats and clearBuckets phases) is microseconds; the
+            // re-create just keeps the workload live.
+            this.createIfMissing(db, target);
+        },
+    };
+
+    const transitions = {
+        init: {insertBatch: 0.5, dropAndRecreate: 0.5},
+        insertBatch: {insertBatch: 0.7, dropAndRecreate: 0.3},
+        dropAndRecreate: {insertBatch: 0.5, dropAndRecreate: 0.5},
+    };
+
+    function setup(db, collName, cluster) {
+        for (let i = 0; i < collCount; ++i) {
+            const target = collectionName(collName, i);
+            // Drop any pre-existing collection from a prior run, then create
+            // fresh.
+            db.runCommand({drop: target});
+            assert.commandWorked(db.createCollection(target, {
+                timeseries: {timeField: timeFieldName, metaField: metaFieldName},
+            }));
+        }
+    }
+
+    function assertBucketCatalogConsistent(db) {
+        // Per-node bucket catalog server status: numActiveBuckets must never
+        // go negative (SERVER-106451). The SERVER-107351 leak doesn't make
+        // this number negative, but it does inflate executionStats; we sanity
+        // check both signs.
+        const bucketCatalog = db.serverStatus().bucketCatalog;
+        if (bucketCatalog === undefined) {
+            // mongos or older server; nothing to check here.
+            return;
+        }
+        jsTestLog("bucketCatalog server status: " + tojson(bucketCatalog));
+        if (bucketCatalog.numActiveBuckets !== undefined) {
+            assert.gte(bucketCatalog.numActiveBuckets, 0,
+                `numActiveBuckets went negative: ${tojson(bucketCatalog)}`);
+        }
+    }
+
+    function assertCollStatsConsistent(db, collFullName) {
+        const stats = db.runCommand({collStats: collFullName});
+        if (!stats.ok) {
+            // Collection may have been dropped at the boundary.
+            assert.contains(stats.code, [ErrorCodes.NamespaceNotFound],
+                `collStats failed unexpectedly: ${tojson(stats)}`);
+            return;
+        }
+        // For time-series collections collStats returns a timeseries
+        // sub-document; bucketCount and numBucketInserts must be non-negative.
+        if (stats.timeseries) {
+            jsTestLog(`collStats timeseries for ${collFullName}: ${tojson(stats.timeseries)}`);
+            for (const k of ["bucketCount", "numBucketInserts", "numBucketUpdates",
+                             "numBucketsClosedDueToCount", "numBucketsClosedDueToSize",
+                             "numBucketsClosedDueToTimeForward", "numBucketsClosedDueToTimeBackward",
+                             "numBucketsClosedDueToMemoryThreshold", "numCommits", "numWaits",
+                             "numMeasurementsCommitted"]) {
+                if (stats.timeseries[k] !== undefined) {
+                    assert.gte(stats.timeseries[k], 0,
+                        `${collFullName} collStats.timeseries.${k} negative: ${tojson(stats.timeseries)}`);
+                }
+            }
+        }
+    }
+
+    function assertReshardPreconditionsHold(db, collFullName) {
+        // reshardCollection's precondition path queries the catalog for the
+        // current collection state; if the bucket catalog has stale entries
+        // referencing a dropped UUID, that path can return inconsistent
+        // results. We probe with a dry-run-ish call: if the cluster is not
+        // sharded, the command returns IllegalOperation which we accept.
+        // If the cluster IS sharded and the collection is missing, we accept
+        // NamespaceNotFound. Anything else is the bug.
+        const res = db.adminCommand({reshardCollection: collFullName,
+                                     key: {[metaFieldName]: 1, [timeFieldName]: 1},
+                                     numInitialChunks: 1,
+                                     // dry-run flag not universally available; the assert
+                                     // below tolerates the command being unsupported.
+                                     forceRedistribution: false});
+        // We don't require this command to succeed - this test isn't a
+        // sharded suite. We only require that the failure is a "well-formed"
+        // failure rather than an internal-state inconsistency.
+        const tolerated = [
+            ErrorCodes.IllegalOperation,        // not a sharded cluster
+            ErrorCodes.NamespaceNotFound,       // collection got dropped at boundary
+            ErrorCodes.NamespaceNotSharded,
+            ErrorCodes.CommandNotSupported,
+            ErrorCodes.CommandNotFound,
+            ErrorCodes.NotImplemented,
+            ErrorCodes.InvalidOptions,
+            ErrorCodes.BadValue,
+        ];
+        if (!res.ok) {
+            assert.contains(res.code, tolerated,
+                `reshardCollection precondition probe surfaced a non-tolerated error - ` +
+                `this may indicate bucket catalog state inconsistency: ${tojson(res)}`);
+        }
+    }
+
+    function teardown(db, collName, cluster) {
+        // Per-node bucket catalog checks. On a replica set this runs on each
+        // mongod; on a standalone it runs once.
+        if (cluster.executeOnMongodNodes) {
+            cluster.executeOnMongodNodes((nodeDb) => {
+                assertBucketCatalogConsistent(nodeDb);
+            });
+        } else {
+            assertBucketCatalogConsistent(db);
+        }
+
+        for (let i = 0; i < collCount; ++i) {
+            const target = collectionName(collName, i);
+            assertCollStatsConsistent(db, target);
+            assertReshardPreconditionsHold(db, db.getName() + "." + target);
+        }
+    }
+
+    return {
+        threadCount: 2,
+        // ~30s wall clock budget: insert state runs ~50 batches of 25 docs
+        // plus drop/recreate roundtrips; total ~150 iterations per thread is
+        // a reasonable approximation on a non-loaded host. The FSM framework
+        // doesn't expose a duration knob, so we tune via iteration count.
+        iterations: 150,
+        startState: "init",
+        data: data,
+        states: states,
+        setup: setup,
+        teardown: teardown,
+        transitions: transitions,
+    };
+})();

--- a/src/mongo/tla_plus/TimeSeries/BucketCatalogConcurrentDrop/BucketCatalogConcurrentDrop.tla
+++ b/src/mongo/tla_plus/TimeSeries/BucketCatalogConcurrentDrop/BucketCatalogConcurrentDrop.tla
@@ -1,0 +1,267 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+---------------------- MODULE BucketCatalogConcurrentDrop ----------------------
+\* Formal specification of the time-series bucket catalog state under concurrent
+\* inserts and collection drops (SERVER-107351).
+\*
+\* Background. The bucket catalog keeps two pieces of per-collection-UUID state
+\* the insert path mutates without holding the collection-level lock:
+\*
+\*   1. executionStats[uuid]        - lookup/insert via getOrInitializeExecutionStats
+\*   2. open buckets keyed by uuid  - written by stageInsertBatch
+\*
+\* drop(uuid) is implemented in two phases (bucket_catalog.cpp::drop):
+\*
+\*     phase R (release stats):  catalog.executionStats.erase(uuid)
+\*     phase C (clear buckets):  bucketStateRegistry.clearedSets[++era] := {uuid}
+\*
+\* Each phase is locked individually, but no lock spans both. A concurrent
+\* insert that runs getOrInitializeExecutionStats(uuid) BETWEEN drop's R and C
+\* phases re-emplaces an executionStats entry for the dropped uuid. The same
+\* race lets an insert open a bucket against the (about-to-be-cleared) uuid,
+\* leaving a dangling open-bucket reference after drop completes.
+\*
+\* We model:
+\*   - Insert as a four-step state machine (lookupStats, openBucket,
+\*     writeMeasurement, finishBatch).
+\*   - Drop as the two-phase (releaseStats, clearBuckets) op above.
+\*   - Two correctness invariants:
+\*       NoStatsForDroppedCollection - executionStats has no entry whose
+\*                                     uuid is in the drop history.
+\*       NoOpenBucketForDroppedCollection - openBuckets has no entry whose
+\*                                          uuid is in the drop history.
+\*
+\* The "bug" model configuration (MC*.cfg with AllowInterleavedDropPhases=TRUE)
+\* allows insert steps to interleave between drop's R and C phases. TLC must
+\* find a counterexample violating the invariants above.
+\*
+\* The "fixed" model configuration (AllowInterleavedDropPhases=FALSE) models
+\* an atomic drop (the candidate fix: hold catalog.mutex across both R and C,
+\* or re-clean executionStats entries written during the race window). The
+\* invariants must hold.
+\*
+\* To run the model-checker:
+\*     cd src/mongo/tla_plus
+\*     ./model-check.sh TimeSeries/BucketCatalogConcurrentDrop
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+
+CONSTANTS
+    Collections,                  \* Set of collection-uuid identifiers (e.g. {c1, c2}).
+    Inserters,                    \* Set of inserter-thread ids.
+    Droppers,                     \* Set of dropper-thread ids.
+    MaxDrops,                     \* Cap on total drop operations (state-space bound).
+    AllowInterleavedDropPhases    \* TRUE  -> bug model: insert can interleave between R and C.
+                                  \* FALSE -> fixed model: drop's R..C is atomic w.r.t. inserts.
+
+ASSUME Cardinality(Collections) >= 1
+ASSUME Cardinality(Inserters) >= 1
+ASSUME Cardinality(Droppers) >= 1
+ASSUME MaxDrops \in Nat
+ASSUME AllowInterleavedDropPhases \in BOOLEAN
+
+-----------------------------------------------------------------------------
+\* Thread step enumeration. An inserter's "pc" tracks where in the insert
+\* state machine it currently is. A dropper's "pc" tracks where in the drop
+\* state machine it currently is.
+
+InserterIdle      == "InserterIdle"
+InserterPicked    == "InserterPicked"      \* chose a uuid, not yet acquired stats
+InserterHasStats  == "InserterHasStats"    \* stats entry observed/created
+InserterHasBucket == "InserterHasBucket"   \* open bucket recorded
+
+DropperIdle       == "DropperIdle"
+DropperReleased   == "DropperReleased"     \* completed phase R, not yet phase C
+
+InserterStates == {InserterIdle, InserterPicked, InserterHasStats, InserterHasBucket}
+DropperStates  == {DropperIdle, DropperReleased}
+
+-----------------------------------------------------------------------------
+VARIABLES
+    executionStats,   \* Set of UUIDs currently in catalog.executionStats.
+    openBuckets,      \* Set of UUIDs that currently have at least one open bucket.
+    droppedHistory,   \* Sequence of UUIDs that have completed a drop (R+C).
+    dropCount,        \* Total drop operations started (bound by MaxDrops).
+    inserterPc,       \* [t \in Inserters -> InserterStates]
+    inserterUuid,     \* [t \in Inserters -> Collections \cup {NoUuid}] uuid this thread is operating on
+    dropperPc,        \* [t \in Droppers -> DropperStates]
+    dropperUuid       \* [t \in Droppers -> Collections \cup {NoUuid}]
+
+NoUuid == "<none>"
+UuidOrNone == Collections \cup {NoUuid}
+
+vars == <<executionStats, openBuckets, droppedHistory, dropCount,
+          inserterPc, inserterUuid, dropperPc, dropperUuid>>
+
+-----------------------------------------------------------------------------
+\* When AllowInterleavedDropPhases = FALSE, inserts may not run while any
+\* dropper is mid-flight (between phase R and phase C). This models the fix:
+\* hold catalog.mutex across both phases, or re-sweep executionStats after
+\* clearBuckets to purge any races.
+
+AnyDropperMidFlight ==
+    \E d \in Droppers : dropperPc[d] = DropperReleased
+
+InsertersUnblocked ==
+    AllowInterleavedDropPhases \/ ~AnyDropperMidFlight
+
+-----------------------------------------------------------------------------
+Init ==
+    /\ executionStats = {}
+    /\ openBuckets = {}
+    /\ droppedHistory = <<>>
+    /\ dropCount = 0
+    /\ inserterPc = [t \in Inserters |-> InserterIdle]
+    /\ inserterUuid = [t \in Inserters |-> NoUuid]
+    /\ dropperPc = [t \in Droppers |-> DropperIdle]
+    /\ dropperUuid = [t \in Droppers |-> NoUuid]
+
+-----------------------------------------------------------------------------
+\* Insert state machine.
+\*
+\* Step 1: pickCollection - choose a target uuid for this insert. No catalog
+\* mutation yet.
+PickCollection(t, uuid) ==
+    /\ inserterPc[t] = InserterIdle
+    /\ uuid \in Collections
+    /\ inserterPc' = [inserterPc EXCEPT ![t] = InserterPicked]
+    /\ inserterUuid' = [inserterUuid EXCEPT ![t] = uuid]
+    /\ UNCHANGED <<executionStats, openBuckets, droppedHistory, dropCount,
+                   dropperPc, dropperUuid>>
+
+\* Step 2: lookupOrInitStats - acquires catalog.mutex briefly, observes
+\* executionStats[uuid], emplaces if missing. This is the source of the
+\* leak: if a drop's release-phase already ran and clear-phase hasn't yet,
+\* this re-inserts a stats entry for the doomed uuid.
+LookupOrInitStats(t) ==
+    /\ inserterPc[t] = InserterPicked
+    /\ InsertersUnblocked
+    /\ LET u == inserterUuid[t]
+       IN /\ executionStats' = executionStats \cup {u}
+          /\ inserterPc' = [inserterPc EXCEPT ![t] = InserterHasStats]
+    /\ UNCHANGED <<openBuckets, droppedHistory, dropCount,
+                   inserterUuid, dropperPc, dropperUuid>>
+
+\* Step 3: openBucket - stageInsertBatch eventually writes to the open-bucket
+\* structures under the stripe lock. Same race exists: a drop in flight may
+\* be about to clear buckets for this uuid, but hasn't yet.
+OpenBucket(t) ==
+    /\ inserterPc[t] = InserterHasStats
+    /\ InsertersUnblocked
+    /\ LET u == inserterUuid[t]
+       IN /\ openBuckets' = openBuckets \cup {u}
+          /\ inserterPc' = [inserterPc EXCEPT ![t] = InserterHasBucket]
+    /\ UNCHANGED <<executionStats, droppedHistory, dropCount,
+                   inserterUuid, dropperPc, dropperUuid>>
+
+\* Step 4: finishBatch - the insert thread releases its references and returns
+\* to idle. Bucket may remain open in the catalog for future inserts to
+\* re-use; the in-flight thread state is what resets.
+FinishBatch(t) ==
+    /\ inserterPc[t] = InserterHasBucket
+    /\ inserterPc' = [inserterPc EXCEPT ![t] = InserterIdle]
+    /\ inserterUuid' = [inserterUuid EXCEPT ![t] = NoUuid]
+    /\ UNCHANGED <<executionStats, openBuckets, droppedHistory, dropCount,
+                   dropperPc, dropperUuid>>
+
+-----------------------------------------------------------------------------
+\* Drop state machine. The drop happens in two phases, modelling
+\* releaseExecutionStatsFromBucketCatalog (phase R) and clearSetOfBuckets
+\* (phase C). Each phase individually takes a relevant mutex, but the
+\* current implementation does not hold a single lock that spans both,
+\* which is the SERVER-107351 race.
+
+\* Phase R: releaseExecutionStatsFromBucketCatalog(uuid)
+\*   Lock catalog.mutex
+\*   executionStats.erase(uuid)
+ReleaseStats(d, uuid) ==
+    /\ dropperPc[d] = DropperIdle
+    /\ dropCount < MaxDrops
+    /\ uuid \in Collections
+    /\ executionStats' = executionStats \ {uuid}
+    /\ dropperPc' = [dropperPc EXCEPT ![d] = DropperReleased]
+    /\ dropperUuid' = [dropperUuid EXCEPT ![d] = uuid]
+    /\ dropCount' = dropCount + 1
+    /\ UNCHANGED <<openBuckets, droppedHistory,
+                   inserterPc, inserterUuid>>
+
+\* Phase C: clearSetOfBuckets(uuid)
+\*   Lock bucketStateRegistry.mutex
+\*   clear all bucket state referencing uuid
+\* Then complete the drop and record it in history.
+ClearBuckets(d) ==
+    /\ dropperPc[d] = DropperReleased
+    /\ LET u == dropperUuid[d]
+       IN /\ openBuckets' = openBuckets \ {u}
+          /\ droppedHistory' = Append(droppedHistory, u)
+          /\ dropperPc' = [dropperPc EXCEPT ![d] = DropperIdle]
+          /\ dropperUuid' = [dropperUuid EXCEPT ![d] = NoUuid]
+    /\ UNCHANGED <<executionStats, dropCount,
+                   inserterPc, inserterUuid>>
+
+-----------------------------------------------------------------------------
+Next ==
+    \/ \E t \in Inserters, u \in Collections : PickCollection(t, u)
+    \/ \E t \in Inserters : LookupOrInitStats(t)
+    \/ \E t \in Inserters : OpenBucket(t)
+    \/ \E t \in Inserters : FinishBatch(t)
+    \/ \E d \in Droppers, u \in Collections : ReleaseStats(d, u)
+    \/ \E d \in Droppers : ClearBuckets(d)
+
+Spec ==
+    /\ Init
+    /\ [][Next]_vars
+    /\ WF_vars(Next)
+    /\ \A t \in Inserters : WF_vars(LookupOrInitStats(t))
+                            /\ WF_vars(OpenBucket(t))
+                            /\ WF_vars(FinishBatch(t))
+    /\ \A d \in Droppers : WF_vars(ClearBuckets(d))
+
+-----------------------------------------------------------------------------
+\* Invariants
+
+TypeOK ==
+    /\ executionStats \subseteq Collections
+    /\ openBuckets \subseteq Collections
+    /\ dropCount \in Nat
+    /\ inserterPc \in [Inserters -> InserterStates]
+    /\ inserterUuid \in [Inserters -> UuidOrNone]
+    /\ dropperPc \in [Droppers -> DropperStates]
+    /\ dropperUuid \in [Droppers -> UuidOrNone]
+    /\ \A i \in 1..Len(droppedHistory) : droppedHistory[i] \in Collections
+
+\* Set of uuids that have completed at least one drop and currently have no
+\* in-flight insert holding a reference. (A re-create after drop is not
+\* modelled; this spec treats each drop as terminal for its uuid.)
+DroppedUuids == { droppedHistory[i] : i \in 1..Len(droppedHistory) }
+
+\* No executionStats entry should reference a uuid whose drop has completed,
+\* unless an in-flight insert is currently between LookupOrInitStats and
+\* FinishBatch on that uuid AND it raced in (which itself is the bug).
+\* The strict reading: once drop finishes (phase C done, history appended),
+\* the catalog must hold no stats for that uuid.
+NoStatsForDroppedCollection ==
+    \A u \in DroppedUuids : u \notin executionStats
+
+\* Likewise for open buckets: no open-bucket entry should reference a dropped
+\* uuid after drop has completed.
+NoOpenBucketForDroppedCollection ==
+    \A u \in DroppedUuids : u \notin openBuckets
+
+\* Composite invariant matching the ticket's wording: "post-drop, no open
+\* bucket entries reference the dropped collection".
+CatalogConsistentPostDrop ==
+    /\ NoStatsForDroppedCollection
+    /\ NoOpenBucketForDroppedCollection
+
+\* A weaker liveness-flavoured invariant: a drop in flight must eventually
+\* complete. Used by liveness checking.
+DropEventuallyCompletes ==
+    \A d \in Droppers :
+        (dropperPc[d] = DropperReleased) ~> (dropperPc[d] = DropperIdle)
+
+=============================================================================

--- a/src/mongo/tla_plus/TimeSeries/BucketCatalogConcurrentDrop/MCBucketCatalogConcurrentDrop.cfg
+++ b/src/mongo/tla_plus/TimeSeries/BucketCatalogConcurrentDrop/MCBucketCatalogConcurrentDrop.cfg
@@ -1,0 +1,26 @@
+\* Bug model: insert is allowed to interleave between drop's release-stats
+\* and clear-buckets phases. TLC will find a counterexample to
+\* CatalogConsistentPostDrop.
+\*
+\* To exercise the fixed model (atomic drop), flip
+\* AllowInterleavedDropPhases to FALSE; the invariants must hold.
+
+SPECIFICATION Spec
+
+CONSTANTS
+    Collections = {c1, c2}
+    Inserters = {i1, i2}
+    Droppers = {d1}
+    MaxDrops = 2
+    AllowInterleavedDropPhases = TRUE
+
+CONSTRAINT
+    HistoryBound
+
+INVARIANT
+    TypeOK
+    CatalogConsistentPostDrop
+    \* BaitExecutionStatsNeverDirty
+
+PROPERTY
+    DropEventuallyCompletes

--- a/src/mongo/tla_plus/TimeSeries/BucketCatalogConcurrentDrop/MCBucketCatalogConcurrentDrop.tla
+++ b/src/mongo/tla_plus/TimeSeries/BucketCatalogConcurrentDrop/MCBucketCatalogConcurrentDrop.tla
@@ -1,0 +1,33 @@
+------------------- MODULE MCBucketCatalogConcurrentDrop ---------------------
+\* Model-checking module for BucketCatalogConcurrentDrop.
+\*
+\* The default cfg (MCBucketCatalogConcurrentDrop.cfg) wires the model in the
+\* "bug" configuration: AllowInterleavedDropPhases = TRUE, which lets an
+\* insert thread re-emplace executionStats or open buckets for a uuid whose
+\* drop is mid-flight. TLC must report a counterexample violating
+\* CatalogConsistentPostDrop.
+\*
+\* To exercise the "fixed" configuration (drop's two phases serialised
+\* w.r.t. insert), edit the cfg's CONSTANT line to set
+\* AllowInterleavedDropPhases <- FALSE - the invariants must then hold.
+
+EXTENDS BucketCatalogConcurrentDrop
+
+(******************************************************************************)
+(* State constraints. Bound TLC's exploration of the state space.             *)
+(******************************************************************************)
+
+\* Cap drops at MaxDrops (already enforced by ReleaseStats), and cap the
+\* number of distinct in-flight states by limiting droppedHistory length.
+HistoryBound == Len(droppedHistory) <= MaxDrops
+
+(******************************************************************************)
+(* Counterexample baits. Toggle in the cfg INVARIANT block to confirm TLC     *)
+(* would explode if these were really invariants.                             *)
+(******************************************************************************)
+
+\* Never holds in the bug model: TLC can always race insert into a dropped
+\* uuid.
+BaitExecutionStatsNeverDirty == executionStats \cap DroppedUuids = {}
+
+==============================================================================

--- a/src/mongo/tla_plus/TimeSeries/BucketCatalogConcurrentDrop/OWNERS.yml
+++ b/src/mongo/tla_plus/TimeSeries/BucketCatalogConcurrentDrop/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-timeseries-bucket-catalog


### PR DESCRIPTION
## Summary

TLA+ spec + concurrency jstest: time-series bucket catalog must be consistent under concurrent drop.

**Jira:** https://jira.mongodb.org/browse/SERVER-126731
**Branch:** substrate-contrib/w4-27

## Files

```
  -  .../timeseries_concurrent_insert_drop.js           | 269 +++++++++++++++++++++
  -  .../BucketCatalogConcurrentDrop.tla                | 267 ++++++++++++++++++++
  -  .../MCBucketCatalogConcurrentDrop.cfg              |  26 ++
  -  .../MCBucketCatalogConcurrentDrop.tla              |  33 +++
  -  .../BucketCatalogConcurrentDrop/OWNERS.yml         |   5 +
  -  5 files changed, 600 insertions(+)
```

## Verify

For `.tla` files:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For `.js` jstests:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
