### PR TITLE
docs(readme): update drivers link to canonical `mongodb.com/docs` URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This will download the appropriate MongoDB Compass package for your platform and
 ## Drivers
 
 Client drivers for most programming languages are available at
-https://docs.mongodb.com/manual/applications/drivers/.
+https://www.mongodb.com/docs/drivers/.
 
 ## Bug Reports
 


### PR DESCRIPTION
The Drivers link in `README.md` points to `https://docs.mongodb.com/manual/applications/drivers/`, which currently goes through two HTTP 301 redirects:

```
docs.mongodb.com/manual/applications/drivers/
  -> www.mongodb.com/docs/manual/applications/drivers/
  -> www.mongodb.com/docs/drivers/
```

Updating directly to the canonical `www.mongodb.com/docs/drivers/` so the link skips the redirect hops.

```diff
-https://docs.mongodb.com/manual/applications/drivers/
+https://www.mongodb.com/docs/drivers/
```