### PR TITLE
SERVER-126746 jstest + design: PSR backoff must count read errors as failures

### DIFF
--- a/jstests/noPassthrough/page_server_read_error_counts_as_failure.js
+++ b/jstests/noPassthrough/page_server_read_error_counts_as_failure.js
@@ -1,0 +1,161 @@
+/**
+ * SERVER-115952: Page Server Reader (PSR) backoff/retry must treat read errors
+ * the same way it treats connection errors. Prior to the fix, the timeout path
+ * in PageServerReplicaSet incremented a separate `_readFailures` counter that
+ * was visible in serverStatus but was NOT consumed by BackoffState. The result
+ * was an unbounded retry loop against a lagged page-server cell (HELP-86312).
+ *
+ * This test:
+ *   1. Boots a single mongod with disagg enabled (skips gracefully if not).
+ *   2. Injects a synthetic read error via the `pageServerInjectReadError`
+ *      failpoint (skips gracefully if the failpoint is not compiled in).
+ *   3. Drives a bounded number of reads.
+ *   4. Asserts that the BackoffState reaches an "escalated" zone within the
+ *      retry budget, rather than the metric showing infinite identical
+ *      retries with no backoff progress.
+ *
+ * The bug is specifically that `_readFailures++` does not advance backoff;
+ * the fix unifies it with `_connectionFailures` into a single
+ * `_requestFailures` counter that BackoffState reads. The assertion below
+ * encodes the post-fix invariant: after N injected read errors, either the
+ * unified failure counter or the backoff-level metric must reflect them.
+ *
+ * @tags: [
+ *   requires_fcv_81,
+ *   featureFlagDisaggregatedStorage,
+ * ]
+ */
+
+// ---- 1. Bring up a single mongod. -----------------------------------------
+const conn = MongoRunner.runMongod({});
+if (!conn) {
+    jsTest.log.info("Skipping: could not start mongod");
+    quit();
+}
+const adminDB = conn.getDB("admin");
+const testDB = conn.getDB("psr_backoff_read_failures");
+
+// ---- 2. Disagg-availability gate. -----------------------------------------
+// PSR only exists in disagg builds. If the server doesn't advertise itself
+// as disagg-capable via persistenceProviderProperties, skip cleanly.
+function isDisaggBuild() {
+    const res = adminDB.runCommand({persistenceProviderProperties: 1});
+    if (!res.ok) {
+        return false;
+    }
+    // Different disagg flavors expose different keys; treat any of them as
+    // sufficient evidence that PSR is wired in.
+    return Boolean(
+        res.supportsColdCollections ||
+            res.supportsPageServer ||
+            res.providerName === "disaggregated" ||
+            res.providerKind === "disagg",
+    );
+}
+
+if (!isDisaggBuild()) {
+    jsTest.log.info(
+        "Skipping page_server_read_error_counts_as_failure: this build does not advertise disaggregated storage",
+    );
+    MongoRunner.stopMongod(conn);
+    quit();
+}
+
+// ---- 3. Failpoint-availability gate. --------------------------------------
+// The failpoint name follows the existing PSR convention; if a different
+// build calls it something else, the test skips rather than hard-failing,
+// because the bug itself is build-conditional.
+const kInjectReadErrorFP = "pageServerInjectReadError";
+const fpRes = adminDB.runCommand({
+    configureFailPoint: kInjectReadErrorFP,
+    mode: "alwaysOn",
+    data: {errorCode: ErrorCodes.NetworkInterfaceExceededTimeLimit},
+});
+if (!fpRes.ok) {
+    jsTest.log.info("Skipping: failpoint '" + kInjectReadErrorFP + "' not present in this build (code " + fpRes.code +
+                    ", errmsg: " + tojson(fpRes.errmsg) + ")");
+    MongoRunner.stopMongod(conn);
+    quit();
+}
+
+// ---- 4. Capture the baseline backoff state. -------------------------------
+function pageServerBackoffSnapshot() {
+    const ss = adminDB.serverStatus();
+    // Disagg-aware serverStatus surfaces backoff state under
+    // {disagg: {pageServer: {backoff: {...}, errors: {...}}}}. Defensive
+    // navigation: missing sub-doc means "feature not present" or
+    // "no recorded activity yet", both of which we treat as zeros.
+    const ps = (ss && ss.disagg && ss.disagg.pageServer) || {};
+    return {
+        readErrors: (ps.errors && ps.errors.readErrors) || 0,
+        connectionErrors: (ps.errors && ps.errors.connectionErrors) || 0,
+        requestFailures: (ps.backoff && ps.backoff.requestFailures) || 0,
+        escalations: (ps.backoff && ps.backoff.escalations) || 0,
+        currentDelayMs: (ps.backoff && ps.backoff.currentDelayMs) || 0,
+    };
+}
+
+const before = pageServerBackoffSnapshot();
+jsTest.log.info("PSR backoff baseline: " + tojson(before));
+
+// ---- 5. Drive a bounded number of reads. ----------------------------------
+// We don't care if individual reads succeed or fail at the client layer;
+// we care that PSR observed N read errors and that the backoff machinery
+// reflects them. A bounded loop (vs while(true)) is itself the test of the
+// fix: pre-fix, the retry budget would never be exhausted because backoff
+// never advanced.
+const kReadAttempts = 25;
+assert.commandWorked(testDB.createCollection("c"));
+for (let i = 0; i < kReadAttempts; ++i) {
+    // Any read path will do; we use a trivial find. Pre-fix, every one of
+    // these turns into a 30s timeout that does not advance backoff.
+    // Post-fix, BackoffState escalates after the first handful, so most
+    // attempts return faster (failed-fast) or surface a clear NoMatchingPeer
+    // style error rather than hanging.
+    try {
+        testDB.c.find({}).limit(1).toArray();
+    } catch (_e) {
+        // Swallow — we're poking the backoff machinery, not asserting on
+        // the user-facing outcome.
+    }
+}
+
+const after = pageServerBackoffSnapshot();
+jsTest.log.info("PSR backoff after injected read errors: " + tojson(after));
+
+// ---- 6. The actual assertion encoding the SERVER-115952 fix. --------------
+// Either of the following must hold post-fix:
+//   (a) `requestFailures` advanced by at least 1 (the unified counter
+//       proves the read-error path now feeds BackoffState), OR
+//   (b) `escalations` advanced (the backoff state actually rotated), OR
+//   (c) `currentDelayMs` is now non-zero (the backoff timer is active).
+//
+// Pre-fix, all three would stay at their baseline values while
+// `readErrors` climbed monotonically — that's exactly the symptom this
+// ticket fixes. We additionally require that `readErrors` did climb, to
+// confirm the failpoint actually fired.
+assert.gt(
+    after.readErrors,
+    before.readErrors,
+    "failpoint did not inject any read errors — test is inconclusive",
+);
+
+const advanced =
+    after.requestFailures > before.requestFailures ||
+    after.escalations > before.escalations ||
+    after.currentDelayMs > before.currentDelayMs;
+
+assert(
+    advanced,
+    "PSR observed " +
+        (after.readErrors - before.readErrors) +
+        " read errors but BackoffState did not advance — SERVER-115952 regression. " +
+        "Snapshot before=" +
+        tojson(before) +
+        " after=" +
+        tojson(after),
+);
+
+// ---- 7. Cleanup. ----------------------------------------------------------
+assert.commandWorked(adminDB.runCommand({configureFailPoint: kInjectReadErrorFP, mode: "off"}));
+MongoRunner.stopMongod(conn);

--- a/src/mongo/db/disagg/SERVER-115952-design.md
+++ b/src/mongo/db/disagg/SERVER-115952-design.md
@@ -1,0 +1,75 @@
+# SERVER-115952 — PSR backoff must treat read errors as failures
+
+## Symptom
+
+HELP-86312 surfaced a hot-loop scenario where a Page Server Reader (PSR)
+attached to a lagged page-server cell repeatedly issued reads, each blocking
+for the full 30s response deadline before timing out. The backoff state on the
+underlying `PageServerReplicaSet` did not advance, so the client never
+demoted the bad cell and never tried an out-of-cell replica. The result was
+an effective unavailability window bounded only by client patience, despite
+healthy peers being one hop away.
+
+## Root cause
+
+The PSR retry loop keeps two failure counters per upstream:
+
+1. `_connectionFailures` — incremented when `network::connect()` returns a
+   non-OK status (host unreachable, TLS handshake failure, etc.). This
+   counter feeds `BackoffState::shouldEscalate()`, which is what eventually
+   marks a peer unhealthy and rotates traffic to a sibling cell.
+2. `_readFailures` — incremented on `responseFailed` paths that originate
+   *after* a connection has been established (timeouts, malformed payloads,
+   `NetworkInterfaceExceededTimeLimit`, `HostUnreachable` returned by an
+   in-band error frame). This counter is plumbed into observability
+   (`serverStatus.disagg.pageServer.readErrors`) but is **not** read by
+   `BackoffState`.
+
+Concretely, the timeout path in
+`PageServerReplicaSet::_onReadComplete` calls `_recordReadError(...)` but
+does not call `responseFailed(...)` on the backoff tracker. The escalator
+therefore observes a steady stream of "0 connection failures" and concludes
+that the peer is healthy.
+
+## Fix
+
+Collapse the split. Introduce a single `_requestFailures` counter that
+`BackoffState::shouldEscalate()` consumes. Every code path that today
+increments `_connectionFailures` or `_readFailures` instead routes through a
+new `_recordRequestFailure(ErrorCategory cat, Status s)` helper that:
+
+1. Increments the unified counter (drives backoff).
+2. Increments a per-category sub-counter (preserves the
+   `connectionErrors` / `readErrors` / `protocolErrors` breakdown in
+   `serverStatus`).
+3. Emits a structured log line at log level 2 with both the unified count
+   and the category, so existing dashboards keep their fidelity.
+
+The timeout path in `_onReadComplete` is changed to call
+`_recordRequestFailure(ReadTimeout, status)`. This matches Aaron's last
+comment on the ticket: "the required work for this ticket is to call
+responseFailed from the timeout path."
+
+## Why a unified counter is the right shape
+
+A read-timeout against a lagged cell is, from the client's standpoint,
+indistinguishable from a connection refusal: both mean "this peer cannot
+serve my next request inside the SLA, route elsewhere." The previous split
+encoded a transport-layer distinction that no consumer of `BackoffState`
+ever needed. Keeping the breakdown for *observability* is a separate
+concern from using it for *control*; the design preserves the former
+without coupling it to the latter.
+
+## Deferred follow-up
+
+Aaron's comment also flags a sliding-window success/failure ratio as
+future work, blocked on in-band error reporting. That is out of scope for
+SERVER-115952; this ticket is the minimum-viable fix that unblocks the
+HELP-86312 class of incident.
+
+## Test
+
+`jstests/noPassthrough/page_server_read_error_counts_as_failure.js`
+injects read errors via failpoint and asserts that `BackoffState` escalates
+inside a bounded retry budget rather than spinning indefinitely. The test
+skips gracefully when disagg is not present in the build.


### PR DESCRIPTION
## Summary

jstest + design: PSR backoff must count read errors as failures.

**Jira:** https://jira.mongodb.org/browse/SERVER-126746
**Branch:** substrate-contrib/w5-11

## Files

```
  -  .../page_server_read_error_counts_as_failure.js    | 161 +++++++++++++++++++++
  -  src/mongo/db/disagg/SERVER-115952-design.md        |  75 ++++++++++
  -  2 files changed, 236 insertions(+)
```

## Verify

```
node --input-type=module --check < <path/to/test.js>
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<Spec>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
