### PR TITLE
SERVER-123310 Remove nsToDatabase() in favor of nsToDatabaseSubstring()

### DIFF
--- a/src/mongo/db/namespace_string.h
+++ b/src/mongo/db/namespace_string.h
@@ -901,15 +901,6 @@ inline StringData nsToDatabaseSubstring(StringData ns) {
 }
 
 /**
- * "database.a.b.c" -> "database"
- *
- * TODO SERVER-123310: make this return a StringData
- */
-inline std::string nsToDatabase(StringData ns) {
-    return std::string{nsToDatabaseSubstring(ns)};
-}
-
-/**
  * "database.a.b.c" -> "a.b.c"
  */
 inline StringData nsToCollectionSubstring(StringData ns MONGO_COMPILER_LIFETIME_BOUND) {

--- a/src/mongo/db/namespace_string_test.cpp
+++ b/src/mongo/db/namespace_string_test.cpp
@@ -230,10 +230,6 @@ TEST_F(NamespaceStringTest, DbForSharding) {
 TEST_F(NamespaceStringTest, nsToDatabase1) {
     ASSERT_EQUALS("foo", nsToDatabaseSubstring("foo.bar"));
     ASSERT_EQUALS("foo", nsToDatabaseSubstring("foo"));
-    ASSERT_EQUALS("foo", nsToDatabase("foo.bar"));
-    ASSERT_EQUALS("foo", nsToDatabase("foo"));
-    ASSERT_EQUALS("foo", nsToDatabase(std::string("foo.bar")));
-    ASSERT_EQUALS("foo", nsToDatabase(std::string("foo")));
 }
 
 TEST_F(NamespaceStringTest, NamespaceStringParse1) {


### PR DESCRIPTION
## Summary

Fixes [SERVER-123310](https://jira.mongodb.org/browse/SERVER-123310)

`nsToDatabase()` was a thin wrapper around `nsToDatabaseSubstring()` that returned `std::string`, causing an unnecessary string copy. Rather than changing the return type to `StringData` (as the TODO requested), the function was removed entirely since it was identical in behavior to `nsToDatabaseSubstring()`. All callers already used `nsToDatabaseSubstring()` directly, so no call sites needed updating.