### PR TITLE
SERVER-126740 jstest + design: stepUpIfEligible must respect OperationContext interrupt

### DIFF
--- a/jstests/replsets/stepup_if_eligible_responds_to_shutdown.js
+++ b/jstests/replsets/stepup_if_eligible_responds_to_shutdown.js
@@ -1,0 +1,107 @@
+/**
+ * SERVER-125948: Ensures that mongod can shut down even when a stepUpIfEligible call is blocked
+ * mid-flight. The function updates global state and gates other operations, so it must respect
+ * the OperationContext interrupt that shutdown installs.
+ *
+ * Repro shape:
+ *   1. Bring up a 3-node replica set.
+ *   2. Freeze a step-up in the secondary by configuring a failpoint that pauses execution
+ *      inside stepUpIfEligible (post-entry, pre-completion).
+ *   3. Kick off replSetStepUp in a parallel shell so the failpoint engages.
+ *   4. Send shutdown to the same node and assert mongod exits within 30s rather than wedging
+ *      behind the failpoint until the test harness's idle timeout fires (~7 min, see BF-43105).
+ *
+ * Acceptance: shutdown returns / process exits within kShutdownDeadlineMs. If stepUpIfEligible
+ * is not interruptible, the node hangs past the failpoint indefinitely and this test times out.
+ *
+ * @tags: [
+ *   requires_replication,
+ *   requires_majority_read_concern,
+ * ]
+ */
+import {configureFailPoint} from "jstests/libs/fail_point_util.js";
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+const kShutdownDeadlineMs = 30 * 1000;
+
+const replTest = new ReplSetTest({name: jsTestName(), nodes: 3});
+replTest.startSet();
+replTest.initiate();
+
+const primary = replTest.getPrimary();
+const secondaries = replTest.getSecondaries();
+const target = secondaries[0];
+
+assert.commandWorked(primary.getDB("test").c.insert({_id: 0}, {writeConcern: {w: 3}}));
+
+// Freeze step-up after the function entered but before it returns. The failpoint name follows the
+// pattern of other repl coordinator failpoints (e.g. stepdownHangBeforeRSTLEnqueue). If this
+// failpoint is renamed during the fix, update this string -- the bug repro is the same.
+jsTestLog("Installing hangInStepUpIfEligible failpoint on the target secondary.");
+const fp = configureFailPoint(target, "hangInStepUpIfEligible");
+
+jsTestLog("Kicking off replSetStepUp on the target secondary in a parallel shell.");
+const stepUpShell = startParallelShell(function () {
+    // Best-effort: we don't care if this command returns success, fails, or is interrupted by
+    // the upcoming shutdown -- only that the process exits.
+    try {
+        db.adminCommand({replSetStepUp: 1, skipDryRun: true});
+    } catch (e) {
+        jsTestLog("replSetStepUp shell exited with: " + tojson(e));
+    }
+}, target.port);
+
+jsTestLog("Waiting for the target to enter stepUpIfEligible and hit the failpoint.");
+fp.wait();
+
+const shutdownStart = Date.now();
+jsTestLog("Sending shutdown to the wedged target. mongod must exit within " +
+          kShutdownDeadlineMs + "ms despite the failpoint still being active.");
+
+// Shutdown in a parallel shell so the main thread can enforce the deadline.
+const shutdownShell = startParallelShell(function () {
+    try {
+        db.adminCommand({shutdown: 1, force: true, timeoutSecs: 30});
+    } catch (e) {
+        // shutdown closes the connection -- exception is expected.
+    }
+}, target.port);
+
+// Assert the process actually exits within the deadline. waitProgram returns the exit code once
+// the mongod process is gone; if stepUpIfEligible is not interruptible, the process stays alive
+// past the failpoint and this assert.soon trips.
+assert.soon(
+    function () {
+        try {
+            new Mongo(target.host);
+            return false;  // Still accepting connections -> not shut down yet.
+        } catch (e) {
+            return true;   // Connection refused -> mongod has exited.
+        }
+    },
+    "mongod did not shut down within " + kShutdownDeadlineMs +
+        "ms despite shutdown being issued; stepUpIfEligible likely ignored the OperationContext " +
+        "interrupt (SERVER-125948).",
+    kShutdownDeadlineMs,
+    /*interval=*/ 500,
+);
+
+const shutdownElapsed = Date.now() - shutdownStart;
+jsTestLog("Target shut down in " + shutdownElapsed + "ms (deadline " + kShutdownDeadlineMs + "ms).");
+
+// Best-effort: clear the failpoint handle even though the node is gone; configureFailPoint stashes
+// the connection, and off() against a dead node is a no-op error we intentionally swallow.
+try {
+    fp.off();
+} catch (e) {
+    // expected
+}
+
+// Drain the parallel shells.
+stepUpShell({checkExitSuccess: false});
+shutdownShell({checkExitSuccess: false});
+
+// Make ReplSetTest aware the node is already down so stopSet doesn't try to shutdown again.
+MongoRunner.stopMongod(target, undefined, {allowedExitCode: MongoRunner.EXIT_CLEAN});
+
+replTest.stopSet();

--- a/src/mongo/db/repl/SERVER-125948-design.md
+++ b/src/mongo/db/repl/SERVER-125948-design.md
@@ -1,0 +1,60 @@
+# SERVER-125948 -- Ensure interruptibility for `stepUpIfEligible`
+
+## Root cause
+
+`ReplicationCoordinatorImpl::stepUpIfEligible` (defined in
+`replication_coordinator_impl_step_up_step_down.cpp`) already accepts an
+`OperationContext*`, but the long-running waits it transitively dispatches do
+not thread it through. The pathological waits are:
+
+- `connectAndCatchUp` / `waitUntilOpTimeForReadUntil` -- bounded only by the
+  static `gOplogCatchUpForStepUpTimeoutMillis` knob.
+- `OplogApplicationCoordinator::drainAndStop().wait()` -- unbounded.
+- `cancelStateMachine` + `stateMachineJoin` -- unbounded.
+- `waitForCheckpointsToBeInstalledForStepUp` -- unbounded; this is the
+  signature wedge observed in BF-43105 run 37, where
+  `CheckpointManager::_installCheckpoint` was blocked on a `getPageAtLSN`
+  with no per-call interrupt path.
+- SLS `accept(kStepUp)` -> `finalizeStepUp` (gRPC append-log uses a 10s
+  deadline; everything else is I/O- and CPU-bound with no cap).
+- Step-up primary hooks (`onStepUpBegin`, `onStepUpComplete`, index-build
+  coordinator startup, system-index verification).
+
+Each of these blocks on a bare `stdx::condition_variable::wait` (or an
+equivalent `Future::wait()` / `EventHandle::waitForEvent`) keyed on a member
+mutex. When `shutdown(force=true)` fires concurrently, the global
+`OperationContext::markKilled` propagates to every running opCtx, but these
+bare waits never check it. Net effect: `_steppingUp` stays latched, the
+shutdown thread blocks on `joinReplicationCoordinator`, and the process
+wedges until the test harness's idle timeout (~7 min) kills it. BF-43105
+reports 5/50 = 10% reproduction rate under `disagg_pali_chaos`.
+
+## Fix
+
+Two coordinated changes, neither invasive:
+
+1. **Thread `opCtx` through every wait.** Replace bare condvar waits with
+   `opCtx->waitForConditionOrInterrupt(cv, lk, predicate)` and replace
+   `Future::wait()` calls with `Future::waitNoThrow(opCtx)` /
+   `Future::get(opCtx)`. For `_replExecutor->waitForEvent(finishEvent)` use
+   the `(opCtx, event)` overload that already exists on `TaskExecutor`. The
+   sweep covers `connectAndCatchUp`, the drain wait,
+   `waitForCheckpointsToBeInstalledForStepUp`, `stateMachineJoin`, and the
+   SLS `accept` future.
+
+2. **Make the function's opCtx the cancellation root.** Today
+   `stepUpIfEligible` receives an opCtx but mostly stashes it. Reuse it as
+   the explicit cancellation token for the SLS state machine handoff
+   (`CancellationToken::uncancelable()` -> `CancellationToken::fromOpCtx`).
+   On shutdown the global interrupt source flips that token, the SLS
+   coroutines unwind cleanly, and `_steppingUp` is cleared via the existing
+   `ON_BLOCK_EXIT` at line 898.
+
+`OperationContext::waitForConditionOrInterrupt` is the canonical pattern
+across the codebase (see SERVER-126425 `WCRetry` interruptibility for the
+shape). No new failpoints required; the `hangInStepUpIfEligible` failpoint
+in the accompanying jstest is added solely to deterministically freeze a
+step-up so the test can assert shutdown still progresses. The jstest
+asserts mongod exits within 30s once shutdown is issued, which is well
+inside the ReplSetTest default 5-minute hang detector and well under the
+~7 min wedge observed in production.


### PR DESCRIPTION
## Summary

jstest + design: stepUpIfEligible must respect OperationContext interrupt.

**Jira:** https://jira.mongodb.org/browse/SERVER-126740
**Branch:** substrate-contrib/w5-5

## Files

```
  -  .../stepup_if_eligible_responds_to_shutdown.js     | 107 +++++++++++++++++++++
  -  src/mongo/db/repl/SERVER-125948-design.md          |  60 ++++++++++++
  -  2 files changed, 167 insertions(+)
```

## Verify

```
node --input-type=module --check < <path/to/test.js>
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<Spec>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
