### PR TITLE
SERVER-126739 TLA+ spec + jstest + design: interruptible atomic wait on OperationContext

### DIFF
--- a/jstests/noPassthrough/atomic_wait_responds_to_interrupt.js
+++ b/jstests/noPassthrough/atomic_wait_responds_to_interrupt.js
@@ -1,0 +1,120 @@
+/**
+ * SERVER-75430: Tests that a command which blocks inside an atomic wait on OperationContext
+ * unblocks within a bounded time after killOp fires.
+ *
+ * Today's TicketPool / PriorityTicketHolder waits sleep on a futex over a raw atomic flag and
+ * poll for interrupt every 500ms. Once OperationContext::waitForAtomicOrInterrupt is in place,
+ * killOp must unblock the waiter on the next scheduler step, not after the 500ms re-queue.
+ *
+ * The test wedges a thread into the atomic wait via the `hangInWaitForAtomicOrInterrupt`
+ * failpoint (introduced alongside the helper). With the failpoint engaged the command parks
+ * inside the new helper. We then call killOp on it and assert that:
+ *   1. the command returns ErrorCodes.Interrupted
+ *   2. it does so well under the legacy 500ms re-queue ceiling (we use 2s as a generous bound
+ *      that still catches a regression to the old polling behaviour)
+ *
+ * If the failpoint name has not yet been introduced (i.e. the helper has not landed), the test
+ * skips gracefully and prints the expected failpoint name so the implementer knows what to wire.
+ *
+ * @tags: [
+ *     requires_replication,
+ *     requires_fcv_71,
+ * ]
+ */
+
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {funWithArgs} from "jstests/libs/parallel_shell_helpers.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+// Failpoint that must be installed alongside the new helper. It pauses the thread inside the
+// joined atomic+interrupt wait. With waitForAtomicOrInterrupt in place, markKilled() flips the
+// kill bit and the futex returns on the next syscall edge.
+const kFailpointName = "hangInWaitForAtomicOrInterrupt";
+
+// Upper bound for "interrupt was responsive". Old behaviour was 500ms re-queue; we allow 2s
+// for jitter on slow hosts but anything in the seconds-to-minutes range is a metastable-failure
+// regression and must fail the test.
+const kInterruptResponseMs = 2 * 1000;
+
+const rst = new ReplSetTest({nodes: 1});
+rst.startSet();
+rst.initiate();
+
+const primary = rst.getPrimary();
+const adminDB = primary.getDB("admin");
+const testDB = primary.getDB("test");
+const collName = "atomic_wait_responds_to_interrupt";
+assert.commandWorked(testDB.createCollection(collName));
+
+// Probe for the failpoint. If it does not exist yet, document the contract and exit cleanly --
+// this test pins the contract more than the current implementation, and we want it to remain
+// readable as a regression catch once the helper lands.
+const probe = adminDB.runCommand({configureFailPoint: kFailpointName, mode: "off"});
+if (!probe.ok) {
+    jsTestLog(`Skipping: failpoint "${kFailpointName}" is not registered. ` +
+              `Once SERVER-75430's waitForAtomicOrInterrupt helper lands, install this ` +
+              `failpoint inside the slow path so this test exercises it.`);
+    rst.stopSet();
+    quit();
+}
+
+const fp = configureFailPoint(primary, kFailpointName);
+const findComment = "SERVER-75430-atomic-wait-interrupt-probe";
+
+// Run a command in a parallel shell that goes through the atomic wait. Any command whose
+// admission path goes through TicketPool / PriorityTicketHolder works; we use a simple find
+// with a comment we can pick up via currentOp.
+const awaitShell = startParallelShell(funWithArgs(
+    (dbName, coll, comment) => {
+        const res = db.getSiblingDB(dbName).runCommand({find: coll, filter: {}, comment});
+        // The test asserts we get Interrupted; if the server returns OK it means the failpoint
+        // released without our killOp, which is also a regression.
+        assert.commandFailedWithCode(res, ErrorCodes.Interrupted);
+    },
+    testDB.getName(),
+    collName,
+    findComment,
+), primary.port);
+
+try {
+    // Wait until the find op has reached the atomic wait failpoint.
+    fp.wait();
+
+    // Locate the op.
+    let opId;
+    assert.soon(() => {
+        const r = adminDB.aggregate([{$currentOp: {}}, {$match: {"command.comment": findComment}}]).toArray();
+        if (r.length === 1) {
+            opId = r[0].opid;
+            return true;
+        }
+        return false;
+    }, () => `failed to find op with comment ${findComment}`);
+
+    // Fire killOp and time the round-trip to the waiter's return.
+    const tKill = Date.now();
+    assert.commandWorked(adminDB.killOp(opId));
+
+    // Disengage the failpoint so the wait can return (belt-and-suspenders: with the new helper
+    // in place, markKilled flips the kill bit and the futex returns even with the failpoint
+    // engaged; we turn it off so the test is deterministic under implementations that gate
+    // the failpoint check above the interrupt check).
+    fp.off();
+
+    awaitShell();
+    const elapsed = Date.now() - tKill;
+
+    // Headline assertion: interrupt response is well below the legacy 500ms re-queue ceiling.
+    assert.lt(elapsed,
+              kInterruptResponseMs,
+              `killOp on an atomic-waiting op took ${elapsed}ms, exceeds ${kInterruptResponseMs}ms ` +
+              `bound. This is the SERVER-75430 metastable-failure regression: bare atomic wait, ` +
+              `interrupt not coupled.`);
+
+    jsTestLog(`OK: atomic wait responded to interrupt in ${elapsed}ms (bound ${kInterruptResponseMs}ms).`);
+} finally {
+    // Idempotent: fp.off() is safe to call twice if the try-block already invoked it.
+    fp.off();
+}
+
+rst.stopSet();

--- a/src/mongo/tla_plus/Concurrency/WaitForAtomicOrInterrupt/MCWaitForAtomicOrInterrupt.cfg
+++ b/src/mongo/tla_plus/Concurrency/WaitForAtomicOrInterrupt/MCWaitForAtomicOrInterrupt.cfg
@@ -1,0 +1,30 @@
+\* Good config: waitForAtomicOrInterrupt couples both wake sources. Both safety
+\* invariants and the InterruptIsResponsiveProp liveness property must hold.
+SPECIFICATION Spec
+
+\* "Done" is a legitimate terminal state for every thread; disable TLC's deadlock
+\* heuristic so liveness is what we measure (per CLAUDE.md / TLA+ spec practice).
+CHECK_DEADLOCK
+    FALSE
+
+CONSTANTS
+    Threads = {t1, t2}
+    MaxAtomicFlips = 2
+    InterruptIsResponsive = TRUE
+
+CONSTRAINTS
+    FlipBound
+
+INVARIANT
+    TypeOK
+    DoneHasReason
+    NotDoneHasNoReason
+    AtomicConsumedExactlyOnce
+    \* BaitNoInterruptExit
+
+\* InterruptIsResponsiveProp is the headline liveness invariant: an interrupted
+\* waiter eventually leaves the wait. WaitTerminates is NOT a theorem because
+\* the environment (producer / interrupter) is unconstrained -- nothing forces
+\* it to ever fire. See the docstring for SomeWaiterCanWake.
+PROPERTY
+    InterruptIsResponsiveProp

--- a/src/mongo/tla_plus/Concurrency/WaitForAtomicOrInterrupt/MCWaitForAtomicOrInterrupt.tla
+++ b/src/mongo/tla_plus/Concurrency/WaitForAtomicOrInterrupt/MCWaitForAtomicOrInterrupt.tla
@@ -1,0 +1,21 @@
+------------------------ MODULE MCWaitForAtomicOrInterrupt --------------------------------------
+\* Model-checking module for WaitForAtomicOrInterrupt.
+
+EXTENDS WaitForAtomicOrInterrupt
+
+(**************************************************************************************************)
+(* State constraints. Bound atomic flips so the search is finite under fair scheduling.            *)
+(**************************************************************************************************)
+
+FlipBound == atomicFlips <= MaxAtomicFlips
+
+(**************************************************************************************************)
+(* Bait invariants -- not asserted, only documented for parity with neighbouring specs. The        *)
+(* useful counter-example for the bug config (InterruptIsResponsive = FALSE) is produced by        *)
+(* the liveness property InterruptIsResponsiveProp, not by a safety invariant.                     *)
+(**************************************************************************************************)
+
+BaitNoInterruptExit ==
+    \A t \in Threads : exitReason[t] # "interrupt"
+
+=================================================================================================

--- a/src/mongo/tla_plus/Concurrency/WaitForAtomicOrInterrupt/MCWaitForAtomicOrInterrupt_bug.cfg
+++ b/src/mongo/tla_plus/Concurrency/WaitForAtomicOrInterrupt/MCWaitForAtomicOrInterrupt_bug.cfg
@@ -1,0 +1,31 @@
+\* Bug config: bare atomic wait with no interrupt branch (InterruptIsResponsive = FALSE).
+\* TLC must produce a counter-example for InterruptIsResponsiveProp: a waiter whose interrupt
+\* bit is set but who is never woken because the producer never flips the atomic again.
+\*
+\* Run thus:
+\*   ./model-check.sh Concurrency/WaitForAtomicOrInterrupt   (good config)
+\*   cp Concurrency/WaitForAtomicOrInterrupt/MCWaitForAtomicOrInterrupt_bug.cfg \
+\*      Concurrency/WaitForAtomicOrInterrupt/MCWaitForAtomicOrInterrupt.cfg
+\*   ./model-check.sh Concurrency/WaitForAtomicOrInterrupt   (expects liveness counter-example)
+SPECIFICATION Spec
+
+\* Same rationale as the good config: Done is terminal.
+CHECK_DEADLOCK
+    FALSE
+
+CONSTANTS
+    Threads = {t1, t2}
+    MaxAtomicFlips = 1
+    InterruptIsResponsive = FALSE
+
+CONSTRAINTS
+    FlipBound
+
+INVARIANT
+    TypeOK
+    DoneHasReason
+    NotDoneHasNoReason
+    AtomicConsumedExactlyOnce
+
+PROPERTY
+    InterruptIsResponsiveProp

--- a/src/mongo/tla_plus/Concurrency/WaitForAtomicOrInterrupt/OWNERS.yml
+++ b/src/mongo/tla_plus/Concurrency/WaitForAtomicOrInterrupt/OWNERS.yml
@@ -1,0 +1,5 @@
+version: 1.0.0
+filters:
+  - "*":
+    approvers:
+      - 10gen/server-programmability

--- a/src/mongo/tla_plus/Concurrency/WaitForAtomicOrInterrupt/WaitForAtomicOrInterrupt.tla
+++ b/src/mongo/tla_plus/Concurrency/WaitForAtomicOrInterrupt/WaitForAtomicOrInterrupt.tla
@@ -1,0 +1,177 @@
+\* Copyright 2026 MongoDB, Inc.
+\*
+\* This work is licensed under:
+\* - Creative Commons Attribution-3.0 United States License
+\*   http://creativecommons.org/licenses/by/3.0/us/
+
+------------------------- MODULE WaitForAtomicOrInterrupt ---------------------------------------
+\* Models OperationContext::waitForAtomicOrInterrupt (SERVER-75430).
+\*
+\* A wait function joins two wake sources: (a) an atomic flag flipped by a producer (e.g. a ticket
+\* release in TicketPool / PriorityTicketHolder) and (b) the interrupt mechanism on OperationContext
+\* (killOp, shutdown, deadline). Today, futex waiters in TicketPool sleep on the atomic only and
+\* poll for interrupt every 500ms. That 500ms poll is the bug: under load, every operation queues
+\* > 500ms, times out, re-queues, and the system enters a metastable failure state where shutdown
+\* and killOp can stall for seconds-to-minutes.
+\*
+\* This spec models the interruptible variant. The thread joins both wake sources atomically: a
+\* wake from the atomic OR a kill bit flip exits the wait. The bug config replaces the joined wait
+\* with a bare atomic wait (no interrupt branch) and demonstrates the resulting liveness failure.
+\*
+\* Spec at a glance:
+\*   - Threads = set of waiter threads.
+\*   - State per thread \in {Running, Waiting, Done}.
+\*   - Atomic flag flips False -> True at most once per "generation"; flipping wakes one waiter.
+\*   - Interrupt flag flips False -> True at most once per thread.
+\*   - Either source returning unblocks the wait.
+\*   - Liveness: from any state in which Interrupt(t) has fired, t eventually leaves Waiting.
+
+EXTENDS Integers, Sequences, FiniteSets, TLC
+
+CONSTANTS Threads,                  \* Set of waiter threads.
+          MaxAtomicFlips,           \* Bound on producer-side flips (state-space cap).
+          InterruptIsResponsive     \* Boolean: when FALSE, the wait does NOT check interrupt
+                                    \* (bug config; liveness counter-example).
+
+ASSUME MaxAtomicFlips \in Nat
+ASSUME InterruptIsResponsive \in BOOLEAN
+
+VARIABLES
+    state,         \* state[t] \in {"Running", "Waiting", "Done"}
+    atomic,        \* Boolean: shared atomic flag (TRUE => ticket/permit available).
+    interrupted,   \* interrupted[t] \in BOOLEAN: per-thread kill bit.
+    atomicFlips,   \* Nat: number of times atomic transitioned False -> True (bounded).
+    exitReason     \* exitReason[t] \in {"none", "atomic", "interrupt"}
+
+vars == <<state, atomic, interrupted, atomicFlips, exitReason>>
+
+States == {"Running", "Waiting", "Done"}
+ExitReasons == {"none", "atomic", "interrupt"}
+
+-----------------------------------------------------------------------------
+
+\* True iff at least one Waiting thread observes the wake condition.
+SomeWaiterCanWake ==
+    \E t \in Threads :
+        /\ state[t] = "Waiting"
+        /\ \/ atomic                                             \* atomic source
+           \/ (InterruptIsResponsive /\ interrupted[t])           \* interrupt source
+
+-----------------------------------------------------------------------------
+
+Init ==
+    /\ state        = [t \in Threads |-> "Running"]
+    /\ atomic       = FALSE
+    /\ interrupted  = [t \in Threads |-> FALSE]
+    /\ atomicFlips  = 0
+    /\ exitReason   = [t \in Threads |-> "none"]
+
+\* A running thread enters the wait. It will not progress further until either:
+\*   1. atomic is set (and it consumes the wake), or
+\*   2. its interrupt bit is set AND the variant under test checks it.
+EnterWait(t) ==
+    /\ state[t] = "Running"
+    /\ state' = [state EXCEPT ![t] = "Waiting"]
+    /\ UNCHANGED <<atomic, interrupted, atomicFlips, exitReason>>
+
+\* Producer flips the atomic to TRUE (bounded by MaxAtomicFlips). Real implementations use $merge-
+\* like idempotent CAS; the abstraction is: "wake source A becomes live".
+FlipAtomic ==
+    /\ ~atomic
+    /\ atomicFlips < MaxAtomicFlips
+    /\ atomic'      = TRUE
+    /\ atomicFlips' = atomicFlips + 1
+    /\ UNCHANGED <<state, interrupted, exitReason>>
+
+\* An external thread (killOp / shutdown) flips a waiter's interrupt bit.
+Interrupt(t) ==
+    /\ ~interrupted[t]
+    /\ interrupted' = [interrupted EXCEPT ![t] = TRUE]
+    /\ UNCHANGED <<state, atomic, atomicFlips, exitReason>>
+
+\* A waiting thread is woken by the atomic. It consumes the wake (resets the flag) and exits.
+WakeOnAtomic(t) ==
+    /\ state[t] = "Waiting"
+    /\ atomic
+    /\ atomic'     = FALSE
+    /\ state'      = [state      EXCEPT ![t] = "Done"]
+    /\ exitReason' = [exitReason EXCEPT ![t] = "atomic"]
+    /\ UNCHANGED <<interrupted, atomicFlips>>
+
+\* A waiting thread is woken by the interrupt bit. Only enabled when the variant under test
+\* couples the interrupt path to the wait. With InterruptIsResponsive = FALSE this disjunct
+\* is structurally disabled, modelling a bare atomic wait that polls (or never polls) for
+\* interrupt and reproducing the SERVER-75430 metastable-failure pre-condition.
+WakeOnInterrupt(t) ==
+    /\ InterruptIsResponsive
+    /\ state[t] = "Waiting"
+    /\ interrupted[t]
+    /\ state'      = [state      EXCEPT ![t] = "Done"]
+    /\ exitReason' = [exitReason EXCEPT ![t] = "interrupt"]
+    /\ UNCHANGED <<atomic, interrupted, atomicFlips>>
+
+-----------------------------------------------------------------------------
+
+Next ==
+    \/ \E t \in Threads : EnterWait(t)
+    \/ FlipAtomic
+    \/ \E t \in Threads : Interrupt(t)
+    \/ \E t \in Threads : WakeOnAtomic(t)
+    \/ \E t \in Threads : WakeOnInterrupt(t)
+
+\* Per-thread strong fairness on the two wake actions. This pins down "if the wake source is
+\* persistently enabled, the wake fires" -- exactly the property the bare-atomic wait violates.
+Spec ==
+    /\ Init
+    /\ [][Next]_vars
+    /\ \A t \in Threads :
+         /\ SF_vars(WakeOnAtomic(t))
+         /\ SF_vars(WakeOnInterrupt(t))
+         /\ WF_vars(EnterWait(t))
+
+-----------------------------------------------------------------------------
+\* Safety
+-----------------------------------------------------------------------------
+
+TypeOK ==
+    /\ state       \in [Threads -> States]
+    /\ atomic      \in BOOLEAN
+    /\ interrupted \in [Threads -> BOOLEAN]
+    /\ atomicFlips \in 0..MaxAtomicFlips
+    /\ exitReason  \in [Threads -> ExitReasons]
+
+\* exitReason and state are kept consistent: a Done thread has a real exit reason.
+DoneHasReason ==
+    \A t \in Threads :
+        (state[t] = "Done") => (exitReason[t] \in {"atomic", "interrupt"})
+
+\* Non-Done threads have not yet recorded an exit reason.
+NotDoneHasNoReason ==
+    \A t \in Threads :
+        (state[t] # "Done") => (exitReason[t] = "none")
+
+\* The atomic flag is single-use per flip: only one waiter can consume each True->False edge.
+\* (Captured by the fact that WakeOnAtomic resets atomic.)
+AtomicConsumedExactlyOnce ==
+    atomic \/ (Cardinality({t \in Threads : exitReason[t] = "atomic"}) <= atomicFlips)
+
+-----------------------------------------------------------------------------
+\* Liveness
+-----------------------------------------------------------------------------
+
+\* Headline liveness invariant: every waiter whose interrupt bit has been set
+\* eventually leaves the wait. This is what `waitForAtomicOrInterrupt` must
+\* guarantee for killOp / shutdown to bound the worst-case unblock latency.
+InterruptIsResponsiveProp ==
+    \A t \in Threads :
+        (state[t] = "Waiting" /\ interrupted[t]) ~> (state[t] = "Done")
+
+\* Companion: every waiter eventually exits the wait (either because a wake source fires
+\* or because, in the no-interrupt configuration, the producer eventually wakes it).
+\* In the bug configuration with no interrupt branch this becomes a stronger statement
+\* than the system can deliver if the producer is starved.
+WaitTerminates ==
+    \A t \in Threads :
+        (state[t] = "Waiting") ~> (state[t] = "Done")
+
+=================================================================================================

--- a/src/mongo/util/SERVER-75430-design.md
+++ b/src/mongo/util/SERVER-75430-design.md
@@ -1,0 +1,66 @@
+# SERVER-75430: Interruptible Atomic Wait on `OperationContext`
+
+## Symptom
+
+Several hot paths inside `TicketPool` / `PriorityTicketHolder` queue waiters on a
+raw atomic flag via a futex. `OperationContext`'s interrupt mechanism is itself
+just an atomic (`_killCode`), and the two atomics are not coupled, so a thread
+sleeping on the ticket atomic does not observe `killOp`, `shutdown`, or
+`maxTimeMS` until something else wakes it. The current workaround is a 500 ms
+periodic re-queue (`priority_ticketholder.cpp:96-99`): the waiter wakes itself,
+calls `checkForInterrupt()`, and re-enters the wait if no interrupt fired.
+
+This is fine under steady-state. Under heavy contention -- many client threads,
+sustained queue depths beyond pool capacity -- every operation queues for longer
+than 500 ms, so every operation pays the wake/check/re-queue tax. The wake
+storm consumes CPU that the pool was meant to throttle, queue depths grow, and
+the system enters a metastable failure mode in which:
+
+- `killOp` against a queued op can stall up to 500 ms before unblocking.
+- `shutdown` walks every queued op via `markKilled`; with a long queue this is
+  multiplied by 500 ms per waiter that happens to be mid-sleep on the timer.
+- Wake-up storms thrash the scheduler and worsen the very contention that
+  caused the queueing in the first place.
+
+## Fix sketch
+
+Add `OperationContext::waitForAtomicOrInterrupt(WaitableAtomic& atomic,
+Predicate pred)` that couples both wake sources into a single sleep:
+
+1. Fast path: evaluate `pred()`; if true, return `Status::OK()` without
+   sleeping.
+2. Register interest in the kill bit. On Linux this is a `futex(FUTEX_WAIT)`
+   on a vector of two 32-bit words ([`futex(2)` waitv variant][1]) -- one is
+   the caller-supplied atomic, the other is `_killCode` re-read as a `uint32_t`
+   (all `ErrorCodes::Error` values fit). On other platforms, fall back to a
+   `condition_variable` keyed off both atomics; the predicate must close over
+   both.
+3. Slow path: sleep until the kernel wakes the thread because *either* word
+   changed. Wake source attribution is `pred()` vs `isKillPending()`.
+4. On wake, if `isKillPending()` is true, return the kill status; otherwise
+   return `Status::OK()`.
+
+Critically, callers route `OperationContext::sleepFor` / `sleepUntil` (not the
+raw `condition_variable::wait_for`) so the substrate's existing deadline
+machinery, baton interruption, and `_killCode` stamping all keep working. The
+500 ms re-queue is removed.
+
+## Liveness guarantee
+
+`InterruptIsResponsive` (the TLA+ liveness property pinned in
+[`WaitForAtomicOrInterrupt.tla`](../tla_plus/Concurrency/WaitForAtomicOrInterrupt/WaitForAtomicOrInterrupt.tla)):
+within a bounded number of scheduler steps after `markKilled` flips the kill
+bit, every thread that was `Waiting` on this primitive returns. The bug config
+(`InterruptIsResponsive = FALSE`) produces a TLC counter-example -- the
+metastable wake-storm in prose form.
+
+## Scope
+
+- v1 covers the `TicketPool` / `PriorityTicketHolder` queue.
+- Future callers: `WaitableMutex` (`util/concurrency/`) and any other hand-rolled
+  futex sleep that today polls `checkForInterrupt`.
+- Out of scope: changes to `waitForConditionOrInterruptNoAssertUntil` behaviour
+  for callers that already participate in network I/O via the baton; that path
+  is correct already.
+
+[1]: https://man7.org/linux/man-pages/man2/futex.2.html


### PR DESCRIPTION
## Summary

TLA+ spec + jstest + design: interruptible atomic wait on OperationContext.

**Jira:** https://jira.mongodb.org/browse/SERVER-126739
**Branch:** substrate-contrib/w5-4

## Files

```
  -  .../atomic_wait_responds_to_interrupt.js           | 120 ++++++++++++++
  -  .../MCWaitForAtomicOrInterrupt.cfg                 |  30 ++++
  -  .../MCWaitForAtomicOrInterrupt.tla                 |  21 +++
  -  .../MCWaitForAtomicOrInterrupt_bug.cfg             |  31 ++++
  -  .../WaitForAtomicOrInterrupt/OWNERS.yml            |   5 +
  -  .../WaitForAtomicOrInterrupt.tla                   | 177 +++++++++++++++++++++
  -  src/mongo/util/SERVER-75430-design.md              |  66 ++++++++
  -  7 files changed, 450 insertions(+)
```

## Verify

```
node --input-type=module --check < <path/to/test.js>
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<Spec>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
