### PR TITLE
SERVER-126737 TLA+ spec + design: object-store backpressure and per-tenant budgets

### DIFF
--- a/src/mongo/db/SLS-4797-DESIGN.md
+++ b/src/mongo/db/SLS-4797-DESIGN.md
@@ -1,0 +1,81 @@
+# SLS-4797: Object-store backpressure and per-tenant budgets
+
+## Problem
+
+The disaggregated storage stack issues requests to an S3-like object
+store from two call sites with very different burst profiles: read-side
+PageServer fetches (per page miss; latency-sensitive) and write-side
+snapshot upload (large chunks; throughput-bound). The store enforces a
+finite global concurrency ceiling. Today every caller competes for it
+without coordination, so one tenant's burst monopolises the global
+slots and starves the rest. Once the store starts returning 429/503 we
+enter the metastable retry spiral the ticket names: retries crowd the
+queue, queue latency exceeds the client timeout, timeouts enqueue more
+retries, and the queue stays pinned long after the trigger cleared.
+
+## Two regimes, two budgets
+
+Read and write get independent admission control under a shared global
+ceiling:
+
+- `kReadBudget[tenant]` — maximum in-flight PageServer fetches per tenant.
+- `kWriteBudget[tenant]` — maximum in-flight snapshot upload parts per
+  tenant.
+- `kGlobalCeiling` — dispatcher cap on total in-flight requests, sized
+  below the store's published 503 threshold.
+
+Invariant we owe the store: `Σ in-flight ≤ kGlobalCeiling`. Invariant we
+owe operators: no tenant's burst can drive another tenant's read budget
+to zero.
+
+## Token-bucket per (tenant, operation-kind)
+
+Each `(tenant, op_kind)` owns a token bucket sized to its budget.
+Admission grabs a token; any terminal completion (2xx / 4xx / 5xx)
+returns it. Retries do not consume a new token — they re-enqueue against
+the same bucket. The dispatcher rotates over buckets that have both
+pending work and a free token. Rotation is round-robin over the
+non-empty bucket set, with weighted-fair degeneration when a tenant's
+budget exceeds another's by more than 2×. Fairness is a property of the
+data structure, not the dispatch policy.
+
+The TLA+ companion at `src/mongo/tla_plus/Disagg/ObjectStoreBackpressure/`
+models this admission discipline. Its bug configuration disables
+per-tenant buckets and shows that the dispatcher's freedom to choose any
+pending request is sufficient to starve other tenants — fairness has to
+be enforced by the data, not promised by policy.
+
+## Hooks
+
+**Shedding under saturation.** When a bucket is at budget and a new
+request arrives, the request is rejected at admission with a typed
+`ObjectStoreBudgetExceeded` error. The caller chooses: PageServer falls
+back to its in-memory miss handling (caller-visible latency); snapshot
+upload defers to the next scheduling tick. We never enqueue above budget
+— that is the metastability trap.
+
+**Fairness across tenants.** The dispatcher rotates only over buckets
+with positive pending and a free token. A tenant whose bucket is empty
+contributes no slots to the rotation but also cannot block another
+tenant's progress. The TLA+ liveness property `FairnessAcrossTenants`
+codifies this: every tenant under sustained load eventually progresses.
+
+**Observability counters.** Per (tenant, kind) we maintain `shedCount`,
+`retryCount`, `inflightHWM`, `dispatchLatency_p99`. These back the SLO
+targets in the ticket (`upload_throttle_rate < 1`,
+`hot_range_materialization_lag_p99 < 1–2s`) and export via the existing
+`disaggStorage_object_store_*` metric tree.
+
+**Key/prefix sharding.** Out of scope here — tracked separately. The
+budget machinery is correct regardless of sharding because budgets are
+tenant-keyed; sharding only affects which physical prefix receives a
+given request, not the admission gate.
+
+## Acceptance
+
+- `BudgetNeverExceeded` and `PerTenantBudgetNeverExceeded` proved in TLC
+  under the healthy configuration.
+- Bug cfg produces a `FairnessAcrossTenants` counter-example, attached
+  to the PR.
+- Integration test injects a heavy tenant burst and asserts lagging
+  tenants' p99 materialization latency stays under 2s.

--- a/src/mongo/tla_plus/Disagg/ObjectStoreBackpressure/MCObjectStoreBackpressure.cfg
+++ b/src/mongo/tla_plus/Disagg/ObjectStoreBackpressure/MCObjectStoreBackpressure.cfg
@@ -1,0 +1,26 @@
+\* Healthy configuration: per-tenant token buckets are active. Both safety
+\* and liveness invariants should hold. See MCObjectStoreBackpressureBug.cfg
+\* for the no-budgets configuration that drives the starvation trace.
+SPECIFICATION Spec
+
+CONSTANTS
+    Tenants = {t1, t2, t3}
+    OpKinds = {READ, WRITE}
+    GlobalCap = 4
+    TenantCap = 2
+    MaxPendingPerBucket = 2
+    BudgetsEnabled = TRUE
+
+INVARIANT
+    TypeOK
+    BudgetNeverExceeded
+    PerTenantBudgetNeverExceeded
+    CountsWellFormed
+
+PROPERTIES
+    FairnessAcrossTenants
+
+CONSTRAINT
+    CounterCeiling
+
+SYMMETRY Symmetry

--- a/src/mongo/tla_plus/Disagg/ObjectStoreBackpressure/MCObjectStoreBackpressure.tla
+++ b/src/mongo/tla_plus/Disagg/ObjectStoreBackpressure/MCObjectStoreBackpressure.tla
@@ -1,0 +1,60 @@
+---------------------------- MODULE MCObjectStoreBackpressure ----------------------------
+\* Model-checking entry point for ObjectStoreBackpressure.tla.
+\* This module defines constants/symmetry/state-constraints for TLC.
+\*
+\* To run the healthy configuration:
+\*     cd src/mongo/tla_plus
+\*     ./model-check.sh Disagg/ObjectStoreBackpressure
+\*
+\* The bug configuration (BudgetsEnabled = FALSE) lives in
+\* MCObjectStoreBackpressureBug.cfg next to this file. It is intentionally
+\* expected to FAIL FairnessAcrossTenants; the failure trace is the
+\* counter-example SLS-4797 calls for. Run it manually with:
+\*     java ... tlc2.TLC -config MCObjectStoreBackpressureBug.cfg \
+\*         MCObjectStoreBackpressure.tla
+
+EXTENDS ObjectStoreBackpressure
+
+(**************************************************************************************************)
+(* Symmetry reductions.                                                                           *)
+(**************************************************************************************************)
+
+\* Tenants and operation-kinds are symmetric: the spec treats them uniformly
+\* up to the per-bucket budget. Permuting their identifiers yields a
+\* behaviour-equivalent state, so TLC can collapse them.
+\*
+\* Note: TLC warns when SYMMETRY is combined with liveness checking, since
+\* fairness obligations are not always preserved under permutation. We use
+\* symmetry only in the healthy cfg, where the spec is expected to PASS;
+\* the bug cfg drops symmetry so its counter-example is unambiguous.
+Symmetry == Permutations(Tenants) \union Permutations(OpKinds)
+
+(**************************************************************************************************)
+(* State constraints.                                                                             *)
+(**************************************************************************************************)
+
+\* Bound the state space so TLC terminates. ShedCount and RetryCount are
+\* monotone observability counters; capping them at MaxPendingPerBucket
+\* keeps the state space finite without affecting any enabling condition
+\* (they appear only on the right-hand side of action updates).
+CounterCeiling ==
+    /\ \A t \in Tenants, k \in OpKinds : shedCount[t][k] <= MaxPendingPerBucket
+    /\ \A t \in Tenants, k \in OpKinds : retryCount[t][k] <= MaxPendingPerBucket
+
+(**************************************************************************************************)
+(* Counter-example baits (model-checking aids).                                                   *)
+(**************************************************************************************************)
+
+\* Bait: confirm at least one tenant can progress under the chosen cfg.
+\* Setting this as an INVARIANT yields a trace where a tenant completes a
+\* request, useful for sanity-checking that the spec is exercised.
+BaitSomeTenantProgressed == \A t \in Tenants : ~progress[t]
+
+\* Bait: confirm the global cap is fully saturated at some point.
+BaitGlobalSaturated == TotalInflight < GlobalCap
+
+\* Bait: confirm the shed path can fire under the healthy cfg (budget shed
+\* requires BudgetsEnabled = TRUE and a bucket already at TenantCap).
+BaitShedFires == \A t \in Tenants, k \in OpKinds : shedCount[t][k] = 0
+
+============================================================================================

--- a/src/mongo/tla_plus/Disagg/ObjectStoreBackpressure/MCObjectStoreBackpressureBug.cfg
+++ b/src/mongo/tla_plus/Disagg/ObjectStoreBackpressure/MCObjectStoreBackpressureBug.cfg
@@ -1,0 +1,43 @@
+\* Bug configuration. Per-tenant token buckets are DISABLED so the dispatcher
+\* only checks the global concurrency cap. Under sustained load one tenant's
+\* burst can pin every in-flight slot to itself and starve the rest; TLC
+\* surfaces this as a FairnessAcrossTenants liveness counter-example.
+\*
+\* This cfg is intentionally expected to FAIL the liveness property. The
+\* purpose is to materialise the trace so reviewers can confirm the spec
+\* discriminates the buggy regime from the healthy one. Run it manually:
+\*     cd src/mongo/tla_plus/Disagg/ObjectStoreBackpressure
+\*     java ... tlc2.TLC -config MCObjectStoreBackpressureBug.cfg \
+\*         MCObjectStoreBackpressure.tla
+\*
+\* Safety invariants (BudgetNeverExceeded, TypeOK, CountsWellFormed) should
+\* still hold even in the bug cfg: the global ceiling is structurally
+\* enforced at dispatch time regardless of per-tenant budgets. Only
+\* FairnessAcrossTenants is expected to fail.
+SPECIFICATION Spec
+
+CONSTANTS
+    Tenants = {t1, t2, t3}
+    OpKinds = {READ, WRITE}
+    GlobalCap = 2
+    TenantCap = 2
+    MaxPendingPerBucket = 2
+    BudgetsEnabled = FALSE
+
+INVARIANT
+    TypeOK
+    BudgetNeverExceeded
+    CountsWellFormed
+
+PROPERTIES
+    \* Expected to FAIL: one tenant's burst pins the global cap and the
+    \* other two tenants never reach progress[t] = TRUE.
+    FairnessAcrossTenants
+
+CONSTRAINT
+    CounterCeiling
+
+\* No SYMMETRY reduction here: when the spec is broken, the counter-example
+\* trace is more legible without permuting tenant identifiers, and TLC's
+\* warning that liveness checks are unsound under symmetry is moot since
+\* we expect a violation anyway.

--- a/src/mongo/tla_plus/Disagg/ObjectStoreBackpressure/ObjectStoreBackpressure.tla
+++ b/src/mongo/tla_plus/Disagg/ObjectStoreBackpressure/ObjectStoreBackpressure.tla
@@ -1,0 +1,289 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+------------------------- MODULE ObjectStoreBackpressure -------------------------
+\* Models the object-store (S3-like) request plane used by the disaggregated
+\* storage stack: PageServers reading pages, snapshot uploaders writing chunks.
+\* The store has finite request concurrency. Without per-tenant budgets, a
+\* single tenant's burst can monopolise the entire global cap and starve the
+\* rest (SLS-4797). This spec is the formal companion to the design at
+\* src/mongo/db/SLS-4797-DESIGN.md.
+\*
+\* The model intentionally tracks requests as per-bucket COUNTS rather than
+\* per-request records. Sets with unique-id records grow without bound and
+\* prevent TLC from forming a lasso, which would make liveness vacuously hold
+\* and hide the starvation bug. Bounded counts admit cyclic states and let
+\* TLC find the counter-example.
+\*
+\* Two configurations are modelled side by side, governed by BudgetsEnabled:
+\*   * BudgetsEnabled = FALSE  (the bug cfg). The dispatcher only checks the
+\*     global GlobalCap. One tenant offering enough requests can pin the
+\*     in-flight slots to itself indefinitely; other tenants stay starved.
+\*     Model-checking under the bug cfg fails FairnessAcrossTenants and
+\*     produces the starvation counter-example.
+\*   * BudgetsEnabled = TRUE  (the healthy cfg). A token-bucket per (tenant,
+\*     opKind) caps each tenant's in-flight share at TenantCap, and the
+\*     global ceiling still applies. Excess offers are shed at admission and
+\*     counted against the observability counter `shedCount`. Under sustained
+\*     load every tenant eventually progresses.
+\*
+\* Operation kinds (OpKinds) split the read path (PageServer fetches) from
+\* the write path (snapshot upload), matching the two-regime split in the
+\* design doc. Each kind has an independent bucket so a heavy write workload
+\* cannot drain the read budget and vice versa.
+\*
+\* Compatible with model-check.sh; see MCObjectStoreBackpressure.cfg for the
+\* two configurations.
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+
+CONSTANTS
+    Tenants,            \* Set of tenant identifiers contending for the store.
+    OpKinds,            \* Set of operation kinds {READ, WRITE} (PageServer vs upload).
+    GlobalCap,          \* Global maximum in-flight requests against the store.
+    TenantCap,          \* Per (tenant, kind) maximum in-flight when budgets are on.
+    MaxPendingPerBucket,\* Per (tenant, kind) ceiling on the queued count.
+    BudgetsEnabled      \* TRUE => per-tenant token buckets active; FALSE => bug cfg.
+
+ASSUME Cardinality(Tenants) > 0
+ASSUME Cardinality(OpKinds) > 0
+ASSUME GlobalCap \in Nat /\ GlobalCap > 0
+ASSUME TenantCap \in Nat /\ TenantCap > 0
+ASSUME TenantCap <= GlobalCap
+ASSUME MaxPendingPerBucket \in Nat /\ MaxPendingPerBucket > 0
+ASSUME BudgetsEnabled \in BOOLEAN
+
+VARIABLES
+    pendingCount,     \* [Tenants -> [OpKinds -> Nat]]: queued count per bucket.
+    inflightCount,    \* [Tenants -> [OpKinds -> Nat]]: in-flight count per bucket.
+    shedCount,        \* [Tenants -> [OpKinds -> Nat]]: cumulative budget-shed count.
+    retryCount,       \* [Tenants -> [OpKinds -> Nat]]: cumulative 429/503 retries.
+    progress          \* [Tenants -> BOOLEAN]: TRUE once tenant has completed >= 1 request.
+
+\* shedCount and retryCount are observability counters. They are unbounded in
+\* principle (monotone increasing), but the state-space CONSTRAINT in the MC
+\* module caps them so TLC explores a finite space. They are NOT used in any
+\* enabling condition, so the spec's behaviour does not depend on their value;
+\* they are pure observers.
+
+vars == << pendingCount, inflightCount, shedCount, retryCount, progress >>
+
+----------------------------------------------------------------------------
+\* Helpers
+----------------------------------------------------------------------------
+
+\* Total in-flight across every (tenant, kind) bucket.
+\* Uses TLC's `SetToSeq` to flatten the Tenants \X OpKinds product into a
+\* sequence and folds with a top-level recursive sum.
+RECURSIVE SumSeq(_)
+SumSeq(seq) ==
+    IF Len(seq) = 0
+    THEN 0
+    ELSE inflightCount[Head(seq)[1]][Head(seq)[2]] + SumSeq(Tail(seq))
+
+TotalInflight ==
+    SumSeq(SetToSeq({ <<t, k>> : t \in Tenants, k \in OpKinds }))
+
+\* Budgets allow new dispatch into bucket (t,k) if the per-bucket cap is not
+\* yet reached. Without budgets, only the global ceiling applies, which is
+\* what produces the starvation trace.
+BudgetAdmits(t, k) ==
+    \/ ~BudgetsEnabled
+    \/ inflightCount[t][k] < TenantCap
+
+\* The global cap is enforced at dispatch time in both configurations: the
+\* object store itself imposes a finite concurrency ceiling.
+GlobalAdmits == TotalInflight < GlobalCap
+
+\* Convenience: at least one bucket has something in-flight.
+AnyInflight == TotalInflight > 0
+
+\* Convenience: bucket has room to enqueue.
+BucketHasRoom(t, k) == pendingCount[t][k] < MaxPendingPerBucket
+
+----------------------------------------------------------------------------
+\* Init
+----------------------------------------------------------------------------
+
+Init ==
+    /\ pendingCount = [t \in Tenants |-> [k \in OpKinds |-> 0]]
+    /\ inflightCount = [t \in Tenants |-> [k \in OpKinds |-> 0]]
+    /\ shedCount = [t \in Tenants |-> [k \in OpKinds |-> 0]]
+    /\ retryCount = [t \in Tenants |-> [k \in OpKinds |-> 0]]
+    /\ progress = [t \in Tenants |-> FALSE]
+
+----------------------------------------------------------------------------
+\* Actions
+----------------------------------------------------------------------------
+
+\* A tenant offers a new request of kind `k`. Admission is checked against
+\* the per-bucket budget when BudgetsEnabled is TRUE; otherwise the request
+\* is always admitted to `pendingCount` and the global cap is checked only
+\* at dispatch time -- this is the bug shape the design eliminates.
+\*
+\* When BudgetsEnabled and the bucket is already at TenantCap of pending +
+\* inflight, the offer is shed at admission and the observability counter
+\* `shedCount` increments. This corresponds to the design doc's "shed under
+\* saturation" hook.
+ClientOffer(t, k) ==
+    /\ t \in Tenants
+    /\ k \in OpKinds
+    /\ BucketHasRoom(t, k)
+    /\ IF BudgetsEnabled /\ (pendingCount[t][k] + inflightCount[t][k]) >= TenantCap
+       THEN /\ shedCount' = [ shedCount EXCEPT
+                                ![t] = [ @ EXCEPT ![k] = @ + 1 ] ]
+            /\ UNCHANGED << pendingCount, inflightCount, retryCount, progress >>
+       ELSE /\ pendingCount' = [ pendingCount EXCEPT
+                                    ![t] = [ @ EXCEPT ![k] = @ + 1 ] ]
+            /\ UNCHANGED << inflightCount, shedCount, retryCount, progress >>
+
+\* Dispatcher picks a pending request from bucket (t,k) and moves it to
+\* inflight. The global cap is enforced here in both configurations. When
+\* BudgetsEnabled is TRUE, the per-bucket cap is also re-checked here.
+\*
+\* The non-determinism over (t,k) is the dispatcher's policy degree of
+\* freedom. In the buggy cfg this lets TLC build a trace where the
+\* dispatcher keeps choosing one tenant forever. In the healthy cfg the
+\* per-bucket budget forces rotation.
+Dispatch(t, k) ==
+    /\ t \in Tenants
+    /\ k \in OpKinds
+    /\ pendingCount[t][k] > 0
+    /\ GlobalAdmits
+    /\ BudgetAdmits(t, k)
+    /\ pendingCount' = [ pendingCount EXCEPT
+                            ![t] = [ @ EXCEPT ![k] = @ - 1 ] ]
+    /\ inflightCount' = [ inflightCount EXCEPT
+                            ![t] = [ @ EXCEPT ![k] = @ + 1 ] ]
+    /\ UNCHANGED << shedCount, retryCount, progress >>
+
+\* Object store returns 2xx for a request in bucket (t,k). The slot is
+\* released and the tenant records progress.
+StoreOk(t, k) ==
+    /\ t \in Tenants
+    /\ k \in OpKinds
+    /\ inflightCount[t][k] > 0
+    /\ inflightCount' = [ inflightCount EXCEPT
+                            ![t] = [ @ EXCEPT ![k] = @ - 1 ] ]
+    /\ progress' = [progress EXCEPT ![t] = TRUE]
+    /\ UNCHANGED << pendingCount, shedCount, retryCount >>
+
+\* Object store returns 429/503 for a request in bucket (t,k). The request
+\* is re-queued for backoff retry, the in-flight slot is released so the
+\* dispatcher can rotate, and the per-bucket retry counter increments.
+StoreThrottle(t, k) ==
+    /\ t \in Tenants
+    /\ k \in OpKinds
+    /\ inflightCount[t][k] > 0
+    /\ BucketHasRoom(t, k)
+    /\ inflightCount' = [ inflightCount EXCEPT
+                            ![t] = [ @ EXCEPT ![k] = @ - 1 ] ]
+    /\ pendingCount' = [ pendingCount EXCEPT
+                            ![t] = [ @ EXCEPT ![k] = @ + 1 ] ]
+    /\ retryCount' = [ retryCount EXCEPT
+                            ![t] = [ @ EXCEPT ![k] = @ + 1 ] ]
+    /\ UNCHANGED << shedCount, progress >>
+
+----------------------------------------------------------------------------
+\* Next / Spec
+----------------------------------------------------------------------------
+
+Next ==
+    \/ \E t \in Tenants, k \in OpKinds : ClientOffer(t, k)
+    \/ \E t \in Tenants, k \in OpKinds : Dispatch(t, k)
+    \/ \E t \in Tenants, k \in OpKinds : StoreOk(t, k)
+    \/ \E t \in Tenants, k \in OpKinds : StoreThrottle(t, k)
+
+\* Fairness assumptions are carefully scoped.
+\*
+\* * WF_vars(\E t,k : Dispatch(t, k))
+\*     The dispatcher is fair as a SYSTEM: if any bucket has a pending
+\*     request and headroom under the caps, the dispatcher must eventually
+\*     dispatch SOME request. This is the realistic model -- a finite-
+\*     thread dispatcher cannot stutter forever -- but it deliberately does
+\*     NOT promise per-bucket fairness. That stronger assumption would mask
+\*     the bug: under per-bucket WF, every bucket would drain, so even the
+\*     no-budgets cfg would trivially satisfy FairnessAcrossTenants. With
+\*     per-system WF only, TLC can construct a trace where the dispatcher
+\*     keeps choosing tenant t1's bucket and never reaches t2's, falsifying
+\*     FairnessAcrossTenants.
+\*
+\* * WF_vars(\E t,k : StoreOk(t, k))
+\*     The object store eventually replies. Same per-system scope: scoped
+\*     as the dispatcher, not per-bucket.
+\*
+\* * WF on per-tenant ClientOffer: under sustained load, every tenant keeps
+\*     offering as long as it has bucket room. This is the "sustained load"
+\*     assumption from the SLS-4797 success criteria; without it the bug
+\*     cfg has no competing tenants to starve.
+\*
+\* We do NOT add WF to StoreThrottle. Throttles model an environmental
+\* fault that may or may not happen; forcing them would over-constrain.
+Spec ==
+    /\ Init
+    /\ [][Next]_vars
+    /\ WF_vars(\E t \in Tenants, k \in OpKinds : Dispatch(t, k))
+    /\ WF_vars(\E t \in Tenants, k \in OpKinds : StoreOk(t, k))
+    /\ \A t \in Tenants :
+            WF_vars(\E k \in OpKinds : ClientOffer(t, k))
+
+----------------------------------------------------------------------------
+\* Invariants -- SAFETY
+----------------------------------------------------------------------------
+
+TypeOK ==
+    /\ pendingCount \in [Tenants -> [OpKinds -> Nat]]
+    /\ inflightCount \in [Tenants -> [OpKinds -> Nat]]
+    /\ shedCount \in [Tenants -> [OpKinds -> Nat]]
+    /\ retryCount \in [Tenants -> [OpKinds -> Nat]]
+    /\ progress \in [Tenants -> BOOLEAN]
+
+\* HEADLINE SAFETY.
+\* The sum of in-flight requests across all tenants never exceeds the
+\* global concurrency ceiling. This is the invariant the object store is
+\* relying on: if we send more, we get back 503s in the real system, which
+\* turns into the metastable retry spiral SLS-4797 also calls out.
+BudgetNeverExceeded == TotalInflight <= GlobalCap
+
+\* Per-tenant budget: when BudgetsEnabled, no tenant exceeds TenantCap in
+\* any single operation-kind bucket. Read and write are independently
+\* budgeted so a write burst cannot starve reads on the same tenant.
+PerTenantBudgetNeverExceeded ==
+    BudgetsEnabled =>
+        \A t \in Tenants, k \in OpKinds :
+            inflightCount[t][k] <= TenantCap
+
+\* Pending and in-flight counts are non-negative and bounded.
+CountsWellFormed ==
+    /\ \A t \in Tenants, k \in OpKinds :
+            pendingCount[t][k] \in 0..MaxPendingPerBucket
+    /\ \A t \in Tenants, k \in OpKinds :
+            inflightCount[t][k] \in 0..GlobalCap
+
+----------------------------------------------------------------------------
+\* Liveness -- FAIRNESS
+----------------------------------------------------------------------------
+
+\* HEADLINE LIVENESS.
+\* Every tenant eventually completes at least one request. Under
+\* BudgetsEnabled this passes: per-bucket caps force the dispatcher to
+\* rotate, and per-tenant WF on ClientOffer guarantees every tenant has
+\* work waiting. Under the bug cfg (BudgetsEnabled = FALSE) one tenant's
+\* burst can pin all GlobalCap slots forever and the others never reach
+\* progress[t] = TRUE -- TLC produces the counter-example trace SLS-4797
+\* asks us to surface.
+FairnessAcrossTenants ==
+    \A t \in Tenants : <>(progress[t])
+
+\* Pending work eventually clears for at least one tenant, on every reset
+\* of the workload pattern. A weaker, easier-to-satisfy companion to
+\* FairnessAcrossTenants for spot-checking the dispatcher.
+SomePendingEventuallyDrains ==
+    ( \E t \in Tenants, k \in OpKinds : pendingCount[t][k] > 0 )
+        ~> ( \E t \in Tenants, k \in OpKinds :
+                pendingCount[t][k] = 0 /\ progress[t] )
+
+================================================================================


### PR DESCRIPTION
## Summary

TLA+ spec + design: object-store backpressure and per-tenant budgets.

**Jira:** https://jira.mongodb.org/browse/SERVER-126737
**Branch:** substrate-contrib/w5-2

## Files

```
  -  src/mongo/db/SLS-4797-DESIGN.md                    |  81 ++++++
  -  .../MCObjectStoreBackpressure.cfg                  |  26 ++
  -  .../MCObjectStoreBackpressure.tla                  |  60 +++++
  -  .../MCObjectStoreBackpressureBug.cfg               |  43 +++
  -  .../ObjectStoreBackpressure.tla                    | 289 +++++++++++++++++++++
  -  5 files changed, 499 insertions(+)
```

## Verify

```
node --input-type=module --check < <path/to/test.js>
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<Spec>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
