### PR TITLE
SERVER-126735 jstest + design: FLE update must handle shard-key change cleanly

### DIFF
--- a/jstests/fle2/fle_update_shard_key_field.js
+++ b/jstests/fle2/fle_update_shard_key_field.js
@@ -1,0 +1,125 @@
+/**
+ * Regression test for the FLE update-shard-key path.
+ *
+ * When a retryable update on an FLE-encrypted collection would change a
+ * document's shard-key field, the write should either:
+ *   (a) succeed with proper cross-shard semantics (delete-on-source +
+ *       insert-on-destination, wrapped in an internal transaction whose
+ *       stmtIds are distinct), OR
+ *   (b) fail with a clean, structured error that names the unsupported
+ *       combination (FLE + shard-key change) rather than the historic
+ *       generic assertion produced by stmtId collision inside the retryable
+ *       internal transaction that the FLE re-write spawns.
+ *
+ * Root cause covered: the BatchedCommandRequest re-write that FLE performs
+ * (`FLEUpdateOperation::serialize` / `appendMongosRequest`) does not
+ * preserve the "this update may change the shard key" flag, so the WCOS
+ * (write contains owning shard) path is not wired through to the mongos
+ * dispatcher and the request is run as a vanilla retryable update with the
+ * default stmtId=0. Inside the FLE retryable internal transaction the
+ * reused stmtId then triggers a TransactionTooOld / IncompleteTransactionHistory
+ * style failure.
+ *
+ * @tags: [
+ *  requires_fcv_70,
+ *  requires_sharding,
+ *  uses_transactions,
+ *  uses_multi_shard_transaction,
+ *  featureFlagFLE2,
+ * ]
+ */
+import {EncryptedClient, isEnterpriseShell} from "jstests/fle2/libs/encrypted_client_util.js";
+import {ShardingTest} from "jstests/libs/shardingtest.js";
+
+if (!isEnterpriseShell()) {
+    jsTestLog("Skipping: enterprise shell required for FLE2");
+    quit();
+}
+
+const st = new ShardingTest({
+    mongos: 1,
+    shards: 2,
+    rs: {nodes: 2},
+});
+
+const dbName = "fle_update_shard_key_field";
+const collName = "patients";
+const ns = `${dbName}.${collName}`;
+
+const adminDB = st.s0.getDB("admin");
+const testDB = st.s0.getDB(dbName);
+testDB.dropDatabase();
+
+// Shard key is on the non-encrypted hashable field `region`. The update
+// will additionally $set an encrypted field (`ssn`) so the request must
+// flow through the FLE re-write path before being dispatched.
+assert.commandWorked(adminDB.runCommand({enableSharding: dbName, primaryShard: st.shard0.shardName}));
+
+const client = new EncryptedClient(st.s0, dbName);
+assert.commandWorked(
+    client.createEncryptionCollection(collName, {
+        encryptedFields: {
+            fields: [
+                {path: "ssn", bsonType: "string", queries: {queryType: "equality"}},
+            ],
+        },
+    }),
+);
+
+assert.commandWorked(adminDB.runCommand({shardCollection: ns, key: {region: 1}}));
+assert.commandWorked(adminDB.runCommand({split: ns, middle: {region: "west"}}));
+assert.commandWorked(adminDB.runCommand({moveChunk: ns, find: {region: "east"}, to: st.shard0.shardName}));
+assert.commandWorked(adminDB.runCommand({moveChunk: ns, find: {region: "west"}, to: st.shard1.shardName}));
+
+// Seed one document on shard0 (`region: "east"`).
+const edb = client.getDB();
+const eColl = edb.getCollection(collName);
+assert.commandWorked(eColl.einsert({_id: 1, region: "east", ssn: "111-22-3333", name: "alice"}));
+
+// The update changes the shard-key field (`region`) AND touches an
+// encrypted field (`ssn`) in the same modifier doc. This is the exact
+// combination that fails today: FLE rewrites the batched command, drops the
+// shard-key-update flag, and the WCOS path on mongos never fires.
+const updateCmd = {
+    update: collName,
+    updates: [{
+        q: {_id: 1, region: "east"},
+        u: {$set: {region: "west", ssn: "999-88-7777"}},
+    }],
+    lsid: {id: UUID()},
+    txnNumber: NumberLong(1),
+};
+
+const res = edb.runCommand(updateCmd);
+
+// Accept either outcome (a) or (b) per the contract above. Both keep the
+// substrate honest: a hard pass means the WCOS flag is now threaded; a
+// clean structured error means the unsupported combination is at least
+// surfaced as such, not as a generic assertion buried in transaction
+// machinery.
+const cleanError = res.ok === 0 && res.code !== undefined && typeof res.errmsg === "string" && res.errmsg.length > 0;
+
+const okWithMove = res.ok === 1 && res.n === 1 && res.nModified === 1;
+
+assert(
+    cleanError || okWithMove,
+    () =>
+        "FLE update that would change shard key returned neither (a) success with cross-shard " +
+        "semantics nor (b) a clean structured error. Raw response: " + tojson(res),
+);
+
+if (okWithMove) {
+    // (a) The doc has moved across shards and the encrypted field round-trips.
+    const moved = edb.getCollection(collName).find({_id: 1}).toArray();
+    assert.eq(moved.length, 1, () => "expected exactly one document, got: " + tojson(moved));
+    assert.eq(moved[0].region, "west", () => "shard key not updated: " + tojson(moved[0]));
+} else {
+    // (b) The error should name the combination, not surface as a stmtId
+    // collision inside an internal transaction. We assert the *shape* of
+    // the response, not a specific error code, so this test stays useful
+    // through whichever fix lands.
+    jsTestLog("FLE update-shard-key returned clean structured error: " + tojson(res));
+    assert(res.code !== ErrorCodes.InternalError, () => "should not surface as InternalError: " + tojson(res));
+}
+
+st.stop();

--- a/src/mongo/db/SERVER-96199-design.md
+++ b/src/mongo/db/SERVER-96199-design.md
@@ -1,0 +1,83 @@
+# SERVER-96199 design partner: FLE update to a document's shard key
+
+## Symptom
+
+A retryable update on an FLE2-encrypted collection that would change the
+value of the document's shard-key field fails with a generic assertion
+from deep inside the internal-transaction machinery. The error surfaces
+as a `TransactionTooOld`-shaped or `IncompleteTransactionHistory`-shaped
+failure rather than a clean, structured error that names the
+combination at fault (FLE + shard-key change).
+
+The bug was first hit by a patch build that flipped a sharded-collections
+passthrough suite to use retryable writes
+(`sharded_collections_jscore_passthrough_with_config_transitions_2`).
+
+## Root cause
+
+Two retryable-write retrofits collide:
+
+1. **Shard-key change** uses a hand-rolled translation: when a retryable
+   update would move a document across shards, mongos converts the
+   update into a multi-statement transaction containing a delete on the
+   source shard and an insert on the destination shard. This predates
+   internal transactions. The two child writes are stamped with the
+   default `stmtId = 0` because, in a standard transaction, `stmtId` is
+   ignored.
+
+2. **FLE2 CRUD** uses retryable internal transactions to atomically
+   update the user document plus the ESC / ECOC bookkeeping
+   collections. In an internal transaction, `stmtId` is *not* ignored:
+   it is the deduplication key for retryability.
+
+When the original write is an FLE update that *also* changes the shard
+key, mongos performs the FLE re-write of the
+`BatchedCommandRequest` first (`FLEUpdateOperation::serialize` /
+`appendMongosRequest`). That re-write drops the
+"this update may change the shard key" flag — the WCOS (write contains
+owning shard) annotation never reaches the mongos dispatcher. The
+dispatcher then runs the request as a vanilla retryable update, which in
+turn spawns the shard-key-change translation, which in turn spawns an
+internal transaction with `stmtId = 0` on both child writes. The reused
+`stmtId` aborts the entire FLE internal transaction.
+
+## Fix
+
+Two viable paths (the ticket calls them out as alternatives; this design
+recommends path A and uses path B as a same-day fallback):
+
+### Path A (preferred): route shard-key change through internal transactions
+
+Switch the shard-key-change codepath to use retryable internal
+transactions. The scaffolding already exists behind a failpoint
+(`useInternalTransactionsForShardKeyUpdates` or equivalent) — the work
+was started under the internal-transactions project and never finished.
+Completing it gives shard-key change the same `stmtId`-aware machinery
+that FLE already uses, removing the collision by construction.
+
+### Path B (fallback): preserve the flag through the FLE re-write
+
+Thread the "may change shard key" bit through
+`FLEUpdateOperation::serialize` and `appendMongosRequest` so the rewritten
+`BatchedCommandRequest` still tells mongos the WCOS path is required.
+Independently, assign distinct `stmtId`s to the delete and insert child
+writes (e.g. `stmtId, stmtId + 1`) so even if the surrounding txn is an
+internal one, deduplication is well-defined. This is a narrower patch
+than path A and is safe to backport.
+
+## Why the jstest accepts either outcome
+
+A regression test that pins one specific error code would become a
+liability the moment either path lands. The companion jstest
+`jstests/fle2/fle_update_shard_key_field.js` asserts the *contract*: the
+write either succeeds with cross-shard semantics (path A or a full fix
+of path B) or fails with a clean structured error (partial path B). Both
+keep the substrate honest; the generic-assertion regression is what we
+refuse to ship.
+
+## Out of scope
+
+`findAndModify` on FLE collections that would change the shard key
+follows the same code path but is gated separately by SERVER-114994
+(UWE / findAndModify). That ticket subsumes the findAndModify variant of
+this fix.


### PR DESCRIPTION
## Summary

jstest + design: FLE update must handle shard-key change cleanly.

**Jira:** https://jira.mongodb.org/browse/SERVER-126735
**Branch:** substrate-contrib/w4-30

## Files

```
  -  jstests/fle2/fle_update_shard_key_field.js | 125 +++++++++++++++++++++++++++++
  -  src/mongo/db/SERVER-96199-design.md        |  83 +++++++++++++++++++
  -  2 files changed, 208 insertions(+)
```

## Verify

For `.tla` files:
```
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<SpecName>
```

For `.js` jstests:
```
node --input-type=module --check < <path/to/test.js>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
