### PR TITLE
SERVER-126747 audit doc + jstest: PALI failover telemetry gaps and recommended metrics

### DIFF
--- a/jstests/replsets/pali_failover_telemetry_gates.js
+++ b/jstests/replsets/pali_failover_telemetry_gates.js
@@ -1,0 +1,120 @@
+/**
+ * SERVER-115688 — PALI failover telemetry audit gate.
+ *
+ * This test is the executable form of the audit at
+ *   src/mongo/db/disagg/pali/PALI-FAILOVER-TELEMETRY-SERVER-115688.md
+ *
+ * It stands up a 3-node replica set, forces a step-up from node 1, and asserts that
+ * `replSetGetStatus` / `serverStatus` expose the six telemetry surfaces the audit identifies as
+ * load-bearing for diagnosing PALI failovers:
+ *
+ *   1. electionMetrics.preStepUpWaitMillis              (transition standby-exit)
+ *   2. electionMetrics.catchupDurationMillis            (transition catchup)
+ *   3. electionMetrics.standbyToPrimaryMillis           (transition standby-exit -> become-primary)
+ *   4. electionMetrics.postStepUpFirstWriteMillis       (transition become-primary)
+ *   5. paliZoneAffinity                                 (zone-binding visibility)
+ *   6. paliPageServerRequests                           (per-endpoint request counters)
+ *
+ * None of these surfaces exist in `master` today. Every assertion below is expected to fail until
+ * the metrics in the audit doc are implemented; the test documents the deliverable.
+ *
+ * Tag: this test is intentionally NOT added to any passing-suite tag set. It is a regression gate
+ * that flips green once SERVER-115688 implementation work lands.
+ *
+ * @tags: [
+ *   requires_replication,
+ *   requires_fcv_80,
+ *   featureFlagPaliFailoverTelemetry,
+ * ]
+ */
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+const testName = jsTestName();
+const rst = new ReplSetTest({name: testName, nodes: 3});
+rst.startSet();
+rst.initiate();
+rst.awaitReplication();
+
+const originalPrimary = rst.getPrimary();
+const secondaries = rst.getSecondaries();
+const stepUpTarget = secondaries[0];
+
+jsTestLog(`Forcing step-up on ${stepUpTarget.host}`);
+
+// Drive a user-visible write on the original primary so post-step-up first-write latency is
+// non-trivial to observe.
+const collName = "pali_telemetry_gates";
+assert.commandWorked(originalPrimary.getDB("test")[collName].insert({_id: 0, seedPriorStepUp: true}));
+rst.awaitReplication();
+
+// Force the step-up. stepUpNoAwaitReplication is the canonical helper for telemetry tests; we want
+// the transitions to fire without ReplSetTest waiting on a quiesced state we are about to probe.
+rst.stepUp(stepUpTarget);
+rst.awaitNodesAgreeOnPrimary();
+const newPrimary = rst.getPrimary();
+assert.eq(newPrimary.host, stepUpTarget.host, "step-up target did not become primary");
+
+// Issue the first user-visible write under the new primary so postStepUpFirstWriteMillis has a
+// defined value to inspect.
+assert.commandWorked(newPrimary.getDB("test")[collName].insert({_id: 1, postStepUp: true}));
+
+const status = assert.commandWorked(newPrimary.adminCommand({replSetGetStatus: 1}));
+const serverStatus = assert.commandWorked(newPrimary.adminCommand({serverStatus: 1}));
+jsTestLog(`replSetGetStatus on new primary: ${tojson(status)}`);
+
+const em = status.electionMetrics || {};
+
+/**
+ * Helper: assert a named numeric field is present and >= 0. Failure message names the audit
+ * section so a reviewer of a red test run can locate the matching paragraph in the .md.
+ */
+function assertNumericMetric(obj, path, auditSection) {
+    const value = path.split(".").reduce((acc, key) => (acc == null ? acc : acc[key]), obj);
+    assert(value !== undefined && value !== null,
+           `[SERVER-115688 audit ${auditSection}] missing metric '${path}': ${tojson(obj)}`);
+    assert(typeof value === "number" && value >= 0,
+           `[SERVER-115688 audit ${auditSection}] metric '${path}' is not a non-negative number: ${tojson(value)}`);
+}
+
+// Audit gap #1: preStepUpWaitMillis — RSTL acquisition wait.
+assertNumericMetric(em, "preStepUpWaitMillis", "Gap 1");
+
+// Audit gap #2: catchupDurationMillis — wall time of catchup phase.
+assertNumericMetric(em, "catchupDurationMillis", "Gap 2");
+
+// Audit gap #3: standbyToPrimaryMillis — RSTL-acquired to transition-complete.
+assertNumericMetric(em, "standbyToPrimaryMillis", "Gap 3");
+
+// Audit gap #4: postStepUpFirstWriteMillis — transition-complete to first user write applied.
+assertNumericMetric(em, "postStepUpFirstWriteMillis", "Gap 4");
+
+// Audit gap #5: paliZoneAffinity block — current zone and bound endpoint sets.
+const zone = serverStatus.paliZoneAffinity;
+assert(zone,
+       "[SERVER-115688 audit Gap 5] serverStatus.paliZoneAffinity missing. Expected " +
+           "{currentZone, pageServerEndpoints[], logServerEndpoints[], outOfZoneRequests24h}");
+assert(typeof zone.currentZone === "string" && zone.currentZone.length > 0,
+       `[SERVER-115688 audit Gap 5] paliZoneAffinity.currentZone is not a non-empty string: ${tojson(zone)}`);
+assert(Array.isArray(zone.pageServerEndpoints),
+       `[SERVER-115688 audit Gap 5] paliZoneAffinity.pageServerEndpoints not an array: ${tojson(zone)}`);
+assert(Array.isArray(zone.logServerEndpoints),
+       `[SERVER-115688 audit Gap 5] paliZoneAffinity.logServerEndpoints not an array: ${tojson(zone)}`);
+assertNumericMetric(zone, "outOfZoneRequests24h", "Gap 5");
+
+// Audit gap #6: per-page-server request counters keyed by endpoint.
+const pageReqs = serverStatus.paliPageServerRequests;
+assert(pageReqs && typeof pageReqs === "object",
+       "[SERVER-115688 audit Gap 6] serverStatus.paliPageServerRequests missing. Expected an " +
+           "object keyed by endpoint with {inFlight, errors, p99LatencyMillis} per entry.");
+const endpoints = Object.keys(pageReqs);
+assert(endpoints.length > 0,
+       `[SERVER-115688 audit Gap 6] paliPageServerRequests has no endpoints: ${tojson(pageReqs)}`);
+for (const ep of endpoints) {
+    const counters = pageReqs[ep];
+    assertNumericMetric(counters, "inFlight", `Gap 6 (${ep})`);
+    assertNumericMetric(counters, "errors", `Gap 6 (${ep})`);
+    assertNumericMetric(counters, "p99LatencyMillis", `Gap 6 (${ep})`);
+}
+
+jsTestLog("All PALI failover telemetry gates passed. SERVER-115688 audit deliverable is complete.");
+rst.stopSet();

--- a/src/mongo/db/disagg/pali/PALI-FAILOVER-TELEMETRY-SERVER-115688.md
+++ b/src/mongo/db/disagg/pali/PALI-FAILOVER-TELEMETRY-SERVER-115688.md
@@ -1,0 +1,81 @@
+# PALI Failover Telemetry Audit — SERVER-115688
+
+**Scope:** observability audit for PALI (disaggregated Page-And-Log Infrastructure) failover. The
+ticket asks that operators (a) identify when a `mongod` is failing over out of its preferred zone
+and (b) identify which page/log servers it is talking to during and after the transition. This
+doc enumerates the failover state machine, lists the observability surfaces expected at each
+transition, and names the gaps the companion jstest pins.
+
+## Failover state machine
+
+A PALI failover walks five transitions. Each has its own SLO and its own diagnostic question.
+
+1. **`primary-loss-detected`** — heartbeat / lease deadline elapsed. *When did we learn, and which signal told us?*
+2. **`quorum-election`** — node calls `replSetRequestVotes`, collects votes. *Who voted, in what term, at what op-time?*
+3. **`catchup`** — newly elected primary drains the catchup window. *How long, against which sync source?*
+4. **`standby-exit`** — node leaves `SECONDARY`, clears the no-op writer, takes RSTL X. *How long did RSTL take, what held it?*
+5. **`become-primary`** — first user write accepted; PALI rebinds page/log server affinity. *When did the first write land, and to which zone?*
+
+## Required telemetry per transition
+
+**Bold** entries are missing or partial; the companion jstest probes for them.
+
+**1. `primary-loss-detected`** — `LOGV2 "Heartbeat reported primary unreachable"` present in
+`replication_coordinator_impl_heartbeat.cpp`. serverStatus exposes only
+`electionMetrics.numStepDownsCausedByHigherTerm`; **no counter for heartbeat-timeout-driven loss**.
+FTDC captures `members[].lastHeartbeatRecv`, coarse.
+
+**2. `quorum-election`** — `LOGV2` from `VoteRequester` present. serverStatus
+`electionMetrics.{electionTimeout,stepUpCmd,priorityTakeover,catchUpTakeover}` counters present.
+FTDC `electionCandidateMetrics.{electionTerm,numVotesNeeded,priorityAtElection}` present.
+
+**3. `catchup`** — `"Caught up to the latest known optime"` / `"Catchup timed out"` log lines
+present. serverStatus has counts (`numCatchUps`, `numCatchUpsSucceeded`, `numCatchUpsTimedOut`).
+**Gap: no per-election `catchupDurationMillis` histogram.** Operators cannot distinguish a 50ms
+catchup from a 4900ms catchup. PALI catchup against a disaggregated log tier is I/O-bound in a way
+classical replica-set catchup is not.
+
+**4. `standby-exit`** — `"Transition to PRIMARY complete"` exists, but **RSTL-X acquisition wait
+is not logged as a structured attr** (rolled into slow-op at >100ms). **serverStatus has no
+`preStepUpWaitMillis`.** Interval between "won election" and "RSTL acquired" is invisible unless
+slow-op fires. FTDC: no dedicated section.
+
+**5. `become-primary`** — transition-complete LOGV2 present. PALI side **does not log the bound
+page-server zone after transition** (Aaron's ticket comment requests a `LOG_EVERY_N` of
+out-of-zone request counts). **No `paliZoneAffinity` serverStatus block** carrying
+`{currentZone, pageServerEndpoints[], logServerEndpoints[], outOfZoneRequests24h}`. **No
+`paliFailoverLatency` FTDC section** carrying the four step-up latencies below.
+
+## Called-out gaps
+
+Four latencies are the load-bearing missing measurements. Each maps to one PALI failover SLO and
+each is asserted in `jstests/replsets/pali_failover_telemetry_gates.js`. The jstest fails today;
+it documents the deliverable in executable form.
+
+1. **`preStepUpWaitMillis`** — "election won" to "RSTL X acquired". Says whether step-up is
+   bottlenecked on long-running reads or on the no-op writer.
+2. **`catchupDurationMillis`** — wall time of the catchup phase. Distinguishes "already up to
+   date" from "waited 4s on an out-of-zone log server".
+3. **`standbyToPrimaryMillis`** — "RSTL acquired" to "transition callback returned". Catches
+   drainage / op-observer cost.
+4. **`postStepUpFirstWriteMillis`** — "transition complete" to "first user write applied".
+   The user-visible failover SLI; PALI re-binding to a remote zone is the suspected regression source.
+
+Two non-latency gaps round out the audit:
+
+5. **Zone affinity log line** — `LOG_EVERY_N(1000)` of
+   `{currentZone, outOfZoneReadsPct, outOfZonePageServerCount}` so operators see "we failed over
+   and are now reading 30% out of zone" without per-request log scraping (Aaron's comment).
+6. **Per-page-server-endpoint counter** — `paliPageServerRequests.{endpoint,inFlight,errors,p99LatencyMillis}`
+   so a known-unhealthy page server can be confirmed as the source of poor primary performance.
+
+## Recommended next steps
+
+1. Add the four `*Millis` fields to `replication_metrics.idl` (or a new `paliFailoverMetrics.idl`)
+   and emit from existing step-up / catchup callsites.
+2. Add `paliZoneAffinity` serverStatus section under `src/mongo/db/disagg/pali/` and wire into FTDC.
+3. Land the `LOG_EVERY_N` zone-affinity log per Aaron's comment.
+4. Convert the jstest from "documents gaps" to "regression gate" once metrics land.
+
+The audit ships no production code — only this doc and the executable gap-list — so reviewers can
+scope the implementation ticket against a concrete metric checklist.


### PR DESCRIPTION
## Summary

audit doc + jstest: PALI failover telemetry gaps and recommended metrics.

**Jira:** https://jira.mongodb.org/browse/SERVER-126747
**Branch:** substrate-contrib/w5-12

## Files

```
  -  jstests/replsets/pali_failover_telemetry_gates.js  | 120 +++++++++++++++++++++
  -  .../pali/PALI-FAILOVER-TELEMETRY-SERVER-115688.md  |  81 ++++++++++++++
  -  2 files changed, 201 insertions(+)
```

## Verify

```
node --input-type=module --check < <path/to/test.js>
cd src/mongo/tla_plus && ./download-tlc.sh && ./model-check.sh <Dir>/<Spec>
```

## Draft status

Opened as Draft. Filed by external contributor (mehar.grewal@mongodb.com).
