### PR TITLE
SERVER-126732 TLA+ spec + jstest: ECOC clustered index must survive concurrent compact + writes

### DIFF
--- a/jstests/fle2/qe_cleanup_compact_race_no_missing_index.js
+++ b/jstests/fle2/qe_cleanup_compact_race_no_missing_index.js
@@ -1,0 +1,171 @@
+/**
+ * Regression test for SERVER-126384.
+ *
+ * QE cleanup/compact operations rename the live ECOC out of the way, release the collection
+ * lock, then re-create the ECOC with the required {clusteredIndex: {key: {_id: 1}, unique: true}}
+ * option. A concurrent user write that arrives in the gap between rename and re-create can
+ * IMPLICITLY create the ECOC namespace with DEFAULT options (i.e. without the clustered index).
+ * The internal create issued by compact/cleanup then silently no-ops because the namespace
+ * already exists, the command returns success, and the ECOC is left permanently missing its
+ * clustered index — degrading subsequent compactions and queries.
+ *
+ * This test drives the race for BOTH compactStructuredEncryptionData and
+ * cleanupStructuredEncryptionData (one collection each), runs concurrent encrypted inserts in
+ * the foreground while the maintenance command runs in a parallel shell, and asserts that
+ * post-race the ECOC namespace always exists with its clustered index option preserved.
+ *
+ * Pairs with the TLA+ specification at:
+ *   src/mongo/tla_plus/FLE/ECOCCompactCleanupRace/ECOCCompactCleanupRace.tla
+ *
+ * @tags: [
+ *   no_selinux,
+ *   does_not_support_transactions,
+ *   does_not_support_stepdowns,
+ *   assumes_unsharded_collection,
+ *   assumes_balancer_off,
+ *   requires_fcv_70,
+ * ]
+ */
+import {EncryptedClient, isEnterpriseShell} from "jstests/fle2/libs/encrypted_client_util.js";
+import {funWithArgs} from "jstests/libs/parallel_shell_helpers.js";
+
+if (!isEnterpriseShell()) {
+    jsTestLog("Skipping test as it requires the enterprise module");
+    quit();
+}
+
+const dbName = "qe_cleanup_compact_race_no_missing_index_db";
+const encryptedFields = {
+    fields: [
+        {
+            path: "ssn",
+            bsonType: "string",
+            queries: {queryType: "equality"},
+        },
+    ],
+};
+
+// Number of concurrent encrypted inserts the foreground shell will fire while the maintenance
+// command runs in the parallel shell. Each insert sleeps briefly so it has a real chance of
+// landing inside the rename->create window.
+const kNumConcurrentInserts = 10;
+const kInterInsertSleepMs = 200;
+
+/**
+ * Reads the live ECOC's collection options from listCollections and returns the options object,
+ * or undefined if the ECOC doesn't exist. Used both pre- and post-race.
+ */
+function getEcocOptions(testDB, ecocName) {
+    const infos = testDB.getCollectionInfos({name: ecocName});
+    if (infos.length === 0) {
+        return undefined;
+    }
+    return infos[0].options;
+}
+
+/**
+ * Asserts the ECOC exists with a clustered index. Failure message includes provenance hints
+ * so the SERVER-126384 race is identifiable in test logs.
+ */
+function assertEcocHasClusteredIndex(testDB, ecocName, phase) {
+    const opts = getEcocOptions(testDB, ecocName);
+    assert.neq(undefined, opts, `[${phase}] ECOC namespace '${ecocName}' does not exist`);
+    assert.neq(
+        undefined,
+        opts.clusteredIndex,
+        `[${phase}] SERVER-126384: ECOC namespace '${ecocName}' is missing its clustered index. ` +
+            `Options observed: ${tojson(opts)}`,
+    );
+}
+
+/**
+ * Body of the parallel shell that runs the maintenance command. Bootstraps its own encrypted
+ * connection against the same local KMS key + key vault, then issues either
+ * compactStructuredEncryptionData or cleanupStructuredEncryptionData against the target
+ * collection.
+ */
+const runMaintenance = function (dbName, collName, command) {
+    const conn = db.getMongo();
+    conn.setAutoEncryption({
+        kmsProviders: {
+            local: {
+                key: BinData(
+                    0,
+                    "/tu9jUCBqZdwCelwE/EAm/4WqdxrSMi04B8e9uAV+m30rI1J2nhKZZtQjdvsSCwuI4erR6IEcEK+5eGUAODv43NDNIR9QheT2edWFewUfHKsl9cnzTc86meIzOmYl6dr",
+                ),
+            },
+        },
+        keyVaultNamespace: dbName + ".keystore",
+        schemaMap: {},
+    });
+    conn.toggleAutoEncryption(true);
+    const sessionDB = db.getSiblingDB(dbName);
+    let reply;
+    if (command === "compact") {
+        reply = assert.commandWorked(sessionDB[collName].compact());
+    } else if (command === "cleanup") {
+        reply = assert.commandWorked(sessionDB.runCommand({cleanupStructuredEncryptionData: collName}));
+    } else {
+        throw new Error(`Unknown maintenance command: ${command}`);
+    }
+    jsTestLog(`Parallel ${command}StructuredEncryptionData reply: ${tojson(reply)}`);
+    conn.toggleAutoEncryption(false);
+    conn.unsetAutoEncryption();
+};
+
+/**
+ * Drives one race iteration: kicks off the maintenance command in a parallel shell, fires
+ * kNumConcurrentInserts encrypted inserts in the foreground with brief pauses, joins, and
+ * checks the ECOC's clustered index option.
+ */
+function runRace(client, collName, maintenanceCmd, port) {
+    const testDB = client.getDB();
+    const ecocName = client.getStateCollectionNamespaces(collName).ecoc;
+
+    // Sanity: pre-race the ECOC must already have its clustered index.
+    assertEcocHasClusteredIndex(testDB, ecocName, `pre-${maintenanceCmd}`);
+
+    const joinMaintenance = startParallelShell(
+        funWithArgs(runMaintenance, dbName, collName, maintenanceCmd),
+        port,
+    );
+
+    client.runEncryptionOperation(() => {
+        const ecoll = testDB[collName];
+        for (let i = 0; i < kNumConcurrentInserts; i++) {
+            const ssn = `${String(i).padStart(3, "0")}-00-${maintenanceCmd === "cleanup" ? "1111" : "0000"}`;
+            assert.commandWorked(
+                ecoll.insertOne({
+                    _id: `${maintenanceCmd}-${i}`,
+                    ssn: ssn,
+                }),
+            );
+            sleep(kInterInsertSleepMs);
+        }
+    });
+
+    jsTestLog(`Waiting for parallel ${maintenanceCmd}StructuredEncryptionData to finish`);
+    joinMaintenance();
+
+    // Core SERVER-126384 assertion: the ECOC must STILL have its clustered index after the
+    // rename/release/create dance has interleaved with user inserts.
+    assertEcocHasClusteredIndex(testDB, ecocName, `post-${maintenanceCmd}`);
+}
+
+const testDB = db.getSiblingDB(dbName);
+testDB.dropDatabase();
+
+const client = new EncryptedClient(db.getMongo(), dbName);
+const port = db.getMongo().port;
+
+// Drive the race against compactStructuredEncryptionData.
+const compactCollName = "compact_race_coll";
+assert.commandWorked(client.createEncryptionCollection(compactCollName, {encryptedFields: encryptedFields}));
+runRace(client, compactCollName, "compact", port);
+
+// Drive the race against cleanupStructuredEncryptionData (same rename/release/create pattern).
+const cleanupCollName = "cleanup_race_coll";
+assert.commandWorked(client.createEncryptionCollection(cleanupCollName, {encryptedFields: encryptedFields}));
+runRace(client, cleanupCollName, "cleanup", port);
+
+jsTestLog("SERVER-126384 regression check passed: ECOC clustered index survived concurrent compact + cleanup + writes.");

--- a/src/mongo/tla_plus/FLE/ECOCCompactCleanupRace/ECOCCompactCleanupRace.tla
+++ b/src/mongo/tla_plus/FLE/ECOCCompactCleanupRace/ECOCCompactCleanupRace.tla
@@ -1,0 +1,289 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+------------------------------ MODULE ECOCCompactCleanupRace --------------------------------------
+\* Formal specification of the race between FLE2 queryable-encryption (QE) cleanup/compact
+\* operations and concurrent user writes against an encrypted collection.
+\*
+\* Reference: SERVER-126384 — "QE cleanup/compact racing with user writes might result in ECOC
+\* collection missing the clustered index".
+\*
+\* Real-world setup (paraphrased from the ticket):
+\*   The `compactStructuredEncryptionData` and `cleanupStructuredEncryptionData` commands operate
+\*   on the per-collection ECOC (encrypted compaction collection). Both commands work by:
+\*     (1) Renaming the live `enxcol_.<name>.ecoc` collection out of the way (to `.ecoc.compact`
+\*         or `.ecoc.cleanup`).
+\*     (2) Releasing the collection lock between rename and create.
+\*     (3) Re-creating an empty `enxcol_.<name>.ecoc` WITH the required clustered index option
+\*         (`{clusteredIndex: {key: {_id: 1}, unique: true}}`).
+\*
+\*   Step (2) opens a window in which a concurrent user insert/update on the encrypted data
+\*   collection (EDC) may implicitly create the ECOC namespace using DEFAULT collection options
+\*   — i.e. WITHOUT the clustered index. When this happens, the internal `create` issued by the
+\*   maintenance command silently no-ops (collection already exists) and the command returns
+\*   success to the caller. The result is a long-lived ECOC missing the clustered index, with
+\*   permanent performance and correctness consequences for subsequent compaction.
+\*
+\* This specification:
+\*   - Models the ECOC namespace as a record describing its existence and creation-time options.
+\*   - Models compact, cleanup, and concurrent user-write actions as distinct steps so the race
+\*     interleaving (rename -> implicit-create -> internal-create) is visible to TLC.
+\*   - Pins the safety invariant ECOCAlwaysClustered: while it exists, the ECOC namespace
+\*     ALWAYS carries the clustered index option.
+\*   - Models the proposed catalog-level fix (Last Comment by Pierlauro Sciarelli): the constant
+\*     `CatalogPinsClusteredIndex`, when TRUE, forces every implicit ECOC creation to use the
+\*     clustered-index option. With this constant FALSE the spec exhibits the bug; with it TRUE
+\*     the bug is masked. Both modes are exercised by the model-check config so the constant
+\*     functions as a regression switch.
+\*
+\* To run the model-checker, first edit the constants in MCECOCCompactCleanupRace.cfg if desired,
+\* then:
+\*     cd src/mongo/tla_plus
+\*     ./model-check.sh FLE/ECOCCompactCleanupRace
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+
+CONSTANTS
+    UserWriters,                 \* Set of concurrent user-write thread ids.
+    MaxMaintenanceOps,           \* Bound on (compact + cleanup) ops to keep state finite.
+    MaxUserWrites,               \* Bound on user-write ops to keep state finite.
+    CatalogPinsClusteredIndex    \* Proposed fix: catalog forces clustered index on every
+                                 \* implicit ECOC create. BOOLEAN.
+
+\* Maintenance commands. cleanup and compact follow the same rename->release->create pattern
+\* against the ECOC namespace; we model them as two separate kinds so the spec can show both
+\* paths exhibit the race.
+COMPACT == "compact"
+CLEANUP == "cleanup"
+MaintenanceKinds == {COMPACT, CLEANUP}
+
+\* ECOC namespace creation provenance, used to make the buggy interleaving observable.
+CREATED_BY_MAINTENANCE == "maintenance"   \* Created by compactor/cleaner with clustered index.
+CREATED_BY_USER_WRITE  == "user_write"    \* Implicitly created by a user insert/update.
+
+\* Phases a maintenance op walks through. RENAMED is the dangerous gap: the original ECOC has
+\* been renamed but a new one has not yet been re-created.
+IDLE     == "idle"
+RENAMED  == "renamed"
+CREATED  == "created"
+DONE     == "done"
+
+MaintenancePhases == {IDLE, RENAMED, CREATED, DONE}
+
+ASSUME Cardinality(UserWriters) > 0
+ASSUME MaxMaintenanceOps \in 1..100
+ASSUME MaxUserWrites \in 1..100
+ASSUME CatalogPinsClusteredIndex \in BOOLEAN
+
+-----------------------------------------------------------------------------
+
+VARIABLES
+    ecocExists,        \* BOOLEAN: does the live ECOC namespace currently exist?
+    ecocClustered,     \* BOOLEAN: if ecocExists, does it have the clustered index option?
+    ecocCreatedBy,     \* Provenance of the current ECOC: maintenance or user_write.
+    ecocTempExists,    \* BOOLEAN: does the renamed-out temp namespace currently exist?
+    maintenancePhase,  \* IDLE | RENAMED | CREATED | DONE (current op state).
+    maintenanceKind,   \* COMPACT | CLEANUP (kind of the in-flight op, if any).
+    maintenanceCount,  \* Number of maintenance ops started (for bounding).
+    userWriteCount,    \* Number of user writes performed (for bounding).
+    history            \* Sequence of observed events, helpful for counterexample readability.
+
+vars == <<ecocExists, ecocClustered, ecocCreatedBy, ecocTempExists,
+          maintenancePhase, maintenanceKind, maintenanceCount, userWriteCount, history>>
+
+-----------------------------------------------------------------------------
+
+\* Initial state: the encrypted collection has just been created. ECOC exists with the
+\* clustered index option, provenance is "maintenance" (the create-encrypted-collection path
+\* installs it). No maintenance op in flight, no user writes yet.
+Init ==
+    /\ ecocExists = TRUE
+    /\ ecocClustered = TRUE
+    /\ ecocCreatedBy = CREATED_BY_MAINTENANCE
+    /\ ecocTempExists = FALSE
+    /\ maintenancePhase = IDLE
+    /\ maintenanceKind = COMPACT  \* Arbitrary placeholder; only meaningful while phase # IDLE.
+    /\ maintenanceCount = 0
+    /\ userWriteCount = 0
+    /\ history = <<>>
+
+\* Convenience operator: record an event for counterexample traces.
+AppendHistory(e) == history' = Append(history, e)
+
+-----------------------------------------------------------------------------
+\* Maintenance command actions (compact or cleanup).
+-----------------------------------------------------------------------------
+
+\* Step 1: start a maintenance op. Atomically rename the current ECOC out of the way under the
+\* collection lock. After this step the ECOC namespace is gone and we are in the RENAMED phase.
+\* This is the model of:
+\*     RenameCollection(enxcol_.<n>.ecoc -> enxcol_.<n>.ecoc.<kind>)  // holds coll lock
+StartMaintenance(kind) ==
+    /\ kind \in MaintenanceKinds
+    /\ maintenancePhase = IDLE
+    /\ maintenanceCount < MaxMaintenanceOps
+    /\ ecocExists                               \* Cannot rename a non-existent ECOC.
+    /\ ~ecocTempExists                          \* No previous temp lying around.
+    /\ ecocExists' = FALSE                      \* Renamed out: live ECOC namespace gone.
+    /\ ecocClustered' = FALSE                   \* (Don't-care while ecocExists' = FALSE.)
+    /\ ecocTempExists' = TRUE
+    /\ maintenancePhase' = RENAMED
+    /\ maintenanceKind' = kind
+    /\ maintenanceCount' = maintenanceCount + 1
+    /\ UNCHANGED <<ecocCreatedBy, userWriteCount>>
+    /\ AppendHistory(<<"maintenance_renamed", kind>>)
+
+\* Step 2: process the renamed-out ECOC (delete it / fold its tokens into ESC). This step does
+\* not touch the live ECOC namespace; we simply mark the temp as gone. It exists primarily so
+\* the spec can demonstrate that user writes happening BEFORE the internal create is what
+\* triggers the bug, regardless of how long this internal processing takes. May fire in either
+\* RENAMED or CREATED phase (real code drops the temp after consuming tokens, which can be
+\* before or after the internal create depending on cleanup vs. compact ordering).
+ProcessRenamedECOC ==
+    /\ maintenancePhase \in {RENAMED, CREATED}
+    /\ ecocTempExists
+    /\ ecocTempExists' = FALSE
+    /\ UNCHANGED <<ecocExists, ecocClustered, ecocCreatedBy,
+                   maintenancePhase, maintenanceKind, maintenanceCount, userWriteCount>>
+    /\ AppendHistory(<<"maintenance_processed_temp", maintenanceKind>>)
+
+\* Step 3: the maintenance op tries to recreate the ECOC with the clustered index option. Two
+\* outcomes mirror the real code path in fle2_compact_cmd.cpp / fle2_cleanup_cmd.cpp:
+\*   (a) The collection does NOT already exist: the create succeeds, installs the clustered
+\*       index, and we transition to CREATED with provenance = maintenance.
+\*   (b) The collection DOES already exist (a concurrent user write implicitly created it
+\*       between RENAMED and here): the create call silently no-ops. The existing namespace
+\*       — created without the clustered index — survives.
+MaintenanceCreateECOC ==
+    /\ maintenancePhase = RENAMED
+    /\ \/ /\ ~ecocExists                        \* (a) Happy path.
+          /\ ecocExists' = TRUE
+          /\ ecocClustered' = TRUE
+          /\ ecocCreatedBy' = CREATED_BY_MAINTENANCE
+          /\ AppendHistory(<<"maintenance_create_ok", maintenanceKind>>)
+       \/ /\ ecocExists                         \* (b) Silent no-op; bug surface.
+          /\ UNCHANGED <<ecocExists, ecocClustered, ecocCreatedBy>>
+          /\ AppendHistory(<<"maintenance_create_noop_collection_exists", maintenanceKind>>)
+    /\ maintenancePhase' = CREATED
+    /\ UNCHANGED <<ecocTempExists, maintenanceKind, maintenanceCount, userWriteCount>>
+
+\* Step 4: maintenance command returns success to the user. Requires the renamed-out temp
+\* namespace to have already been processed and dropped, mirroring the actual command which
+\* will not return until its compactor has consumed the temp's tokens.
+MaintenanceFinish ==
+    /\ maintenancePhase = CREATED
+    /\ ~ecocTempExists
+    /\ maintenancePhase' = IDLE
+    /\ UNCHANGED <<ecocExists, ecocClustered, ecocCreatedBy, ecocTempExists,
+                   maintenanceKind, maintenanceCount, userWriteCount>>
+    /\ AppendHistory(<<"maintenance_done", maintenanceKind>>)
+
+-----------------------------------------------------------------------------
+\* User write action.
+-----------------------------------------------------------------------------
+
+\* A concurrent user insert/update on the EDC. When the writer reaches the inner FLE write path
+\* it must touch the ECOC. If the ECOC namespace does not currently exist, MongoDB will
+\* IMPLICITLY create it. There are two sub-cases:
+\*   - With the proposed catalog-level fix (CatalogPinsClusteredIndex = TRUE): the implicit
+\*     create uses {clusteredIndex: {key: {_id: 1}, unique: true}}. Bug masked.
+\*   - Without the fix (CatalogPinsClusteredIndex = FALSE): the implicit create uses DEFAULT
+\*     options. ECOC ends up without its clustered index. Bug reproduces.
+\* If the ECOC namespace already exists, the user write simply targets it; no creation happens
+\* and the clustered-index property is unchanged.
+UserWrite(w) ==
+    /\ w \in UserWriters
+    /\ userWriteCount < MaxUserWrites
+    /\ IF ecocExists
+       THEN /\ UNCHANGED <<ecocExists, ecocClustered, ecocCreatedBy>>
+            /\ AppendHistory(<<"user_write_to_existing_ecoc", w>>)
+       ELSE /\ ecocExists' = TRUE
+            /\ ecocClustered' = CatalogPinsClusteredIndex
+            /\ ecocCreatedBy' = CREATED_BY_USER_WRITE
+            /\ AppendHistory(<<"user_write_implicit_create_ecoc",
+                                w, CatalogPinsClusteredIndex>>)
+    /\ userWriteCount' = userWriteCount + 1
+    /\ UNCHANGED <<ecocTempExists, maintenancePhase, maintenanceKind, maintenanceCount>>
+
+-----------------------------------------------------------------------------
+
+Next ==
+    \/ \E k \in MaintenanceKinds : StartMaintenance(k)
+    \/ ProcessRenamedECOC
+    \/ MaintenanceCreateECOC
+    \/ MaintenanceFinish
+    \/ \E w \in UserWriters : UserWrite(w)
+
+\* Allow infinite stuttering once both bounds are hit.
+Done ==
+    /\ maintenanceCount = MaxMaintenanceOps
+    /\ userWriteCount = MaxUserWrites
+    /\ maintenancePhase = IDLE
+
+Spec == /\ Init
+        /\ [][Next \/ (Done /\ UNCHANGED vars)]_vars
+        /\ WF_vars(ProcessRenamedECOC)
+        /\ WF_vars(MaintenanceCreateECOC)
+        /\ WF_vars(MaintenanceFinish)
+
+-----------------------------------------------------------------------------
+\* Invariants
+-----------------------------------------------------------------------------
+
+TypeOK ==
+    /\ ecocExists \in BOOLEAN
+    /\ ecocClustered \in BOOLEAN
+    /\ ecocCreatedBy \in {CREATED_BY_MAINTENANCE, CREATED_BY_USER_WRITE}
+    /\ ecocTempExists \in BOOLEAN
+    /\ maintenancePhase \in MaintenancePhases
+    /\ maintenanceKind \in MaintenanceKinds
+    /\ maintenanceCount \in 0..MaxMaintenanceOps
+    /\ userWriteCount \in 0..MaxUserWrites
+    \* history is a Seq of event tuples whose first element is a string label; we deliberately
+    \* avoid an explicit Seq(STRING) constraint because TLC cannot enumerate STRING. The bound
+    \* below matches the worst case: 4 events per maintenance op (rename, process_temp, create,
+    \* done) plus 1 event per user write.
+    /\ Len(history) \in 0..(4 * MaxMaintenanceOps + MaxUserWrites)
+
+\* The core safety invariant from SERVER-126384: the ECOC namespace, whenever it exists, MUST
+\* carry the clustered index. (It is permissible for ECOC to not exist — e.g. mid-rename — but
+\* once it exists it must be clustered.)
+\*
+\* Without the catalog-level fix, this invariant is violated by the interleaving:
+\*   StartMaintenance(compact)            // ecocExists = FALSE
+\*   UserWrite(w)                         // ecocExists = TRUE, ecocClustered = FALSE
+\*   MaintenanceCreateECOC (no-op branch) // ecocExists stays TRUE, ecocClustered stays FALSE
+\*   MaintenanceFinish
+\* With CatalogPinsClusteredIndex = TRUE the user-write branch sets ecocClustered = TRUE, and
+\* the invariant holds for every reachable state.
+ECOCAlwaysClustered ==
+    ecocExists => ecocClustered
+
+\* While a maintenance op is in flight, exactly one of {live ECOC, temp ECOC} is "the ECOC
+\* token store" in the catalog (and during the RENAMED phase only the temp exists, until the
+\* user write implicitly recreates the live one).
+ECOCExistenceConsistent ==
+    /\ maintenancePhase = IDLE => ~ecocTempExists
+    /\ maintenancePhase = CREATED => ~ecocTempExists \/ ecocExists
+
+\* The maintenance op cannot accidentally end with no ECOC at all (would break subsequent FLE
+\* writes outright). After Finish the ECOC must exist.
+ECOCExistsAfterMaintenance ==
+    maintenancePhase = IDLE => ecocExists
+
+-----------------------------------------------------------------------------
+\* Liveness
+-----------------------------------------------------------------------------
+
+\* Every started maintenance op eventually returns to IDLE.
+MaintenanceEventuallyFinishes ==
+    maintenancePhase # IDLE ~> maintenancePhase = IDLE
+
+\* The ECOC namespace is eventually present and clustered (under the fix).
+ECOCEventuallyClustered ==
+    <>[](ecocExists /\ ecocClustered)
+
+===================================================================================================

--- a/src/mongo/tla_plus/FLE/ECOCCompactCleanupRace/MCECOCCompactCleanupRace.cfg
+++ b/src/mongo/tla_plus/FLE/ECOCCompactCleanupRace/MCECOCCompactCleanupRace.cfg
@@ -1,0 +1,23 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    UserWriters = {w1, w2}
+    MaxMaintenanceOps = 2
+    MaxUserWrites = 3
+    \* Toggle this to FALSE to reproduce SERVER-126384 as an ECOCAlwaysClustered counterexample,
+    \* or to TRUE to demonstrate that pinning the clustered index at the catalog level masks the
+    \* race. The check-in default is TRUE so CI sees a clean run; the regression test of record
+    \* lives in jstests/fle2/qe_cleanup_compact_race_no_missing_index.js.
+    CatalogPinsClusteredIndex = TRUE
+
+CONSTRAINTS
+    HistoryLengthBound
+
+INVARIANT
+    TypeOK
+    ECOCAlwaysClustered
+    ECOCExistenceConsistent
+    ECOCExistsAfterMaintenance
+
+PROPERTY
+    MaintenanceEventuallyFinishes

--- a/src/mongo/tla_plus/FLE/ECOCCompactCleanupRace/MCECOCCompactCleanupRace.tla
+++ b/src/mongo/tla_plus/FLE/ECOCCompactCleanupRace/MCECOCCompactCleanupRace.tla
@@ -1,0 +1,23 @@
+------------------------------ MODULE MCECOCCompactCleanupRace ------------------------------------
+\* Model-checking module for ECOCCompactCleanupRace.
+
+EXTENDS ECOCCompactCleanupRace
+
+(****************************************************************************************************)
+(* State constraints.                                                                                *)
+(****************************************************************************************************)
+
+\* TLC state-space cap. Maintenance and user-write counts are bounded by constants already; this
+\* additional bound on history-length keeps trace-driven counterexamples readable.
+HistoryLengthBound == Len(history) < 24
+
+(****************************************************************************************************)
+(* Counterexample baits.                                                                             *)
+(****************************************************************************************************)
+
+\* Bait invariant: if model-checked with CatalogPinsClusteredIndex = FALSE, TLC produces the
+\* race trace described in SERVER-126384. Flip CatalogPinsClusteredIndex to TRUE in the .cfg and
+\* the invariant holds across the full state space.
+BaitECOCAlwaysExists == ecocExists
+
+===================================================================================================

--- a/src/mongo/tla_plus/FLE/ECOCCompactCleanupRace/OWNERS.yml
+++ b/src/mongo/tla_plus/FLE/ECOCCompactCleanupRace/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-security


### PR DESCRIPTION
## Summary

TLA+ spec + jstest: ECOC clustered index must survive concurrent compact + writes.

**Jira:** https://jira.mongodb.org/browse/SERVER-126732
**Branch:** substrate-contrib/w4-28

## Files

```
  -  .../qe_cleanup_compact_race_no_missing_index.js    | 171 ++++++++++++
  -  .../ECOCCompactCleanupRace.tla                     | 289 +++++++++++++++++++++
  -  .../MCECOCCompactCleanupRace.cfg                   |  23 ++
  -  .../MCECOCCompactCleanupRace.tla                   |  23 ++
  -  .../tla_plus/FLE/ECOCCompactCleanupRace/OWNERS.yml |   5 +
  -  5 files changed, 511 insertions(+)
```

## Verify

For `.tla` files:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For `.js` jstests:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
