### PR TITLE
SERVER-126733 TLA+ spec + jstest: FLE2 compact must not deadlock on simultaneous setFCV

### DIFF
--- a/jstests/fle2/fle2_compact_setfcv_no_deadlock.js
+++ b/jstests/fle2/fle2_compact_setfcv_no_deadlock.js
@@ -1,0 +1,178 @@
+/**
+ * Regression test for SERVER-122159.
+ *
+ * The FLE2 compact and cleanup commands previously could deadlock with a
+ * concurrent setFeatureCompatibilityVersion (setFCV) command. The deadlock
+ * cycle reported in the ticket is:
+ *
+ *   1. setFCV  thread takes MultiDocumentTransactionsBarrier in S mode.
+ *   2. compact thread takes the Global lock in IX mode (via AutoGetDb on the
+ *      EDC namespace inside the FLE2 command).
+ *   3. compact thread's internal transaction tries to take
+ *      MultiDocumentTransactionsBarrier in IX mode and blocks on setFCV.
+ *   4. setFCV  thread tries to take Global in S and blocks on compact.
+ *
+ * The FixedFCVRegion taken at the top of compact/cleanup is intended to
+ * serialise these two commands; this test exercises the race that occurs if
+ * that protection fails. It runs compactStructuredEncryptionData (and
+ * separately cleanupStructuredEncryptionData) concurrently with a setFCV
+ * downgrade/upgrade and asserts both finish well within a bounded deadline.
+ * If the SERVER-122159 deadlock returns, both commands hang on each other
+ * and the test fails the deadline assertion.
+ *
+ * @tags: [
+ *   requires_replication,
+ *   requires_fcv_80,
+ *   assumes_against_mongod_not_mongos,
+ * ]
+ */
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {funWithArgs} from "jstests/libs/parallel_shell_helpers.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+import {EncryptedClient, isEnterpriseShell} from "jstests/fle2/libs/encrypted_client_util.js";
+
+if (!isEnterpriseShell()) {
+    jsTestLog("Skipping FLE2 compact/setFCV deadlock test: requires enterprise shell.");
+    quit();
+}
+
+// Hard upper bound for each command -- well beyond expected wall clock for
+// either command on an idle test cluster, but short enough that a real
+// deadlock will trip it long before the evergreen task timeout.
+const kDeadlineMs = 60 * 1000;
+
+const rst = new ReplSetTest({nodes: 1});
+rst.startSet();
+rst.initiate();
+
+const primary = rst.getPrimary();
+const adminDB = primary.getDB("admin");
+
+// Start at latest FCV so the downgrade/upgrade pair has real work to do
+// (and so it takes the same locks the bug-trace reports it takes).
+assert.commandWorked(adminDB.runCommand({setFeatureCompatibilityVersion: latestFCV, confirm: true}));
+
+const dbName = "fle2_compact_setfcv_no_deadlock_db";
+const collName = "encrypted";
+
+// Build a QE-enabled encrypted collection on the primary. The
+// EncryptedClient wraps a libmongocrypt-aware connection so the compact and
+// cleanup commands have their compactionTokens populated automatically when
+// run through the encrypted shell.
+const client = new EncryptedClient(primary, dbName);
+assert.commandWorked(
+    client.createEncryptionCollection(collName, {
+        encryptedFields: {
+            fields: [
+                {
+                    path: "firstName",
+                    bsonType: "string",
+                    queries: {queryType: "equality"},
+                },
+            ],
+        },
+    }),
+);
+
+const edb = client.getDB();
+const ecoll = edb.getCollection(collName);
+
+// Insert a few encrypted documents so compact / cleanup actually has work
+// to do on the state collections (otherwise the command short-circuits
+// before hitting the lock-acquisition window that exhibits the bug).
+for (let i = 0; i < 20; ++i) {
+    assert.commandWorked(ecoll.einsert({_id: i, firstName: "n" + (i % 5)}));
+}
+
+/**
+ * Park the FLE2 command at `compactFailpointName` (which fires while compact
+ * is holding the Global IX lock + ecoc.lock X lock), then race a setFCV
+ * downgrade+upgrade against it.
+ *
+ * Asserts both commands return within `kDeadlineMs`.
+ */
+function runConcurrent(label, compactFailpointName, fle2Command) {
+    jsTestLog("=== " + label + ": starting concurrent " + fle2Command + " + setFCV ===");
+
+    // Park the FLE2 command in the middle of its locked region.
+    const fp = configureFailPoint(primary, compactFailpointName);
+
+    // The FLE2 command runs in a separate parallel shell that constructs its
+    // own EncryptedClient -- libmongocrypt fills in the compactionTokens /
+    // cleanupTokens automatically.
+    const fleShell = startParallelShell(
+        funWithArgs(
+            async function (dbN, collN, fle2Cmd) {
+                const {EncryptedClient} = await import("jstests/fle2/libs/encrypted_client_util.js");
+                const c = new EncryptedClient(db.getMongo(), dbN);
+                const cmd = {};
+                cmd[fle2Cmd] = collN;
+                const res = c.getDB().runCommand(cmd);
+                assert.commandWorked(res);
+            },
+            dbName,
+            collName,
+            fle2Command,
+        ),
+        primary.port,
+    );
+
+    // Wait until the FLE2 command is parked inside its locked region.
+    fp.wait();
+
+    // Race a setFCV downgrade against the parked compact in a third shell.
+    // Pre-bug, this deadlocks; post-fix, setFCV must either wait cleanly
+    // until compact releases, be serialised against compact's FixedFCVRegion,
+    // or otherwise resolve without forming a cycle in the wait-for graph.
+    const fcvShell = startParallelShell(function () {
+        assert.commandWorked(
+            db.adminCommand({setFeatureCompatibilityVersion: lastLTSFCV, confirm: true}),
+        );
+        assert.commandWorked(
+            db.adminCommand({setFeatureCompatibilityVersion: latestFCV, confirm: true}),
+        );
+    }, primary.port);
+
+    // Give setFCV a moment to actually start requesting its barrier / global
+    // locks so the wait-for graph would be cyclic if the bug were present.
+    sleep(2000);
+
+    // Release the FLE2 failpoint -- both shells must now make progress.
+    fp.off();
+
+    // Bounded-time join: if either side is still running past kDeadlineMs
+    // the deadlock has regressed.
+    const start = Date.now();
+
+    fleShell({checkExitSuccess: true, timeoutMS: kDeadlineMs});
+    const fleElapsed = Date.now() - start;
+    assert.lt(
+        fleElapsed,
+        kDeadlineMs,
+        label + ": FLE2 " + fle2Command + " did not complete within " + kDeadlineMs +
+            " ms -- SERVER-122159 deadlock may have regressed (elapsed=" + fleElapsed + " ms)",
+    );
+
+    fcvShell({checkExitSuccess: true, timeoutMS: kDeadlineMs});
+    const fcvElapsed = Date.now() - start;
+    assert.lt(
+        fcvElapsed,
+        kDeadlineMs,
+        label + ": setFCV did not complete within " + kDeadlineMs +
+            " ms -- SERVER-122159 deadlock may have regressed (elapsed=" + fcvElapsed + " ms)",
+    );
+
+    jsTestLog("=== " + label + ": done (fle=" + fleElapsed + " ms, setFCV=" + fcvElapsed + " ms) ===");
+}
+
+// `fleCompactHangBeforeECOCCreateUnsharded` parks the compact command after
+// it has taken Global-IX (via AutoGetDb) + ecoc.lock-X, but before the
+// internal-txn that exhibited the SERVER-122159 wait on the
+// MultiDocumentTransactionsBarrier -- exactly the window the ticket reports.
+runConcurrent("compact", "fleCompactHangBeforeECOCCreateUnsharded", "compactStructuredEncryptionData");
+
+// The corresponding cleanup-side hang failpoint lives in fle2_compact.cpp and
+// parks cleanup while it is mid-flight through the internal transaction.
+runConcurrent("cleanup", "fleCleanupHangBeforeNullAnchorUpdate", "cleanupStructuredEncryptionData");
+
+rst.stopSet();

--- a/src/mongo/tla_plus/FLE/FLE2CompactSetFCVDeadlock/FLE2CompactSetFCVDeadlock.tla
+++ b/src/mongo/tla_plus/FLE/FLE2CompactSetFCVDeadlock/FLE2CompactSetFCVDeadlock.tla
@@ -1,0 +1,277 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+---------------------- MODULE FLE2CompactSetFCVDeadlock ------------------------
+\* Models the lock-acquisition resource graph between the FLE2 compact/cleanup
+\* command thread and a concurrent setFeatureCompatibilityVersion (setFCV)
+\* thread, and checks for a deadlock-freedom invariant on the wait-for graph.
+\*
+\* Background (see SERVER-122159):
+\*
+\* The FLE2 compact/cleanup command path (fle2_cleanup_cmd.cpp / fle2_compact_cmd.cpp)
+\* first acquires the global lock in IX mode via AutoGetDb on the encrypted data
+\* collection's database, then later starts an internal transaction which has to
+\* acquire the MultiDocumentTransactionsBarrier (MDTB) lock in IX mode before
+\* proceeding.
+\*
+\* The setFCV command path (set_feature_compatibility_version_command.cpp) takes
+\* the global lock in S mode, which under d_concurrency.cpp requires first taking
+\* the MultiDocumentTransactionsBarrier lock in S mode, then taking the global
+\* lock (S) afterwards.
+\*
+\* Conflict matrix between the two threads' resource requests:
+\*   - Global lock: IX (Compact) vs S (setFCV) -- incompatible.
+\*   - MDTB lock:   IX (Compact) vs S (setFCV) -- incompatible.
+\*
+\* A FixedFCVRegion is created at the beginning of the FLE2 compact/cleanup
+\* commands which was intended to make this race impossible by blocking setFCV
+\* once compact has started. The bug is that the FixedFCVRegion no longer
+\* provides that guarantee, so the following interleaving is reachable:
+\*
+\*   1. setFCV  acquires MDTB in S  (still trying to take Global S).
+\*   2. Compact acquires Global IX  (via AutoGetDb).
+\*   3. Compact tries to acquire MDTB IX (for the internal txn). Blocks on
+\*      setFCV's MDTB-S holder.
+\*   4. setFCV  tries to acquire Global S. Blocks on Compact's Global-IX holder.
+\*
+\* The wait-for graph then has the cycle
+\*     setFCV --(waits MDTB)-> Compact --(waits Global)-> setFCV
+\* which is the deadlock.
+\*
+\* The fix (per the bug report) is to enforce a consistent acquisition order:
+\* either Compact must acquire MDTB before Global, or setFCV must be blocked
+\* by an outer barrier (e.g. a refreshed FixedFCVRegion) before compact can
+\* start grabbing Global. This spec models the bug as a configurable
+\* `CompactAcquiresInOrder' flag so that the deadlock-freedom invariant fails
+\* with the bug enabled and passes with the fix enabled.
+\*
+\* To model-check this spec:
+\*     cd src/mongo/tla_plus
+\*     ./model-check.sh FLE/FLE2CompactSetFCVDeadlock
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+
+CONSTANTS
+    \* Whether the FLE2 compact/cleanup thread acquires its locks in the
+    \* deadlock-safe order (MDTB before Global). When TRUE, the wait-for graph
+    \* can never form a cycle (fixed behaviour). When FALSE, the buggy
+    \* interleaving from SERVER-122159 is reachable.
+    CompactAcquiresInOrder
+
+\* Threads.
+Compact == "Compact"
+SetFCV  == "SetFCV"
+Threads == {Compact, SetFCV}
+
+\* Lock resources.
+GlobalLock == "Global"
+MDTBLock   == "MDTB"
+Resources  == {GlobalLock, MDTBLock}
+
+\* Lock modes -- only the modes that appear in this race are modelled.
+\*   IX is held by the FLE2 internal-txn client thread.
+\*   S  is held by the setFCV thread.
+Modes == {"IX", "S"}
+
+\* IX and S are mutually incompatible. (See MongoDB's lock compatibility matrix.)
+\* S-S and IX-IX are both compatible, so only the mixed pairs return TRUE.
+Conflicts(m1, m2) ==
+    \/ (m1 = "IX" /\ m2 = "S")
+    \/ (m1 = "S"  /\ m2 = "IX")
+
+\* Mode requested by thread t on resource r per the production code.
+RequestedMode(t, r) ==
+    CASE t = Compact /\ r = GlobalLock -> "IX"
+      [] t = Compact /\ r = MDTBLock   -> "IX"
+      [] t = SetFCV  /\ r = GlobalLock -> "S"
+      [] t = SetFCV  /\ r = MDTBLock   -> "S"
+
+\* Per-thread program-counter states.
+\*   "idle"        : thread has not started.
+\*   "want_<R>"    : thread is about to request resource R.
+\*   "blocked_<R>" : thread is waiting for resource R.
+\*   "done"        : thread released its locks and completed.
+PCStates == {"idle",
+             "want_MDTB", "blocked_MDTB",
+             "want_Global", "blocked_Global",
+             "done"}
+
+VARIABLES
+    \* heldBy[r] is a set of <<thread, mode>> records currently holding r.
+    heldBy,
+    \* pc[t] is the program-counter state of thread t.
+    pc,
+    \* held[t] is the set of resources thread t currently holds (for cleanup).
+    held
+
+vars == <<heldBy, pc, held>>
+
+-------------------------------------------------------------------------------
+\* Helpers.
+-------------------------------------------------------------------------------
+
+\* TRUE iff there is some holder of r whose mode conflicts with mode m.
+SomeHolderConflicts(r, m) ==
+    \E h \in heldBy[r] : Conflicts(h.mode, m)
+
+\* The acquisition order each thread follows.
+\*   - SetFCV always goes MDTB-first then Global (matches d_concurrency.cpp).
+\*   - Compact's order depends on CompactAcquiresInOrder:
+\*       * TRUE  (fixed)  : MDTB first, then Global -- same order as SetFCV.
+\*       * FALSE (buggy)  : Global first (via AutoGetDb), then MDTB
+\*                          (via internal txn).
+\*
+\* Steps returned as a sequence of resources to acquire.
+Order(t) ==
+    CASE t = SetFCV                            -> <<MDTBLock, GlobalLock>>
+      [] t = Compact /\ CompactAcquiresInOrder -> <<MDTBLock, GlobalLock>>
+      [] t = Compact /\ ~CompactAcquiresInOrder -> <<GlobalLock, MDTBLock>>
+
+\* The "want_..." state for resource r.
+WantPC(r)    == IF r = MDTBLock THEN "want_MDTB"    ELSE "want_Global"
+\* The "blocked_..." state for resource r.
+BlockedPC(r) == IF r = MDTBLock THEN "blocked_MDTB" ELSE "blocked_Global"
+
+\* TRUE iff thread t is currently waiting (blocked) on resource r.
+WaitingOn(t, r) ==
+    pc[t] = BlockedPC(r)
+
+\* The wait-for graph: t1 -> t2 iff t1 is waiting on a resource currently held
+\* in a conflicting mode by t2.
+WaitsFor(t1, t2) ==
+    /\ t1 # t2
+    /\ \E r \in Resources :
+        /\ WaitingOn(t1, r)
+        /\ \E h \in heldBy[r] :
+            /\ h.thread = t2
+            /\ Conflicts(h.mode, RequestedMode(t1, r))
+
+\* TRUE iff the wait-for graph contains a 2-cycle.
+\* We only have two threads, so a 2-cycle is the only possible cycle.
+HasCycle2 ==
+    \E t1, t2 \in Threads :
+        /\ t1 # t2
+        /\ WaitsFor(t1, t2)
+        /\ WaitsFor(t2, t1)
+
+-------------------------------------------------------------------------------
+\* Initial state and transitions.
+-------------------------------------------------------------------------------
+
+Init ==
+    /\ heldBy = [r \in Resources |-> {}]
+    /\ pc    = [t \in Threads   |-> "idle"]
+    /\ held  = [t \in Threads   |-> {}]
+
+\* Thread t starts up and announces it wants its first resource.
+Start(t) ==
+    /\ pc[t] = "idle"
+    /\ LET firstResource == Order(t)[1] IN
+        pc' = [pc EXCEPT ![t] = WantPC(firstResource)]
+    /\ UNCHANGED <<heldBy, held>>
+
+\* Thread t tries to acquire resource r in its requested mode.
+\* Successful path: no conflict -> grant -> advance pc to "want_<next>"
+\*                  or "done" if r was the last resource in t's order.
+TryAcquire(t, r) ==
+    /\ pc[t] = WantPC(r)
+    /\ ~SomeHolderConflicts(r, RequestedMode(t, r))
+    /\ heldBy' = [heldBy EXCEPT ![r] = @ \union
+                    {[thread |-> t, mode |-> RequestedMode(t, r)]}]
+    /\ held'   = [held   EXCEPT ![t] = @ \union {r}]
+    /\ LET ord    == Order(t)
+           idx    == CHOOSE i \in 1..Len(ord) : ord[i] = r
+           nextPC == IF idx = Len(ord)
+                     THEN "done"
+                     ELSE WantPC(ord[idx + 1])
+       IN  pc' = [pc EXCEPT ![t] = nextPC]
+
+\* Thread t requests resource r, finds a conflicting holder, and blocks.
+BlockOnAcquire(t, r) ==
+    /\ pc[t] = WantPC(r)
+    /\ SomeHolderConflicts(r, RequestedMode(t, r))
+    /\ pc' = [pc EXCEPT ![t] = BlockedPC(r)]
+    /\ UNCHANGED <<heldBy, held>>
+
+\* A blocked thread t becomes unblocked when no holder conflicts with its
+\* requested mode anymore. It transitions back to its "want_<R>" state, from
+\* which TryAcquire will fire next.
+Unblock(t, r) ==
+    /\ pc[t] = BlockedPC(r)
+    /\ ~SomeHolderConflicts(r, RequestedMode(t, r))
+    /\ pc' = [pc EXCEPT ![t] = WantPC(r)]
+    /\ UNCHANGED <<heldBy, held>>
+
+\* A done thread releases all its held resources. This models the end of the
+\* command -- not a partial unlock. Compact / setFCV both release their locks
+\* together when the command finishes.
+Release(t) ==
+    /\ pc[t] = "done"
+    /\ held[t] # {}
+    /\ heldBy' = [r \in Resources |->
+                    {h \in heldBy[r] : h.thread # t}]
+    /\ held'   = [held EXCEPT ![t] = {}]
+    /\ UNCHANGED pc
+
+Next ==
+    \/ \E t \in Threads : Start(t)
+    \/ \E t \in Threads : \E r \in Resources : TryAcquire(t, r)
+    \/ \E t \in Threads : \E r \in Resources : BlockOnAcquire(t, r)
+    \/ \E t \in Threads : \E r \in Resources : Unblock(t, r)
+    \/ \E t \in Threads : Release(t)
+
+Spec == /\ Init
+        /\ [][Next]_vars
+        /\ WF_vars(Next)
+
+-------------------------------------------------------------------------------
+\* Invariants.
+-------------------------------------------------------------------------------
+
+TypeOK ==
+    /\ pc \in [Threads -> PCStates]
+    /\ held \in [Threads -> SUBSET Resources]
+    /\ \A r \in Resources :
+        \A h \in heldBy[r] :
+            /\ h.thread \in Threads
+            /\ h.mode \in Modes
+
+\* Lock-manager invariant: no two holders of the same resource hold modes that
+\* conflict with each other.
+LockManagerConsistent ==
+    \A r \in Resources :
+        \A h1, h2 \in heldBy[r] :
+            (h1 # h2) => ~Conflicts(h1.mode, h2.mode)
+
+\* The held-set on each thread always matches heldBy's per-resource records.
+HeldSetConsistent ==
+    \A t \in Threads :
+        \A r \in Resources :
+            (r \in held[t]) <=> (\E h \in heldBy[r] : h.thread = t)
+
+\* Deadlock-freedom: the wait-for graph never has a cycle.
+\* With CompactAcquiresInOrder = TRUE  : invariant should hold.
+\* With CompactAcquiresInOrder = FALSE : TLC will produce the SERVER-122159
+\* counter-example trace.
+DeadlockFree == ~HasCycle2
+
+\* The trio of useful invariants.
+Invariants ==
+    /\ TypeOK
+    /\ LockManagerConsistent
+    /\ HeldSetConsistent
+    /\ DeadlockFree
+
+-------------------------------------------------------------------------------
+\* Liveness.
+-------------------------------------------------------------------------------
+
+\* In a deadlock-free run, every thread that starts eventually reaches "done"
+\* and then releases. Used only with CompactAcquiresInOrder = TRUE.
+EventuallyAllDone ==
+    \A t \in Threads : (pc[t] # "idle") ~> (pc[t] = "done")
+
+================================================================================

--- a/src/mongo/tla_plus/FLE/FLE2CompactSetFCVDeadlock/MCFLE2CompactSetFCVDeadlock.cfg
+++ b/src/mongo/tla_plus/FLE/FLE2CompactSetFCVDeadlock/MCFLE2CompactSetFCVDeadlock.cfg
@@ -1,0 +1,23 @@
+\* Default (fixed) configuration: Compact acquires MDTB before Global.
+\* DeadlockFree should hold.
+\*
+\* CHECK_DEADLOCK is disabled because both threads reach a terminal "done"
+\* state with empty held-sets when the protocol completes successfully. That
+\* terminal state is the success case, not the wait-for-graph deadlock we are
+\* checking via the DeadlockFree invariant.
+SPECIFICATION Spec
+
+CONSTANTS
+    CompactAcquiresInOrder = TRUE
+
+INVARIANT
+    TypeOK
+    LockManagerConsistent
+    HeldSetConsistent
+    DeadlockFree
+
+PROPERTY
+    EventuallyAllDone
+
+CHECK_DEADLOCK
+    FALSE

--- a/src/mongo/tla_plus/FLE/FLE2CompactSetFCVDeadlock/MCFLE2CompactSetFCVDeadlock.tla
+++ b/src/mongo/tla_plus/FLE/FLE2CompactSetFCVDeadlock/MCFLE2CompactSetFCVDeadlock.tla
@@ -1,0 +1,37 @@
+----------------- MODULE MCFLE2CompactSetFCVDeadlock --------------------------
+\* Model-checking module for FLE2CompactSetFCVDeadlock.
+\*
+\* The default configuration (MCFLE2CompactSetFCVDeadlock.cfg) sets
+\*   CompactAcquiresInOrder = TRUE
+\* which models the FIX -- the wait-for graph is acyclic and DeadlockFree holds.
+\*
+\* The bug configuration (MCFLE2CompactSetFCVDeadlock_Bug.cfg) sets
+\*   CompactAcquiresInOrder = FALSE
+\* which models the buggy code path described in SERVER-122159. TLC produces a
+\* counter-example trace whose final state has setFCV waiting on Global (held
+\* by Compact in IX) and Compact waiting on MDTB (held by setFCV in S) -- the
+\* cycle reported in the ticket.
+
+EXTENDS FLE2CompactSetFCVDeadlock
+
+(******************************************************************************)
+(* State constraints.                                                         *)
+(******************************************************************************)
+
+\* The state space is finite (two threads, two resources, two modes,
+\* bounded pc states, and threads can only re-acquire after Release wipes
+\* held[t]). No state constraint is needed; this exists so configs that want
+\* to assert one can reference it.
+NoExtraConstraint == TRUE
+
+(******************************************************************************)
+(* Counterexamples / baits.                                                   *)
+(******************************************************************************)
+
+\* Bait: the bug-trace must reach the cycle state -- if the model is correct,
+\* this should fail (TLC reports a violation, which is the counter-example we
+\* want) when CompactAcquiresInOrder = FALSE, and should hold (no cycle ever)
+\* when CompactAcquiresInOrder = TRUE.
+BaitNoCycleEverReached == ~HasCycle2
+
+================================================================================

--- a/src/mongo/tla_plus/FLE/FLE2CompactSetFCVDeadlock/MCFLE2CompactSetFCVDeadlock_Bug.cfg
+++ b/src/mongo/tla_plus/FLE/FLE2CompactSetFCVDeadlock/MCFLE2CompactSetFCVDeadlock_Bug.cfg
@@ -1,0 +1,19 @@
+\* Bug configuration: Compact acquires Global (via AutoGetDb) before MDTB
+\* (via internal txn). TLC must report a DeadlockFree violation reproducing
+\* the cycle described in SERVER-122159.
+\*
+\* CHECK_DEADLOCK is disabled: the wait-for cycle is detected via the
+\* DeadlockFree invariant, not via TLC's no-enabled-action heuristic.
+SPECIFICATION Spec
+
+CONSTANTS
+    CompactAcquiresInOrder = FALSE
+
+INVARIANT
+    TypeOK
+    LockManagerConsistent
+    HeldSetConsistent
+    DeadlockFree
+
+CHECK_DEADLOCK
+    FALSE

--- a/src/mongo/tla_plus/FLE/FLE2CompactSetFCVDeadlock/OWNERS.yml
+++ b/src/mongo/tla_plus/FLE/FLE2CompactSetFCVDeadlock/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-catalog-and-routing


### PR DESCRIPTION
## Summary

TLA+ spec + jstest: FLE2 compact must not deadlock on simultaneous setFCV.

**Jira:** https://jira.mongodb.org/browse/SERVER-126733
**Branch:** substrate-contrib/w4-29

## Files

```
  -  jstests/fle2/fle2_compact_setfcv_no_deadlock.js    | 178 +++++++++++++
  -  .../FLE2CompactSetFCVDeadlock.tla                  | 277 +++++++++++++++++++++
  -  .../MCFLE2CompactSetFCVDeadlock.cfg                |  23 ++
  -  .../MCFLE2CompactSetFCVDeadlock.tla                |  37 +++
  -  .../MCFLE2CompactSetFCVDeadlock_Bug.cfg            |  19 ++
  -  .../FLE/FLE2CompactSetFCVDeadlock/OWNERS.yml       |   5 +
  -  6 files changed, 539 insertions(+)
```

## Verify

For `.tla` files:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For `.js` jstests:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
