### PR TITLE
SERVER-130410: Independent Replication Network Compression Control

### DIFF
--- a/jstests/multiVersion/genericBinVersion/replication_network_compression_mixed_version.js
+++ b/jstests/multiVersion/genericBinVersion/replication_network_compression_mixed_version.js
@@ -1,5 +1,5 @@
 /**
- * SERVER-130410: mixed-version (rolling upgrade) compatibility for the replication network
+ * mixed-version (rolling upgrade) compatibility for the replication network
  * compression feature (replication.networkCompression.compressors / setParameter
  * replicationNetworkCompression).
  *
@@ -108,6 +108,25 @@ function runMixedVersionScenario({label, primaryVersion, secondaryVersion, lates
     const primary = rst.getPrimary();
     const secondary = rst.getSecondary();
 
+    // Sanity that the orientation is what we asked for (so the "sync source is OLD" vs
+    // "fetcher is OLD" intent actually held and the test isn't silently trivial). node 0 was created
+    // with primaryVersion and node 1 (priority 0) with secondaryVersion, so HARD-assert that the
+    // elected primary is exactly node 0 and the secondary is node 1 before driving any writes. If a
+    // stray election ever flipped the orientation we must fail loudly here rather than run a
+    // version-swapped, silently meaningless scenario.
+    assert.eq(
+        primary.host,
+        rst.nodes[0].host,
+        `[${label}] expected node 0 (binVersion=${primaryVersion}) to be primary, but ` +
+            `${primary.host} is - orientation flipped, the scenario would be invalid`,
+    );
+    assert.eq(
+        secondary.host,
+        rst.nodes[1].host,
+        `[${label}] expected node 1 (binVersion=${secondaryVersion}) to be secondary, but ` +
+            `${secondary.host} is - orientation flipped, the scenario would be invalid`,
+    );
+
     // Baseline: some data already replicated during initiate; drive a fresh batch so we know the
     // steady-state oplog fetcher connection (whatever it negotiated) carries real traffic.
     driveReplication(primary, rst, "steady");
@@ -119,8 +138,6 @@ function runMixedVersionScenario({label, primaryVersion, secondaryVersion, lates
     // And the data must be identical on both the old and the new binary.
     assertDataConsistent(rst, kNumDocs);
 
-    // Sanity that the orientation is what we asked for (so the "sync source is OLD" vs
-    // "fetcher is OLD" intent actually held and the test isn't silently trivial).
     const primaryVer =
         assert.commandWorked(primary.adminCommand({buildInfo: 1})).version;
     const secondaryVer =

--- a/jstests/multiVersion/genericBinVersion/replication_network_compression_mixed_version.js
+++ b/jstests/multiVersion/genericBinVersion/replication_network_compression_mixed_version.js
@@ -1,0 +1,169 @@
+/**
+ * SERVER-130410: mixed-version (rolling upgrade) compatibility for the replication network
+ * compression feature (replication.networkCompression.compressors / setParameter
+ * replicationNetworkCompression).
+ *
+ * The feature is expressed on the wire by a NEW, optional, internal-stability hello field
+ * "replicationCompressionClient" that only a "latest" oplog fetcher / initial-sync cloner sends,
+ * and which tells the server to negotiate that connection against the replication candidate set
+ * instead of net.compression.compressors. A "last-lts" binary does not know this field.
+ *
+ * This test proves the feature degrades SAFELY across a version boundary, i.e. it must not break
+ * replication regardless of which side is old:
+ *
+ *   (1) latest secondary  <- last-lts primary (sync source is OLD):
+ *       The latest node advertises "replicationCompressionClient" plus its replication allow-list,
+ *       but the old sync source ignores the unknown field and simply negotiates the connection the
+ *       way it always has (against its own net.compression.compressors). Replication must keep
+ *       working and data must stay consistent. The replication channel may or may not be
+ *       compressed, but it must never error out or stall.
+ *
+ *   (2) last-lts secondary <- latest primary (fetcher is OLD):
+ *       The old fetcher never sends the marker, so the latest primary treats it as an ordinary
+ *       internal connection and negotiates against net.compression.compressors, exactly as before
+ *       this feature existed. Replication must keep working and data must stay consistent.
+ *
+ * Notes:
+ *   - replicationNetworkCompression is a "latest"-only setParameter. It MUST NOT be passed to a
+ *     last-lts binary (that binary would fail to start on the unknown parameter), so we only ever
+ *     set it on the latest node.
+ *   - We intentionally keep net.compression.compressors at its default (snappy,zstd,zlib) so the
+ *     union registers all algorithms on the latest node and the old node negotiates normally; the
+ *     point of this test is wire compatibility, not a specific negotiated algorithm.
+ *
+ * @tags: [
+ *   requires_replication,
+ *   requires_persistence,
+ * ]
+ */
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+
+const dbName = "repl_netcompress_mixed";
+const collName = "c";
+const kNumDocs = 500;
+
+// Push a batch of reasonably-sized documents through the primary and wait for the secondary to
+// catch up, so the replication channel is actually exercised.
+function driveReplication(primary, rst, tag) {
+    const coll = primary.getDB(dbName)[collName];
+    const bulk = coll.initializeUnorderedBulkOp();
+    const filler = "x".repeat(1024);
+    for (let i = 0; i < kNumDocs; ++i) {
+        bulk.insert({_id: `${tag}-${i}`, payload: filler});
+    }
+    assert.commandWorked(bulk.execute({w: 2}));
+    rst.awaitReplication();
+}
+
+// Assert both nodes agree on the document count for our test collection, i.e. replication actually
+// delivered every write across the version boundary. Writes were done with w:2 and followed by
+// awaitReplication(), so the secondary is already caught up; we still poll defensively. Reads are
+// issued directly against each node's connection with secondaryOk so a secondary will serve them.
+function assertDataConsistent(rst, expectedCount) {
+    for (const node of rst.nodes) {
+        const testDb = node.getDB(dbName);
+        // getMongo().setSecondaryOk() is the version-portable way to allow reads on a secondary
+        // from this shell connection.
+        node.getMongo().setSecondaryOk();
+        assert.soon(
+            () => testDb[collName].countDocuments({}) === expectedCount,
+            () => `node ${node.host} never reached ${expectedCount} docs (had ` +
+                `${testDb[collName].countDocuments({})})`,
+        );
+    }
+}
+
+// Run one mixed-version orientation. `primaryVersion`/`secondaryVersion` are binVersions. Only the
+// "latest" node (if any) receives replicationNetworkCompression, since a last-lts binary rejects
+// the unknown parameter. `latestReplValue` is what to set on the latest node's replication
+// compression option.
+function runMixedVersionScenario({label, primaryVersion, secondaryVersion, latestReplValue}) {
+    jsTest.log.info(`[replNetCompress mixed] scenario: ${label}`);
+
+    const makeNodeOpts = (binVersion, isPrimaryCandidate) => {
+        const opts = {binVersion};
+        // Only the latest binary understands replicationNetworkCompression.
+        if (binVersion === "latest" && latestReplValue !== undefined) {
+            opts.setParameter = {replicationNetworkCompression: latestReplValue};
+        }
+        // Force the intended topology: the "primary" node keeps default priority, the other is
+        // priority 0 so it cannot steal the primary role and flip our orientation.
+        if (!isPrimaryCandidate) {
+            opts.rsConfig = {priority: 0};
+        }
+        return opts;
+    };
+
+    const rst = new ReplSetTest({
+        name: `repl_netcompress_mixed_${label}`,
+        nodes: [
+            makeNodeOpts(primaryVersion, true),
+            makeNodeOpts(secondaryVersion, false),
+        ],
+    });
+    rst.startSet();
+    rst.initiate();
+    rst.awaitSecondaryNodes();
+
+    const primary = rst.getPrimary();
+    const secondary = rst.getSecondary();
+
+    // Baseline: some data already replicated during initiate; drive a fresh batch so we know the
+    // steady-state oplog fetcher connection (whatever it negotiated) carries real traffic.
+    driveReplication(primary, rst, "steady");
+
+    // The whole point: replication must be healthy across the version boundary.
+    assert.commandWorked(primary.adminCommand({replSetGetStatus: 1}));
+    assert(rst.getPrimary(), `[${label}] replica set lost its primary in a mixed-version set`);
+
+    // And the data must be identical on both the old and the new binary.
+    assertDataConsistent(rst, kNumDocs);
+
+    // Sanity that the orientation is what we asked for (so the "sync source is OLD" vs
+    // "fetcher is OLD" intent actually held and the test isn't silently trivial).
+    const primaryVer =
+        assert.commandWorked(primary.adminCommand({buildInfo: 1})).version;
+    const secondaryVer =
+        assert.commandWorked(secondary.adminCommand({buildInfo: 1})).version;
+    jsTest.log.info(`[replNetCompress mixed] ${label}: primary=${primaryVer}, secondary=` +
+        `${secondaryVer}`);
+
+    rst.stopSet();
+}
+
+// ---------------------------------------------------------------------------
+// (1) Sync source is OLD: latest secondary fetching from a last-lts primary, with the latest node
+//     requesting replication compression (zstd). The old primary must ignore the unknown
+//     "replicationCompressionClient" hello field and keep replicating without error.
+// ---------------------------------------------------------------------------
+runMixedVersionScenario({
+    label: "old_primary_new_secondary_repl_zstd",
+    primaryVersion: "last-lts",
+    secondaryVersion: "latest",
+    latestReplValue: "zstd",
+});
+
+// ---------------------------------------------------------------------------
+// (2) Fetcher is OLD: last-lts secondary fetching from a latest primary. The old fetcher never
+//     advertises the marker, so the latest primary negotiates the internal connection against
+//     net.compression.compressors just as it did before the feature. Setting replication
+//     compression on the latest PRIMARY must not disturb the old secondary's replication.
+// ---------------------------------------------------------------------------
+runMixedVersionScenario({
+    label: "new_primary_old_secondary_repl_zstd",
+    primaryVersion: "latest",
+    secondaryVersion: "last-lts",
+    latestReplValue: "zstd",
+});
+
+// ---------------------------------------------------------------------------
+// (3) Sync source is OLD, latest secondary explicitly DISABLES replication compression. This must
+//     also degrade cleanly: the latest fetcher suppresses its compression offer, the old primary
+//     sees a normal (uncompressed) internal connection, replication stays healthy.
+// ---------------------------------------------------------------------------
+runMixedVersionScenario({
+    label: "old_primary_new_secondary_repl_disabled",
+    primaryVersion: "last-lts",
+    secondaryVersion: "latest",
+    latestReplValue: "disabled",
+});

--- a/jstests/noPassthrough/replication/replication_network_compression.js
+++ b/jstests/noPassthrough/replication/replication_network_compression.js
@@ -405,9 +405,10 @@ function runScenario({label, secondaryValue, expectCompressorGrew, extraForbid})
 })();
 
 // ---------------------------------------------------------------------------
-// 4. End-to-end functional scenarios on a 2-node replica set. These observe the sync source's
-//    decompressor counters to prove the fetcher's channel actually negotiated the expected
-//    algorithm (or no algorithm at all).
+// 4. End-to-end functional scenarios on a 2-node replica set. Oplog fetching pulls batches FROM
+//    the sync source, so the sync source COMPRESSES the responses and the fetcher decompresses
+//    them. These scenarios therefore observe the sync source's compressor counters to prove the
+//    fetcher's channel actually negotiated the expected algorithm (or no algorithm at all).
 // ---------------------------------------------------------------------------
 
 // Default (unset): inherit process-wide list -> some compression is negotiated. The exact

--- a/jstests/noPassthrough/replication/replication_network_compression.js
+++ b/jstests/noPassthrough/replication/replication_network_compression.js
@@ -1,0 +1,1183 @@
+/**
+ * SERVER-130410: verify the replication.networkCompression.compressors option (and its
+ * setParameter form replicationNetworkCompression) controls, per node, which compressor(s) the
+ * oplog fetcher advertises to its sync source WITHOUT affecting the process-wide
+ * net.compression.compressors setting used by every other connection on the node.
+ *
+ * The main steady-state functional signal we assert on is the sync source's
+ *   serverStatus().network.compression.<name>.compressor.bytesIn
+ * counter: it grows when the sync source compresses oplog batches for a fetcher connection
+ * negotiated with <name>. For receiving-side paths (initial sync cloner, rollback common-point
+ * reader, and external client requests), the test uses the receiver's decompressor.bytesIn counter.
+ *
+ * The parameter is STARTUP-ONLY: it can be provided via the command line, the YAML config, or an
+ * initial --setParameter, but cannot be changed at runtime. This test also verifies that a
+ * runtime setParameter is refused.
+ *
+ * @tags: [requires_replication, requires_persistence]
+ */
+import {ReplSetTest} from "jstests/libs/replsettest.js";
+import {funWithArgs} from "jstests/libs/parallel_shell_helpers.js";
+import {RollbackTest} from "jstests/replsets/libs/rollback_test.js";
+
+// The default/inherit scenario advertises the full snappy/zstd/zlib set on the process-wide port.
+// Explicit replication-compressor scenarios disable net compression and configure the requested
+// replication compressor on both nodes, so process-wide decompressor counters stay attributable to
+// the replication data channel under test.
+const kProcessCompressors = "snappy,zstd,zlib";
+
+// Read the sync source's per-compressor COMPRESSOR bytesIn counters. Returns a plain object
+// keyed by compressor name so the test math is easy to read.
+//
+// SERVER-130410: the oplog fetcher pulls batches FROM the sync source over an exhaust cursor, so
+// the sync source COMPRESSES those oplog responses on the fetcher's connection. That
+// compressor direction carries the bulk replicated data and is the reliable signal for which
+// algorithm the replication channel negotiated. The reverse (sync source decompressor) only sees
+// the fetcher's tiny exhaust-cursor requests, which do not move measurable bytes when process-wide
+// net compression is disabled - so a decompressor-based check reports a false "uncompressed" even
+// though replication is compressed. Measuring the compressor avoids that false negative.
+function getCompressorBytesIn(node) {
+    const ss = assert.commandWorked(node.adminCommand({serverStatus: 1}));
+    const out = {};
+    if (!ss.network || !ss.network.compression) {
+        return out;
+    }
+    for (const name of Object.keys(ss.network.compression)) {
+        const c = ss.network.compression[name].compressor;
+        out[name] = c ? c.bytesIn : 0;
+    }
+    return out;
+}
+
+// Read a node's per-compressor DECOMPRESSOR bytesIn counters. Returns a plain object keyed by
+// compressor name.
+//
+// SERVER-130410: use this on the RECEIVING side of a data transfer, i.e. the node that DECOMPRESSES
+// inbound compressed messages:
+//   - the initial-sync collection cloner and the rollback common-point reader pull bulk data FROM
+//     the sync source as query responses, so the SYNCING/ROLLING-BACK node decompresses it, and
+//   - an external client that pushes a large compressed request makes the SERVER it connects to
+//     decompress it.
+// For the steady-state oplog fetcher the bulk data flows the other way (the sync source compresses
+// the oplog it streams to the fetcher), so measure that direction with getCompressorBytesIn() on the
+// sync source instead - the sync source's decompressor only ever sees the fetcher's tiny exhaust
+// requests and would report a false "uncompressed".
+function getDecompressorBytesIn(node) {
+    const ss = assert.commandWorked(node.adminCommand({serverStatus: 1}));
+    const out = {};
+    if (!ss.network || !ss.network.compression) {
+        return out;
+    }
+    for (const name of Object.keys(ss.network.compression)) {
+        const d = ss.network.compression[name].decompressor;
+        out[name] = d ? d.bytesIn : 0;
+    }
+    return out;
+}
+
+// Diff two compressor snapshots; returns {name: delta} only for names that grew.
+function decompressorDelta(before, after) {
+    const grew = {};
+    for (const name of Object.keys(after)) {
+        const b = before[name] || 0;
+        const a = after[name] || 0;
+        if (a > b) {
+            grew[name] = a - b;
+        }
+    }
+    return grew;
+}
+
+const kReplicationCompressionNegotiationLogId = 10130422;
+
+function hasReplicationCompressionNegotiationLog(node, expectedCompressed, expectedCompressors) {
+    const log = assert.commandWorked(node.adminCommand({getLog: "global"})).log;
+    return log.some((line) => {
+        let entry;
+        try {
+            entry = JSON.parse(line);
+        } catch (e) {
+            return false;
+        }
+        if (entry.id !== kReplicationCompressionNegotiationLogId || !entry.attr) {
+            return false;
+        }
+        if (entry.attr.compressed !== expectedCompressed) {
+            return false;
+        }
+        if (expectedCompressors === undefined) {
+            return true;
+        }
+        return bsonWoCompare(entry.attr.negotiatedCompressors || [], expectedCompressors) === 0;
+    });
+}
+
+// Drive enough oplog traffic from the primary that any compressed replication channel is
+// guaranteed to move measurable bytes through the sync source's compressor. Individual docs are
+// made ~1 KiB and repeated so total payload comfortably exceeds any per-batch overhead, including
+// on debug builds.
+function generateOplogTraffic(primary, dbName, collName, iteration) {
+    const coll = primary.getDB(dbName)[collName];
+    const bulk = coll.initializeUnorderedBulkOp();
+    const filler = "x".repeat(1024);
+    for (let i = 0; i < 200; ++i) {
+        bulk.insert({_id: `${iteration}-${i}`, payload: filler});
+    }
+    assert.commandWorked(bulk.execute({w: 2}));
+}
+
+// Run one scenario. `secondaryValue` is what we pass to the secondary as
+// replicationNetworkCompression at startup (undefined = don't set it, i.e. inherit process
+// default). `expectCompressorGrew` is the compressor name we expect to see compressor bytes on at
+// the sync source, or null when we expect NO compressor bytes (uncompressed channel).
+function runScenario({label, secondaryValue, expectCompressorGrew, extraForbid}) {
+    jsTest.log.info(`[replicationNetworkCompression] scenario: ${label}`);
+
+    // serverStatus().network.compression.* counters are process-wide, not connection-scoped. For
+    // explicit replication-compression scenarios, disable the process-wide net compressor list on
+    // both nodes and configure the replication compressor on both sides; otherwise heartbeat/internal
+    // traffic could grow unrelated decompressor counters and make a correct replication channel look
+    // like it used the wrong compressor.
+    const explicitReplicationCompressor =
+        secondaryValue !== undefined && secondaryValue !== "disabled";
+    const useDisabledProcessCompressors =
+        expectCompressorGrew === null || explicitReplicationCompressor;
+    const processCompressors = useDisabledProcessCompressors ? "disabled" : kProcessCompressors;
+
+    const primaryOpts = {
+        networkMessageCompressors: processCompressors,
+    };
+    if (explicitReplicationCompressor) {
+        primaryOpts.setParameter = {replicationNetworkCompression: secondaryValue};
+    }
+
+    const secondaryOpts = {
+        networkMessageCompressors: processCompressors,
+    };
+    if (secondaryValue !== undefined) {
+        secondaryOpts.setParameter = {replicationNetworkCompression: secondaryValue};
+    }
+
+    const rst = new ReplSetTest({
+        name: `replication_network_compression_${label}`,
+        nodes: [
+            // Primary acts as sync source. Use the per-scenario process/replication compressor
+            // settings so counter assertions cannot be polluted by unrelated net-compressed
+            // internal traffic.
+            primaryOpts,
+            // Secondary is the node under test.
+            secondaryOpts,
+        ],
+    });
+    rst.startSet();
+    rst.initiate();
+
+    const primary = rst.getPrimary();
+    const secondary = rst.getSecondary();
+
+    // Baseline: some traffic already flowed during initiate; snapshot the sync source (primary)
+    // counters AFTER the secondary is up and steady so any growth we observe is attributable
+    // to the writes we drive below on this fetcher's channel.
+    rst.awaitReplication();
+    const before = getCompressorBytesIn(primary);
+
+    // Drive several rounds of writes so the fetcher pulls new batches through its already-
+    // established sync-source connection. We deliberately do NOT force a reconnect here: the
+    // channel that came up during initiate is the one we want to observe.
+    for (let i = 0; i < 5; ++i) {
+        generateOplogTraffic(primary, "netcompress", "c", i);
+    }
+    rst.awaitReplication();
+
+    const after = getCompressorBytesIn(primary);
+    const grew = decompressorDelta(before, after);
+    jsTest.log.info(
+        `[replicationNetworkCompression] scenario ${label} compressor delta on sync source: ` +
+            tojson(grew),
+    );
+
+    if (expectCompressorGrew === null) {
+        // Disabled / empty-after-filter: the replication channel is uncompressed. This scenario
+        // also disables process-wide net compression on both nodes, so no unrelated heartbeat or
+        // internal RPC can grow the process-wide compressor counters.
+        assert.eq(
+            {},
+            grew,
+            `[${label}] expected no compressor growth on sync source (channel should be ` +
+                `uncompressed), but saw: ${tojson(grew)}`,
+        );
+    } else {
+        assert(
+            grew[expectCompressorGrew] && grew[expectCompressorGrew] > 0,
+            `[${label}] expected compressor '${expectCompressorGrew}' bytesIn to grow on ` +
+                `sync source, delta was: ${tojson(grew)}`,
+        );
+        // If the operator listed only one algorithm, no other compressor should have been
+        // used on the replication channel.
+        if (extraForbid) {
+            for (const name of extraForbid) {
+                assert(
+                    !grew[name],
+                    `[${label}] compressor '${name}' unexpectedly grew on sync source ` +
+                        `despite not being in the allow-list: ${tojson(grew)}`,
+                );
+            }
+        }
+    }
+
+    rst.stopSet();
+}
+
+// ---------------------------------------------------------------------------
+// 1. Startup validation: bad values must be rejected up front, both via CLI/YAML and
+//    setParameter. This locks in that a typo/malicious value can never silently degrade
+//    replication.
+// ---------------------------------------------------------------------------
+(function testStartupRejectsInvalidValues() {
+    jsTest.log.info("[replicationNetworkCompression] startup rejects invalid values");
+
+    // "disabled" mixed with an algorithm name is illegal (parser must reject).
+    assert.throws(() =>
+        MongoRunner.runMongod({
+            setParameter: {replicationNetworkCompression: "disabled,snappy"},
+        }),
+    );
+
+    // Whitespace-only / garbage token is illegal.
+    assert.throws(() =>
+        MongoRunner.runMongod({
+            setParameter: {replicationNetworkCompression: ","},
+        }),
+    );
+})();
+
+// ---------------------------------------------------------------------------
+// 2. Startup accepts and reflects every legal value in getParameter. This proves the
+//    YAML/CLI -> setParameter seeding wiring in storeMongodOptions works.
+// ---------------------------------------------------------------------------
+(function testStartupAcceptsLegalValues() {
+    jsTest.log.info("[replicationNetworkCompression] startup accepts legal values");
+    const cases = ["", "disabled", "snappy", "zstd", "zstd,snappy"];
+    for (const v of cases) {
+        const conn = MongoRunner.runMongod({
+            networkMessageCompressors: kProcessCompressors,
+            setParameter: {replicationNetworkCompression: v},
+        });
+        assert.neq(null, conn, `mongod failed to start with replicationNetworkCompression="${v}"`);
+        const res = assert.commandWorked(
+            conn.adminCommand({getParameter: 1, replicationNetworkCompression: 1}),
+        );
+        assert.eq(
+            v,
+            res.replicationNetworkCompression,
+            `getParameter did not echo back the value we set for "${v}": ${tojson(res)}`,
+        );
+        MongoRunner.stopMongod(conn);
+    }
+})();
+
+// ---------------------------------------------------------------------------
+// 3. Runtime setParameter must be REJECTED (SERVER-130410): replicationNetworkCompression is
+//    declared set_at: [startup] only. Attempting to change it at runtime - with a legal value,
+//    with an illegal value, and even with a value that equals the current one - must fail and
+//    must NOT mutate the stored value. Changing compression requires editing the config /
+//    command line and restarting mongod.
+// ---------------------------------------------------------------------------
+(function testRuntimeSetParameterRejected() {
+    jsTest.log.info("[replicationNetworkCompression] runtime setParameter is rejected");
+    const startupValue = "zstd";
+    const conn = MongoRunner.runMongod({
+        networkMessageCompressors: kProcessCompressors,
+        setParameter: {replicationNetworkCompression: startupValue},
+    });
+    const admin = conn.getDB("admin");
+
+    // Sanity: the startup value is present.
+    let res = assert.commandWorked(
+        admin.runCommand({getParameter: 1, replicationNetworkCompression: 1}),
+    );
+    assert.eq(startupValue, res.replicationNetworkCompression);
+
+    // Every runtime setParameter attempt must fail, including one that would be a no-op:
+    // startup-only enforcement must not depend on whether the value would actually change.
+    for (const v of ["", "disabled", "snappy", "zstd,snappy", startupValue, "disabled,snappy"]) {
+        const r = admin.runCommand({setParameter: 1, replicationNetworkCompression: v});
+        assert.commandFailed(
+            r,
+            `runtime setParameter must be refused (startup-only) for value "${v}": ${tojson(r)}`,
+        );
+    }
+
+    // Stored value must be exactly the startup value; no attempt above may have leaked through.
+    res = assert.commandWorked(
+        admin.runCommand({getParameter: 1, replicationNetworkCompression: 1}),
+    );
+    assert.eq(
+        startupValue,
+        res.replicationNetworkCompression,
+        "runtime setParameter attempts must not mutate the stored startup value",
+    );
+
+    MongoRunner.stopMongod(conn);
+})();
+
+// ---------------------------------------------------------------------------
+// 4. End-to-end functional scenarios on a 2-node replica set. These observe the sync source's
+//    decompressor counters to prove the fetcher's channel actually negotiated the expected
+//    algorithm (or no algorithm at all).
+// ---------------------------------------------------------------------------
+
+// Default (unset): inherit process-wide list -> some compression is negotiated. The exact
+// algorithm depends on the server's negotiation policy given both sides list
+// snappy,zstd,zlib; we just require that SOME compressor grew on the sync source, which
+// distinguishes this case from the "disabled" case below.
+runScenario({
+    label: "default_inherits_process",
+    secondaryValue: undefined,
+    // We don't assert a specific name here; assert at least one grew via a custom check:
+    // reuse the runner with a sentinel by picking the algorithm the process-wide policy will
+    // pick. Both mongo negotiation and the manager keep the CLIENT's order, so the fetcher's
+    // client-side order is the process-wide compressor list order = snappy first.
+    expectCompressorGrew: "snappy",
+});
+
+// "disabled": the replication channel must be uncompressed; no compressor grows on the sync
+// source as a result of fetcher traffic.
+runScenario({
+    label: "disabled",
+    secondaryValue: "disabled",
+    expectCompressorGrew: null,
+});
+
+// Single-algorithm subset: force zstd. This proves the allow-list actually narrows the
+// negotiation: even though snappy is available process-wide (and would otherwise be chosen
+// first by ordering), the fetcher only offered zstd, so the channel MUST end up using zstd
+// and snappy/zlib decompressors must NOT have grown.
+runScenario({
+    label: "only_zstd",
+    secondaryValue: "zstd",
+    expectCompressorGrew: "zstd",
+    extraForbid: ["snappy", "zlib"],
+});
+
+// Single-algorithm subset: force zlib. Same logic as above, different algorithm.
+runScenario({
+    label: "only_zlib",
+    secondaryValue: "zlib",
+    expectCompressorGrew: "zlib",
+    extraForbid: ["snappy", "zstd"],
+});
+
+// Comma-separated preference order: "zstd,snappy". The client's advertised order is the
+// negotiation preference; server picks the first entry it also supports, which is zstd.
+runScenario({
+    label: "zstd_then_snappy_prefers_zstd",
+    secondaryValue: "zstd,snappy",
+    expectCompressorGrew: "zstd",
+    extraForbid: ["zlib"],
+});
+
+// ---------------------------------------------------------------------------
+// 5. Isolation: replicationNetworkCompression must not affect client-facing traffic. This
+//    test brings up a secondary with replicationNetworkCompression=disabled but the full
+//    process-wide compressor list, then runs a shell client against it that negotiates
+//    snappy. The client-facing decompressor counters on the SECONDARY must grow, proving that
+//    disabling the replication channel did not accidentally disable client compression.
+// ---------------------------------------------------------------------------
+(function testDoesNotAffectClientFacingCompression() {
+    jsTest.log.info("[replicationNetworkCompression] isolation: client-facing still compressed");
+    const rst = new ReplSetTest({
+        name: "replication_network_compression_isolation",
+        nodes: [
+            {networkMessageCompressors: kProcessCompressors},
+            {
+                networkMessageCompressors: kProcessCompressors,
+                setParameter: {replicationNetworkCompression: "disabled"},
+            },
+        ],
+    });
+    rst.startSet();
+    rst.initiate();
+    const secondary = rst.getSecondary();
+
+    // Open a NEW connection to the secondary that negotiates snappy on the client side. The
+    // default Mongo shell connection used by rst.getSecondary() is uncompressed, so we build
+    // a compressed one explicitly via the raw mongo program.
+    const before = getDecompressorBytesIn(secondary);
+    assert.eq(
+        0,
+        runMongoProgram(
+            "mongo",
+            "--host",
+            secondary.host,
+            "--networkMessageCompressors=snappy",
+            "--eval",
+            // Push enough bytes to trip the compressor's minimum-size gate.
+            "for (let i = 0; i < 50; ++i) { assert.commandWorked(" +
+                "db.adminCommand({hello: 1, payload: 'x'.repeat(4096)})); }",
+        ),
+        "compressed client shell against secondary failed",
+    );
+    const after = getDecompressorBytesIn(secondary);
+    const grew = decompressorDelta(before, after);
+    assert(
+        grew["snappy"] && grew["snappy"] > 0,
+        "client-facing snappy compression on the secondary should still work when " +
+            "replicationNetworkCompression=disabled; delta was: " +
+            tojson(grew),
+    );
+
+    rst.stopSet();
+})();
+
+// ---------------------------------------------------------------------------
+// 5b. Scoping (SERVER-130410): replicationNetworkCompression must scope to the replication
+//     sync-source connection ONLY. Other internal (internalClient) connections - heartbeats and,
+//     in a sharded cluster, intra-cluster RPC - must keep using net.compression.compressors. The
+//     server distinguishes them via the "replicationCompressionClient" hello marker that only
+//     replication data-plane clients send; heartbeats do not send it.
+//
+//     We assert this end-to-end with a node configured net=snappy, replication=disabled. Because
+//     heartbeats between the two nodes are internal connections that do NOT carry the replication
+//     marker, they must negotiate against the net set (snappy) rather than being forced
+//     uncompressed by replication=disabled. We verify the cluster stays healthy while the net set is
+//     otherwise active, and use the replication-client negotiation log to prove the marked data-plane
+//     connection itself negotiated uncompressed even though net compression remained enabled.
+// ---------------------------------------------------------------------------
+(function testReplicationCompressionDoesNotDisableInternalNonReplicationConnections() {
+    jsTest.log.info(
+        "[replicationNetworkCompression] scoping: replication=disabled must not touch heartbeats");
+    const rst = new ReplSetTest({
+        name: "replication_network_compression_scoping",
+        nodes: [
+            {networkMessageCompressors: "snappy"},
+            {
+                networkMessageCompressors: "snappy",
+                setParameter: {replicationNetworkCompression: "disabled"},
+            },
+        ],
+    });
+    rst.startSet();
+    rst.initiate();
+
+    const primary = rst.getPrimary();
+    const secondary = rst.getSecondary();
+
+    assert.soon(
+        () => hasReplicationCompressionNegotiationLog(secondary, false, []),
+        "secondary did not log an uncompressed replication compression negotiation while " +
+            "replicationNetworkCompression=disabled and net compression stayed enabled",
+    );
+
+    // Drive fresh replication traffic while net compression remains enabled. We intentionally do
+    // NOT assert on process-wide decompressor counters here: heartbeat/internal RPC can legitimately
+    // use snappy and share those counters. The dedicated disabled scenario above verifies the
+    // replication data channel with net compression disabled to keep the counter signal isolated.
+    rst.awaitReplication();
+    for (let i = 0; i < 5; ++i) {
+        generateOplogTraffic(primary, "netcompress_scope", "c", i);
+    }
+    rst.awaitReplication();
+
+    // Heartbeats are internal, non-replication connections. If replication=disabled had leaked into
+    // them, the replica set could not maintain its topology. A healthy set (stable primary, both
+    // nodes reachable) demonstrates heartbeats continued to work under the net set.
+    assert.commandWorked(primary.adminCommand({replSetGetStatus: 1}));
+    assert.eq(2, rst.nodes.length);
+    assert(rst.getPrimary(), "replica set lost its primary; heartbeats may have been disrupted");
+
+    rst.stopSet();
+})();
+
+// Returns the compressor an EXTERNAL shell client (one that advertised `clientAdvertises` and is
+// NOT an internal replica-set client) actually negotiated with the server at `host`, or the
+// string "NONE" when the server offered nothing. db.hello().compression reflects the compressors
+// negotiated during the connection handshake, so this observes the client-facing
+// (net.compression.compressors) side independently of the replication channel. This is how the
+// decoupling tests below prove that the union registry never leaks replication-only algorithms to
+// external clients.
+function externalClientNegotiatedCompression(host, clientAdvertises) {
+    clearRawMongoProgramOutput();
+    const rc = runMongoProgram(
+        "mongo",
+        "--host",
+        host,
+        "--networkMessageCompressors=" + clientAdvertises,
+        "--eval",
+        "const c = db.hello().compression; " +
+            "print('NEGOTIATED_COMPRESSION=' + (c && c.length ? c.join(',') : 'NONE'));",
+    );
+    assert.eq(0, rc, `external client shell failed against ${host} (advertised ${clientAdvertises})`);
+    const out = rawMongoProgramOutput(".*");
+    const m = out.match(/NEGOTIATED_COMPRESSION=(\S+)/);
+    assert(m, `could not find negotiation marker in shell output: ${out}`);
+    return m[1];
+}
+
+// ---------------------------------------------------------------------------
+// 7. Decoupling headline (SERVER-130410): net.compression.compressors DISABLED while replication
+//    compression is ENABLED. This is the whole point of the feature and was previously impossible.
+//    We prove three things at once:
+//      (a) the node STARTS even though the only requested compressor comes from the replication
+//          option (the algorithm is folded into the process-wide capability union at startup so it
+//          gets registered), and
+//      (b) the replication channel is compressed with the chosen algorithm, and
+//      (c) external client-facing connections stay UNCOMPRESSED (net: disabled is still honored).
+//
+//    Note both nodes set replicationNetworkCompression: the secondary's fetcher must ADVERTISE the
+//    algorithm, AND the primary (sync source) must ACCEPT it on the internal connection. If the
+//    primary left the option at its default it would inherit net (disabled) for internal clients
+//    and reject the offer, leaving the channel uncompressed.
+// ---------------------------------------------------------------------------
+(function testNetDisabledReplicationEnabledDecoupling() {
+    jsTest.log.info("[replicationNetworkCompression] decoupling: net disabled, replication enabled");
+    const kReplAlgo = "zstd";
+
+    const rst = new ReplSetTest({
+        name: "replication_network_compression_decouple",
+        nodes: [
+            {
+                networkMessageCompressors: "disabled",
+                setParameter: {replicationNetworkCompression: kReplAlgo},
+            },
+            {
+                networkMessageCompressors: "disabled",
+                setParameter: {replicationNetworkCompression: kReplAlgo},
+            },
+        ],
+    });
+    // (a) A failure here would mean the replication-only algorithm was not registered into the
+    // union at startup (net was disabled), which is exactly the bug this feature fixes.
+    rst.startSet();
+    rst.initiate();
+
+    const primary = rst.getPrimary();
+    const secondary = rst.getSecondary();
+    rst.awaitReplication();
+
+    // (b) Drive traffic and confirm the sync source's kReplAlgo COMPRESSOR grows, i.e. the
+    // replication channel negotiated compression even though net.compression.compressors: disabled.
+    // The sync source compresses the oplog batches it streams to the fetcher, so its compressor is
+    // the reliable signal; its decompressor only sees the fetcher's tiny exhaust requests.
+    const before = getCompressorBytesIn(primary);
+    for (let i = 0; i < 5; ++i) {
+        generateOplogTraffic(primary, "netcompress_decouple", "c", i);
+    }
+    rst.awaitReplication();
+    const grew = decompressorDelta(before, getCompressorBytesIn(primary));
+    jsTest.log.info("[replicationNetworkCompression] decouple compressor delta: " + tojson(grew));
+    assert(
+        grew[kReplAlgo] && grew[kReplAlgo] > 0,
+        `expected replication channel to use '${kReplAlgo}' despite net disabled; delta: ${tojson(grew)}`,
+    );
+
+    // (c) An external client that advertises the very same algorithm must NOT get it: with net
+    // disabled the server offers nothing to a client-facing connection, so the union algorithm is
+    // reachable by replication only.
+    assert.eq(
+        "NONE",
+        externalClientNegotiatedCompression(secondary.host, kReplAlgo),
+        "external client negotiated compression against a net-disabled node; net.compression." +
+            "compressors: disabled must keep client-facing connections uncompressed",
+    );
+
+    rst.stopSet();
+})();
+
+// ---------------------------------------------------------------------------
+// 8. Independent algorithm selection (SERVER-130410): net advertises ONE algorithm to clients,
+//    while replication uses a DIFFERENT algorithm that is not in the net list at all. This proves
+//    the two policies are chosen from independent candidate sets even though both algorithms share
+//    a single process-wide capability union:
+//      - the replication channel uses zstd (the sync source's zstd compressor grew), and
+//      - an external client that advertises snappy gets snappy (net set), while an external client
+//        that advertises zstd gets NOTHING (zstd is replication-only, never offered to clients).
+// ---------------------------------------------------------------------------
+(function testNetAndReplicationUseDifferentAlgorithms() {
+    jsTest.log.info(
+        "[replicationNetworkCompression] independent selection: net=snappy, replication=zstd");
+    const kNetAlgo = "snappy";
+    const kReplAlgo = "zstd";
+
+    const rst = new ReplSetTest({
+        name: "replication_network_compression_independent",
+        nodes: [
+            {
+                networkMessageCompressors: kNetAlgo,
+                setParameter: {replicationNetworkCompression: kReplAlgo},
+            },
+            {
+                networkMessageCompressors: kNetAlgo,
+                setParameter: {replicationNetworkCompression: kReplAlgo},
+            },
+        ],
+    });
+    rst.startSet();
+    rst.initiate();
+
+    const primary = rst.getPrimary();
+    const secondary = rst.getSecondary();
+    rst.awaitReplication();
+
+    // Replication channel must use zstd. Measure the sync source's COMPRESSOR: it compresses the
+    // oplog batches it streams to the fetcher (the reverse decompressor only sees the fetcher's tiny
+    // exhaust requests). Because net=snappy is still enabled here, the process-wide snappy compressor
+    // counter can legitimately grow from heartbeats / other internal connections, so we do NOT assert
+    // "snappy stayed flat" off that process-global counter (it would be flaky). The robust proof that
+    // snappy is the net-only algorithm and zstd is replication-only is the pair of external-client
+    // negotiation checks below.
+    const before = getCompressorBytesIn(primary);
+    for (let i = 0; i < 5; ++i) {
+        generateOplogTraffic(primary, "netcompress_independent", "c", i);
+    }
+    rst.awaitReplication();
+    const grew = decompressorDelta(before, getCompressorBytesIn(primary));
+    jsTest.log.info(
+        "[replicationNetworkCompression] independent compressor delta on sync source: " +
+            tojson(grew));
+    assert(
+        grew[kReplAlgo] && grew[kReplAlgo] > 0,
+        `expected replication channel to use '${kReplAlgo}'; delta: ${tojson(grew)}`,
+    );
+
+    // External client advertising the net algorithm gets it (net set governs client-facing).
+    assert.eq(
+        kNetAlgo,
+        externalClientNegotiatedCompression(secondary.host, kNetAlgo),
+        `external client should negotiate '${kNetAlgo}' (in net.compression.compressors)`,
+    );
+    // External client advertising the replication-only algorithm gets NOTHING: even though zstd is
+    // in the process-wide union (so replication can use it), it is never offered to a client-facing
+    // connection because it is not in net.compression.compressors.
+    assert.eq(
+        "NONE",
+        externalClientNegotiatedCompression(secondary.host, kReplAlgo),
+        `replication-only algorithm '${kReplAlgo}' must not be offered to external clients`,
+    );
+
+    rst.stopSet();
+})();
+
+// ---------------------------------------------------------------------------
+// 9. Initial (full) sync uses replication compression on the collection-cloner connection
+//    (SERVER-130410). The cloner connection now applies the exact same replicationNetworkCompression
+//    policy as the steady-state oplog fetcher (shared helper applyReplicationNetworkCompressionToManager),
+//    so full sync gets compressed just like incremental sync, and even works when
+//    net.compression.compressors: disabled.
+//
+//    Signal: the bulk collection data flows sync source -> the syncing node as query responses, so
+//    the SYNCING NODE decompresses it. The per-compressor decompressor.bytesIn counters are
+//    process-global (MessageCompressorRegistry), so client-side (DBClientConnection) decompression
+//    on the cloner connection is reflected in the syncing node's serverStatus. We seed several MB of
+//    compressible data so the cloner payload dominates the tiny initial-sync oplog stream; a large
+//    zstd decompressor delta on the fresh node therefore attributes to the cloner connection.
+// ---------------------------------------------------------------------------
+(function testInitialSyncUsesReplicationCompression() {
+    jsTest.log.info(
+        "[replicationNetworkCompression] initial sync: net disabled, replication=zstd on cloner");
+    const kReplAlgo = "zstd";
+
+    const rst = new ReplSetTest({
+        name: "replication_network_compression_initial_sync",
+        nodes: [
+            {
+                networkMessageCompressors: "disabled",
+                setParameter: {replicationNetworkCompression: kReplAlgo},
+            },
+        ],
+    });
+    rst.startSet();
+    rst.initiate();
+
+    const primary = rst.getPrimary();
+
+    // Seed several MiB of NEAR-INCOMPRESSIBLE data BEFORE adding the syncing node. We deliberately
+    // avoid a repeated filler: with highly compressible data the decompressor.bytesIn counter (which
+    // measures COMPRESSED input bytes) would stay tiny and be indistinguishable from the small oplog
+    // stream also fetched during initial sync. Random-ish base36 payloads keep the compressed volume
+    // in the MiB range so a large decompressor.bytesIn delta can be attributed to the cloner.
+    function randomPayload(len) {
+        let s = "";
+        while (s.length < len) {
+            s += Math.random().toString(36).slice(2);
+        }
+        return s.substring(0, len);
+    }
+    const dbName = "initialsync_compress";
+    const collName = "big";
+    const bulk = primary.getDB(dbName)[collName].initializeUnorderedBulkOp();
+    const kNumDocs = 3000;
+    for (let i = 0; i < kNumDocs; ++i) {
+        bulk.insert({_id: i, payload: randomPayload(2048)});
+    }
+    assert.commandWorked(bulk.execute());
+    rst.awaitReplication();
+
+    // Add a fresh node that must full-sync from the primary. Same config: net disabled so a client
+    // connection would normally be uncompressed, but replicationNetworkCompression=zstd must still
+    // compress the cloner connection.
+    const newNode = rst.add({
+        networkMessageCompressors: "disabled",
+        setParameter: {replicationNetworkCompression: kReplAlgo},
+        rsConfig: {votes: 0, priority: 0},
+    });
+    rst.reInitiate();
+    rst.awaitSecondaryNodes(null, [newNode]);
+    rst.awaitReplication();
+
+    // A large zstd decompressor delta on the freshly-synced node proves the cloner connection
+    // negotiated replication compression despite net.compression.compressors: disabled. Snapshot is
+    // taken against an empty baseline since the node started fresh for this initial sync. We require
+    // a threshold well above the few KiB the tiny initial-sync oplog stream could contribute, so the
+    // signal is attributable to the multi-MiB collection-cloner payload rather than the oplog fetcher.
+    const kMinClonerBytes = 256 * 1024;
+    const grew = decompressorDelta({}, getDecompressorBytesIn(newNode));
+    jsTest.log.info(
+        "[replicationNetworkCompression] initial sync decompressor delta: " + tojson(grew));
+    assert(
+        grew[kReplAlgo] && grew[kReplAlgo] > kMinClonerBytes,
+        `expected initial-sync cloner connection to use '${kReplAlgo}' despite net disabled ` +
+            `(need > ${kMinClonerBytes} compressed bytes to attribute to the cloner, not the ` +
+            `oplog fetcher); delta: ${tojson(grew)}`,
+    );
+
+    // Sanity: the freshly-synced node actually cloned the data.
+    assert.eq(
+        kNumDocs,
+        newNode.getDB(dbName)[collName].countDocuments({}),
+        "initial-synced node is missing cloned documents",
+    );
+
+    rst.stopSet();
+})();
+
+// ---------------------------------------------------------------------------
+// 10. Inheritance under net disabled (SERVER-130410): when replicationNetworkCompression is left
+//     unset (its default value is the empty string ""), it INHERITS net.compression.compressors
+//     rather than forcing any particular behavior of its own (see
+//     parseReplicationNetworkCompression: "" -> inheritProcessDefault). Therefore, if net is
+//     disabled AND the replication option is untouched, the replication channel must come up
+//     UNCOMPRESSED. This pins the "empty == inherit" semantics end-to-end so that an operator who
+//     never sets the replication option gets exactly the net behavior (here: no compression),
+//     which the earlier scenarios (all run with the full net list) do not exercise.
+// ---------------------------------------------------------------------------
+(function testInheritFollowsNetDisabled() {
+    jsTest.log.info(
+        "[replicationNetworkCompression] inherit: net disabled + replication unset -> uncompressed");
+
+    const rst = new ReplSetTest({
+        name: "replication_network_compression_inherit_net_disabled",
+        nodes: [
+            // Both nodes disable net compression and leave replicationNetworkCompression at its
+            // default (""), i.e. inherit the (disabled) net set on the replication connection too.
+            {networkMessageCompressors: "disabled"},
+            {networkMessageCompressors: "disabled"},
+        ],
+    });
+    rst.startSet();
+    rst.initiate();
+
+    const primary = rst.getPrimary();
+    rst.awaitReplication();
+
+    // Measure the sync source's COMPRESSOR: if the channel were (incorrectly) compressed the sync
+    // source would compress the oplog it streams, growing this counter. Its decompressor only sees
+    // the fetcher's tiny exhaust requests and would stay ~flat even for a compressed channel, which
+    // would make this "must be uncompressed" assertion pass vacuously.
+    const before = getCompressorBytesIn(primary);
+    for (let i = 0; i < 5; ++i) {
+        generateOplogTraffic(primary, "netcompress_inherit", "c", i);
+    }
+    rst.awaitReplication();
+    const grew = decompressorDelta(before, getCompressorBytesIn(primary));
+    jsTest.log.info(
+        "[replicationNetworkCompression] inherit-under-net-disabled compressor delta: " +
+            tojson(grew));
+    assert.eq(
+        {},
+        grew,
+        "with net.compression.compressors=disabled and replicationNetworkCompression left unset " +
+            "(inherit), the replication channel must be uncompressed; delta: " + tojson(grew),
+    );
+
+    rst.stopSet();
+})();
+
+// ---------------------------------------------------------------------------
+// 11. Asymmetric / disjoint allow-lists (SERVER-130410): the fetcher and its sync source advertise
+//     DISJOINT replication allow-lists. With net disabled on both nodes, one node permits only
+//     snappy on the replication connection and the other permits only zstd, so their candidate sets
+//     do not intersect on the replication channel. serverNegotiate() then finds no mutually
+//     permitted-and-registered algorithm and the connection must fall back SAFELY to uncompressed:
+//     it must NOT error, must NOT pick a non-permitted algorithm, and replication must keep working.
+//     (Note: this config-level mismatch is logged at DEBUG level 3 as "not permitted" (id 10130415)
+//     on the sync source; it does NOT raise the rate-limited WARNING 10130417, which is reserved
+//     for an algorithm that is permitted but not compiled into the build. Both algorithms here are
+//     present in a standard build, so we assert the observable functional outcome instead.)
+//     The disjoint pairing holds no matter which node is elected primary, since the intersection is
+//     empty in either orientation, so we do not need to pin the topology.
+// ---------------------------------------------------------------------------
+(function testAsymmetricDisjointAllowListsFallBackUncompressed() {
+    jsTest.log.info(
+        "[replicationNetworkCompression] asymmetric: disjoint repl allow-lists -> uncompressed");
+
+    const rst = new ReplSetTest({
+        name: "replication_network_compression_asymmetric",
+        nodes: [
+            {
+                networkMessageCompressors: "disabled",
+                setParameter: {replicationNetworkCompression: "zstd"},
+            },
+            {
+                networkMessageCompressors: "disabled",
+                setParameter: {replicationNetworkCompression: "snappy"},
+            },
+        ],
+    });
+    rst.startSet();
+    rst.initiate();
+
+    const primary = rst.getPrimary();
+    rst.awaitReplication();
+
+    // Measure the sync source's COMPRESSOR (it compresses the oplog it streams to the fetcher). A
+    // successful negotiation would grow it; a correct fall-back-to-uncompressed leaves it flat.
+    const before = getCompressorBytesIn(primary);
+    for (let i = 0; i < 5; ++i) {
+        generateOplogTraffic(primary, "netcompress_asym", "c", i);
+    }
+    rst.awaitReplication();
+    const grew = decompressorDelta(before, getCompressorBytesIn(primary));
+    jsTest.log.info(
+        "[replicationNetworkCompression] asymmetric compressor delta on sync source: " +
+            tojson(grew));
+    assert.eq(
+        {},
+        grew,
+        "disjoint replication allow-lists (snappy vs zstd) must negotiate an UNCOMPRESSED channel " +
+            "rather than pick a non-permitted algorithm; delta: " + tojson(grew),
+    );
+
+    // A failed compression negotiation must not break replication: the set stays healthy and data
+    // still flows (the traffic above already replicated via awaitReplication).
+    assert.commandWorked(primary.adminCommand({replSetGetStatus: 1}));
+    assert(rst.getPrimary(), "replica set lost its primary after a disjoint-allow-list negotiation");
+
+    rst.stopSet();
+})();
+
+// ---------------------------------------------------------------------------
+// 12. Rollback uses replication compression on the sync-source connection (SERVER-130410).
+//     Rollback is a replication data-plane path too: to find the common point, the rolling-back
+//     node reads its sync source's remote oplog over a dedicated DBClientConnection created in
+//     BackgroundSync::_runRollback (via OplogInterfaceRemote). That connection now applies the same
+//     node-local replicationNetworkCompression policy as the oplog fetcher and the initial-sync
+//     cloner, so rollback traffic is compressed identically - and, in particular, honors
+//     replication.networkCompression.compressors even when net.compression.compressors: disabled.
+//
+//     Discriminating signal: with net disabled everywhere and replication=zstd, the ONLY way the
+//     rolling-back node's zstd decompressor can advance is through a repl-compressed connection.
+//     We isolate the rollback connection specifically from the (also-compressed) steady-state oplog
+//     fetcher using two facts:
+//       - a baseline is taken while the rolling-back node is still partitioned from its sync source
+//         (its fetcher cannot pull, so the counter is quiescent), and
+//       - the `bgSyncHangAfterRunRollback` failpoint freezes the node the instant _runRollback()
+//         returns - i.e. AFTER the common-point search read the remote oplog over the rollback
+//         connection, but BEFORE the oplog fetcher resumes. A watcher shell snapshots the counter
+//         at that frozen point (serverStatus still responds while the producer thread sleeps), then
+//         releases the failpoint. The delta is therefore attributable to the rollback connection.
+//     We seed many sync-source branch oplog entries so the common-point search moves well over the
+//     threshold, comfortably above the tiny OplogStartMissing probe the fetcher issues just before
+//     rollback begins. OplogInterfaceRemote projects remote oplog entries down to {ts, t}, so the
+//     signal comes from entry count rather than application document payload size.
+// ---------------------------------------------------------------------------
+(function testRollbackUsesReplicationCompression() {
+    jsTest.log.info(
+        "[replicationNetworkCompression] rollback: net disabled, replication=zstd on rollback conn");
+    const kReplAlgo = "zstd";
+    // Well above what the pre-rollback OplogStartMissing fetch could contribute, so a delta past
+    // this can only come from the common-point search reading the large sync-source branch. Keep the
+    // threshold modest because the remote oplog query projects each oplog entry down to {ts, t}.
+    const kMinRollbackRemoteBytes = 4 * 1024;
+
+    const nodeOptions = {
+        networkMessageCompressors: "disabled",
+        setParameter: {replicationNetworkCompression: kReplAlgo},
+    };
+    const rollbackTest = new RollbackTest(
+        "replication_network_compression_rollback", undefined, nodeOptions);
+
+    // Divergent branch on the rolling-back node (these ops get rolled back).
+    const rollbackNode = rollbackTest.transitionToRollbackOperations();
+    {
+        const bulk = rollbackNode.getDB("rollback_compress").doomed.initializeUnorderedBulkOp();
+        for (let i = 0; i < 50; ++i) {
+            bulk.insert({_id: `doomed-${i}`});
+        }
+        assert.commandWorked(bulk.execute({w: 1}));
+    }
+
+    // Sync-source branch: a large set of ops the rolling-back node has never seen. The common-point
+    // search must read all of these back over the rollback connection, which is the traffic we
+    // measure.
+    rollbackTest.transitionToSyncSourceOperationsBeforeRollback();
+    const syncSource = rollbackTest.getPrimary();
+    {
+        const bulk = syncSource.getDB("rollback_compress").winner.initializeUnorderedBulkOp();
+        for (let i = 0; i < 5000; ++i) {
+            bulk.insert({_id: `winner-${i}`});
+        }
+        assert.commandWorked(bulk.execute({w: 1}));
+    }
+
+    // Baseline BEFORE rollback: the node is still partitioned from its sync source, so its fetcher
+    // is idle and the zstd decompressor is quiescent.
+    const before = getDecompressorBytesIn(rollbackNode);
+
+    // Freeze the node right after the common-point search completes but before the fetcher resumes.
+    assert.commandWorked(rollbackNode.adminCommand(
+        {configureFailPoint: "bgSyncHangAfterRunRollback", mode: "alwaysOn"}));
+
+    // Watcher: wait for the frozen point, snapshot the rollback node's compressed-bytes counter,
+    // stash it on the (healthy) sync source, then release the failpoint so rollback can finish.
+    const awaitWatcher = startParallelShell(
+        funWithArgs(
+            function (rbPort, ssHost, algo) {
+                const rb = new Mongo("localhost:" + rbPort);
+                // Poll the log for the failpoint-hit marker (id 21095). serverStatus keeps
+                // responding while the producer thread sleeps in the failpoint loop.
+                assert.soon(
+                    () => {
+                        const log = assert.commandWorked(rb.adminCommand({getLog: "global"})).log;
+                        return log.some(
+                            (line) => line.includes("bgSyncHangAfterRunRollback failpoint is set"));
+                    },
+                    "timed out waiting for bgSyncHangAfterRunRollback failpoint to engage",
+                    5 * 60 * 1000,
+                );
+                const ss = assert.commandWorked(rb.adminCommand({serverStatus: 1}));
+                let bytes = 0;
+                if (ss.network && ss.network.compression && ss.network.compression[algo] &&
+                    ss.network.compression[algo].decompressor) {
+                    bytes = ss.network.compression[algo].decompressor.bytesIn;
+                }
+                const src = new Mongo(ssHost);
+                assert.commandWorked(src.getDB("rollback_compress")
+                                         .probe.insert({_id: "atRollbackHang", bytes: bytes}));
+                assert.commandWorked(rb.adminCommand(
+                    {configureFailPoint: "bgSyncHangAfterRunRollback", mode: "off"}));
+            },
+            rollbackNode.port,
+            syncSource.host,
+            kReplAlgo),
+        null,
+        true,
+    );
+
+    // Trigger the rollback. This reconnects the partition; the rolling-back node reads the remote
+    // oplog over the rollback connection, hits the failpoint (watcher snapshots + releases), then
+    // resumes and rejoins as a secondary.
+    rollbackTest.transitionToSyncSourceOperationsDuringRollback();
+    rollbackTest.transitionToSteadyStateOperations();
+    awaitWatcher();
+
+    const probe = syncSource.getDB("rollback_compress").probe.findOne({_id: "atRollbackHang"});
+    assert(probe, "watcher did not record a rollback-hang decompressor snapshot");
+    const delta = probe.bytes - (before[kReplAlgo] || 0);
+    jsTest.log.info(
+        `[replicationNetworkCompression] rollback connection zstd decompressor delta: ${delta}`);
+    assert(
+        delta > kMinRollbackRemoteBytes,
+        `expected the rollback common-point connection to negotiate '${kReplAlgo}' despite ` +
+            `net.compression.compressors: disabled (need > ${kMinRollbackRemoteBytes} compressed ` +
+            `bytes read from the sync source's remote oplog), but delta was ${delta}. A zero/near-` +
+            `zero delta means the rollback connection was left uncompressed (the SERVER-130410 gap ` +
+            `in BackgroundSync::_runRollback).`,
+    );
+
+    // stop() runs RollbackTest's built-in data-consistency checks, proving the rollback itself
+    // completed correctly under replication-only compression (functional coverage of the path).
+    rollbackTest.stop();
+})();
+
+// ---------------------------------------------------------------------------
+// 13. Both disabled (SERVER-130410): net.compression.compressors=disabled AND
+//     replicationNetworkCompression=disabled on both nodes. Nothing on the node may negotiate
+//     compression - neither the replication data channel nor client-facing connections. This is the
+//     "fully uncompressed" corner of the net x repl matrix and complements the inherit-under-net-
+//     disabled case (which reaches the same channel state through the default "" inherit path).
+// ---------------------------------------------------------------------------
+(function testBothDisabledUncompressedEverywhere() {
+    jsTest.log.info(
+        "[replicationNetworkCompression] both disabled: net=disabled + replication=disabled");
+
+    const rst = new ReplSetTest({
+        name: "replication_network_compression_both_disabled",
+        nodes: [
+            {
+                networkMessageCompressors: "disabled",
+                setParameter: {replicationNetworkCompression: "disabled"},
+            },
+            {
+                networkMessageCompressors: "disabled",
+                setParameter: {replicationNetworkCompression: "disabled"},
+            },
+        ],
+    });
+    rst.startSet();
+    rst.initiate();
+
+    const primary = rst.getPrimary();
+    const secondary = rst.getSecondary();
+    rst.awaitReplication();
+
+    // Replication channel must be uncompressed: the sync source's compressor must not grow from
+    // fetcher traffic.
+    const before = getCompressorBytesIn(primary);
+    for (let i = 0; i < 5; ++i) {
+        generateOplogTraffic(primary, "netcompress_both_disabled", "c", i);
+    }
+    rst.awaitReplication();
+    const grew = decompressorDelta(before, getCompressorBytesIn(primary));
+    jsTest.log.info(
+        "[replicationNetworkCompression] both-disabled compressor delta on sync source: " +
+            tojson(grew));
+    assert.eq(
+        {},
+        grew,
+        "with net.compression.compressors=disabled and replicationNetworkCompression=disabled the " +
+            "replication channel must be uncompressed; delta: " + tojson(grew),
+    );
+
+    // Client-facing connections must also be uncompressed: even advertising a real algorithm, an
+    // external client gets nothing because net is disabled and replication=disabled adds nothing.
+    assert.eq(
+        "NONE",
+        externalClientNegotiatedCompression(secondary.host, "zstd"),
+        "external client negotiated compression while both net and replication compression are " +
+            "disabled",
+    );
+    assert.eq(
+        "NONE",
+        externalClientNegotiatedCompression(secondary.host, "snappy"),
+        "external client negotiated compression while both net and replication compression are " +
+            "disabled",
+    );
+
+    rst.stopSet();
+})();
+
+// ---------------------------------------------------------------------------
+// 14. CLI config path (SERVER-130410): the feature is exposed both as a setParameter
+//     (replicationNetworkCompression) and as a config option
+//     (replication.networkCompression.compressors, short name replicationNetworkCompressionCompressors,
+//     source: [yaml, cli]). All earlier scenarios drive the setParameter form; this one exercises the
+//     CLI/config bridge in storeMongodOptions(), which seeds gReplicationNetworkCompression from the
+//     config value and folds the algorithm into the process-wide capability union. We bring up a set
+//     with net disabled and the compressor supplied ONLY via the config option, and verify:
+//       (a) getParameter reflects the seeded value (bridge wired), and
+//       (b) the replication channel is actually compressed with that algorithm.
+// ---------------------------------------------------------------------------
+(function testConfigOptionPathCompresses() {
+    jsTest.log.info(
+        "[replicationNetworkCompression] CLI config path: replicationNetworkCompressionCompressors");
+    const kReplAlgo = "zstd";
+
+    const rst = new ReplSetTest({
+        name: "replication_network_compression_config_path",
+        nodes: [
+            // Supply the algorithm via the CLI/config option (NOT --setParameter) on both nodes so
+            // the fetcher advertises it and the sync source accepts it on the marked connection.
+            {networkMessageCompressors: "disabled", replicationNetworkCompressionCompressors: kReplAlgo},
+            {networkMessageCompressors: "disabled", replicationNetworkCompressionCompressors: kReplAlgo},
+        ],
+    });
+    rst.startSet();
+    rst.initiate();
+
+    const primary = rst.getPrimary();
+    const secondary = rst.getSecondary();
+    rst.awaitReplication();
+
+    // (a) The config value must have been seeded into the (startup-only) setParameter.
+    for (const node of [primary, secondary]) {
+        const res = assert.commandWorked(
+            node.adminCommand({getParameter: 1, replicationNetworkCompression: 1}));
+        assert.eq(
+            kReplAlgo,
+            res.replicationNetworkCompression,
+            `config option replicationNetworkCompressionCompressors was not seeded into the ` +
+                `replicationNetworkCompression setParameter: ${tojson(res)}`,
+        );
+    }
+
+    // (b) The replication channel must use the configured algorithm even though net is disabled.
+    const before = getCompressorBytesIn(primary);
+    for (let i = 0; i < 5; ++i) {
+        generateOplogTraffic(primary, "netcompress_config_path", "c", i);
+    }
+    rst.awaitReplication();
+    const grew = decompressorDelta(before, getCompressorBytesIn(primary));
+    jsTest.log.info(
+        "[replicationNetworkCompression] config-path compressor delta on sync source: " +
+            tojson(grew));
+    assert(
+        grew[kReplAlgo] && grew[kReplAlgo] > 0,
+        `expected the config-supplied replication compressor '${kReplAlgo}' to be used on the ` +
+            `replication channel; delta: ${tojson(grew)}`,
+    );
+
+    rst.stopSet();
+})();
+
+// ---------------------------------------------------------------------------
+// 15. Conflicting config + setParameter must be REJECTED (SERVER-130410): storeMongodOptions()
+//     seeds the setParameter from replication.networkCompression.compressors and calls
+//     checkConflictWithSetParameter(), so supplying BOTH the config option AND an initial
+//     --setParameter replicationNetworkCompression is an ambiguous startup command and must fail
+//     rather than silently letting one form win.
+// ---------------------------------------------------------------------------
+(function testConfigOptionConflictsWithSetParameterRejected() {
+    jsTest.log.info(
+        "[replicationNetworkCompression] config option + setParameter conflict is rejected");
+    assert.throws(
+        () => MongoRunner.runMongod({
+            networkMessageCompressors: "disabled",
+            replicationNetworkCompressionCompressors: "zstd",
+            setParameter: {replicationNetworkCompression: "snappy"},
+        }),
+        [],
+        "supplying both replication.networkCompression.compressors and the " +
+            "replicationNetworkCompression setParameter must fail startup",
+    );
+})();
+
+// ---------------------------------------------------------------------------
+// 16. Unknown / not-compiled algorithm fails startup (SERVER-130410): a syntactically valid but
+//     unregistered compressor name is folded into the process-wide capability union and then caught
+//     by MessageCompressorRegistry::finalizeSupportedCompressors() (AllCompressorsRegistered
+//     initializer), which uassertStatusOK()s a BadValue. This is a HARD startup error, not a silent
+//     "dropped -> uncompressed" downgrade, for both the setParameter and the config/CLI forms.
+// ---------------------------------------------------------------------------
+(function testUnknownAlgorithmFailsStartup() {
+    jsTest.log.info("[replicationNetworkCompression] unknown algorithm fails startup");
+    // Not a MongoDB compressor (only noop/snappy/zlib/zstd are ever registered), so it can never be
+    // present in any build - a stable "valid token, unregistered" input.
+    const kBogusAlgo = "zstd_notacompressor";
+
+    // setParameter form.
+    assert.throws(
+        () => MongoRunner.runMongod({setParameter: {replicationNetworkCompression: kBogusAlgo}}),
+        [],
+        `replicationNetworkCompression='${kBogusAlgo}' (setParameter) must fail startup, not be ` +
+            `silently dropped`,
+    );
+
+    // config/CLI form.
+    assert.throws(
+        () => MongoRunner.runMongod({replicationNetworkCompressionCompressors: kBogusAlgo}),
+        [],
+        `replicationNetworkCompressionCompressors='${kBogusAlgo}' (config/CLI) must fail startup, ` +
+            `not be silently dropped`,
+    );
+})();

--- a/jstests/noPassthrough/replication/replication_network_compression.js
+++ b/jstests/noPassthrough/replication/replication_network_compression.js
@@ -18,7 +18,8 @@
  */
 import {ReplSetTest} from "jstests/libs/replsettest.js";
 import {funWithArgs} from "jstests/libs/parallel_shell_helpers.js";
-import {RollbackTest} from "jstests/replsets/libs/rollback_test.js";
+import {restartServerReplication, stopServerReplication} from "jstests/libs/write_concern_util.js";
+import {waitForState} from "jstests/replsets/rslib.js";
 
 // The default/inherit scenario advertises the full snappy/zstd/zlib set on the process-wide port.
 // Explicit replication-compressor scenarios disable net compression and configure the requested
@@ -29,7 +30,7 @@ const kProcessCompressors = "snappy,zstd,zlib";
 // Read the sync source's per-compressor COMPRESSOR bytesIn counters. Returns a plain object
 // keyed by compressor name so the test math is easy to read.
 //
-// SERVER-130410: the oplog fetcher pulls batches FROM the sync source over an exhaust cursor, so
+// The oplog fetcher pulls batches FROM the sync source over an exhaust cursor, so
 // the sync source COMPRESSES those oplog responses on the fetcher's connection. That
 // compressor direction carries the bulk replicated data and is the reliable signal for which
 // algorithm the replication channel negotiated. The reverse (sync source decompressor) only sees
@@ -52,7 +53,7 @@ function getCompressorBytesIn(node) {
 // Read a node's per-compressor DECOMPRESSOR bytesIn counters. Returns a plain object keyed by
 // compressor name.
 //
-// SERVER-130410: use this on the RECEIVING side of a data transfer, i.e. the node that DECOMPRESSES
+// Use this on the RECEIVING side of a data transfer, i.e. the node that DECOMPRESSES
 // inbound compressed messages:
 //   - the initial-sync collection cloner and the rollback common-point reader pull bulk data FROM
 //     the sync source as query responses, so the SYNCING/ROLLING-BACK node decompresses it, and
@@ -70,6 +71,24 @@ function getDecompressorBytesIn(node) {
     }
     for (const name of Object.keys(ss.network.compression)) {
         const d = ss.network.compression[name].decompressor;
+        out[name] = d ? d.bytesIn : 0;
+    }
+    return out;
+}
+
+// Read a node's serverStatus().repl.compression per-compressor byte counters, which
+// account for the replication-data-plane subset of network.compression. `direction` is "compressor"
+// or "decompressor". Returns {name: bytesIn}. Unlike the process-wide network.compression counters,
+// these only include traffic on replication-marked connections, so they are attributable to the
+// replication channel even when net compression is also enabled.
+function getReplCompressionBytesIn(node, direction) {
+    const ss = assert.commandWorked(node.adminCommand({serverStatus: 1}));
+    const out = {};
+    if (!ss.repl || !ss.repl.compression) {
+        return out;
+    }
+    for (const name of Object.keys(ss.repl.compression)) {
+        const d = ss.repl.compression[name][direction];
         out[name] = d ? d.bytesIn : 0;
     }
     return out;
@@ -175,11 +194,13 @@ function runScenario({label, secondaryValue, expectCompressorGrew, extraForbid})
     const primary = rst.getPrimary();
     const secondary = rst.getSecondary();
 
-    // Baseline: some traffic already flowed during initiate; snapshot the sync source (primary)
-    // counters AFTER the secondary is up and steady so any growth we observe is attributable
-    // to the writes we drive below on this fetcher's channel.
+    // Baseline: some traffic already flowed during initiate; snapshot process-wide and
+    // repl.compression counters AFTER the secondary is up and steady so any growth we observe is
+    // attributable to the writes we drive below on this fetcher's channel.
     rst.awaitReplication();
     const before = getCompressorBytesIn(primary);
+    const replCompressorBefore = getReplCompressionBytesIn(primary, "compressor");
+    const replDecompressorBefore = getReplCompressionBytesIn(secondary, "decompressor");
 
     // Drive several rounds of writes so the fetcher pulls new batches through its already-
     // established sync-source connection. We deliberately do NOT force a reconnect here: the
@@ -191,9 +212,21 @@ function runScenario({label, secondaryValue, expectCompressorGrew, extraForbid})
 
     const after = getCompressorBytesIn(primary);
     const grew = decompressorDelta(before, after);
+    const replCompressorGrew = decompressorDelta(
+        replCompressorBefore, getReplCompressionBytesIn(primary, "compressor"));
+    const replDecompressorGrew = decompressorDelta(
+        replDecompressorBefore, getReplCompressionBytesIn(secondary, "decompressor"));
     jsTest.log.info(
         `[replicationNetworkCompression] scenario ${label} compressor delta on sync source: ` +
             tojson(grew),
+    );
+    jsTest.log.info(
+        `[replicationNetworkCompression] scenario ${label} repl.compression compressor delta: ` +
+            tojson(replCompressorGrew),
+    );
+    jsTest.log.info(
+        `[replicationNetworkCompression] scenario ${label} repl.compression decompressor delta: ` +
+            tojson(replDecompressorGrew),
     );
 
     if (expectCompressorGrew === null) {
@@ -206,11 +239,35 @@ function runScenario({label, secondaryValue, expectCompressorGrew, extraForbid})
             `[${label}] expected no compressor growth on sync source (channel should be ` +
                 `uncompressed), but saw: ${tojson(grew)}`,
         );
+        assert.eq(
+            {},
+            replCompressorGrew,
+            `[${label}] expected no repl.compression compressor growth on sync source, but saw: ` +
+                tojson(replCompressorGrew),
+        );
+        assert.eq(
+            {},
+            replDecompressorGrew,
+            `[${label}] expected no repl.compression decompressor growth on fetcher, but saw: ` +
+                tojson(replDecompressorGrew),
+        );
     } else {
         assert(
             grew[expectCompressorGrew] && grew[expectCompressorGrew] > 0,
             `[${label}] expected compressor '${expectCompressorGrew}' bytesIn to grow on ` +
                 `sync source, delta was: ${tojson(grew)}`,
+        );
+        assert(
+            replCompressorGrew[expectCompressorGrew] &&
+                replCompressorGrew[expectCompressorGrew] > 0,
+            `[${label}] expected repl.compression.${expectCompressorGrew}.compressor to grow on ` +
+                `sync source, delta was: ${tojson(replCompressorGrew)}`,
+        );
+        assert(
+            replDecompressorGrew[expectCompressorGrew] &&
+                replDecompressorGrew[expectCompressorGrew] > 0,
+            `[${label}] expected repl.compression.${expectCompressorGrew}.decompressor to grow ` +
+                `on fetcher, delta was: ${tojson(replDecompressorGrew)}`,
         );
         // If the operator listed only one algorithm, no other compressor should have been
         // used on the replication channel.
@@ -220,6 +277,18 @@ function runScenario({label, secondaryValue, expectCompressorGrew, extraForbid})
                     !grew[name],
                     `[${label}] compressor '${name}' unexpectedly grew on sync source ` +
                         `despite not being in the allow-list: ${tojson(grew)}`,
+                );
+                assert(
+                    !replCompressorGrew[name],
+                    `[${label}] repl.compression compressor '${name}' unexpectedly grew on ` +
+                        `sync source despite not being in the allow-list: ` +
+                        tojson(replCompressorGrew),
+                );
+                assert(
+                    !replDecompressorGrew[name],
+                    `[${label}] repl.compression decompressor '${name}' unexpectedly grew on ` +
+                        `fetcher despite not being in the allow-list: ` +
+                        tojson(replDecompressorGrew),
                 );
             }
         }
@@ -249,6 +318,20 @@ function runScenario({label, secondaryValue, expectCompressorGrew, extraForbid})
             setParameter: {replicationNetworkCompression: ","},
         }),
     );
+
+    // A value that is only whitespace is non-empty but contains no compressor names, so it must be
+    // rejected rather than silently treated as inherit (which is reserved for a truly empty "").
+    for (const blank of [" ", "\t", "  ,  "]) {
+        assert.throws(
+            () =>
+                MongoRunner.runMongod({
+                    setParameter: {replicationNetworkCompression: blank},
+                }),
+            [],
+            `replicationNetworkCompression=${tojson(blank)} (whitespace/separators only) must ` +
+                `fail startup, not be treated as inherit`,
+        );
+    }
 })();
 
 // ---------------------------------------------------------------------------
@@ -277,7 +360,7 @@ function runScenario({label, secondaryValue, expectCompressorGrew, extraForbid})
 })();
 
 // ---------------------------------------------------------------------------
-// 3. Runtime setParameter must be REJECTED (SERVER-130410): replicationNetworkCompression is
+// 3. Runtime setParameter must be REJECTED: replicationNetworkCompression is
 //    declared set_at: [startup] only. Attempting to change it at runtime - with a legal value,
 //    with an illegal value, and even with a value that equals the current one - must fail and
 //    must NOT mutate the stored value. Changing compression requires editing the config /
@@ -402,8 +485,12 @@ runScenario({
 
     // Open a NEW connection to the secondary that negotiates snappy on the client side. The
     // default Mongo shell connection used by rst.getSecondary() is uncompressed, so we build
-    // a compressed one explicitly via the raw mongo program.
+    // a compressed one explicitly via the raw mongo program. Snapshot repl.compression too: external
+    // client traffic must grow network.compression but must NOT be attributed to the replication
+    // data-plane subset.
     const before = getDecompressorBytesIn(secondary);
+    const replCompressorBefore = getReplCompressionBytesIn(secondary, "compressor");
+    const replDecompressorBefore = getReplCompressionBytesIn(secondary, "decompressor");
     assert.eq(
         0,
         runMongoProgram(
@@ -427,11 +514,31 @@ runScenario({
             tojson(grew),
     );
 
+    // The same external client connection must not pollute serverStatus().repl.compression. This
+    // directly verifies that the new repl.compression counters are a replication-marker subset, not
+    // just another view of all network compression traffic.
+    const replCompressorGrew = decompressorDelta(
+        replCompressorBefore, getReplCompressionBytesIn(secondary, "compressor"));
+    const replDecompressorGrew = decompressorDelta(
+        replDecompressorBefore, getReplCompressionBytesIn(secondary, "decompressor"));
+    assert.eq(
+        {},
+        replCompressorGrew,
+        "external client response compression must not be counted in repl.compression compressor " +
+            "counters; delta: " + tojson(replCompressorGrew),
+    );
+    assert.eq(
+        {},
+        replDecompressorGrew,
+        "external client request compression must not be counted in repl.compression decompressor " +
+            "counters; delta: " + tojson(replDecompressorGrew),
+    );
+
     rst.stopSet();
 })();
 
 // ---------------------------------------------------------------------------
-// 5b. Scoping (SERVER-130410): replicationNetworkCompression must scope to the replication
+// 5b. Scoping: replicationNetworkCompression must scope to the replication
 //     sync-source connection ONLY. Other internal (internalClient) connections - heartbeats and,
 //     in a sharded cluster, intra-cluster RPC - must keep using net.compression.compressors. The
 //     server distinguishes them via the "replicationCompressionClient" hello marker that only
@@ -469,15 +576,35 @@ runScenario({
             "replicationNetworkCompression=disabled and net compression stayed enabled",
     );
 
-    // Drive fresh replication traffic while net compression remains enabled. We intentionally do
-    // NOT assert on process-wide decompressor counters here: heartbeat/internal RPC can legitimately
-    // use snappy and share those counters. The dedicated disabled scenario above verifies the
-    // replication data channel with net compression disabled to keep the counter signal isolated.
+    // Drive fresh replication traffic while net compression remains enabled. Process-wide counters
+    // are intentionally not used here because heartbeat/internal RPC can legitimately use snappy and
+    // share those counters. The dedicated repl.compression counters, however, must stay flat because
+    // the marked replication data-plane connection negotiated uncompressed.
     rst.awaitReplication();
+    const replCompressorBefore = getReplCompressionBytesIn(primary, "compressor");
+    const replDecompressorBefore = getReplCompressionBytesIn(secondary, "decompressor");
     for (let i = 0; i < 5; ++i) {
         generateOplogTraffic(primary, "netcompress_scope", "c", i);
     }
     rst.awaitReplication();
+    const replCompressorGrew = decompressorDelta(
+        replCompressorBefore, getReplCompressionBytesIn(primary, "compressor"));
+    const replDecompressorGrew = decompressorDelta(
+        replDecompressorBefore, getReplCompressionBytesIn(secondary, "decompressor"));
+    assert.eq(
+        {},
+        replCompressorGrew,
+        "replicationNetworkCompression=disabled must keep the replication data-plane uncompressed " +
+            "even when net compression is enabled; sync-source repl.compression compressor delta: " +
+            tojson(replCompressorGrew),
+    );
+    assert.eq(
+        {},
+        replDecompressorGrew,
+        "replicationNetworkCompression=disabled must keep the replication data-plane uncompressed " +
+            "even when net compression is enabled; fetcher repl.compression decompressor delta: " +
+            tojson(replDecompressorGrew),
+    );
 
     // Heartbeats are internal, non-replication connections. If replication=disabled had leaked into
     // them, the replica set could not maintain its topology. A healthy set (stable primary, both
@@ -515,7 +642,7 @@ function externalClientNegotiatedCompression(host, clientAdvertises) {
 }
 
 // ---------------------------------------------------------------------------
-// 7. Decoupling headline (SERVER-130410): net.compression.compressors DISABLED while replication
+// 7. Decoupling headline: net.compression.compressors DISABLED while replication
 //    compression is ENABLED. This is the whole point of the feature and was previously impossible.
 //    We prove three things at once:
 //      (a) the node STARTS even though the only requested compressor comes from the replication
@@ -560,6 +687,10 @@ function externalClientNegotiatedCompression(host, clientAdvertises) {
     // The sync source compresses the oplog batches it streams to the fetcher, so its compressor is
     // the reliable signal; its decompressor only sees the fetcher's tiny exhaust requests.
     const before = getCompressorBytesIn(primary);
+    // Observability: the primary is the sync source, so it COMPRESSES oplog for the
+    // fetcher. serverStatus().repl.compression.<algo>.compressor must grow for the replication
+    // portion specifically (a subset of network.compression).
+    const replBefore = getReplCompressionBytesIn(primary, "compressor");
     for (let i = 0; i < 5; ++i) {
         generateOplogTraffic(primary, "netcompress_decouple", "c", i);
     }
@@ -569,6 +700,17 @@ function externalClientNegotiatedCompression(host, clientAdvertises) {
     assert(
         grew[kReplAlgo] && grew[kReplAlgo] > 0,
         `expected replication channel to use '${kReplAlgo}' despite net disabled; delta: ${tojson(grew)}`,
+    );
+
+    // The dedicated repl.compression counter must attribute this to the replication data plane.
+    const replGrew = decompressorDelta(replBefore, getReplCompressionBytesIn(primary, "compressor"));
+    jsTest.log.info(
+        "[replicationNetworkCompression] decouple repl.compression compressor delta: " +
+            tojson(replGrew));
+    assert(
+        replGrew[kReplAlgo] && replGrew[kReplAlgo] > 0,
+        `expected serverStatus().repl.compression.${kReplAlgo}.compressor to grow on the sync ` +
+            `source; delta: ${tojson(replGrew)}`,
     );
 
     // (c) An external client that advertises the very same algorithm must NOT get it: with net
@@ -585,7 +727,7 @@ function externalClientNegotiatedCompression(host, clientAdvertises) {
 })();
 
 // ---------------------------------------------------------------------------
-// 8. Independent algorithm selection (SERVER-130410): net advertises ONE algorithm to clients,
+// 8. Independent algorithm selection: net advertises ONE algorithm to clients,
 //    while replication uses a DIFFERENT algorithm that is not in the net list at all. This proves
 //    the two policies are chosen from independent candidate sets even though both algorithms share
 //    a single process-wide capability union:
@@ -627,6 +769,7 @@ function externalClientNegotiatedCompression(host, clientAdvertises) {
     // snappy is the net-only algorithm and zstd is replication-only is the pair of external-client
     // negotiation checks below.
     const before = getCompressorBytesIn(primary);
+    const replBefore = getReplCompressionBytesIn(primary, "compressor");
     for (let i = 0; i < 5; ++i) {
         generateOplogTraffic(primary, "netcompress_independent", "c", i);
     }
@@ -638,6 +781,20 @@ function externalClientNegotiatedCompression(host, clientAdvertises) {
     assert(
         grew[kReplAlgo] && grew[kReplAlgo] > 0,
         `expected replication channel to use '${kReplAlgo}'; delta: ${tojson(grew)}`,
+    );
+
+    // The replication-data-plane subset must attribute the same growth to zstd specifically. This
+    // pins that the replication channel (not net snappy) drove the zstd bytes.
+    const replGrew = decompressorDelta(replBefore, getReplCompressionBytesIn(primary, "compressor"));
+    assert(
+        replGrew[kReplAlgo] && replGrew[kReplAlgo] > 0,
+        `expected serverStatus().repl.compression.${kReplAlgo}.compressor to grow on the sync ` +
+            `source; delta: ${tojson(replGrew)}`,
+    );
+    assert(
+        !replGrew[kNetAlgo],
+        `net-only algorithm '${kNetAlgo}' must not appear in the replication-data-plane counters; ` +
+            `delta: ${tojson(replGrew)}`,
     );
 
     // External client advertising the net algorithm gets it (net set governs client-facing).
@@ -660,7 +817,7 @@ function externalClientNegotiatedCompression(host, clientAdvertises) {
 
 // ---------------------------------------------------------------------------
 // 9. Initial (full) sync uses replication compression on the collection-cloner connection
-//    (SERVER-130410). The cloner connection now applies the exact same replicationNetworkCompression
+//    The cloner connection now applies the exact same replicationNetworkCompression
 //    policy as the steady-state oplog fetcher (shared helper applyReplicationNetworkCompressionToManager),
 //    so full sync gets compressed just like incremental sync, and even works when
 //    net.compression.compressors: disabled.
@@ -741,6 +898,18 @@ function externalClientNegotiatedCompression(host, clientAdvertises) {
             `oplog fetcher); delta: ${tojson(grew)}`,
     );
 
+    // Observability: the syncing node DECOMPRESSES the cloned collection data, so its
+    // replication-only decompressor counter must also reflect it (subset of network.compression).
+    const replGrew = decompressorDelta({}, getReplCompressionBytesIn(newNode, "decompressor"));
+    jsTest.log.info(
+        "[replicationNetworkCompression] initial sync repl.compression decompressor delta: " +
+            tojson(replGrew));
+    assert(
+        replGrew[kReplAlgo] && replGrew[kReplAlgo] > kMinClonerBytes,
+        `expected serverStatus().repl.compression.${kReplAlgo}.decompressor on the syncing node ` +
+            `to grow from the cloner connection; delta: ${tojson(replGrew)}`,
+    );
+
     // Sanity: the freshly-synced node actually cloned the data.
     assert.eq(
         kNumDocs,
@@ -752,7 +921,7 @@ function externalClientNegotiatedCompression(host, clientAdvertises) {
 })();
 
 // ---------------------------------------------------------------------------
-// 10. Inheritance under net disabled (SERVER-130410): when replicationNetworkCompression is left
+// 10. Inheritance under net disabled: when replicationNetworkCompression is left
 //     unset (its default value is the empty string ""), it INHERITS net.compression.compressors
 //     rather than forcing any particular behavior of its own (see
 //     parseReplicationNetworkCompression: "" -> inheritProcessDefault). Therefore, if net is
@@ -804,7 +973,7 @@ function externalClientNegotiatedCompression(host, clientAdvertises) {
 })();
 
 // ---------------------------------------------------------------------------
-// 11. Asymmetric / disjoint allow-lists (SERVER-130410): the fetcher and its sync source advertise
+// 11. Asymmetric / disjoint allow-lists: the fetcher and its sync source advertise
 //     DISJOINT replication allow-lists. With net disabled on both nodes, one node permits only
 //     snappy on the replication connection and the other permits only zstd, so their candidate sets
 //     do not intersect on the replication channel. serverNegotiate() then finds no mutually
@@ -838,11 +1007,15 @@ function externalClientNegotiatedCompression(host, clientAdvertises) {
     rst.initiate();
 
     const primary = rst.getPrimary();
+    const secondary = rst.getSecondary();
     rst.awaitReplication();
 
     // Measure the sync source's COMPRESSOR (it compresses the oplog it streams to the fetcher). A
     // successful negotiation would grow it; a correct fall-back-to-uncompressed leaves it flat.
+    // The dedicated repl.compression counters must also stay flat for a disjoint negotiation.
     const before = getCompressorBytesIn(primary);
+    const replCompressorBefore = getReplCompressionBytesIn(primary, "compressor");
+    const replDecompressorBefore = getReplCompressionBytesIn(secondary, "decompressor");
     for (let i = 0; i < 5; ++i) {
         generateOplogTraffic(primary, "netcompress_asym", "c", i);
     }
@@ -857,6 +1030,22 @@ function externalClientNegotiatedCompression(host, clientAdvertises) {
         "disjoint replication allow-lists (snappy vs zstd) must negotiate an UNCOMPRESSED channel " +
             "rather than pick a non-permitted algorithm; delta: " + tojson(grew),
     );
+    const replCompressorGrew = decompressorDelta(
+        replCompressorBefore, getReplCompressionBytesIn(primary, "compressor"));
+    const replDecompressorGrew = decompressorDelta(
+        replDecompressorBefore, getReplCompressionBytesIn(secondary, "decompressor"));
+    assert.eq(
+        {},
+        replCompressorGrew,
+        "disjoint allow-lists must leave sync-source repl.compression compressor counters flat; " +
+            "delta: " + tojson(replCompressorGrew),
+    );
+    assert.eq(
+        {},
+        replDecompressorGrew,
+        "disjoint allow-lists must leave fetcher repl.compression decompressor counters flat; " +
+            "delta: " + tojson(replDecompressorGrew),
+    );
 
     // A failed compression negotiation must not break replication: the set stays healthy and data
     // still flows (the traffic above already replicated via awaitReplication).
@@ -867,7 +1056,7 @@ function externalClientNegotiatedCompression(host, clientAdvertises) {
 })();
 
 // ---------------------------------------------------------------------------
-// 12. Rollback uses replication compression on the sync-source connection (SERVER-130410).
+// 12. Rollback uses replication compression on the sync-source connection.
 //     Rollback is a replication data-plane path too: to find the common point, the rolling-back
 //     node reads its sync source's remote oplog over a dedicated DBClientConnection created in
 //     BackgroundSync::_runRollback (via OplogInterfaceRemote). That connection now applies the same
@@ -875,12 +1064,23 @@ function externalClientNegotiatedCompression(host, clientAdvertises) {
 //     cloner, so rollback traffic is compressed identically - and, in particular, honors
 //     replication.networkCompression.compressors even when net.compression.compressors: disabled.
 //
+//     BRIDGE-FREE by design: the usual RollbackTest harness routes ALL replication through
+//     mongobridge to create the partitions it needs, but mongobridge cannot relay a COMPRESSED
+//     replication stream - it proxies the wire protocol and desynchronizes the request/response ids
+//     on OP_COMPRESSED exhaust frames (bridge error Location50765 "Response ID did not match the
+//     sent message ID"), so the bridged set never forms once replicationNetworkCompression is
+//     enabled with net disabled. We therefore induce the rollback WITHOUT any network proxy, using
+//     the stopReplProducer failpoint (stopServerReplication) plus a forced election. A single
+//     arbiter gives the surviving data node a voting majority after the future-rollback node steps
+//     down, so no partition is required.
+//
 //     Discriminating signal: with net disabled everywhere and replication=zstd, the ONLY way the
 //     rolling-back node's zstd decompressor can advance is through a repl-compressed connection.
 //     We isolate the rollback connection specifically from the (also-compressed) steady-state oplog
 //     fetcher using two facts:
-//       - a baseline is taken while the rolling-back node is still partitioned from its sync source
-//         (its fetcher cannot pull, so the counter is quiescent), and
+//       - the rolling-back node's producer is STALLED (stopServerReplication) while we stage the
+//         divergent branches, so a baseline snapshot taken then finds the zstd decompressor
+//         quiescent, and
 //       - the `bgSyncHangAfterRunRollback` failpoint freezes the node the instant _runRollback()
 //         returns - i.e. AFTER the common-point search read the remote oplog over the rollback
 //         connection, but BEFORE the oplog fetcher resumes. A watcher shell snapshots the counter
@@ -900,15 +1100,69 @@ function externalClientNegotiatedCompression(host, clientAdvertises) {
     // threshold modest because the remote oplog query projects each oplog entry down to {ts, t}.
     const kMinRollbackRemoteBytes = 4 * 1024;
 
-    const nodeOptions = {
+    const dataOpts = {
         networkMessageCompressors: "disabled",
         setParameter: {replicationNetworkCompression: kReplAlgo},
     };
-    const rollbackTest = new RollbackTest(
-        "replication_network_compression_rollback", undefined, nodeOptions);
+    // 3-node set, NO mongobridge: two data nodes plus an arbiter. The arbiter lets the surviving
+    // data node win the election after the future-rollback node steps down, so we can force the
+    // divergence with failpoints instead of a network partition.
+    const rst = new ReplSetTest({
+        name: "replication_network_compression_rollback",
+        nodes: [
+            {rsConfig: {priority: 1}},        // node 0: starts primary, will roll back
+            {rsConfig: {priority: 1}},        // node 1: becomes primary / rollback sync source
+            {rsConfig: {arbiterOnly: true}},  // arbiter: sways the election without a bridge
+        ],
+        nodeOptions: dataOpts,
+        settings: {
+            // Disable catchup takeover. Node 0 accumulates the (uncommitted) doomed branch, making
+            // it FRESHER than node 1; with catchup takeover enabled it would repeatedly re-seize the
+            // primary from the freshly elected node 1 (vote denials "can see a healthy primary ... of
+            // equal or greater priority"), so node 1 could never hold the primary long enough to
+            // build the divergent branch node 0 must roll back.
+            catchUpTakeoverDelayMillis: -1,
+            // Disable new-primary catch-up. When node 1 is elected it is BEHIND node 0 (which holds
+            // the doomed branch). With catch-up enabled the new primary would try to pull node 0's
+            // fresher oplog before becoming writable - but node 1's producer is stalled
+            // (stopServerReplication), so catch-up would stall and node 1 would never become a
+            // writable primary, hanging ReplSetTest.stepUp() in an election-retry loop. Disabling
+            // catch-up makes node 1 writable immediately AND ensures it never applies node 0's doomed
+            // ops, which is exactly the divergence node 0 must roll back.
+            catchUpTimeoutMillis: 0,
+        },
+    });
+    rst.startSet();
+    rst.initiate();
 
-    // Divergent branch on the rolling-back node (these ops get rolled back).
-    const rollbackNode = rollbackTest.transitionToRollbackOperations();
+    const rollbackNode = rst.nodes[0];
+    const syncSource = rst.nodes[1];
+
+    // Make node 0 the initial primary (everything is caught up here, so a normal stepUp is fine).
+    // Compare by host: getPrimary() may return a different connection object than rst.nodes[0], so an
+    // object-identity (!==) check could wrongly stepUp again and perturb the election.
+    if (rst.getPrimary().host !== rollbackNode.host) {
+        rst.stepUp(rollbackNode);
+    }
+    waitForState(rollbackNode, ReplSetTest.State.PRIMARY);
+
+    // Local (w:1) writes must commit without a majority so the doomed branch can form on node 0
+    // alone. The default majority write concern would otherwise block once we stall node 1.
+    assert.commandWorked(rollbackNode.adminCommand({
+        setDefaultRWConcern: 1,
+        defaultWriteConcern: {w: 1},
+        writeConcern: {w: "majority"},
+    }));
+    assert.commandWorked(rollbackNode.getDB("rollback_compress").seed.insert(
+        {_id: "seed"}, {writeConcern: {w: 2, wtimeout: ReplSetTest.kDefaultTimeoutMS}}));
+    rst.awaitReplication();
+
+    // Stall the future sync source so it never learns the doomed branch, and stall the rolling-back
+    // node so it will NOT begin rollback until we have staged the full sync-source branch to read.
+    stopServerReplication(syncSource);
+    stopServerReplication(rollbackNode);
+
+    // Doomed branch: ops that exist only on node 0 (w:1) and must be rolled back.
     {
         const bulk = rollbackNode.getDB("rollback_compress").doomed.initializeUnorderedBulkOp();
         for (let i = 0; i < 50; ++i) {
@@ -917,11 +1171,23 @@ function externalClientNegotiatedCompression(host, clientAdvertises) {
         assert.commandWorked(bulk.execute({w: 1}));
     }
 
-    // Sync-source branch: a large set of ops the rolling-back node has never seen. The common-point
-    // search must read all of these back over the rollback connection, which is the traffic we
-    // measure.
-    rollbackTest.transitionToSyncSourceOperationsBeforeRollback();
-    const syncSource = rollbackTest.getPrimary();
+    // Step node 0 down (this also freezes it from elections) and elect node 1. Node 1 is behind (it
+    // never saw the doomed branch) and is still stalled, but the arbiter gives it a voting majority
+    // and stopReplProducer does not block elections. Use ReplSetTest.stepUp with
+    // awaitReplicationBeforeStepUp:false: node 1 must NOT wait to catch up to node 0's doomed ops
+    // (that divergence is exactly what we are creating). The helper retries replSetStepUp and waits
+    // for the set to agree on the new primary, so it is robust against the election-timing races that
+    // a hand-rolled replSetStepUp loop would hit (repeated stepUps can knock a freshly elected
+    // primary back down).
+    assert.commandWorked(rollbackNode.adminCommand({replSetStepDown: 300, force: true}));
+    rst.stepUp(syncSource, {awaitReplicationBeforeStepUp: false});
+    waitForState(syncSource, ReplSetTest.State.PRIMARY);
+    // node 1 is primary now; clear its producer stall (harmless while primary) for a clean teardown.
+    restartServerReplication(syncSource);
+
+    // Sync-source branch: a large set of ops on the NEW primary's divergent branch. Node 0's
+    // common-point search reads all of these back over the rollback connection - the traffic we
+    // measure. OplogInterfaceRemote projects entries to {ts, t}, so volume comes from entry count.
     {
         const bulk = syncSource.getDB("rollback_compress").winner.initializeUnorderedBulkOp();
         for (let i = 0; i < 5000; ++i) {
@@ -930,9 +1196,10 @@ function externalClientNegotiatedCompression(host, clientAdvertises) {
         assert.commandWorked(bulk.execute({w: 1}));
     }
 
-    // Baseline BEFORE rollback: the node is still partitioned from its sync source, so its fetcher
-    // is idle and the zstd decompressor is quiescent.
+    // Baseline BEFORE node 0 resumes fetching and rolls back: its producer is still stalled, so the
+    // zstd decompressor is quiescent.
     const before = getDecompressorBytesIn(rollbackNode);
+    const replBefore = getReplCompressionBytesIn(rollbackNode, "decompressor");
 
     // Freeze the node right after the common-point search completes but before the fetcher resumes.
     assert.commandWorked(rollbackNode.adminCommand(
@@ -940,32 +1207,79 @@ function externalClientNegotiatedCompression(host, clientAdvertises) {
 
     // Watcher: wait for the frozen point, snapshot the rollback node's compressed-bytes counter,
     // stash it on the (healthy) sync source, then release the failpoint so rollback can finish.
+    //
+    // IMPORTANT: rollback via recoverToStableTimestamp CLOSES the node's client connections while it
+    // runs, so any single cached connection to the rolling-back node will throw a network error
+    // mid-rollback. The watcher therefore reconnects with a FRESH Mongo() on every poll iteration and
+    // tolerates transient failures, only succeeding once the node has hung at the post-rollback
+    // failpoint (at which point it serves commands again and the counters reflect exactly the
+    // common-point read done over the rollback connection, before the steady-state fetcher resumes).
     const awaitWatcher = startParallelShell(
         funWithArgs(
             function (rbPort, ssHost, algo) {
-                const rb = new Mongo("localhost:" + rbPort);
-                // Poll the log for the failpoint-hit marker (id 21095). serverStatus keeps
-                // responding while the producer thread sleeps in the failpoint loop.
+                const rbHost = "localhost:" + rbPort;
+                let snapped = null;
                 assert.soon(
                     () => {
-                        const log = assert.commandWorked(rb.adminCommand({getLog: "global"})).log;
-                        return log.some(
-                            (line) => line.includes("bgSyncHangAfterRunRollback failpoint is set"));
+                        try {
+                            const rb = new Mongo(rbHost);
+                            const res = rb.adminCommand({getLog: "global"});
+                            if (!res.ok || !res.log ||
+                                !res.log.some((line) => line.includes(
+                                    "bgSyncHangAfterRunRollback failpoint is set"))) {
+                                return false;
+                            }
+                            const ss = rb.adminCommand({serverStatus: 1});
+                            if (!ss.ok) {
+                                return false;
+                            }
+                            let bytes = 0;
+                            if (ss.network && ss.network.compression &&
+                                ss.network.compression[algo] &&
+                                ss.network.compression[algo].decompressor) {
+                                bytes = ss.network.compression[algo].decompressor.bytesIn;
+                            }
+                            let replBytes = 0;
+                            if (ss.repl && ss.repl.compression && ss.repl.compression[algo] &&
+                                ss.repl.compression[algo].decompressor) {
+                                replBytes = ss.repl.compression[algo].decompressor.bytesIn;
+                            }
+                            snapped = {bytes: bytes, replBytes: replBytes};
+                            return true;
+                        } catch (e) {
+                            // Rollback closes client connections; retry with a fresh connection.
+                            return false;
+                        }
                     },
                     "timed out waiting for bgSyncHangAfterRunRollback failpoint to engage",
                     5 * 60 * 1000,
                 );
-                const ss = assert.commandWorked(rb.adminCommand({serverStatus: 1}));
-                let bytes = 0;
-                if (ss.network && ss.network.compression && ss.network.compression[algo] &&
-                    ss.network.compression[algo].decompressor) {
-                    bytes = ss.network.compression[algo].decompressor.bytesIn;
+                try {
+                    const src = new Mongo(ssHost);
+                    assert.commandWorked(src.getDB("rollback_compress").probe.insert({
+                        _id: "atRollbackHang",
+                        bytes: snapped.bytes,
+                        replBytes: snapped.replBytes,
+                    }));
+                } finally {
+                    // Always release the rollback failpoint (resiliently), else the main thread would
+                    // hang in awaitSecondaryNodes() until the test's global timeout.
+                    assert.soon(
+                        () => {
+                            try {
+                                const rb = new Mongo(rbHost);
+                                return rb.adminCommand({
+                                    configureFailPoint: "bgSyncHangAfterRunRollback",
+                                    mode: "off",
+                                }).ok === 1;
+                            } catch (e) {
+                                return false;
+                            }
+                        },
+                        "failed to release bgSyncHangAfterRunRollback failpoint",
+                        60 * 1000,
+                    );
                 }
-                const src = new Mongo(ssHost);
-                assert.commandWorked(src.getDB("rollback_compress")
-                                         .probe.insert({_id: "atRollbackHang", bytes: bytes}));
-                assert.commandWorked(rb.adminCommand(
-                    {configureFailPoint: "bgSyncHangAfterRunRollback", mode: "off"}));
             },
             rollbackNode.port,
             syncSource.host,
@@ -974,12 +1288,14 @@ function externalClientNegotiatedCompression(host, clientAdvertises) {
         true,
     );
 
-    // Trigger the rollback. This reconnects the partition; the rolling-back node reads the remote
-    // oplog over the rollback connection, hits the failpoint (watcher snapshots + releases), then
-    // resumes and rejoins as a secondary.
-    rollbackTest.transitionToSyncSourceOperationsDuringRollback();
-    rollbackTest.transitionToSteadyStateOperations();
+    // Trigger the rollback WITHOUT a bridge: resume node 0's replication. It syncs from the new
+    // primary, detects the divergent doomed branch (OplogStartMissing), and runs rollback - reading
+    // the sync source's remote oplog over the compressed rollback connection, hitting the failpoint
+    // (watcher snapshots + releases), then rejoining as a secondary.
+    restartServerReplication(rollbackNode);
     awaitWatcher();
+    rst.awaitSecondaryNodes(null, [rollbackNode]);
+    rst.awaitReplication();
 
     const probe = syncSource.getDB("rollback_compress").probe.findOne({_id: "atRollbackHang"});
     assert(probe, "watcher did not record a rollback-hang decompressor snapshot");
@@ -991,17 +1307,36 @@ function externalClientNegotiatedCompression(host, clientAdvertises) {
         `expected the rollback common-point connection to negotiate '${kReplAlgo}' despite ` +
             `net.compression.compressors: disabled (need > ${kMinRollbackRemoteBytes} compressed ` +
             `bytes read from the sync source's remote oplog), but delta was ${delta}. A zero/near-` +
-            `zero delta means the rollback connection was left uncompressed (the SERVER-130410 gap ` +
+            `zero delta means the rollback connection was left uncompressed (the gap ` +
             `in BackgroundSync::_runRollback).`,
     );
 
-    // stop() runs RollbackTest's built-in data-consistency checks, proving the rollback itself
-    // completed correctly under replication-only compression (functional coverage of the path).
-    rollbackTest.stop();
+    const replDelta = probe.replBytes - (replBefore[kReplAlgo] || 0);
+    jsTest.log.info(
+        `[replicationNetworkCompression] rollback repl.compression zstd decompressor delta: ` +
+            `${replDelta}`);
+    assert(
+        replDelta > kMinRollbackRemoteBytes,
+        `expected serverStatus().repl.compression.${kReplAlgo}.decompressor on the rolling-back ` +
+            `node to grow from the rollback common-point connection, but delta was ${replDelta}`,
+    );
+
+    // Data-consistency checks after a rollback performed under replication-only compression prove
+    // the rollback itself completed correctly (functional coverage of the path), and that the doomed
+    // branch was actually discarded.
+    rst.awaitReplication();
+    rst.checkReplicatedDataHashes();
+    rst.checkOplogs();
+    assert.eq(
+        0,
+        rollbackNode.getDB("rollback_compress").doomed.countDocuments({}),
+        "doomed branch was not rolled back off node 0",
+    );
+    rst.stopSet();
 })();
 
 // ---------------------------------------------------------------------------
-// 13. Both disabled (SERVER-130410): net.compression.compressors=disabled AND
+// 13. Both disabled: net.compression.compressors=disabled AND
 //     replicationNetworkCompression=disabled on both nodes. Nothing on the node may negotiate
 //     compression - neither the replication data channel nor client-facing connections. This is the
 //     "fully uncompressed" corner of the net x repl matrix and complements the inherit-under-net-
@@ -1032,8 +1367,10 @@ function externalClientNegotiatedCompression(host, clientAdvertises) {
     rst.awaitReplication();
 
     // Replication channel must be uncompressed: the sync source's compressor must not grow from
-    // fetcher traffic.
+    // fetcher traffic. The dedicated repl.compression counters must also stay flat.
     const before = getCompressorBytesIn(primary);
+    const replCompressorBefore = getReplCompressionBytesIn(primary, "compressor");
+    const replDecompressorBefore = getReplCompressionBytesIn(secondary, "decompressor");
     for (let i = 0; i < 5; ++i) {
         generateOplogTraffic(primary, "netcompress_both_disabled", "c", i);
     }
@@ -1047,6 +1384,22 @@ function externalClientNegotiatedCompression(host, clientAdvertises) {
         grew,
         "with net.compression.compressors=disabled and replicationNetworkCompression=disabled the " +
             "replication channel must be uncompressed; delta: " + tojson(grew),
+    );
+    const replCompressorGrew = decompressorDelta(
+        replCompressorBefore, getReplCompressionBytesIn(primary, "compressor"));
+    const replDecompressorGrew = decompressorDelta(
+        replDecompressorBefore, getReplCompressionBytesIn(secondary, "decompressor"));
+    assert.eq(
+        {},
+        replCompressorGrew,
+        "with both net and replication compression disabled, sync-source repl.compression " +
+            "compressor counters must not grow; delta: " + tojson(replCompressorGrew),
+    );
+    assert.eq(
+        {},
+        replDecompressorGrew,
+        "with both net and replication compression disabled, fetcher repl.compression decompressor " +
+            "counters must not grow; delta: " + tojson(replDecompressorGrew),
     );
 
     // Client-facing connections must also be uncompressed: even advertising a real algorithm, an
@@ -1068,7 +1421,7 @@ function externalClientNegotiatedCompression(host, clientAdvertises) {
 })();
 
 // ---------------------------------------------------------------------------
-// 14. CLI config path (SERVER-130410): the feature is exposed both as a setParameter
+// 14. CLI config path: the feature is exposed both as a setParameter
 //     (replicationNetworkCompression) and as a config option
 //     (replication.networkCompression.compressors, short name replicationNetworkCompressionCompressors,
 //     source: [yaml, cli]). All earlier scenarios drive the setParameter form; this one exercises the
@@ -1113,6 +1466,7 @@ function externalClientNegotiatedCompression(host, clientAdvertises) {
 
     // (b) The replication channel must use the configured algorithm even though net is disabled.
     const before = getCompressorBytesIn(primary);
+    const replBefore = getReplCompressionBytesIn(primary, "compressor");
     for (let i = 0; i < 5; ++i) {
         generateOplogTraffic(primary, "netcompress_config_path", "c", i);
     }
@@ -1127,11 +1481,19 @@ function externalClientNegotiatedCompression(host, clientAdvertises) {
             `replication channel; delta: ${tojson(grew)}`,
     );
 
+    // The replication-data-plane subset must attribute the growth to the configured algorithm.
+    const replGrew = decompressorDelta(replBefore, getReplCompressionBytesIn(primary, "compressor"));
+    assert(
+        replGrew[kReplAlgo] && replGrew[kReplAlgo] > 0,
+        `expected serverStatus().repl.compression.${kReplAlgo}.compressor to grow on the sync ` +
+            `source for the config-supplied compressor; delta: ${tojson(replGrew)}`,
+    );
+
     rst.stopSet();
 })();
 
 // ---------------------------------------------------------------------------
-// 15. Conflicting config + setParameter must be REJECTED (SERVER-130410): storeMongodOptions()
+// 15. Conflicting config + setParameter must be REJECTED: storeMongodOptions()
 //     seeds the setParameter from replication.networkCompression.compressors and calls
 //     checkConflictWithSetParameter(), so supplying BOTH the config option AND an initial
 //     --setParameter replicationNetworkCompression is an ambiguous startup command and must fail
@@ -1153,7 +1515,7 @@ function externalClientNegotiatedCompression(host, clientAdvertises) {
 })();
 
 // ---------------------------------------------------------------------------
-// 16. Unknown / not-compiled algorithm fails startup (SERVER-130410): a syntactically valid but
+// 16. Unknown / not-compiled algorithm fails startup: a syntactically valid but
 //     unregistered compressor name is folded into the process-wide capability union and then caught
 //     by MessageCompressorRegistry::finalizeSupportedCompressors() (AllCompressorsRegistered
 //     initializer), which uassertStatusOK()s a BadValue. This is a HARD startup error, not a silent
@@ -1180,4 +1542,247 @@ function externalClientNegotiatedCompression(host, clientAdvertises) {
         `replicationNetworkCompressionCompressors='${kBogusAlgo}' (config/CLI) must fail startup, ` +
             `not be silently dropped`,
     );
+})();
+
+// ---------------------------------------------------------------------------
+// 17. Replication narrows to a SUBSET of a full net set. Both the net list and the
+//     replication list share a single process-wide capability union; here net advertises the full
+//     snappy,zstd,zlib set to clients while replication narrows to a single algorithm (zstd) that
+//     is ALSO in the net set. This is the "repl is a subset of net" case (distinct from #8, where
+//     the replication algorithm is NOT in the net set). We prove two independent facts:
+//       (a) the replication channel negotiates exactly zstd - even though net ordering would pick
+//           snappy first for any non-replication client - because the fetcher advertises only the
+//           replication allow-list, and
+//       (b) narrowing replication to zstd does NOT shrink the client-facing net set: external
+//           clients advertising snappy or zlib (net members that are NOT the replication algorithm)
+//           still negotiate them, proving the two policies are selected independently from the
+//           shared union.
+// ---------------------------------------------------------------------------
+(function testReplicationNarrowsToSubsetOfFullNetSet() {
+    jsTest.log.info(
+        "[replicationNetworkCompression] subset: net=full union, replication narrows to zstd");
+    const kReplAlgo = "zstd";
+
+    const rst = new ReplSetTest({
+        name: "replication_network_compression_subset_of_full_net",
+        nodes: [
+            {
+                networkMessageCompressors: kProcessCompressors,
+                setParameter: {replicationNetworkCompression: kReplAlgo},
+            },
+            {
+                networkMessageCompressors: kProcessCompressors,
+                setParameter: {replicationNetworkCompression: kReplAlgo},
+            },
+        ],
+    });
+    rst.startSet();
+    rst.initiate();
+
+    const primary = rst.getPrimary();
+    const secondary = rst.getSecondary();
+    rst.awaitReplication();
+
+    // (a) The replication channel used zstd. Because the fetcher advertises only its replication
+    // allow-list ([zstd]), the sync source compresses the oplog it streams with zstd, so its zstd
+    // compressor grows. zstd is in the net set too, but internal (non-replication) clients advertise
+    // the net list in its configured order (snappy first), so heartbeats negotiate snappy - leaving
+    // the zstd growth attributable to the replication fetcher.
+    const before = getCompressorBytesIn(primary);
+    for (let i = 0; i < 5; ++i) {
+        generateOplogTraffic(primary, "netcompress_subset", "c", i);
+    }
+    rst.awaitReplication();
+    const grew = decompressorDelta(before, getCompressorBytesIn(primary));
+    jsTest.log.info(
+        "[replicationNetworkCompression] subset compressor delta on sync source: " + tojson(grew));
+    assert(
+        grew[kReplAlgo] && grew[kReplAlgo] > 0,
+        `expected the replication channel to narrow to '${kReplAlgo}' even though net offered the ` +
+            `full set; delta: ${tojson(grew)}`,
+    );
+    // Pin it: the repl-marked fetcher connection negotiated EXACTLY [zstd], not snappy/zlib, despite
+    // net advertising all three.
+    assert.soon(
+        () => hasReplicationCompressionNegotiationLog(secondary, true, [kReplAlgo]),
+        `replication connection should negotiate exactly [${kReplAlgo}] when replication narrows a ` +
+            `full net set to that subset`,
+    );
+
+    // (b) Narrowing replication to zstd must not remove the other net algorithms from the
+    // client-facing set. External clients advertising snappy or zlib (net members other than the
+    // replication algorithm) still negotiate them; if replication narrowing had wrongly shrunk the
+    // client-facing net set to just zstd, these would return NONE.
+    assert.eq(
+        "snappy",
+        externalClientNegotiatedCompression(secondary.host, "snappy"),
+        "external client advertising snappy must still negotiate snappy: narrowing " +
+            "replication to zstd must not shrink the client-facing net set",
+    );
+    assert.eq(
+        "zlib",
+        externalClientNegotiatedCompression(secondary.host, "zlib"),
+        "external client advertising zlib must still negotiate zlib: narrowing " +
+            "replication to zstd must not shrink the client-facing net set",
+    );
+
+    rst.stopSet();
+})();
+
+// ---------------------------------------------------------------------------
+// 18. Ordered replication list is independent of a single (non-disabled) net algorithm
+//     net advertises ONE algorithm to clients (snappy) while replication uses an
+//     ORDERED list of two OTHER algorithms (zlib,zstd), neither present in the net set. Earlier
+//     ordered-preference coverage (zstd_then_snappy) runs only with net disabled; this exercises
+//     ordering while net compression stays ACTIVE. We prove:
+//       (a) the replication channel picks the FIRST advertised algorithm (zlib) - client-advertised
+//           order is the negotiation preference - and does NOT fall through to the second (zstd),
+//       (b) neither replication-only algorithm is ever offered to external clients (only snappy is),
+//           and
+//       (c) an external client advertising snappy still negotiates snappy.
+//     Because zlib/zstd are NOT in the net set, their compressor growth on the sync source can only
+//     originate from the replication channel (heartbeats use snappy), giving a clean ordering signal.
+// ---------------------------------------------------------------------------
+(function testReplicationOrderedListIndependentOfSingleNetAlgo() {
+    jsTest.log.info(
+        "[replicationNetworkCompression] ordered: net=snappy, replication=zlib,zstd (prefers zlib)");
+    const kNetAlgo = "snappy";
+    const kReplFirst = "zlib";
+    const kReplSecond = "zstd";
+    const kReplList = `${kReplFirst},${kReplSecond}`;
+
+    const rst = new ReplSetTest({
+        name: "replication_network_compression_ordered_independent",
+        nodes: [
+            {
+                networkMessageCompressors: kNetAlgo,
+                setParameter: {replicationNetworkCompression: kReplList},
+            },
+            {
+                networkMessageCompressors: kNetAlgo,
+                setParameter: {replicationNetworkCompression: kReplList},
+            },
+        ],
+    });
+    rst.startSet();
+    rst.initiate();
+
+    const primary = rst.getPrimary();
+    const secondary = rst.getSecondary();
+    rst.awaitReplication();
+
+    // (a) The sync source compresses the oplog stream with the FIRST negotiated compressor (zlib).
+    // zlib and zstd are not in the net set, so only the replication channel could grow either of
+    // their compressors; a growing zlib with a flat zstd proves the client-advertised order won even
+    // while net=snappy stayed enabled.
+    const before = getCompressorBytesIn(primary);
+    for (let i = 0; i < 5; ++i) {
+        generateOplogTraffic(primary, "netcompress_ordered", "c", i);
+    }
+    rst.awaitReplication();
+    const grew = decompressorDelta(before, getCompressorBytesIn(primary));
+    jsTest.log.info(
+        "[replicationNetworkCompression] ordered compressor delta on sync source: " + tojson(grew));
+    assert(
+        grew[kReplFirst] && grew[kReplFirst] > 0,
+        `expected the replication channel to use the first-preference '${kReplFirst}'; delta: ` +
+            `${tojson(grew)}`,
+    );
+    assert(
+        !grew[kReplSecond],
+        `second-preference '${kReplSecond}' must not have carried replication data while ` +
+            `'${kReplFirst}' was available; delta: ${tojson(grew)}`,
+    );
+    // The channel is compressed (repl-marked connection negotiated a non-empty set).
+    assert.soon(
+        () => hasReplicationCompressionNegotiationLog(secondary, true),
+        "replication connection should negotiate a compressed channel for an ordered repl list " +
+            "even under a single non-disabled net algorithm",
+    );
+
+    // (b) The replication-only algorithms must never be offered to external clients.
+    assert.eq(
+        "NONE",
+        externalClientNegotiatedCompression(secondary.host, kReplFirst),
+        `replication-only algorithm '${kReplFirst}' must not be offered to external clients`,
+    );
+    assert.eq(
+        "NONE",
+        externalClientNegotiatedCompression(secondary.host, kReplSecond),
+        `replication-only algorithm '${kReplSecond}' must not be offered to external clients`,
+    );
+    // (c) The net algorithm is still offered to clients.
+    assert.eq(
+        kNetAlgo,
+        externalClientNegotiatedCompression(secondary.host, kNetAlgo),
+        `external client advertising the net algorithm '${kNetAlgo}' must negotiate it`,
+    );
+
+    rst.stopSet();
+})();
+
+// ---------------------------------------------------------------------------
+// 19. Inherit under a single net algorithm. replicationNetworkCompression is left
+//     UNSET (default "" -> inherit net.compression.compressors). #4 covers inherit under the full
+//     net set and #10 covers inherit under net disabled; this pins the remaining inherit corner: a
+//     net set with exactly one algorithm (snappy). The replication channel must inherit and
+//     negotiate that algorithm.
+//
+//     Signal: snappy is the ONLY process-wide algorithm here, so heartbeats also use snappy and the
+//     process-wide snappy compressor counter cannot isolate the replication channel. We therefore
+//     assert via the replication negotiation log (id 10130422), which is emitted ONLY for the
+//     repl-marked fetcher connection and records that connection's negotiated compressors.
+// ---------------------------------------------------------------------------
+(function testInheritFollowsSingleNetAlgo() {
+    jsTest.log.info(
+        "[replicationNetworkCompression] inherit: net=snappy + replication unset -> snappy");
+    const kNetAlgo = "snappy";
+
+    const rst = new ReplSetTest({
+        name: "replication_network_compression_inherit_single_net",
+        nodes: [
+            // Both nodes advertise a single net algorithm and leave replicationNetworkCompression at
+            // its default (""), i.e. inherit the net set on the replication connection.
+            {networkMessageCompressors: kNetAlgo},
+            {networkMessageCompressors: kNetAlgo},
+        ],
+    });
+    rst.startSet();
+    rst.initiate();
+
+    const primary = rst.getPrimary();
+    const secondary = rst.getSecondary();
+    rst.awaitReplication();
+
+    // The repl-marked fetcher connection inherited the net set and negotiated snappy.
+    assert.soon(
+        () => hasReplicationCompressionNegotiationLog(secondary, true, [kNetAlgo]),
+        `inherit under net=${kNetAlgo}: the replication connection should negotiate ${kNetAlgo}`,
+    );
+
+    // Drive traffic and confirm the inherited algorithm is attributed to the replication data plane.
+    const replCompressorBefore = getReplCompressionBytesIn(primary, "compressor");
+    const replDecompressorBefore = getReplCompressionBytesIn(secondary, "decompressor");
+    for (let i = 0; i < 5; ++i) {
+        generateOplogTraffic(primary, "netcompress_inherit_single", "c", i);
+    }
+    rst.awaitReplication();
+    assert.commandWorked(primary.adminCommand({replSetGetStatus: 1}));
+
+    const replCompressorGrew = decompressorDelta(
+        replCompressorBefore, getReplCompressionBytesIn(primary, "compressor"));
+    const replDecompressorGrew = decompressorDelta(
+        replDecompressorBefore, getReplCompressionBytesIn(secondary, "decompressor"));
+    assert(
+        replCompressorGrew[kNetAlgo] && replCompressorGrew[kNetAlgo] > 0,
+        `expected inherited algorithm '${kNetAlgo}' to grow on the sync source's ` +
+            `repl.compression compressor; delta: ${tojson(replCompressorGrew)}`,
+    );
+    assert(
+        replDecompressorGrew[kNetAlgo] && replDecompressorGrew[kNetAlgo] > 0,
+        `expected inherited algorithm '${kNetAlgo}' to grow on the fetcher's ` +
+            `repl.compression decompressor; delta: ${tojson(replDecompressorGrew)}`,
+    );
+
+    rst.stopSet();
 })();

--- a/src/mongo/db/BUILD.bazel
+++ b/src/mongo/db/BUILD.bazel
@@ -403,6 +403,7 @@ mongo_cc_library(
         "//src/mongo/db/repl:replica_set_messages",
         "//src/mongo/db/storage:storage_options",
         "//src/mongo/s:common_s",
+        "//src/mongo/transport:message_compressor",
         "//src/mongo/util/options_parser",
     ],
 )

--- a/src/mongo/db/mongod_options.cpp
+++ b/src/mongo/db/mongod_options.cpp
@@ -25,6 +25,7 @@
 #include "mongo/db/mongod_options_sharding_gen.h"
 #include "mongo/db/mongod_options_storage_gen.h"
 #include "mongo/db/repl/repl_server_parameters_gen.h"
+#include "mongo/db/repl/replication_network_compression.h"
 #include "mongo/db/repl/repl_set_config_params_gen.h"
 #include "mongo/db/repl/repl_settings.h"
 #include "mongo/db/server_feature_flags_gen.h"
@@ -38,6 +39,7 @@
 #include "mongo/db/topology/cluster_role.h"
 #include "mongo/logv2/log.h"
 #include "mongo/platform/atomic.h"
+#include "mongo/transport/message_compressor_registry.h"
 #include "mongo/util/assert_util.h"
 #include "mongo/util/options_parser/startup_options.h"
 #include "mongo/util/str.h"
@@ -553,6 +555,39 @@ Status storeMongodOptions(const moe::Environment& params) {
     if (!replSettingsWithStatus.isOK())
         return replSettingsWithStatus.getStatus();
     const repl::ReplSettings& replSettings(replSettingsWithStatus.getValue());
+
+    // Seed the replicationNetworkCompression setParameter from the YAML/CLI config
+    // replication.networkCompression.compressors, if the operator supplied one. We reject a
+    // conflicting setParameter entry so an inconsistent startup command is refused up front rather
+    // than silently having one form win. The setParameter is startup-only, so once seeded here the
+    // value is fixed for the lifetime of this mongod process.
+    if (params.count("replication.networkCompression.compressors")) {
+        auto conflictStatus = checkConflictWithSetParameter(
+            "replication.networkCompression.compressors", "replicationNetworkCompression");
+        if (!conflictStatus.isOK())
+            return conflictStatus;
+        const auto value =
+            params["replication.networkCompression.compressors"].as<std::string>();
+        repl::ReplicationNetworkCompressionSetting parsed;
+        auto s = repl::parseReplicationNetworkCompression(value, &parsed);
+        if (!s.isOK())
+            return s;
+        *repl::gReplicationNetworkCompression = value;
+    }
+
+    // Fold an explicit replicationNetworkCompression allow-list into the process-wide compressor
+    // union so those algorithms get registered even when net.compression.compressors is "disabled"
+    // (inherit/disabled add nothing). Read the FINAL parameter value, not just
+    // params.count("replication.networkCompression.compressors"), so the --setParameter form is
+    // covered too. Must run here (after net seeding and setParameter application, before compressors
+    // register); moving it into the config-option branch above would skip setParameter and leave
+    // replication compression silently inoperative.
+    {
+        const auto setting = repl::getReplicationNetworkCompressionSetting();
+        if (!setting.disabled && !setting.inheritProcessDefault) {
+            MessageCompressorRegistry::get().addReplicationCompressors(setting.allowList);
+        }
+    }
 
     if (replSettings.isReplSet()) {
         if ((params.count("security.authorization") &&

--- a/src/mongo/db/mongod_options_replication.idl
+++ b/src/mongo/db/mongod_options_replication.idl
@@ -80,3 +80,27 @@ configs:
         arg_vartype: Bool
         short_name: serverless
         source: [yaml, cli]
+
+    #
+    # SERVER-130410: replication-specific network compression control, negotiated independently
+    # of the client-facing net.compression.compressors. Value semantics:
+    #   ""         -> inherit process-wide net.compression.compressors (default)
+    #   "disabled" -> negotiate replication data-plane connections uncompressed
+    #   "a,b,c"    -> use exactly these algorithms for replication data-plane connections, even if
+    #                 net.compression.compressors is "disabled"
+    # Algorithms listed here are merged into the process-wide capability set at startup so they get
+    # registered and can be decoded regardless of net.compression.compressors. This option is
+    # startup-only; the equivalent setParameter (replicationNetworkCompression) is likewise
+    # startup-only. Changing the algorithm requires editing the configuration and restarting mongod.
+    #
+    "replication.networkCompression.compressors":
+        section: "Replica set options"
+        description: >-
+            Comma-separated compressor list for replication data-plane sync-source connections.
+            Empty/default inherits net.compression.compressors; "disabled" negotiates these
+            connections uncompressed. Explicit algorithms are independent of
+            net.compression.compressors and may be used even when net compression is disabled.
+            Startup-only.
+        short_name: replicationNetworkCompressionCompressors
+        arg_vartype: String
+        source: [yaml, cli]

--- a/src/mongo/db/mongod_options_replication.idl
+++ b/src/mongo/db/mongod_options_replication.idl
@@ -82,7 +82,7 @@ configs:
         source: [yaml, cli]
 
     #
-    # SERVER-130410: replication-specific network compression control, negotiated independently
+    # replication-specific network compression control, negotiated independently
     # of the client-facing net.compression.compressors. Value semantics:
     #   ""         -> inherit process-wide net.compression.compressors (default)
     #   "disabled" -> negotiate replication data-plane connections uncompressed

--- a/src/mongo/db/repl/BUILD.bazel
+++ b/src/mongo/db/repl/BUILD.bazel
@@ -324,14 +324,17 @@ mongo_cc_library(
     name = "repl_server_parameters",
     srcs = [
         "oplog_application_steady_state.cpp",
+        "replication_network_compression.cpp",
         ":repl_server_parameters_gen",
     ],
     hdrs = [
         "oplog_application_steady_state.h",
+        "replication_network_compression.h",
     ],
     deps = [
         "//src/mongo/client:read_preference",
         "//src/mongo/db:server_base",
+        "//src/mongo/transport:message_compressor",
     ],
 )
 
@@ -1118,6 +1121,7 @@ mongo_cc_library(
         ":oplog",
         ":primary_only_service",
         ":repl_coordinator_interface",
+        ":repl_server_parameters",
         ":repl_settings",
         ":replica_set_messages",
         ":replication_auth",
@@ -1858,6 +1862,7 @@ mongo_cc_unit_test(
         "read_concern_args_test.cpp",
         "repl_client_info_test.cpp",
         "repl_set_write_concern_mode_definitions_test.cpp",
+        "replication_network_compression_test.cpp",
         "replication_process_test.cpp",
         "reporter_test.cpp",
         "scatter_gather_test.cpp",
@@ -1940,6 +1945,7 @@ mongo_cc_unit_test(
         "//src/mongo/executor:network_interface_thread_pool",
         "//src/mongo/executor:thread_pool_task_executor_test_fixture",
         "//src/mongo/rpc:command_status",
+        "//src/mongo/transport:message_compressor",
         "//src/mongo/transport:transport_layer_mock",
         "//src/mongo/unittest",
         "//src/mongo/unittest:task_executor_proxy",

--- a/src/mongo/db/repl/bgsync.cpp
+++ b/src/mongo/db/repl/bgsync.cpp
@@ -25,6 +25,7 @@
 #include "mongo/db/repl/repl_server_parameters_gen.h"
 #include "mongo/db/repl/replication_coordinator.h"
 #include "mongo/db/repl/replication_coordinator_external_state.h"
+#include "mongo/db/repl/replication_network_compression.h"
 #include "mongo/db/repl/replication_process.h"
 #include "mongo/db/repl/storage_interface.h"
 #include "mongo/db/repl/sync_source_selector.h"
@@ -722,6 +723,15 @@ void BackgroundSync::_runRollback(OperationContext* opCtx,
     auto getConnection = [&connection, source]() -> DBClientBase* {
         if (!connection) {
             connection = std::make_unique<DBClientConnection>();
+            // SERVER-130410: the rollback common-point search reads the sync source's remote oplog
+            // over this connection (via OplogInterfaceRemote), so it is a replication data-plane
+            // connection just like the oplog fetcher and the initial-sync cloner. Apply the same
+            // node-local replicationNetworkCompression policy before the "hello" handshake runs so
+            // rollback traffic negotiates compression identically to those connections (and, in
+            // particular, honors replication.networkCompression.compressors even when
+            // net.compression.compressors is "disabled"). Must be set before connect() below, which
+            // is where DBClientConnection sends "hello".
+            applyReplicationNetworkCompressionToManager(connection->getCompressorManager());
             connection->setSoTimeout(durationCount<Milliseconds>(kRollbackOplogSocketTimeout) /
                                      1000.0);
             connection->connect(source, "Rollback"sv, boost::none);

--- a/src/mongo/db/repl/bgsync.cpp
+++ b/src/mongo/db/repl/bgsync.cpp
@@ -723,14 +723,9 @@ void BackgroundSync::_runRollback(OperationContext* opCtx,
     auto getConnection = [&connection, source]() -> DBClientBase* {
         if (!connection) {
             connection = std::make_unique<DBClientConnection>();
-            // SERVER-130410: the rollback common-point search reads the sync source's remote oplog
-            // over this connection (via OplogInterfaceRemote), so it is a replication data-plane
-            // connection just like the oplog fetcher and the initial-sync cloner. Apply the same
-            // node-local replicationNetworkCompression policy before the "hello" handshake runs so
-            // rollback traffic negotiates compression identically to those connections (and, in
-            // particular, honors replication.networkCompression.compressors even when
-            // net.compression.compressors is "disabled"). Must be set before connect() below, which
-            // is where DBClientConnection sends "hello".
+            // Rollback reads the sync source's remote oplog over this connection, so treat it as
+            // replication data-plane traffic. Apply the replication compression policy before
+            // connect(), where DBClientConnection sends hello and negotiates compression.
             applyReplicationNetworkCompressionToManager(connection->getCompressorManager());
             connection->setSoTimeout(durationCount<Milliseconds>(kRollbackOplogSocketTimeout) /
                                      1000.0);

--- a/src/mongo/db/repl/bgsync.h
+++ b/src/mongo/db/repl/bgsync.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include <string_view>
 
 #include "mongo/base/status.h"
 #include "mongo/bson/bsonobj.h"

--- a/src/mongo/db/repl/bgsync.h
+++ b/src/mongo/db/repl/bgsync.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <string_view>
+
 #include "mongo/base/status.h"
 #include "mongo/bson/bsonobj.h"
 #include "mongo/db/operation_context.h"

--- a/src/mongo/db/repl/hello/hello.idl
+++ b/src/mongo/db/repl/hello/hello.idl
@@ -287,12 +287,9 @@ commands:
                 optional: true
                 stability: stable
             replicationCompressionClient:
-                # SERVER-130410: set to true by the replication oplog fetcher, initial-sync cloner,
-                # and rollback remote oplog reader so the server negotiates wire compression for
-                # this connection using replication.networkCompression.compressors instead of
-                # net.compression.compressors. Absent on all other connections (external clients,
-                # heartbeats, shard RPC), which
-                # continue to use net.compression.compressors.
+                # Set by replication data-plane clients so the server applies the replication
+                # compression policy for this connection. Absent on external clients, heartbeats,
+                # and shard RPC, which continue using the normal net.compression policy.
                 type: safeBool
                 optional: true
                 stability: internal

--- a/src/mongo/db/repl/hello/hello.idl
+++ b/src/mongo/db/repl/hello/hello.idl
@@ -286,6 +286,16 @@ commands:
                 type: HelloInternalClientField
                 optional: true
                 stability: stable
+            replicationCompressionClient:
+                # SERVER-130410: set to true by the replication oplog fetcher, initial-sync cloner,
+                # and rollback remote oplog reader so the server negotiates wire compression for
+                # this connection using replication.networkCompression.compressors instead of
+                # net.compression.compressors. Absent on all other connections (external clients,
+                # heartbeats, shard RPC), which
+                # continue to use net.compression.compressors.
+                type: safeBool
+                optional: true
+                stability: internal
             client:
                 type: ClientMetadata
                 optional: true

--- a/src/mongo/db/repl/initial_sync/all_database_cloner.cpp
+++ b/src/mongo/db/repl/initial_sync/all_database_cloner.cpp
@@ -107,14 +107,10 @@ Status AllDatabaseCloner::ensurePrimaryOrSecondary(
 
 BaseCloner::AfterStageBehavior AllDatabaseCloner::connectStage() {
     auto* client = getClient();
-    // SERVER-130410: apply the node-local replicationNetworkCompression setting to the cloner's
-    // sync-source connection before the handshake runs, using the exact same helper (and thus the
-    // exact same policy) as the oplog fetcher. This is what extends replication-only compressor
-    // negotiation to the bulk collection-data transfer of initial sync, not just the oplog stream.
-    // It must run before connect()/ensureConnection() below (which is where DBClientConnection
-    // sends "hello"). The setting is startup-only, so re-applying it on every connectStage()
-    // invocation is idempotent; doing so mirrors the fetcher and keeps the manager state
-    // consistent across in-attempt reconnects.
+    // Initial sync clones collection data from the sync source, so treat this connection as
+    // replication data-plane traffic. Apply the replication compression policy before
+    // connect()/ensureConnection(), where DBClientConnection sends hello and negotiates compression.
+    // Reapplying is safe across reconnects because it resets this manager's per-session state.
     applyReplicationNetworkCompressionToManager(client->getCompressorManager());
     // If the client already has the address (from a previous attempt), we must allow it to
     // handle the reconnect itself. This is necessary to get correct backoff behavior.

--- a/src/mongo/db/repl/initial_sync/all_database_cloner.cpp
+++ b/src/mongo/db/repl/initial_sync/all_database_cloner.cpp
@@ -22,6 +22,7 @@
 #include "mongo/db/repl/replication_consistency_markers_gen.h"
 #include "mongo/db/repl/replication_consistency_markers_impl.h"
 #include "mongo/db/repl/replication_coordinator.h"
+#include "mongo/db/repl/replication_network_compression.h"
 #include "mongo/db/server_options.h"
 #include "mongo/db/service_context.h"
 #include "mongo/db/tenant_id.h"
@@ -106,6 +107,15 @@ Status AllDatabaseCloner::ensurePrimaryOrSecondary(
 
 BaseCloner::AfterStageBehavior AllDatabaseCloner::connectStage() {
     auto* client = getClient();
+    // SERVER-130410: apply the node-local replicationNetworkCompression setting to the cloner's
+    // sync-source connection before the handshake runs, using the exact same helper (and thus the
+    // exact same policy) as the oplog fetcher. This is what extends replication-only compressor
+    // negotiation to the bulk collection-data transfer of initial sync, not just the oplog stream.
+    // It must run before connect()/ensureConnection() below (which is where DBClientConnection
+    // sends "hello"). The setting is startup-only, so re-applying it on every connectStage()
+    // invocation is idempotent; doing so mirrors the fetcher and keeps the manager state
+    // consistent across in-attempt reconnects.
+    applyReplicationNetworkCompressionToManager(client->getCompressorManager());
     // If the client already has the address (from a previous attempt), we must allow it to
     // handle the reconnect itself. This is necessary to get correct backoff behavior.
     if (client->getServerHostAndPort() != getSource()) {

--- a/src/mongo/db/repl/oplog_fetcher.cpp
+++ b/src/mongo/db/repl/oplog_fetcher.cpp
@@ -484,18 +484,10 @@ Status OplogFetcher::_connect() {
         if (_isShuttingDown()) {
             return Status(ErrorCodes::CallbackCanceled, "oplog fetcher shutting down");
         }
-        // SERVER-130410: apply the node-local replicationNetworkCompression setting to this
-        // fetcher's sync-source connection before the handshake runs. This is a purely
-        // client-side decision: we simply narrow (or suppress) the "compression" array in the
-        // hello sent by DBClientConnection, so the connection is negotiated using the operator's
-        // chosen subset (or uncompressed). Because the same DBClientConnection instance (and
-        // therefore the same MessageCompressorManager instance) is reused across auto-reconnects,
-        // we re-apply the setting on every loop iteration to keep the manager state consistent;
-        // the setting itself is startup-only, so this is idempotent on a running mongod. This
-        // does not disable client-facing compression on this node, and it does not require any
-        // server-side change. The initial-sync collection cloner applies the very same helper on
-        // its own connection (AllDatabaseCloner::connectStage) so both replication client
-        // connections share one policy.
+        // Oplog fetching is replication data-plane traffic, so apply the replication compression
+        // policy before connect()/ensureConnection(), where DBClientConnection sends hello and
+        // negotiates compression. Reapplying is safe across reconnects because it resets this
+        // manager's per-session state.
         applyReplicationNetworkCompressionToManager(_conn->getCompressorManager());
         connectStatus = [&] {
             try {

--- a/src/mongo/db/repl/oplog_fetcher.cpp
+++ b/src/mongo/db/repl/oplog_fetcher.cpp
@@ -34,6 +34,7 @@
 #include "mongo/db/repl/repl_network_traffic_stats.h"
 #include "mongo/db/repl/repl_server_parameters_gen.h"
 #include "mongo/db/repl/replication_auth.h"
+#include "mongo/db/repl/replication_network_compression.h"
 #include "mongo/db/repl/replication_process.h"
 #include "mongo/db/repl/sync_source_selector.h"
 #include "mongo/db/service_context.h"
@@ -483,6 +484,19 @@ Status OplogFetcher::_connect() {
         if (_isShuttingDown()) {
             return Status(ErrorCodes::CallbackCanceled, "oplog fetcher shutting down");
         }
+        // SERVER-130410: apply the node-local replicationNetworkCompression setting to this
+        // fetcher's sync-source connection before the handshake runs. This is a purely
+        // client-side decision: we simply narrow (or suppress) the "compression" array in the
+        // hello sent by DBClientConnection, so the connection is negotiated using the operator's
+        // chosen subset (or uncompressed). Because the same DBClientConnection instance (and
+        // therefore the same MessageCompressorManager instance) is reused across auto-reconnects,
+        // we re-apply the setting on every loop iteration to keep the manager state consistent;
+        // the setting itself is startup-only, so this is idempotent on a running mongod. This
+        // does not disable client-facing compression on this node, and it does not require any
+        // server-side change. The initial-sync collection cloner applies the very same helper on
+        // its own connection (AllDatabaseCloner::connectStage) so both replication client
+        // connections share one policy.
+        applyReplicationNetworkCompressionToManager(_conn->getCompressorManager());
         connectStatus = [&] {
             try {
                 if (!connectStatus.isOK()) {

--- a/src/mongo/db/repl/repl_server_parameters.idl
+++ b/src/mongo/db/repl/repl_server_parameters.idl
@@ -393,7 +393,10 @@ server_parameters:
             This node-local startup-only policy applies both when this node fetches replication data
             and when another member fetches replication data from this node. It can be set via the
             command line, replication.networkCompression.compressors in YAML, or initial
-            --setParameter.
+            --setParameter. In a mixed-version replica set, an older binary's fetcher does not send
+            the replicationCompressionClient hello marker, so this node treats that connection as an
+            ordinary internal connection and negotiates it against net.compression.compressors
+            instead of this policy.
         set_at: [startup]
         cpp_vartype: synchronized_value<std::string>
         cpp_varname: gReplicationNetworkCompression

--- a/src/mongo/db/repl/repl_server_parameters.idl
+++ b/src/mongo/db/repl/repl_server_parameters.idl
@@ -382,35 +382,18 @@ server_parameters:
 
     replicationNetworkCompression:
         description: >-
-            Controls whether, and with which algorithm(s), replication data-plane sync-source
-            connections (the oplog fetcher, the initial-sync collection cloner, and rollback remote
-            oplog reads) advertise wire compression. It affects ONLY those replication data-plane
-            connections: other internal connections such as replica-set heartbeats and
-            sharded-cluster RPC continue to use
-            net.compression.compressors, exactly as before this option existed. Accepted values:
-              ""         - (default) inherit process-wide net.compression.compressors; the
-                           replication data-plane connection is negotiated identically to any other
-                           outbound connection on this node.
-              "disabled" - do not advertise any compressor. The replication data-plane connection is
-                           negotiated uncompressed regardless of net.compression.compressors.
-              "<name>[,<name>...]" - advertise only the listed algorithms (e.g. "snappy",
-                           "zstd", "zlib", or "zstd,snappy"). Names must be part of the process-wide
-                           capability set (the union of net.compression.compressors and the
-                           replication.networkCompression.compressors provided at startup); names
-                           outside that union are dropped. If the filtered list is empty the
-                           connection is negotiated uncompressed. The listed order is the client
-                           preference order sent in the "hello" handshake.
-            This is a node-local replication data-plane policy: when this node fetches oplog or
-            cloned collection data from a sync source, it controls what the local replication client
-            advertises; when another replica set member fetches data from this node, it controls
-            what this node is willing to accept for that replication-marked connection. It does not
-            change the ability of this node to
-            accept ordinary client-facing compressed connections. This option is startup-only: it
-            can be set via the command line, the YAML config file
-            (replication.networkCompression.compressors) or an initial --setParameter, but cannot
-            be changed at runtime. Changing the algorithm requires editing the configuration and
-            restarting mongod so that the requested algorithms are registered in the process-wide
-            capability set. See SERVER-130410.
+            Controls wire compression for replication data-plane connections (oplog fetcher,
+            initial-sync collection cloner, and rollback remote oplog reads). Other connections,
+            including heartbeats, shard RPC, and external clients, continue to use
+            net.compression.compressors. Accepted values:
+              ""         - (default) inherit net.compression.compressors.
+              "disabled" - negotiate replication data-plane connections uncompressed.
+              "<name>[,<name>...]" - use only the listed compressors, in client preference order.
+                           Unknown or not-compiled compressors are startup errors.
+            This node-local startup-only policy applies both when this node fetches replication data
+            and when another member fetches replication data from this node. It can be set via the
+            command line, replication.networkCompression.compressors in YAML, or initial
+            --setParameter.
         set_at: [startup]
         cpp_vartype: synchronized_value<std::string>
         cpp_varname: gReplicationNetworkCompression

--- a/src/mongo/db/repl/repl_server_parameters.idl
+++ b/src/mongo/db/repl/repl_server_parameters.idl
@@ -36,6 +36,8 @@ global:
         - "mongo/client/read_preference_validators.h"
         - "mongo/db/repl/repl_worker_pool_thread_count.h"
         - "mongo/db/repl/oplog_application_steady_state.h"
+        - "mongo/db/repl/replication_network_compression.h"
+        - "mongo/util/synchronized_value.h"
 
 imports:
     - "mongo/db/basic_types.idl"
@@ -376,6 +378,45 @@ server_parameters:
         default: 5
         validator:
             gte: 0
+        redact: false
+
+    replicationNetworkCompression:
+        description: >-
+            Controls whether, and with which algorithm(s), replication data-plane sync-source
+            connections (the oplog fetcher, the initial-sync collection cloner, and rollback remote
+            oplog reads) advertise wire compression. It affects ONLY those replication data-plane
+            connections: other internal connections such as replica-set heartbeats and
+            sharded-cluster RPC continue to use
+            net.compression.compressors, exactly as before this option existed. Accepted values:
+              ""         - (default) inherit process-wide net.compression.compressors; the
+                           replication data-plane connection is negotiated identically to any other
+                           outbound connection on this node.
+              "disabled" - do not advertise any compressor. The replication data-plane connection is
+                           negotiated uncompressed regardless of net.compression.compressors.
+              "<name>[,<name>...]" - advertise only the listed algorithms (e.g. "snappy",
+                           "zstd", "zlib", or "zstd,snappy"). Names must be part of the process-wide
+                           capability set (the union of net.compression.compressors and the
+                           replication.networkCompression.compressors provided at startup); names
+                           outside that union are dropped. If the filtered list is empty the
+                           connection is negotiated uncompressed. The listed order is the client
+                           preference order sent in the "hello" handshake.
+            This is a node-local replication data-plane policy: when this node fetches oplog or
+            cloned collection data from a sync source, it controls what the local replication client
+            advertises; when another replica set member fetches data from this node, it controls
+            what this node is willing to accept for that replication-marked connection. It does not
+            change the ability of this node to
+            accept ordinary client-facing compressed connections. This option is startup-only: it
+            can be set via the command line, the YAML config file
+            (replication.networkCompression.compressors) or an initial --setParameter, but cannot
+            be changed at runtime. Changing the algorithm requires editing the configuration and
+            restarting mongod so that the requested algorithms are registered in the process-wide
+            capability set. See SERVER-130410.
+        set_at: [startup]
+        cpp_vartype: synchronized_value<std::string>
+        cpp_varname: gReplicationNetworkCompression
+        default: ""
+        validator:
+            callback: validateReplicationNetworkCompression
         redact: false
 
     oplogApplicationEnforcesSteadyStateConstraints:

--- a/src/mongo/db/repl/replication_info.cpp
+++ b/src/mongo/db/repl/replication_info.cpp
@@ -61,6 +61,7 @@
 #include "mongo/rpc/topology_version_gen.h"
 #include "mongo/transport/hello_metrics.h"
 #include "mongo/transport/message_compressor_manager.h"
+#include "mongo/transport/message_compressor_registry.h"
 #include "mongo/transport/session.h"
 #include "mongo/util/assert_util.h"
 #include "mongo/util/clock_source.h"
@@ -269,6 +270,13 @@ public:
                 result);
         }
 
+        // replication-data-plane view of network compression. Same shape as
+        // serverStatus().network.compression, but the byte counters include only traffic on
+        // replication-marked connections (oplog fetcher, initial-sync cloner, rollback remote oplog
+        // reader, and this node's oplog responses to its secondaries). Reported as a subset view:
+        // the same bytes are still present in network.compression.
+        appendReplicationMessageCompressionStats(&result);
+
         return result.obj();
     }
 };
@@ -439,21 +447,11 @@ public:
         // line.
         auto result = replyBuilder->getBodyBuilder();
         if (opCtx->getClient()->session()) {
-            // SERVER-130410: negotiate compression using a candidate set that depends on the
-            // connection type so that net.compression.compressors (client-facing) and
-            // replication.networkCompression.compressors negotiate independently. The oplog fetcher,
-            // initial-sync cloner, and rollback remote oplog reader tag their pre-auth hello with
-            // "replicationCompressionClient" so the sync-source data-plane connection uses the
-            // replication candidate set; other connections normally omit that marker and fall back
-            // to the net set inside serverNegotiate(),
-            // matching pre-SERVER-130410 behavior.
-            //
-            // This marker is a routing hint, not an authorization boundary: hello is pre-auth and
-            // the internalClient field is also client-supplied. A peer that spoofs both fields can
-            // at most select the compressor policy for its own connection; it still cannot access
-            // replication data without completing the normal internal (__system) authentication.
-            // The compressor-id permit list in MessageCompressorManager remains the wire-level
-            // guard that prevents out-of-domain compressors on a negotiated connection.
+            // Choose the server-side compressor candidate set per connection. Replication
+            // data-plane clients send replicationCompressionClient so their sync-source connection
+            // can use the replication compression policy; all other connections use net.compression.
+            // The marker is only a negotiation hint: replication data access still requires normal
+            // internal authentication.
             const bool isReplicationCompressionClient =
                 isInternalClient && cmd.getReplicationCompressionClient().value_or(false);
             boost::optional<std::vector<std::string>> replCompressorAllowList;
@@ -469,8 +467,12 @@ public:
                 // inheritProcessDefault: leave disengaged so serverNegotiate() uses the net set
                 // (the replication connection inherits net.compression.compressors).
             }
-            MessageCompressorManager::forSession(opCtx->getClient()->session())
-                .serverNegotiate(cmd.getCompression(), &result, replCompressorAllowList);
+            auto& mgr = MessageCompressorManager::forSession(opCtx->getClient()->session());
+            // Count server-side compressed bytes for replication-marked connections under
+            // serverStatus().repl.compression. This is accounting-only; the inbound server-side
+            // manager does not emit client hello markers.
+            mgr.countAsReplicationCompressionTrafficForThisSession(isReplicationCompressionClient);
+            mgr.serverNegotiate(cmd.getCompression(), &result, replCompressorAllowList);
         }
 
         bool isInitialHandshake = false;

--- a/src/mongo/db/repl/replication_info.cpp
+++ b/src/mongo/db/repl/replication_info.cpp
@@ -32,6 +32,7 @@
 #include "mongo/db/repl/read_concern_level.h"
 #include "mongo/db/repl/repl_set_config.h"
 #include "mongo/db/repl/replication_coordinator.h"
+#include "mongo/db/repl/replication_network_compression.h"
 #include "mongo/db/repl/replication_process.h"
 #include "mongo/db/repl/split_horizon/split_horizon.h"
 #include "mongo/db/server_options.h"
@@ -430,17 +431,47 @@ public:
             connectionTagsToSet |= Client::kKeepOpen;
         }
 
+        auto client = opCtx->getClient();
+        const auto internalClient = cmd.getInternalClient();
+        const bool isInternalClient = internalClient.has_value();
+
         // Negotiate compressors before logging metadata so we can include the result in the log
         // line.
         auto result = replyBuilder->getBodyBuilder();
         if (opCtx->getClient()->session()) {
+            // SERVER-130410: negotiate compression using a candidate set that depends on the
+            // connection type so that net.compression.compressors (client-facing) and
+            // replication.networkCompression.compressors negotiate independently. The oplog fetcher,
+            // initial-sync cloner, and rollback remote oplog reader tag their pre-auth hello with
+            // "replicationCompressionClient" so the sync-source data-plane connection uses the
+            // replication candidate set; other connections normally omit that marker and fall back
+            // to the net set inside serverNegotiate(),
+            // matching pre-SERVER-130410 behavior.
+            //
+            // This marker is a routing hint, not an authorization boundary: hello is pre-auth and
+            // the internalClient field is also client-supplied. A peer that spoofs both fields can
+            // at most select the compressor policy for its own connection; it still cannot access
+            // replication data without completing the normal internal (__system) authentication.
+            // The compressor-id permit list in MessageCompressorManager remains the wire-level
+            // guard that prevents out-of-domain compressors on a negotiated connection.
+            const bool isReplicationCompressionClient =
+                isInternalClient && cmd.getReplicationCompressionClient().value_or(false);
+            boost::optional<std::vector<std::string>> replCompressorAllowList;
+            if (isReplicationCompressionClient) {
+                auto setting = repl::getReplicationNetworkCompressionSetting();
+                if (setting.disabled) {
+                    // Force uncompressed for the replication connection regardless of
+                    // net.compression.
+                    replCompressorAllowList.emplace();
+                } else if (!setting.inheritProcessDefault) {
+                    replCompressorAllowList.emplace(std::move(setting.allowList));
+                }
+                // inheritProcessDefault: leave disengaged so serverNegotiate() uses the net set
+                // (the replication connection inherits net.compression.compressors).
+            }
             MessageCompressorManager::forSession(opCtx->getClient()->session())
-                .serverNegotiate(cmd.getCompression(), &result);
+                .serverNegotiate(cmd.getCompression(), &result, replCompressorAllowList);
         }
-
-        auto client = opCtx->getClient();
-        const auto internalClient = cmd.getInternalClient();
-        const bool isInternalClient = internalClient.has_value();
 
         bool isInitialHandshake = false;
         if (ClientMetadata::tryFinalize(client)) {

--- a/src/mongo/db/repl/replication_info.cpp
+++ b/src/mongo/db/repl/replication_info.cpp
@@ -471,7 +471,17 @@ public:
             // Count server-side compressed bytes for replication-marked connections under
             // serverStatus().repl.compression. This is accounting-only; the inbound server-side
             // manager does not emit client hello markers.
-            mgr.countAsReplicationCompressionTrafficForThisSession(isReplicationCompressionClient);
+            //
+            // The replicationCompressionClient marker is only present on the initial data-plane
+            // handshake hello. A replication connection's later hellos (topology monitoring /
+            // awaitable isMaster) do NOT carry the marker, so an unconditional assignment here would
+            // reset the flag to false on the very next monitoring hello and the sync source would
+            // stop attributing its oplog-response compression to repl.compression. The connection's
+            // role is fixed for its lifetime, so make the flag STICKY: only ever set it true, never
+            // clear it from a subsequent non-marker hello.
+            if (isReplicationCompressionClient) {
+                mgr.countAsReplicationCompressionTrafficForThisSession(true);
+            }
             mgr.serverNegotiate(cmd.getCompression(), &result, replCompressorAllowList);
         }
 

--- a/src/mongo/db/repl/replication_network_compression.cpp
+++ b/src/mongo/db/repl/replication_network_compression.cpp
@@ -71,11 +71,15 @@ Status parseReplicationNetworkCompression(std::string_view value,
                                           ReplicationNetworkCompressionSetting* out) {
     *out = ReplicationNetworkCompressionSetting{};
 
-    const std::string trimmed = trim(value);
-    if (trimmed.empty()) {
+    // Only a truly empty value inherits the process default. A non-empty value that is only
+    // whitespace/separators is an explicit (mis)configuration and must fail below rather than be
+    // silently treated as inherit, matching the "does not contain any compressor names" rejection.
+    if (value.empty()) {
         out->inheritProcessDefault = true;
         return Status::OK();
     }
+
+    const std::string trimmed = trim(value);
 
     // Any non-empty value is an explicit override of the process default. The struct defaults to
     // inherit=true, so clear it before returning from either the disabled or allow-list branches.
@@ -89,13 +93,8 @@ Status parseReplicationNetworkCompression(std::string_view value,
         return Status::OK();
     }
 
-    // Comma-separated list of compressor names. Empty segments (e.g. from a trailing comma such as
-    // "snappy,") are tolerated and ignored; duplicates are deduplicated while preserving first-seen
-    // order (client-advertised order is the negotiation preference order, so keeping the
-    // first occurrence gives the operator predictable ordering). Note: a truly empty value ("") was
-    // already handled above as "inherit"; here 'trimmed' is non-empty, so an input consisting solely
-    // of separators (e.g. "," or ",,") is a malformed list and is rejected below rather than being
-    // silently downgraded to inherit, which would hide a configuration typo.
+    // Parse comma-separated compressor names. Empty segments are ignored, duplicates are removed
+    // while preserving first-seen order, and a non-empty value with no names is rejected.
     std::vector<std::string> parsed;
     size_t start = 0;
     while (start <= trimmed.size()) {
@@ -120,10 +119,8 @@ Status parseReplicationNetworkCompression(std::string_view value,
     }
 
     if (parsed.empty()) {
-        // 'trimmed' was non-empty (the empty "" case is handled earlier as inherit) yet produced no
-        // names, i.e. the value was nothing but separators/whitespace (e.g. "," or ", ,"). Reject it
-        // as malformed rather than silently treating it as inherit, so an operator's typo surfaces
-        // immediately instead of quietly leaving replication compression at the process default.
+        // Reject non-empty values that contained only separators/whitespace instead of treating
+        // them as inherit, so configuration typos surface at startup.
         return {ErrorCodes::BadValue,
                 str::stream() << "replicationNetworkCompression: '" << value
                               << "' does not contain any compressor names"};
@@ -141,15 +138,9 @@ Status validateReplicationNetworkCompression(std::string_view value,
 
 ReplicationNetworkCompressionSetting getReplicationNetworkCompressionSetting() {
     ReplicationNetworkCompressionSetting result;
-    // synchronized_value<std::string> exposes a locked accessor via operator*; take a snapshot
-    // as a plain std::string so we don't hold the lock while parsing.
+    // Take a plain std::string snapshot so we don't hold the synchronized_value lock while parsing.
     std::string snapshot = *gReplicationNetworkCompression;
-    // The value can only be set at startup (set_at: [startup]) and is checked by
-    // validateReplicationNetworkCompression before it is stored, so by the time replication reads
-    // it here it MUST parse cleanly. A parse failure therefore means the invariant was violated
-    // (e.g. a future code path wrote gReplicationNetworkCompression directly, bypassing the
-    // validator). Fail loudly with the offending value rather than silently degrading to "inherit
-    // process default", which would mask the bug and could change compression behavior invisibly.
+    // Startup validation should guarantee this parses; fail loudly if that invariant is broken.
     auto status = parseReplicationNetworkCompression(snapshot, &result);
     tassert(10130420,
             str::stream() << "stored replicationNetworkCompression value did not parse: '"
@@ -160,10 +151,11 @@ ReplicationNetworkCompressionSetting getReplicationNetworkCompressionSetting() {
 
 void applyReplicationNetworkCompressionToManager(MessageCompressorManager& mgr) {
     auto setting = getReplicationNetworkCompressionSetting();
-    // SERVER-130410: mark this connection as a replication client so the server routes it (and only
-    // it) through the replication candidate set. This must be set in every branch below, including
-    // "inherit", so heartbeats / shard RPC (which never call this helper) stay on the net set.
+    // Mark replication data-plane connections so hello carries the replication marker and compressed
+    // bytes are counted under serverStatus().repl.compression. Other internal connections do not
+    // call this helper and continue using the normal net.compression policy.
     mgr.markReplicationClientForThisSession(true);
+    mgr.countAsReplicationCompressionTrafficForThisSession(true);
     if (setting.inheritProcessDefault) {
         // Advertise the process-wide net.compression.compressors list: clear any per-session
         // suppression and allow-list left over from a previous (re)connect.

--- a/src/mongo/db/repl/replication_network_compression.cpp
+++ b/src/mongo/db/repl/replication_network_compression.cpp
@@ -1,0 +1,185 @@
+/**
+ *    Copyright (C) 2026-present MongoDB, Inc.
+ *
+ *    This program is free software: you can redistribute it and/or modify
+ *    it under the terms of the Server Side Public License, version 1,
+ *    as published by MongoDB, Inc.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    Server Side Public License for more details.
+ *
+ *    You should have received a copy of the Server Side Public License
+ *    along with this program. If not, see
+ *    <http://www.mongodb.com/licensing/server-side-public-license>.
+ *
+ *    As a special exception, the copyright holders give permission to link the
+ *    code of portions of this program with the OpenSSL library under certain
+ *    conditions as described in each individual source file and distribute
+ *    linked combinations including the program with the OpenSSL library. You
+ *    must comply with the Server Side Public License in all respects for
+ *    all of the code used other than as permitted herein. If you modify file(s)
+ *    with this exception, you may extend this exception to your version of the
+ *    file(s), but you are not obligated to do so. If you do not wish to do so,
+ *    delete this exception statement from your version. If you delete this
+ *    exception statement from all source files in the program, then also delete
+ *    it in the license file.
+ */
+
+#include "mongo/db/repl/replication_network_compression.h"
+
+#include "mongo/base/error_codes.h"
+#include "mongo/db/repl/repl_server_parameters_gen.h"
+#include "mongo/transport/message_compressor_manager.h"
+#include "mongo/util/assert_util.h"
+#include "mongo/util/ctype.h"
+#include "mongo/util/str.h"
+
+#include <algorithm>
+
+namespace mongo {
+namespace repl {
+namespace {
+
+std::string trim(std::string_view s) {
+    size_t b = 0;
+    size_t e = s.size();
+    // Use mongo::ctype (locale-independent, POSIX/C semantics) rather than <cctype> std::isspace,
+    // which is locale-dependent and has UB on negative char values.
+    while (b < e && ctype::isSpace(s[b]))
+        ++b;
+    while (e > b && ctype::isSpace(s[e - 1]))
+        --e;
+    return std::string(s.substr(b, e - b));
+}
+
+std::string toLowerCopy(const std::string& s) {
+    std::string out;
+    out.reserve(s.size());
+    // Use mongo::ctype::toLower (locale-independent) rather than <cctype> std::tolower so the
+    // "disabled" token comparison is stable regardless of the process locale.
+    for (char c : s) {
+        out.push_back(ctype::toLower(c));
+    }
+    return out;
+}
+
+}  // namespace
+
+Status parseReplicationNetworkCompression(std::string_view value,
+                                          ReplicationNetworkCompressionSetting* out) {
+    *out = ReplicationNetworkCompressionSetting{};
+
+    const std::string trimmed = trim(value);
+    if (trimmed.empty()) {
+        out->inheritProcessDefault = true;
+        return Status::OK();
+    }
+
+    // Any non-empty value is an explicit override of the process default. The struct defaults to
+    // inherit=true, so clear it before returning from either the disabled or allow-list branches.
+    out->inheritProcessDefault = false;
+
+    // "disabled" (case-insensitive) is a reserved token. It cannot be combined with algorithm
+    // names: e.g. "disabled,snappy" is rejected to avoid ambiguity.
+    const std::string lowered = toLowerCopy(trimmed);
+    if (lowered == "disabled") {
+        out->disabled = true;
+        return Status::OK();
+    }
+
+    // Comma-separated list of compressor names. Empty segments (e.g. from a trailing comma such as
+    // "snappy,") are tolerated and ignored; duplicates are deduplicated while preserving first-seen
+    // order (client-advertised order is the negotiation preference order, so keeping the
+    // first occurrence gives the operator predictable ordering). Note: a truly empty value ("") was
+    // already handled above as "inherit"; here 'trimmed' is non-empty, so an input consisting solely
+    // of separators (e.g. "," or ",,") is a malformed list and is rejected below rather than being
+    // silently downgraded to inherit, which would hide a configuration typo.
+    std::vector<std::string> parsed;
+    size_t start = 0;
+    while (start <= trimmed.size()) {
+        size_t comma = trimmed.find(',', start);
+        std::string_view tok = (comma == std::string::npos)
+            ? std::string_view(trimmed).substr(start)
+            : std::string_view(trimmed).substr(start, comma - start);
+        std::string name = trim(tok);
+        if (!name.empty()) {
+            if (toLowerCopy(name) == "disabled") {
+                return {ErrorCodes::BadValue,
+                        "replicationNetworkCompression: 'disabled' cannot be combined with "
+                        "compressor names"};
+            }
+            if (std::find(parsed.begin(), parsed.end(), name) == parsed.end()) {
+                parsed.push_back(std::move(name));
+            }
+        }
+        if (comma == std::string::npos)
+            break;
+        start = comma + 1;
+    }
+
+    if (parsed.empty()) {
+        // 'trimmed' was non-empty (the empty "" case is handled earlier as inherit) yet produced no
+        // names, i.e. the value was nothing but separators/whitespace (e.g. "," or ", ,"). Reject it
+        // as malformed rather than silently treating it as inherit, so an operator's typo surfaces
+        // immediately instead of quietly leaving replication compression at the process default.
+        return {ErrorCodes::BadValue,
+                str::stream() << "replicationNetworkCompression: '" << value
+                              << "' does not contain any compressor names"};
+    }
+
+    out->allowList = std::move(parsed);
+    return Status::OK();
+}
+
+Status validateReplicationNetworkCompression(std::string_view value,
+                                             const boost::optional<TenantId>& /*tenantId*/) {
+    ReplicationNetworkCompressionSetting sink;
+    return parseReplicationNetworkCompression(value, &sink);
+}
+
+ReplicationNetworkCompressionSetting getReplicationNetworkCompressionSetting() {
+    ReplicationNetworkCompressionSetting result;
+    // synchronized_value<std::string> exposes a locked accessor via operator*; take a snapshot
+    // as a plain std::string so we don't hold the lock while parsing.
+    std::string snapshot = *gReplicationNetworkCompression;
+    // The value can only be set at startup (set_at: [startup]) and is checked by
+    // validateReplicationNetworkCompression before it is stored, so by the time replication reads
+    // it here it MUST parse cleanly. A parse failure therefore means the invariant was violated
+    // (e.g. a future code path wrote gReplicationNetworkCompression directly, bypassing the
+    // validator). Fail loudly with the offending value rather than silently degrading to "inherit
+    // process default", which would mask the bug and could change compression behavior invisibly.
+    auto status = parseReplicationNetworkCompression(snapshot, &result);
+    tassert(10130420,
+            str::stream() << "stored replicationNetworkCompression value did not parse: '"
+                          << snapshot << "': " << status.reason(),
+            status.isOK());
+    return result;
+}
+
+void applyReplicationNetworkCompressionToManager(MessageCompressorManager& mgr) {
+    auto setting = getReplicationNetworkCompressionSetting();
+    // SERVER-130410: mark this connection as a replication client so the server routes it (and only
+    // it) through the replication candidate set. This must be set in every branch below, including
+    // "inherit", so heartbeats / shard RPC (which never call this helper) stay on the net set.
+    mgr.markReplicationClientForThisSession(true);
+    if (setting.inheritProcessDefault) {
+        // Advertise the process-wide net.compression.compressors list: clear any per-session
+        // suppression and allow-list left over from a previous (re)connect.
+        mgr.enableCompressionForThisSession();
+        mgr.setCompressorAllowListForThisSession({});
+    } else if (setting.disabled) {
+        // Negotiate this connection uncompressed regardless of net.compression.compressors.
+        mgr.disableCompressionForThisSession();
+        mgr.setCompressorAllowListForThisSession({});
+    } else {
+        // Advertise the operator-chosen subset; clientBegin() intersects it with the process-wide
+        // capability set before advertising.
+        mgr.enableCompressionForThisSession();
+        mgr.setCompressorAllowListForThisSession(std::move(setting.allowList));
+    }
+}
+
+}  // namespace repl
+}  // namespace mongo

--- a/src/mongo/db/repl/replication_network_compression.h
+++ b/src/mongo/db/repl/replication_network_compression.h
@@ -1,0 +1,127 @@
+/**
+ *    Copyright (C) 2026-present MongoDB, Inc.
+ *
+ *    This program is free software: you can redistribute it and/or modify
+ *    it under the terms of the Server Side Public License, version 1,
+ *    as published by MongoDB, Inc.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    Server Side Public License for more details.
+ *
+ *    You should have received a copy of the Server Side Public License
+ *    along with this program. If not, see
+ *    <http://www.mongodb.com/licensing/server-side-public-license>.
+ *
+ *    As a special exception, the copyright holders give permission to link the
+ *    code of portions of this program with the OpenSSL library under certain
+ *    conditions as described in each individual source file and distribute
+ *    linked combinations including the program with the OpenSSL library. You
+ *    must comply with the Server Side Public License in all respects for
+ *    all of the code used other than as permitted herein. If you modify file(s)
+ *    with this exception, you may extend this exception to your version of the
+ *    file(s), but you are not obligated to do so. If you do not wish to do so,
+ *    delete this exception statement from your version. If you delete this
+ *    exception statement from all source files in the program, then also delete
+ *    it in the license file.
+ */
+
+#pragma once
+
+#include "mongo/base/status.h"
+#include "mongo/util/modules.h"
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <boost/optional/optional.hpp>
+
+namespace mongo {
+class TenantId;
+class MessageCompressorManager;
+
+namespace repl {
+
+/*
+ * Parsed form of the replicationNetworkCompression setParameter /
+ * replication.networkCompression.compressors YAML value.
+ *
+ *   inheritProcessDefault == true  -> caller must not touch the manager (advertise the
+ *                                     process-wide net.compression.compressors list). This is the
+ *                                     default (empty value); inheriting net keeps replication
+ *                                     compression unchanged on upgrade.
+ *   inheritProcessDefault == false && disabled == true
+ *                                  -> caller must call disableCompressionForThisSession()
+ *                                     and NOT set an allow-list.
+ *   inheritProcessDefault == false && disabled == false
+ *                                  -> caller must clear disable state and pass allowList as
+ *                                     the per-session allow-list. Order is preserved.
+ */
+struct ReplicationNetworkCompressionSetting {
+    bool inheritProcessDefault{true};
+    bool disabled{false};
+    std::vector<std::string> allowList;
+};
+
+/*
+ * Parses a replicationNetworkCompression value. Accepts:
+ *   - ""          -> inheritProcessDefault=true
+ *   - "disabled"  -> inheritProcessDefault=false, disabled=true (case-insensitive)
+ *   - "a,b,c"     -> inheritProcessDefault=false, allowList={"a","b","c"}
+ *                    (trimmed, non-empty entries only)
+ *
+ * Returns a non-OK Status only for structurally invalid input. Empty segments in an otherwise
+ * non-empty list are tolerated (for example "snappy,"), but a non-empty value that consists only
+ * of separators/whitespace (for example ",") is rejected rather than silently treated as inherit.
+ * Individual compressor names are NOT validated against the process-wide registry here; startup
+ * folds this list into the registry union and finalizeSupportedCompressors() performs the same
+ * fail-fast availability check as net.compression.compressors.
+ */
+MONGO_MOD_PUBLIC Status parseReplicationNetworkCompression(
+    std::string_view value, ReplicationNetworkCompressionSetting* out);
+
+/*
+ * IDL validator callback. Delegates to parseReplicationNetworkCompression().
+ */
+MONGO_MOD_PUBLIC Status validateReplicationNetworkCompression(
+    std::string_view value, const boost::optional<TenantId>& tenantId);
+
+/*
+ * Loads the current value of the replicationNetworkCompression server parameter and returns
+ * it in parsed form. Thread-safe.
+ */
+MONGO_MOD_PUBLIC ReplicationNetworkCompressionSetting getReplicationNetworkCompressionSetting();
+
+/*
+ * Applies the node-local replicationNetworkCompression setting to a client-side
+ * MessageCompressorManager (i.e. the manager owned by a DBClientConnection used to talk to the
+ * sync source) right before its "hello" handshake runs. This is the single source of truth for
+ * the client side of SERVER-130410 and is shared by every replication client connection so their
+ * compressor negotiation cannot drift:
+ *
+ *   - the steady-state / initial-sync oplog fetcher (OplogFetcher::_connect),
+ *   - the initial-sync collection cloner connection (AllDatabaseCloner::connectStage), and
+ *   - the rollback remote oplog connection (BackgroundSync::_runRollback).
+ *
+ * The mapping is:
+ *   inheritProcessDefault -> enableCompressionForThisSession() + clear allow-list (advertise the
+ *                            process-wide net.compression.compressors list);
+ *   disabled              -> disableCompressionForThisSession() + clear allow-list (negotiate
+ *                            uncompressed regardless of net.compression.compressors);
+ *   otherwise             -> enableCompressionForThisSession() + set the allow-list (advertise the
+ *                            operator-chosen subset, intersected with the process-wide capability
+ *                            set inside clientBegin()).
+ *
+ * MUST be called before the handshake is sent, and only from the thread that drives that
+ * connection's (re)connect (the manager setters are not internally synchronized). Because the
+ * same manager instance is reused across DBClientConnection auto-reconnects, re-invoking this on
+ * each (re)connect keeps the manager's state consistent with the stored setting; the setting
+ * itself is startup-only, so on a running mongod this simply re-applies the fixed configuration.
+ * This is purely a client-side decision and requires no server-side change.
+ */
+MONGO_MOD_PUBLIC void applyReplicationNetworkCompressionToManager(MessageCompressorManager& mgr);
+
+}  // namespace repl
+}  // namespace mongo

--- a/src/mongo/db/repl/replication_network_compression.h
+++ b/src/mongo/db/repl/replication_network_compression.h
@@ -45,19 +45,11 @@ class MessageCompressorManager;
 namespace repl {
 
 /*
- * Parsed form of the replicationNetworkCompression setParameter /
- * replication.networkCompression.compressors YAML value.
+ * Parsed form of replicationNetworkCompression / replication.networkCompression.compressors.
  *
- *   inheritProcessDefault == true  -> caller must not touch the manager (advertise the
- *                                     process-wide net.compression.compressors list). This is the
- *                                     default (empty value); inheriting net keeps replication
- *                                     compression unchanged on upgrade.
- *   inheritProcessDefault == false && disabled == true
- *                                  -> caller must call disableCompressionForThisSession()
- *                                     and NOT set an allow-list.
- *   inheritProcessDefault == false && disabled == false
- *                                  -> caller must clear disable state and pass allowList as
- *                                     the per-session allow-list. Order is preserved.
+ *   inheritProcessDefault == true  -> inherit net.compression.compressors (default empty value).
+ *   disabled == true               -> negotiate replication data-plane connections uncompressed.
+ *   otherwise                      -> use allowList as the ordered per-session compressor list.
  */
 struct ReplicationNetworkCompressionSetting {
     bool inheritProcessDefault{true};
@@ -67,17 +59,12 @@ struct ReplicationNetworkCompressionSetting {
 
 /*
  * Parses a replicationNetworkCompression value. Accepts:
- *   - ""          -> inheritProcessDefault=true
- *   - "disabled"  -> inheritProcessDefault=false, disabled=true (case-insensitive)
- *   - "a,b,c"     -> inheritProcessDefault=false, allowList={"a","b","c"}
- *                    (trimmed, non-empty entries only)
+ *   - ""          -> inherit net.compression.compressors
+ *   - "disabled"  -> negotiate uncompressed (case-insensitive)
+ *   - "a,b,c"     -> ordered allow-list, with whitespace trimmed and empty entries ignored
  *
- * Returns a non-OK Status only for structurally invalid input. Empty segments in an otherwise
- * non-empty list are tolerated (for example "snappy,"), but a non-empty value that consists only
- * of separators/whitespace (for example ",") is rejected rather than silently treated as inherit.
- * Individual compressor names are NOT validated against the process-wide registry here; startup
- * folds this list into the registry union and finalizeSupportedCompressors() performs the same
- * fail-fast availability check as net.compression.compressors.
+ * A non-empty value containing only separators/whitespace is rejected. Compressor availability is
+ * checked later during startup finalization, not by this parser.
  */
 MONGO_MOD_PUBLIC Status parseReplicationNetworkCompression(
     std::string_view value, ReplicationNetworkCompressionSetting* out);
@@ -96,30 +83,13 @@ MONGO_MOD_PUBLIC ReplicationNetworkCompressionSetting getReplicationNetworkCompr
 
 /*
  * Applies the node-local replicationNetworkCompression setting to a client-side
- * MessageCompressorManager (i.e. the manager owned by a DBClientConnection used to talk to the
- * sync source) right before its "hello" handshake runs. This is the single source of truth for
- * the client side of SERVER-130410 and is shared by every replication client connection so their
- * compressor negotiation cannot drift:
+ * MessageCompressorManager before DBClientConnection sends hello. Used by replication data-plane
+ * clients such as the oplog fetcher, initial-sync collection cloner, and rollback remote oplog
+ * reader.
  *
- *   - the steady-state / initial-sync oplog fetcher (OplogFetcher::_connect),
- *   - the initial-sync collection cloner connection (AllDatabaseCloner::connectStage), and
- *   - the rollback remote oplog connection (BackgroundSync::_runRollback).
- *
- * The mapping is:
- *   inheritProcessDefault -> enableCompressionForThisSession() + clear allow-list (advertise the
- *                            process-wide net.compression.compressors list);
- *   disabled              -> disableCompressionForThisSession() + clear allow-list (negotiate
- *                            uncompressed regardless of net.compression.compressors);
- *   otherwise             -> enableCompressionForThisSession() + set the allow-list (advertise the
- *                            operator-chosen subset, intersected with the process-wide capability
- *                            set inside clientBegin()).
- *
- * MUST be called before the handshake is sent, and only from the thread that drives that
- * connection's (re)connect (the manager setters are not internally synchronized). Because the
- * same manager instance is reused across DBClientConnection auto-reconnects, re-invoking this on
- * each (re)connect keeps the manager's state consistent with the stored setting; the setting
- * itself is startup-only, so on a running mongod this simply re-applies the fixed configuration.
- * This is purely a client-side decision and requires no server-side change.
+ * Must be called by the connection's (re)connect thread before the handshake. Reapply on reconnect
+ * because DBClientConnection reuses the same manager and these per-session setters are not
+ * internally synchronized.
  */
 MONGO_MOD_PUBLIC void applyReplicationNetworkCompressionToManager(MessageCompressorManager& mgr);
 

--- a/src/mongo/db/repl/replication_network_compression_test.cpp
+++ b/src/mongo/db/repl/replication_network_compression_test.cpp
@@ -1,0 +1,96 @@
+/**
+ *    Copyright (C) 2026-present MongoDB, Inc.
+ *
+ *    This program is free software: you can redistribute it and/or modify
+ *    it under the terms of the Server Side Public License, version 1,
+ *    as published by MongoDB, Inc.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    Server Side Public License for more details.
+ *
+ *    You should have received a copy of the Server Side Public License
+ *    along with this program. If not, see
+ *    <http://www.mongodb.com/licensing/server-side-public-license>.
+ *
+ *    As a special exception, the copyright holders give permission to link the
+ *    code of portions of this program with the OpenSSL library under certain
+ *    conditions as described in each individual source file and distribute
+ *    linked combinations including the program with the OpenSSL library. You
+ *    must comply with the Server Side Public License in all respects for
+ *    all of the code used other than as permitted herein. If you modify file(s)
+ *    with this exception, you may extend this exception to your version of the
+ *    file(s), but you are not obligated to do so. If you do not wish to do so,
+ *    delete this exception statement from your version. If you delete this
+ *    exception statement from all source files in the program, then also delete
+ *    it in the license file.
+ */
+
+#include "mongo/db/repl/replication_network_compression.h"
+
+#include "mongo/transport/message_compressor_registry.h"
+#include "mongo/transport/message_compressor_snappy.h"
+#include "mongo/unittest/unittest.h"
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace mongo {
+namespace repl {
+namespace {
+
+TEST(ReplicationNetworkCompression, ParseDistinguishesInheritDisabledAndAllowList) {
+    ReplicationNetworkCompressionSetting setting;
+
+    ASSERT_OK(parseReplicationNetworkCompression("", &setting));
+    ASSERT_TRUE(setting.inheritProcessDefault);
+    ASSERT_FALSE(setting.disabled);
+    ASSERT_TRUE(setting.allowList.empty());
+
+    ASSERT_OK(parseReplicationNetworkCompression("disabled", &setting));
+    ASSERT_FALSE(setting.inheritProcessDefault);
+    ASSERT_TRUE(setting.disabled);
+    ASSERT_TRUE(setting.allowList.empty());
+
+    ASSERT_OK(parseReplicationNetworkCompression(" zstd, snappy, zstd, ", &setting));
+    ASSERT_FALSE(setting.inheritProcessDefault);
+    ASSERT_FALSE(setting.disabled);
+    ASSERT_EQ(2U, setting.allowList.size());
+    ASSERT_EQ(std::string{"zstd"}, setting.allowList[0]);
+    ASSERT_EQ(std::string{"snappy"}, setting.allowList[1]);
+}
+
+TEST(ReplicationNetworkCompression, ParseRejectsMalformedValues) {
+    ReplicationNetworkCompressionSetting setting;
+
+    ASSERT_NOT_OK(parseReplicationNetworkCompression(",", &setting));
+    ASSERT_NOT_OK(parseReplicationNetworkCompression("disabled,snappy", &setting));
+}
+
+TEST(ReplicationNetworkCompression, ExplicitAllowListDrivesRegistryUnion) {
+    ReplicationNetworkCompressionSetting setting;
+    ASSERT_OK(parseReplicationNetworkCompression("snappy", &setting));
+    ASSERT_FALSE(setting.inheritProcessDefault);
+    ASSERT_FALSE(setting.disabled);
+
+    MessageCompressorRegistry registry;
+    registry.setSupportedCompressors(std::vector<std::string>{});
+    if (!setting.disabled && !setting.inheritProcessDefault) {
+        registry.addReplicationCompressors(setting.allowList);
+    }
+    registry.registerImplementation(std::make_unique<SnappyMessageCompressor>());
+    ASSERT_OK(registry.finalizeSupportedCompressors());
+
+    ASSERT_TRUE(registry.getNetCompressorNames().empty());
+    const auto& unionNames = registry.getCompressorNames();
+    ASSERT_TRUE(std::find(unionNames.begin(), unionNames.end(), "snappy") != unionNames.end());
+    const auto& replNames = registry.getReplCompressorNames();
+    ASSERT_TRUE(std::find(replNames.begin(), replNames.end(), "snappy") != replNames.end());
+}
+
+}  // namespace
+}  // namespace repl
+}  // namespace mongo

--- a/src/mongo/transport/message_compressor_base.h
+++ b/src/mongo/transport/message_compressor_base.h
@@ -100,6 +100,41 @@ public:
         return _decompressBytesOut.loadRelaxed();
     }
 
+    /*
+     * Replication-only views of the same counters. These accumulate ONLY the bytes that flowed on
+     * replication data-plane connections: the oplog fetcher, initial-sync cloner, and rollback
+     * remote oplog reader on the syncing side, and the sync source's responses to them on the
+     * serving side. They are a SUBSET of the counters above: replication traffic is still counted in
+     * the process-wide (net) totals as well, so the existing serverStatus().network.compression
+     * numbers are unchanged; these extra counters just let serverStatus().repl.compression report
+     * the replication portion independently.
+     */
+    int64_t getReplicationCompressorBytesIn() const {
+        return _replCompressBytesIn.loadRelaxed();
+    }
+    int64_t getReplicationCompressorBytesOut() const {
+        return _replCompressBytesOut.loadRelaxed();
+    }
+    int64_t getReplicationDecompressorBytesIn() const {
+        return _replDecompressBytesIn.loadRelaxed();
+    }
+    int64_t getReplicationDecompressorBytesOut() const {
+        return _replDecompressBytesOut.loadRelaxed();
+    }
+
+    /*
+     * Bump the replication-only counters. Called by MessageCompressorManager after a successful
+     * compress/decompress when the connection is attributed to replication data-plane traffic, in
+     * addition to the process-wide counterHit* below. Thread-safe (atomic).
+     */
+    void counterHitReplicationCompress(int64_t bytesIn, int64_t bytesOut) {
+        _replCompressBytesIn.addAndFetch(bytesIn);
+        _replCompressBytesOut.addAndFetch(bytesOut);
+    }
+    void counterHitReplicationDecompress(int64_t bytesIn, int64_t bytesOut) {
+        _replDecompressBytesIn.addAndFetch(bytesIn);
+        _replDecompressBytesOut.addAndFetch(bytesOut);
+    }
 
 protected:
     /*
@@ -134,5 +169,13 @@ private:
 
     Atomic<long long> _decompressBytesIn;
     Atomic<long long> _decompressBytesOut;
+
+    // Replication-data-plane subset counters; these bytes are also included in the process-wide
+    // counters above.
+    Atomic<long long> _replCompressBytesIn;
+    Atomic<long long> _replCompressBytesOut;
+
+    Atomic<long long> _replDecompressBytesIn;
+    Atomic<long long> _replDecompressBytesOut;
 };
 }  // namespace mongo

--- a/src/mongo/transport/message_compressor_manager.cpp
+++ b/src/mongo/transport/message_compressor_manager.cpp
@@ -369,12 +369,21 @@ void MessageCompressorManager::serverNegotiate(
     const boost::optional<std::vector<std::string>>& serverCompressorAllowList) {
     LOGV2_DEBUG(22934, 3, "Starting server-side compression negotiation");
 
+    // Make the replication data-plane candidate set sticky for the connection's lifetime. A hello
+    // that supplies an explicit allow-list carries the replicationCompressionClient marker; a later
+    // hello on the same connection may re-advertise compression without the marker
+    // (serverCompressorAllowList == boost::none), and using the net set for that renegotiation would
+    // silently drop replication compression when net.compression is disabled. Only ever record it,
+    // never clear it, matching the sticky repl.compression accounting flag.
+    if (serverCompressorAllowList) {
+        _serverReplicationCompressorAllowListForThisSession = *serverCompressorAllowList;
+    }
+
     // No advertised compressions, just asking for the last negotiated result.
     if (!clientCompressors) {
         // If we haven't negotiated any compressors yet, then don't append anything to the
         // output - this makes this compatible with older versions of MongoDB that don't
         // support compression.
-        std::vector<std::string> ret;
         if (_negotiated.empty()) {
             LOGV2_DEBUG(22935, 3, "Compression negotiation not requested by client");
             // client didn't request compression and nothing was negotiated. Engage an empty
@@ -405,8 +414,11 @@ void MessageCompressorManager::serverNegotiate(
         return;
     }
 
-    const std::vector<std::string>& allowed = serverCompressorAllowList
-        ? *serverCompressorAllowList
+    // Prefer the sticky replication candidate set over the per-hello argument so a later
+    // marker-less renegotiation on a replication connection keeps its candidate set instead of
+    // falling back to net.compression.compressors.
+    const std::vector<std::string>& allowed = _serverReplicationCompressorAllowListForThisSession
+        ? *_serverReplicationCompressorAllowListForThisSession
         : _registry->getNetCompressorNames();
 
     // build this connection's compressor-id permit list from 'allowed', not from
@@ -462,11 +474,10 @@ void MessageCompressorManager::serverNegotiate(
         // When this is a replication connection (a candidate list was supplied) that
         // permitted at least one advertised algorithm but none of them are registered in this
         // build, the channel is silently uncompressed despite the operator having configured
-        // replicationNetworkCompression. Surface it at WARNING (rate-limited, since it recurs on
-        // every reconnect) so this is not only visible at DEBUG level 3. With uncompiled algorithms
-        // now rejected at startup, reaching this branch indicates an unexpected registry
-        // inconsistency rather than an ordinary misconfiguration.
-        if (serverCompressorAllowList && droppedPermittedButUnregistered) {
+        // replicationNetworkCompression. Surface it at WARNING so this is not only visible at
+        // DEBUG level 3. With uncompiled algorithms now rejected at startup, reaching this branch
+        // indicates an unexpected registry inconsistency rather than an ordinary misconfiguration.
+        if (_serverReplicationCompressorAllowListForThisSession && droppedPermittedButUnregistered) {
             LOGV2_WARNING(10130417,
                           "A replication connection advertised compressor(s) permitted by "
                           "replicationNetworkCompression, but none are available in this build; the "

--- a/src/mongo/transport/message_compressor_manager.cpp
+++ b/src/mongo/transport/message_compressor_manager.cpp
@@ -11,6 +11,7 @@
 #include "mongo/bson/bsonobj.h"
 #include "mongo/bson/bsonobjbuilder.h"
 #include "mongo/logv2/log.h"
+#include "mongo/logv2/log_severity_suppressor.h"
 #include "mongo/rpc/message.h"
 #include "mongo/rpc/op_compressed.h"
 #include "mongo/transport/message_compressor_registry.h"
@@ -19,10 +20,12 @@
 #include "mongo/util/decorable.h"
 #include "mongo/util/shared_buffer.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <string>
 #include <string_view>
 #include <utility>
+#include <vector>
 
 #include <boost/move/utility_core.hpp>
 #include <boost/optional/optional.hpp>
@@ -49,6 +52,17 @@ StatusWith<Message> MessageCompressorManager::compressMessage(
     if (compressorId) {
         compressor = _registry->getCompressor(*compressorId);
         invariant(compressor);
+        // an explicit id is normally the echo-back id captured by
+        // decompressMessage(). Since the registry is now the net/repl union, a registered compressor
+        // may still be outside this connection's policy. Do not emit unpermitted compressors; legacy
+        // callers with no permit list keep the old behavior.
+        if (!_isCompressorPermittedForThisSession(*compressorId)) {
+            LOGV2_DEBUG(10130418,
+                        3,
+                        "Compressor not permitted for this connection; sending uncompressed",
+                        "compressorId"_attr = static_cast<int>(*compressorId));
+            return {msg};
+        }
     } else if (!_negotiated.empty()) {
         compressor = _negotiated[0];
     } else {
@@ -112,6 +126,15 @@ StatusWith<Message> MessageCompressorManager::decompressMessage(const Message& m
                 "Compression algorithm specified in message is not available"};
     }
 
+    // registry membership now means process capability, not per-connection policy.
+    // Once a permit list is engaged, reject compressed frames whose compressor was not permitted for
+    // this connection - otherwise an external connection could decompress a replication-only frame and
+    // net.compression.compressors: disabled would not truly disable it. Legacy callers without a permit
+    // list keep the old registry-wide behavior.
+    if (!_isCompressorPermittedForThisSession(compressionHeader.compressorId)) {
+        return {ErrorCodes::BadValue, "Compressor was not negotiated for this connection"};
+    }
+
     if (compressorId) {
         *compressorId = compressor->getId();
     }
@@ -165,15 +188,89 @@ void MessageCompressorManager::clientBegin(BSONObjBuilder* output) {
 
     // We're about to update the compressor list with the negotiation result from the server.
     _negotiated.clear();
+    _advertisedCompressors.clear();
+    // Until clientFinish() accepts the server's hello response, this client connection has not
+    // negotiated any inbound compressed response. Engage an empty permit list now so a malformed
+    // peer cannot send OP_COMPRESSED during the handshake and have it decoded via the process-wide
+    // union registry.
+    _permittedCompressorIds.emplace();
+    _permittedCompressorIds->fill(false);
 
-    auto& compressorList = _registry->getCompressorNames();
-    if (compressorList.size() == 0)
+    // tag replication data-plane connections (oplog fetcher, initial-sync cloner,
+    // rollback remote oplog reader) so the server applies the replication compression policy to this
+    // connection only. Emit the marker even when compression is suppressed or inherited, so other
+    // internal connections (heartbeats, shard RPC) continue to negotiate against net.compression.
+    if (_isReplicationClient) {
+        output->append(kReplicationCompressionClientFieldName, true);
+    }
+
+    // per-session opt-out used for replicationNetworkCompression: "disabled".
+    // Omit the "compression" array from hello so this connection negotiates uncompressed, without
+    // changing the process-wide net.compression.compressors policy or any other connection.
+    if (!_offerCompressionOnClientBegin) {
+        LOGV2_DEBUG(
+            10130410,
+            3,
+            "Compression advertisement suppressed for this connection; negotiating uncompressed");
+        return;
+    }
+
+    // replication data-plane clients may provide a per-session compressor allow-list.
+    // Advertise its intersection with the process-wide net/repl capability union. After normal
+    // startup finalization this is expected to be a no-op filter, but it keeps tests/direct callers
+    // from advertising compressors the process did not register. Preserve caller order as negotiation
+    // preference; an empty intersection means this connection negotiates uncompressed.
+    if (!_allowListedCompressors.empty()) {
+        const auto& compressorList = _registry->getCompressorNames();
+        std::vector<std::string_view> filtered;
+        filtered.reserve(_allowListedCompressors.size());
+        for (const auto& name : _allowListedCompressors) {
+            const auto it = std::find(compressorList.begin(), compressorList.end(), name);
+            if (it == compressorList.end()) {
+                LOGV2_DEBUG(10130411,
+                            3,
+                            "Ignoring per-session compressor not registered process-wide",
+                            "compressor"_attr = name);
+                continue;
+            }
+            filtered.push_back(*it);
+        }
+        if (filtered.empty()) {
+            static logv2::SeveritySuppressor logSeverity{
+                Seconds{60}, logv2::LogSeverity::Warning(), logv2::LogSeverity::Debug(3)};
+            LOGV2_DEBUG(10130412,
+                        logSeverity().toInt(),
+                        "Requested per-session compressors are not registered process-wide; this "
+                        "connection will be uncompressed",
+                        "requestedCompressors"_attr = _allowListedCompressors);
+            return;
+        }
+        BSONArrayBuilder sub(output->subarrayStart("compression"));
+        for (const auto& e : filtered) {
+            LOGV2_DEBUG(10130413,
+                        3,
+                        "Offering compressor to server (per-session allow-list)",
+                        "compressor"_attr = e);
+            sub.append(e);
+            _advertisedCompressors.emplace_back(e);
+        }
+        sub.doneFast();
+        return;
+    }
+
+    // Default path: advertise only the client-facing net set (net.compression.compressors). A
+    // connection without a per-session allow-list is treated as external, so it must not offer
+    // replication-only compressors. When net.compression.compressors: disabled this set is empty
+    // and nothing is advertised.
+    const auto& netCompressorList = _registry->getNetCompressorNames();
+    if (netCompressorList.empty())
         return;
 
     BSONArrayBuilder sub(output->subarrayStart("compression"));
-    for (const auto& e : _registry->getCompressorNames()) {
+    for (const auto& e : netCompressorList) {
         LOGV2_DEBUG(22929, 3, "Offering compressor to server", "compressor"_attr = e);
         sub.append(e);
+        _advertisedCompressors.push_back(e);
     }
     sub.doneFast();
 }
@@ -185,29 +282,84 @@ void MessageCompressorManager::clientFinish(const BSONObj& input) {
     // We've just called clientBegin, so the list of compressors should be empty.
     invariant(_negotiated.empty());
 
+    // Start from an empty inbound permit list. Only compressors accepted from the server's hello
+    // response below become legal for subsequent OP_COMPRESSED responses on this client connection.
+    _permittedCompressorIds.emplace();
+    auto& permitted = *_permittedCompressorIds;
+    permitted.fill(false);
+
+    auto logReplicationNegotiationResult = [&] {
+        if (!_isReplicationClient) {
+            return;
+        }
+        std::vector<std::string> negotiatedNames;
+        negotiatedNames.reserve(_negotiated.size());
+        for (const auto* compressor : _negotiated) {
+            negotiatedNames.emplace_back(compressor->getName());
+        }
+        LOGV2(10130422,
+              "Replication network compression negotiation completed",
+              "compressed"_attr = !_negotiated.empty(),
+              "negotiatedCompressors"_attr = negotiatedNames);
+    };
+
     // If the server didn't send back a "compression" array, then we assume compression is not
     // supported by this server and just return. We've already disabled compression by clearing
-    // out the _negotiated array above.
+    // out the _negotiated array above, and the empty permit list rejects any compressed response.
     if (elem.eoo()) {
         LOGV2_DEBUG(22931,
                     3,
                     "No compression algorithms were sent from the server. This connection will be "
                     "uncompressed");
+        logReplicationNegotiationResult();
         return;
     }
 
     LOGV2_DEBUG(22932, 3, "Received message compressors from server");
     for (const auto& e : elem.Obj()) {
-        auto algoName = e.checkAndGetStringData();
+        std::string algoName{e.checkAndGetStringData()};
+
+        // SERVER-130410: only accept a compressor this client actually advertised on the matching
+        // clientBegin(). A well-behaved server echoes back a subset of what we offered, but a
+        // malformed or malicious peer could name a compressor we never offered - including one we
+        // deliberately withheld via disableCompressionForThisSession() or a per-session allow-list
+        // (e.g. replicationNetworkCompression). Accepting it would let the peer override this
+        // connection's local compression policy. Names outside our advertised set are ignored.
+        const bool advertised = std::find(_advertisedCompressors.begin(),
+                                          _advertisedCompressors.end(),
+                                          algoName) != _advertisedCompressors.end();
+        if (!advertised) {
+            LOGV2_DEBUG(10130421,
+                        3,
+                        "Ignoring compressor not advertised by this client in server hello response",
+                        "compressor"_attr = algoName);
+            continue;
+        }
+
         auto ret = _registry->getCompressor(algoName);
+        // Defend against a malformed or malicious server response. getCompressor() returns nullptr
+        // for an unknown/unregistered name, and dereferencing it (ret->getName()) would crash the
+        // client. Skip unknown names so the connection simply negotiates the remaining understood
+        // compressors, or ends up uncompressed if none are understood. (An advertised name is
+        // normally registered, so this is a belt-and-suspenders guard.)
+        if (!ret) {
+            LOGV2_DEBUG(10130419,
+                        3,
+                        "Ignoring unknown compressor in server hello response",
+                        "compressor"_attr = algoName);
+            continue;
+        }
         LOGV2_DEBUG(22933, 3, "Adding compressor", "compressor"_attr = ret->getName());
         _negotiated.push_back(ret);
+        permitted[ret->getId()] = true;
     }
+    logReplicationNegotiationResult();
 }
 
 void MessageCompressorManager::serverNegotiate(
     const boost::optional<std::vector<std::string_view>>& clientCompressors,
-    BSONObjBuilder* result) {
+    BSONObjBuilder* result,
+    const boost::optional<std::vector<std::string>>& serverCompressorAllowList) {
     LOGV2_DEBUG(22934, 3, "Starting server-side compression negotiation");
 
     // No advertised compressions, just asking for the last negotiated result.
@@ -218,6 +370,15 @@ void MessageCompressorManager::serverNegotiate(
         std::vector<std::string> ret;
         if (_negotiated.empty()) {
             LOGV2_DEBUG(22935, 3, "Compression negotiation not requested by client");
+            // SERVER-130410: the client did not request compression and nothing has been negotiated
+            // on this connection. Engage an empty whitelist so any compressed frame that arrives
+            // anyway is rejected. Without this, _permittedCompressorIds stays disengaged and
+            // decompressMessage()/echo-back compressMessage() would fall back to the process-wide
+            // registry (net union replication) - letting an external client that never negotiated
+            // compression use a replication-only algorithm and bypass net.compression.compressors:
+            // disabled.
+            _permittedCompressorIds.emplace();
+            _permittedCompressorIds->fill(false);
         } else {
             BSONArrayBuilder sub(result->subarrayStart("compression"));
             for (const auto& algo : _negotiated) {
@@ -234,25 +395,98 @@ void MessageCompressorManager::serverNegotiate(
     // First we go through all the compressor names that the client has requested support for
     if (clientCompressors->empty()) {
         LOGV2_DEBUG(22936, 3, "No compressors provided");
+        // SERVER-130410: engage an empty whitelist so this (server) connection rejects any
+        // compressed frame; the client asked for no compression.
+        _permittedCompressorIds.emplace();
+        _permittedCompressorIds->fill(false);
         return;
     }
 
+    // SERVER-130410: determine the candidate set for this connection type. External, client-facing
+    // connections use net.compression.compressors; internal replica-set connections pass their own
+    // candidate list (replication.networkCompression.compressors). A client compressor is accepted
+    // only if it is BOTH in this candidate set AND registered process-wide. Filtering by the net
+    // set here (rather than the net union replication union) is what preserves
+    // net.compression.compressors: disabled for external clients even though the union registry may
+    // contain replication-only algorithms.
+    const std::vector<std::string>& allowed = serverCompressorAllowList
+        ? *serverCompressorAllowList
+        : _registry->getNetCompressorNames();
+
+    // SERVER-130410: engage this connection's compressor-id whitelist from the candidate set
+    // 'allowed' (NOT the net union replication union registry). This re-establishes the pre-change
+    // invariant "registry-visible == this connection's candidate set" so that decompressMessage()
+    // and the echo-back path in compressMessage() cannot use an out-of-domain algorithm (e.g. a
+    // replication-only compressor on an external connection). Populating from 'allowed' (rather than
+    // the negotiated subset) keeps in-domain behavior identical to before the change. When 'allowed'
+    // is empty (net.compression.compressors: disabled), the whitelist stays all-false and the
+    // connection is truly uncompressed.
+    _permittedCompressorIds.emplace();
+    auto& permitted = *_permittedCompressorIds;
+    permitted.fill(false);
+    for (const auto& name : allowed) {
+        if (auto* c = _registry->getCompressor(name)) {
+            permitted[c->getId()] = true;
+        }
+    }
+
+    // SERVER-130410: track whether the client advertised a compressor that this connection is
+    // permitted to use but that this build has NOT registered process-wide. This is a defensive
+    // guard: a compressor named in net.compression.compressors or
+    // replication.networkCompression.compressors that is not compiled into this build now fails
+    // startup outright (finalizeSupportedCompressors), so on a correctly started node this state
+    // should not arise. If it ever does (e.g. a registry inconsistency), the connection silently
+    // ends up uncompressed, so we still surface it below rather than fail the negotiation.
+    bool droppedPermittedButUnregistered = false;
     for (const auto& curName : *clientCompressors) {
-        MessageCompressorBase* cur;
+        // Note: named 'isCandidate' rather than 'permitted' to avoid shadowing the
+        // '_permittedCompressorIds' array reference bound above (would trip -Wshadow / -Werror).
+        const bool isCandidate = std::any_of(
+            allowed.begin(), allowed.end(), [&](const std::string& allowedName) {
+                return std::string_view(allowedName) == curName;
+            });
+        if (!isCandidate) {
+            LOGV2_DEBUG(10130415,
+                        3,
+                        "Rejecting compressor not permitted for this connection type",
+                        "compressor"_attr = curName);
+            continue;
+        }
         // If the MessageCompressorRegistry knows about a compressor with that name, then it is
         // valid and we add it to our list of negotiated compressors.
-        if ((cur = _registry->getCompressor(curName))) {
+        if (auto* cur = _registry->getCompressor(curName)) {
             LOGV2_DEBUG(22937, 3, "supported compressor", "compressor"_attr = cur->getName());
             _negotiated.push_back(cur);
         } else {  // Otherwise the compressor is not supported and we skip over it.
             LOGV2_DEBUG(22938, 3, "compressor is not supported", "compressor"_attr = curName);
+            droppedPermittedButUnregistered = true;
         }
     }
 
     // If the number of compressors that were eventually negotiated is greater than 0, then
     // we should send that back to the client.
     if (_negotiated.empty()) {
-        LOGV2_DEBUG(22939, 3, "Could not agree on compressor to use");
+        // SERVER-130410: When this is a replication connection (a candidate list was supplied) that
+        // permitted at least one advertised algorithm but none of them are registered in this
+        // build, the channel is silently uncompressed despite the operator having configured
+        // replicationNetworkCompression. Surface it at WARNING (rate-limited, since it recurs on
+        // every reconnect) so this is not only visible at DEBUG level 3. With uncompiled algorithms
+        // now rejected at startup, reaching this branch indicates an unexpected registry
+        // inconsistency rather than an ordinary misconfiguration.
+        if (serverCompressorAllowList && droppedPermittedButUnregistered) {
+            static logv2::SeveritySuppressor logSeverity{
+                Seconds{60}, logv2::LogSeverity::Warning(), logv2::LogSeverity::Debug(3)};
+            LOGV2_DEBUG(10130417,
+                        logSeverity().toInt(),
+                        "A replication connection advertised compressor(s) permitted by "
+                        "replicationNetworkCompression, but none are available in this build; the "
+                        "connection will be uncompressed. Only compressors present at startup can "
+                        "be used",
+                        "clientAdvertised"_attr = *clientCompressors,
+                        "permittedCandidates"_attr = allowed);
+        } else {
+            LOGV2_DEBUG(22939, 3, "Could not agree on compressor to use");
+        }
     } else {
         BSONArrayBuilder sub(result->subarrayStart("compression"));
         for (const auto& algo : _negotiated) {

--- a/src/mongo/transport/message_compressor_manager.cpp
+++ b/src/mongo/transport/message_compressor_manager.cpp
@@ -11,7 +11,6 @@
 #include "mongo/bson/bsonobj.h"
 #include "mongo/bson/bsonobjbuilder.h"
 #include "mongo/logv2/log.h"
-#include "mongo/logv2/log_severity_suppressor.h"
 #include "mongo/rpc/message.h"
 #include "mongo/rpc/op_compressed.h"
 #include "mongo/transport/message_compressor_registry.h"
@@ -107,6 +106,14 @@ StatusWith<Message> MessageCompressorManager::compressMessage(
     auto realCompressedSize = sws.getValue();
     outMessage.setLen(realCompressedSize + CompressionHeader::size() + MsgData::MsgDataHeaderSize);
 
+    // Additionally attribute this message to the replication-specific counters when this connection
+    // is marked as replication data-plane traffic. This is a subset of the process-wide counters the
+    // compressor already bumped inside compressData(), so serverStatus().network.compression is
+    // unchanged; serverStatus().repl.compression reports just the replication portion.
+    if (_countAsReplicationCompressionTraffic) {
+        compressor->counterHitReplicationCompress(input.length(), realCompressedSize);
+    }
+
     return {Message(outputMessageBuffer)};
 }
 
@@ -180,6 +187,13 @@ StatusWith<Message> MessageCompressorManager::decompressMessage(const Message& m
 
     outMessage.setLen(sws.getValue() + MsgData::MsgDataHeaderSize);
 
+    // Additionally attribute this message to the replication-specific counters when this connection
+    // is marked as replication data-plane traffic. This is a subset of the process-wide counters
+    // that decompressData() already bumped, so serverStatus().network.compression is unchanged.
+    if (_countAsReplicationCompressionTraffic) {
+        compressor->counterHitReplicationDecompress(input.length(), sws.getValue());
+    }
+
     return {Message(outputMessageBuffer)};
 }
 
@@ -227,22 +241,18 @@ void MessageCompressorManager::clientBegin(BSONObjBuilder* output) {
         for (const auto& name : _allowListedCompressors) {
             const auto it = std::find(compressorList.begin(), compressorList.end(), name);
             if (it == compressorList.end()) {
-                LOGV2_DEBUG(10130411,
-                            3,
-                            "Ignoring per-session compressor not registered process-wide",
-                            "compressor"_attr = name);
+                LOGV2_WARNING(10130411,
+                              "Ignoring per-session compressor not registered process-wide",
+                              "compressor"_attr = name);
                 continue;
             }
             filtered.push_back(*it);
         }
         if (filtered.empty()) {
-            static logv2::SeveritySuppressor logSeverity{
-                Seconds{60}, logv2::LogSeverity::Warning(), logv2::LogSeverity::Debug(3)};
-            LOGV2_DEBUG(10130412,
-                        logSeverity().toInt(),
-                        "Requested per-session compressors are not registered process-wide; this "
-                        "connection will be uncompressed",
-                        "requestedCompressors"_attr = _allowListedCompressors);
+            LOGV2_WARNING(10130412,
+                          "Requested per-session compressors are not registered process-wide; this "
+                          "connection will be uncompressed",
+                          "requestedCompressors"_attr = _allowListedCompressors);
             return;
         }
         BSONArrayBuilder sub(output->subarrayStart("compression"));
@@ -319,12 +329,9 @@ void MessageCompressorManager::clientFinish(const BSONObj& input) {
     for (const auto& e : elem.Obj()) {
         std::string algoName{e.checkAndGetStringData()};
 
-        // SERVER-130410: only accept a compressor this client actually advertised on the matching
-        // clientBegin(). A well-behaved server echoes back a subset of what we offered, but a
-        // malformed or malicious peer could name a compressor we never offered - including one we
-        // deliberately withheld via disableCompressionForThisSession() or a per-session allow-list
-        // (e.g. replicationNetworkCompression). Accepting it would let the peer override this
-        // connection's local compression policy. Names outside our advertised set are ignored.
+        // Only accept compressors this client actually advertised in clientBegin(). A malformed
+        // peer could otherwise override this connection's local compression policy, including
+        // disabled compression or a per-session allow-list.
         const bool advertised = std::find(_advertisedCompressors.begin(),
                                           _advertisedCompressors.end(),
                                           algoName) != _advertisedCompressors.end();
@@ -370,13 +377,9 @@ void MessageCompressorManager::serverNegotiate(
         std::vector<std::string> ret;
         if (_negotiated.empty()) {
             LOGV2_DEBUG(22935, 3, "Compression negotiation not requested by client");
-            // SERVER-130410: the client did not request compression and nothing has been negotiated
-            // on this connection. Engage an empty whitelist so any compressed frame that arrives
-            // anyway is rejected. Without this, _permittedCompressorIds stays disengaged and
-            // decompressMessage()/echo-back compressMessage() would fall back to the process-wide
-            // registry (net union replication) - letting an external client that never negotiated
-            // compression use a replication-only algorithm and bypass net.compression.compressors:
-            // disabled.
+            // client didn't request compression and nothing was negotiated. Engage an empty
+            // permit list so any stray compressed frame is rejected; otherwise the disengaged
+            // list falls back to the process-wide net/repl registry and bypasses a disabled net policy.
             _permittedCompressorIds.emplace();
             _permittedCompressorIds->fill(false);
         } else {
@@ -395,32 +398,21 @@ void MessageCompressorManager::serverNegotiate(
     // First we go through all the compressor names that the client has requested support for
     if (clientCompressors->empty()) {
         LOGV2_DEBUG(22936, 3, "No compressors provided");
-        // SERVER-130410: engage an empty whitelist so this (server) connection rejects any
-        // compressed frame; the client asked for no compression.
+        // Engage an empty permit list so this server connection rejects any compressed frame; the
+        // client asked for no compression.
         _permittedCompressorIds.emplace();
         _permittedCompressorIds->fill(false);
         return;
     }
 
-    // SERVER-130410: determine the candidate set for this connection type. External, client-facing
-    // connections use net.compression.compressors; internal replica-set connections pass their own
-    // candidate list (replication.networkCompression.compressors). A client compressor is accepted
-    // only if it is BOTH in this candidate set AND registered process-wide. Filtering by the net
-    // set here (rather than the net union replication union) is what preserves
-    // net.compression.compressors: disabled for external clients even though the union registry may
-    // contain replication-only algorithms.
     const std::vector<std::string>& allowed = serverCompressorAllowList
         ? *serverCompressorAllowList
         : _registry->getNetCompressorNames();
 
-    // SERVER-130410: engage this connection's compressor-id whitelist from the candidate set
-    // 'allowed' (NOT the net union replication union registry). This re-establishes the pre-change
-    // invariant "registry-visible == this connection's candidate set" so that decompressMessage()
-    // and the echo-back path in compressMessage() cannot use an out-of-domain algorithm (e.g. a
-    // replication-only compressor on an external connection). Populating from 'allowed' (rather than
-    // the negotiated subset) keeps in-domain behavior identical to before the change. When 'allowed'
-    // is empty (net.compression.compressors: disabled), the whitelist stays all-false and the
-    // connection is truly uncompressed.
+    // build this connection's compressor-id permit list from 'allowed', not from
+    // the process-wide net/repl registry. This keeps external connections from using
+    // replication-only compressors while preserving in-domain behavior. If 'allowed'
+    // is empty, the permit list stays all-false and the connection is uncompressed.
     _permittedCompressorIds.emplace();
     auto& permitted = *_permittedCompressorIds;
     permitted.fill(false);
@@ -430,8 +422,8 @@ void MessageCompressorManager::serverNegotiate(
         }
     }
 
-    // SERVER-130410: track whether the client advertised a compressor that this connection is
-    // permitted to use but that this build has NOT registered process-wide. This is a defensive
+    // Track whether the client advertised a compressor that this connection is permitted to use but
+    // that this build has NOT registered process-wide. This is a defensive
     // guard: a compressor named in net.compression.compressors or
     // replication.networkCompression.compressors that is not compiled into this build now fails
     // startup outright (finalizeSupportedCompressors), so on a correctly started node this state
@@ -439,6 +431,7 @@ void MessageCompressorManager::serverNegotiate(
     // ends up uncompressed, so we still surface it below rather than fail the negotiation.
     bool droppedPermittedButUnregistered = false;
     for (const auto& curName : *clientCompressors) {
+        MessageCompressorBase* cur;
         // Note: named 'isCandidate' rather than 'permitted' to avoid shadowing the
         // '_permittedCompressorIds' array reference bound above (would trip -Wshadow / -Werror).
         const bool isCandidate = std::any_of(
@@ -454,7 +447,7 @@ void MessageCompressorManager::serverNegotiate(
         }
         // If the MessageCompressorRegistry knows about a compressor with that name, then it is
         // valid and we add it to our list of negotiated compressors.
-        if (auto* cur = _registry->getCompressor(curName)) {
+        if ((cur = _registry->getCompressor(curName))) {
             LOGV2_DEBUG(22937, 3, "supported compressor", "compressor"_attr = cur->getName());
             _negotiated.push_back(cur);
         } else {  // Otherwise the compressor is not supported and we skip over it.
@@ -466,7 +459,7 @@ void MessageCompressorManager::serverNegotiate(
     // If the number of compressors that were eventually negotiated is greater than 0, then
     // we should send that back to the client.
     if (_negotiated.empty()) {
-        // SERVER-130410: When this is a replication connection (a candidate list was supplied) that
+        // When this is a replication connection (a candidate list was supplied) that
         // permitted at least one advertised algorithm but none of them are registered in this
         // build, the channel is silently uncompressed despite the operator having configured
         // replicationNetworkCompression. Surface it at WARNING (rate-limited, since it recurs on
@@ -474,16 +467,13 @@ void MessageCompressorManager::serverNegotiate(
         // now rejected at startup, reaching this branch indicates an unexpected registry
         // inconsistency rather than an ordinary misconfiguration.
         if (serverCompressorAllowList && droppedPermittedButUnregistered) {
-            static logv2::SeveritySuppressor logSeverity{
-                Seconds{60}, logv2::LogSeverity::Warning(), logv2::LogSeverity::Debug(3)};
-            LOGV2_DEBUG(10130417,
-                        logSeverity().toInt(),
-                        "A replication connection advertised compressor(s) permitted by "
-                        "replicationNetworkCompression, but none are available in this build; the "
-                        "connection will be uncompressed. Only compressors present at startup can "
-                        "be used",
-                        "clientAdvertised"_attr = *clientCompressors,
-                        "permittedCandidates"_attr = allowed);
+            LOGV2_WARNING(10130417,
+                          "A replication connection advertised compressor(s) permitted by "
+                          "replicationNetworkCompression, but none are available in this build; the "
+                          "connection will be uncompressed. Only compressors present at startup can "
+                          "be used",
+                          "clientAdvertised"_attr = *clientCompressors,
+                          "permittedCandidates"_attr = allowed);
         } else {
             LOGV2_DEBUG(22939, 3, "Could not agree on compressor to use");
         }

--- a/src/mongo/transport/message_compressor_manager.h
+++ b/src/mongo/transport/message_compressor_manager.h
@@ -223,6 +223,18 @@ private:
     std::vector<std::string> _advertisedCompressors;
     std::vector<MessageCompressorBase*> _negotiated;
     MessageCompressorRegistry* _registry;
+
+    // Server-side sticky candidate set for a replication data-plane session. serverNegotiate()
+    // records the replication allow-list whenever a hello supplies one (i.e. carries the
+    // replicationCompressionClient marker). Later hellos on the SAME connection may re-advertise
+    // compression without the marker (so no allow-list is supplied); without this stickiness such a
+    // renegotiation would fall back to net.compression.compressors and, when net is disabled,
+    // silently drop the replication compression already negotiated. Keeping the candidate set for
+    // the connection's lifetime mirrors the sticky accounting flag used for repl.compression and
+    // keeps the negotiated result stable. boost::none means this connection was never identified as
+    // a replication data-plane session and keeps the historical net-set behavior.
+    boost::optional<std::vector<std::string>> _serverReplicationCompressorAllowListForThisSession;
+
     // Note: _offerCompressionOnClientBegin and _allowListedCompressors are declared
     // near the top of the class so that inline member functions can see them without
     // relying on delayed parsing of class-body member initializers.

--- a/src/mongo/transport/message_compressor_manager.h
+++ b/src/mongo/transport/message_compressor_manager.h
@@ -11,7 +11,10 @@
 #include "mongo/transport/session.h"
 #include "mongo/util/modules.h"
 
+#include <array>
+#include <limits>
 #include <memory>
+#include <string>
 #include <string_view>
 #include <vector>
 
@@ -29,6 +32,19 @@ class [[MONGO_MOD_PUBLIC]] MessageCompressorManager {
     MessageCompressorManager(const MessageCompressorManager&) = delete;
     MessageCompressorManager& operator=(const MessageCompressorManager&) = delete;
 
+    // Forward-declared members used by inline methods below. Full private section
+    // with initializers appears at the end of the class.
+    bool _offerCompressionOnClientBegin{true};
+    std::vector<std::string> _allowListedCompressors;
+    // SERVER-130410: true only on the manager of a replication data-plane client connection (the
+    // oplog fetcher, initial-sync cloner, or rollback remote oplog reader, marked via
+    // markReplicationClientForThisSession()). When set, clientBegin() adds the
+    // "replicationCompressionClient" marker to the hello request so the server routes this
+    // connection (and ONLY this connection) through the replication candidate
+    // set. Other internal connections (heartbeats, shard RPC) leave this false and are negotiated
+    // like any external client (net.compression.compressors), restoring pre-SERVER-130410 behavior.
+    bool _isReplicationClient{false};
+
 public:
     /*
      * Default constructor. Uses the global MessageCompressorRegistry.
@@ -45,11 +61,102 @@ public:
     MessageCompressorManager& operator=(MessageCompressorManager&&) = default;
 
     /*
-     * Called by a client constructing a "hello" request. This function will append the result
-     * of _registry->getCompressorNames() to the BSONObjBuilder as a BSON array. If no compressors
+     * Called by a client constructing a "hello" request. With no per-session state this appends
+     * the client-facing net set (MessageCompressorRegistry::getNetCompressorNames(), i.e.
+     * net.compression.compressors) to the BSONObjBuilder as a BSON array. If no net compressors
      * are configured, it won't append anything.
+     *
+     * If a per-session allow-list has been set (setCompressorAllowListForThisSession(), used by
+     * replication data-plane connections), it instead advertises the intersection of that list with
+     * the process-wide capability set (getCompressorNames(), the net union replication union). This
+     * is what lets a replication-only compressor be advertised even when net.compression.compressors:
+     * disabled (SERVER-130410).
+     *
+     * If disableCompressionForThisSession() has been called on this manager, this function will
+     * not advertise any compressor to the server, and the resulting connection will be negotiated
+     * uncompressed regardless of any setting.
      */
     void clientBegin(BSONObjBuilder* output);
+
+    /*
+     * Suppresses compressor advertisement on the next (and subsequent) clientBegin() calls made
+     * on this manager. This is a per-session, client-side switch: it has no effect on the
+     * server-side negotiation of any other connection. A connection that opted out simply won't
+     * have negotiated any compressor, so compressMessage() returns the original message unchanged
+     * and decompressMessage() rejects any compressed response once the handshake completes.
+     *
+     * Must be called before the "hello" handshake is sent on the underlying connection. Once set,
+     * the suppression persists across DBClientConnection auto-reconnects because the manager
+     * instance is reused.
+     */
+    void disableCompressionForThisSession() {
+        _offerCompressionOnClientBegin = false;
+    }
+
+    /*
+     * Re-enables compressor advertisement on the next clientBegin() call. Provided so that a
+     * manager instance can be flipped back to normal behavior if the caller later decides to
+     * offer compression on subsequent handshakes; the change only takes effect on the next
+     * handshake, not on an already-negotiated connection.
+     */
+    void enableCompressionForThisSession() {
+        _offerCompressionOnClientBegin = true;
+    }
+
+    bool isCompressionOfferedForThisSession() const {
+        return _offerCompressionOnClientBegin;
+    }
+
+    /*
+     * Restricts the compressors advertised by clientBegin() on this manager to the given
+     * allow-list, intersected with the process-wide capability set (getCompressorNames(), the
+     * union of net.compression.compressors and replication.networkCompression.compressors). Names
+     * not present in that union are silently ignored so that a per-session preference can never
+     * widen the process capability surface. Intersecting against the union (rather than only the
+     * net set) is what lets a replication-only compressor be advertised even when
+     * net.compression.compressors: disabled. Passing an empty vector clears the allow-list and
+     * returns to advertising the net set.
+     *
+     * This is meant for replication data-plane connections using
+     * replication.networkCompression.compressors YAML/setParameter (SERVER-130410) which lets
+     * an operator negotiate sync-source data transfer with a subset of the process-wide compressor
+     * list (e.g. force zstd on replication while the client-facing port keeps snappy,zstd,zlib).
+     * It has no effect on any other connection.
+     */
+    void setCompressorAllowListForThisSession(std::vector<std::string> allowList) {
+        _allowListedCompressors = std::move(allowList);
+    }
+
+    const std::vector<std::string>& getCompressorAllowListForThisSession() const {
+        return _allowListedCompressors;
+    }
+
+    /*
+     * Name of the boolean "hello" field used by replication data-plane clients (oplog fetcher,
+     * initial-sync cloner, rollback remote oplog reader). internalClient is too broad: heartbeats,
+     * mongos-to-mongod traffic, and shard RPC are internal too but must keep using
+     * net.compression.compressors. This marker routes only replication data-plane connections
+     * through the replication compression policy, which may inherit net.compression.compressors.
+     * Older servers ignore the unknown field because "hello" is non-strict.
+     */
+    static constexpr auto kReplicationCompressionClientFieldName = "replicationCompressionClient";
+
+    /*
+     * SERVER-130410: Marks (or unmarks) this manager as belonging to a replication data-plane
+     * client connection. Set by applyReplicationNetworkCompressionToManager() for the oplog fetcher,
+     * the initial-sync cloner, and the rollback remote oplog reader. When marked, clientBegin()
+     * appends kReplicationCompressionClientFieldName:true to the hello request. This is orthogonal
+     * to the allow-list / suppression state: an "inherit" replication connection is still a
+     * replication client even though it advertises the net set. Persists across DBClientConnection
+     * auto-reconnects because the manager instance is reused.
+     */
+    void markReplicationClientForThisSession(bool isReplicationClient) {
+        _isReplicationClient = isReplicationClient;
+    }
+
+    bool isReplicationClientForThisSession() const {
+        return _isReplicationClient;
+    }
 
     /*
      * Called by a client that has received a "hello" response (received after calling
@@ -64,11 +171,25 @@ public:
     /*
      * Called by a server that has received a "hello" request.
      *
+     * A client-advertised compressor is accepted only if it is BOTH permitted for this connection
+     * type AND registered process-wide. The candidate set is chosen by 'serverCompressorAllowList':
+     *   - boost::none (default): external, client-facing connection. The candidate set is
+     *     net.compression.compressors (MessageCompressorRegistry::getNetCompressorNames()). When
+     *     net.compression.compressors: disabled this set is empty, so such connections are always
+     *     negotiated uncompressed, independently of replication.networkCompression.compressors.
+     *   - engaged: internal replica-set connection. The provided list is the candidate set
+     *     (replication.networkCompression.compressors for this node). An empty list forces the
+     *     connection uncompressed.
+     * This is what lets net.compression.compressors and replication.networkCompression.compressors
+     * negotiate independently. See SERVER-130410.
+     *
      * If no compressors are configured that match those requested by the client, then it will
      * not append anything to the BSONObjBuilder output.
      */
     void serverNegotiate(const boost::optional<std::vector<std::string_view>>& clientCompressors,
-                         BSONObjBuilder*);
+                         BSONObjBuilder* result,
+                         const boost::optional<std::vector<std::string>>&
+                             serverCompressorAllowList = boost::none);
 
     /*
      * Returns a new Message containing the compressed contentx of 'msg'. If compressorId is null,
@@ -92,14 +213,17 @@ public:
      *
      * If an error occurs in the compressor, it will return a Status error.
      *
-     * This can be called before Compression is negotiated with the client. This class has a
-     * pointer to the global MessageCompressorRegistry and can lookup any message's compressor
-     * by ID number through that registry. As long as the compressor has been enabled process-wide,
-     * it can decompress any message without negotiation.
+     * This class has a pointer to the global MessageCompressorRegistry and can look up a message's
+     * compressor by ID number through that registry. Callers that have not engaged a per-connection
+     * permit list keep the historical negotiation-agnostic behavior for any process-wide registered
+     * compressor. Once serverNegotiate() or the clientBegin()/clientFinish() handshake has
+     * established this connection's permit list, only compressors permitted for this connection may
+     * be decompressed.
      *
      * If the 'compressorId' parameter is non-null, it will be populated with the compressor
-     * used. If 'decompressMessage' returns succesfully, then that value can be fed back into
-     * compressMessage, ensuring that the same compressor is used on both sides of a conversation.
+     * used. If 'decompressMessage' returns successfully, then that value can be fed back into
+     * compressMessage, ensuring that the same compressor is used on both sides of a conversation
+     * subject to the same per-connection permit-list check.
      */
     StatusWith<Message> decompressMessage(const Message& msg,
                                           MessageCompressorId* compressorId = nullptr,
@@ -107,11 +231,52 @@ public:
 
     const std::vector<MessageCompressorBase*>& getNegotiatedCompressors() const;
 
+    // SERVER-130410: true once this connection has established a compressor-id permit list. On the
+    // server side this happens via serverNegotiate(); on the client side it is initialized empty by
+    // clientBegin() and finalized by clientFinish(). Used by the ingress workflow to reject
+    // OP_COMPRESSED messages that arrive before any compression negotiation has run; otherwise a
+    // pre-negotiation frame would fall back to the process-wide union registry and could use a
+    // replication-only compressor on an external connection.
+    bool hasCompressorPermitListForThisSession() const {
+        return _permittedCompressorIds.has_value();
+    }
+
     static MessageCompressorManager& forSession(const std::shared_ptr<transport::Session>& session);
 
 private:
+    // SERVER-130410: per-connection permit list of compressor ids that are allowed to appear on the
+    // wire for THIS connection. On the server it is engaged by serverNegotiate() from the
+    // connection's candidate set 'allowed' (net.compression.compressors for external clients,
+    // replication.networkCompression.compressors for replication connections) intersected with the
+    // process-wide registry. On the client it is initialized empty by clientBegin() and populated by
+    // clientFinish() from the compressors the client both advertised and accepted from the server.
+    //
+    // Rationale: the process-wide registry is the union net union replication, so it is larger than
+    // any single connection's candidate set. Before SERVER-130410 registry == the single candidate
+    // set, which made the negotiation-agnostic decompressMessage()/echo-back compressMessage()
+    // lookups (which consult the registry directly) safe. The union broke that invariant. This
+    // permit list re-establishes "registry-visible == this connection's candidate set" per connection.
+    // When boost::none (legacy/direct callers that have not negotiated) the check below returns true
+    // and the original full-registry semantics are preserved unchanged.
+    boost::optional<std::array<bool, std::numeric_limits<MessageCompressorId>::max() + 1>>
+        _permittedCompressorIds;
+
+    // Returns true if 'id' may be used on the wire for this connection. Returns true unconditionally
+    // when the permit list has not been engaged, preserving pre-SERVER-130410 behavior only for
+    // legacy/direct callers that have not run compression negotiation.
+    bool _isCompressorPermittedForThisSession(MessageCompressorId id) const {
+        if (!_permittedCompressorIds) {
+            return true;
+        }
+        return (*_permittedCompressorIds)[id];
+    }
+
+    std::vector<std::string> _advertisedCompressors;
     std::vector<MessageCompressorBase*> _negotiated;
     MessageCompressorRegistry* _registry;
+    // Note: _offerCompressionOnClientBegin and _allowListedCompressors are declared
+    // near the top of the class so that inline member functions can see them without
+    // relying on delayed parsing of class-body member initializers.
 };
 
 }  // namespace mongo

--- a/src/mongo/transport/message_compressor_manager.h
+++ b/src/mongo/transport/message_compressor_manager.h
@@ -107,10 +107,6 @@ public:
         _allowListedCompressors = std::move(allowList);
     }
 
-    const std::vector<std::string>& getCompressorAllowListForThisSession() const {
-        return _allowListedCompressors;
-    }
-
     /*
      * Hello marker used by replication data-plane clients so the server applies the replication
      * compression policy instead of the normal net.compression policy. Older servers ignore the
@@ -127,10 +123,6 @@ public:
         _isReplicationClient = isReplicationClient;
     }
 
-    bool isReplicationClientForThisSession() const {
-        return _isReplicationClient;
-    }
-
     /*
      * Marks whether this connection's compression bytes count toward serverStatus().repl.compression.
      * Kept separate from markReplicationClientForThisSession(): server-side inbound replication
@@ -138,10 +130,6 @@ public:
      */
     void countAsReplicationCompressionTrafficForThisSession(bool countAsReplicationTraffic) {
         _countAsReplicationCompressionTraffic = countAsReplicationTraffic;
-    }
-
-    bool countsAsReplicationCompressionTrafficForThisSession() const {
-        return _countAsReplicationCompressionTraffic;
     }
 
     /*

--- a/src/mongo/transport/message_compressor_manager.h
+++ b/src/mongo/transport/message_compressor_manager.h
@@ -36,14 +36,16 @@ class [[MONGO_MOD_PUBLIC]] MessageCompressorManager {
     // with initializers appears at the end of the class.
     bool _offerCompressionOnClientBegin{true};
     std::vector<std::string> _allowListedCompressors;
-    // SERVER-130410: true only on the manager of a replication data-plane client connection (the
-    // oplog fetcher, initial-sync cloner, or rollback remote oplog reader, marked via
-    // markReplicationClientForThisSession()). When set, clientBegin() adds the
-    // "replicationCompressionClient" marker to the hello request so the server routes this
-    // connection (and ONLY this connection) through the replication candidate
-    // set. Other internal connections (heartbeats, shard RPC) leave this false and are negotiated
-    // like any external client (net.compression.compressors), restoring pre-SERVER-130410 behavior.
+    // True for replication data-plane client connections (oplog fetcher, initial sync, rollback).
+    // When set, clientBegin() adds the replicationCompressionClient marker so the server applies
+    // the replication compression policy; other internal clients keep using net.compression.
     bool _isReplicationClient{false};
+
+    // true when compression bytes on this connection should be attributed to
+    // serverStatus().repl.compression. This is intentionally independent from _isReplicationClient:
+    // client-side replication data-plane connections need both (send marker + count bytes), while
+    // the server side of a marked replication connection only needs the accounting flag.
+    bool _countAsReplicationCompressionTraffic{false};
 
 public:
     /*
@@ -61,20 +63,9 @@ public:
     MessageCompressorManager& operator=(MessageCompressorManager&&) = default;
 
     /*
-     * Called by a client constructing a "hello" request. With no per-session state this appends
-     * the client-facing net set (MessageCompressorRegistry::getNetCompressorNames(), i.e.
-     * net.compression.compressors) to the BSONObjBuilder as a BSON array. If no net compressors
-     * are configured, it won't append anything.
-     *
-     * If a per-session allow-list has been set (setCompressorAllowListForThisSession(), used by
-     * replication data-plane connections), it instead advertises the intersection of that list with
-     * the process-wide capability set (getCompressorNames(), the net union replication union). This
-     * is what lets a replication-only compressor be advertised even when net.compression.compressors:
-     * disabled (SERVER-130410).
-     *
-     * If disableCompressionForThisSession() has been called on this manager, this function will
-     * not advertise any compressor to the server, and the resulting connection will be negotiated
-     * uncompressed regardless of any setting.
+     * Called by a client constructing a "hello" request. By default, advertises the client-facing
+     * net.compression compressors. A per-session allow-list restricts what is advertised for
+     * replication data-plane connections; disableCompressionForThisSession() advertises nothing.
      */
     void clientBegin(BSONObjBuilder* output);
 
@@ -108,20 +99,9 @@ public:
     }
 
     /*
-     * Restricts the compressors advertised by clientBegin() on this manager to the given
-     * allow-list, intersected with the process-wide capability set (getCompressorNames(), the
-     * union of net.compression.compressors and replication.networkCompression.compressors). Names
-     * not present in that union are silently ignored so that a per-session preference can never
-     * widen the process capability surface. Intersecting against the union (rather than only the
-     * net set) is what lets a replication-only compressor be advertised even when
-     * net.compression.compressors: disabled. Passing an empty vector clears the allow-list and
-     * returns to advertising the net set.
-     *
-     * This is meant for replication data-plane connections using
-     * replication.networkCompression.compressors YAML/setParameter (SERVER-130410) which lets
-     * an operator negotiate sync-source data transfer with a subset of the process-wide compressor
-     * list (e.g. force zstd on replication while the client-facing port keeps snappy,zstd,zlib).
-     * It has no effect on any other connection.
+     * Restricts compressors advertised by clientBegin() to this per-session allow-list,
+     * intersected with the process-wide net/repl capability set. This lets replication data-plane
+     * clients advertise replication-only compressors; passing an empty vector returns to the net set.
      */
     void setCompressorAllowListForThisSession(std::vector<std::string> allowList) {
         _allowListedCompressors = std::move(allowList);
@@ -132,23 +112,16 @@ public:
     }
 
     /*
-     * Name of the boolean "hello" field used by replication data-plane clients (oplog fetcher,
-     * initial-sync cloner, rollback remote oplog reader). internalClient is too broad: heartbeats,
-     * mongos-to-mongod traffic, and shard RPC are internal too but must keep using
-     * net.compression.compressors. This marker routes only replication data-plane connections
-     * through the replication compression policy, which may inherit net.compression.compressors.
-     * Older servers ignore the unknown field because "hello" is non-strict.
+     * Hello marker used by replication data-plane clients so the server applies the replication
+     * compression policy instead of the normal net.compression policy. Older servers ignore the
+     * unknown field because hello is non-strict.
      */
     static constexpr auto kReplicationCompressionClientFieldName = "replicationCompressionClient";
 
     /*
-     * SERVER-130410: Marks (or unmarks) this manager as belonging to a replication data-plane
-     * client connection. Set by applyReplicationNetworkCompressionToManager() for the oplog fetcher,
-     * the initial-sync cloner, and the rollback remote oplog reader. When marked, clientBegin()
-     * appends kReplicationCompressionClientFieldName:true to the hello request. This is orthogonal
-     * to the allow-list / suppression state: an "inherit" replication connection is still a
-     * replication client even though it advertises the net set. Persists across DBClientConnection
-     * auto-reconnects because the manager instance is reused.
+     * Marks this manager as a replication data-plane client. clientBegin() will add
+     * kReplicationCompressionClientFieldName to hello; the flag persists across reconnects because
+     * the manager instance is reused.
      */
     void markReplicationClientForThisSession(bool isReplicationClient) {
         _isReplicationClient = isReplicationClient;
@@ -156,6 +129,19 @@ public:
 
     bool isReplicationClientForThisSession() const {
         return _isReplicationClient;
+    }
+
+    /*
+     * Marks whether this connection's compression bytes count toward serverStatus().repl.compression.
+     * Kept separate from markReplicationClientForThisSession(): server-side inbound replication
+     * connections need accounting without emitting the client hello marker.
+     */
+    void countAsReplicationCompressionTrafficForThisSession(bool countAsReplicationTraffic) {
+        _countAsReplicationCompressionTraffic = countAsReplicationTraffic;
+    }
+
+    bool countsAsReplicationCompressionTrafficForThisSession() const {
+        return _countAsReplicationCompressionTraffic;
     }
 
     /*
@@ -181,7 +167,7 @@ public:
      *     (replication.networkCompression.compressors for this node). An empty list forces the
      *     connection uncompressed.
      * This is what lets net.compression.compressors and replication.networkCompression.compressors
-     * negotiate independently. See SERVER-130410.
+     * negotiate independently.
      *
      * If no compressors are configured that match those requested by the client, then it will
      * not append anything to the BSONObjBuilder output.
@@ -208,22 +194,13 @@ public:
     /*
      * Returns a new Message containing the decompressed copy of the input message.
      *
-     * If the compressor specified in the input message is not supported, it will return a Status
-     * error.
+     * If the compressor is not supported or decompression fails, it returns a Status error.
+     * Once this connection has established a permit list via negotiation, only compressors permitted
+     * for this connection may be decompressed. Legacy/direct callers without a permit list keep the
+     * historical registry-wide behavior.
      *
-     * If an error occurs in the compressor, it will return a Status error.
-     *
-     * This class has a pointer to the global MessageCompressorRegistry and can look up a message's
-     * compressor by ID number through that registry. Callers that have not engaged a per-connection
-     * permit list keep the historical negotiation-agnostic behavior for any process-wide registered
-     * compressor. Once serverNegotiate() or the clientBegin()/clientFinish() handshake has
-     * established this connection's permit list, only compressors permitted for this connection may
-     * be decompressed.
-     *
-     * If the 'compressorId' parameter is non-null, it will be populated with the compressor
-     * used. If 'decompressMessage' returns successfully, then that value can be fed back into
-     * compressMessage, ensuring that the same compressor is used on both sides of a conversation
-     * subject to the same per-connection permit-list check.
+     * If 'compressorId' is non-null, it is populated with the compressor used and may be fed back
+     * into compressMessage(), subject to the same per-connection permit-list check.
      */
     StatusWith<Message> decompressMessage(const Message& msg,
                                           MessageCompressorId* compressorId = nullptr,
@@ -231,12 +208,9 @@ public:
 
     const std::vector<MessageCompressorBase*>& getNegotiatedCompressors() const;
 
-    // SERVER-130410: true once this connection has established a compressor-id permit list. On the
-    // server side this happens via serverNegotiate(); on the client side it is initialized empty by
-    // clientBegin() and finalized by clientFinish(). Used by the ingress workflow to reject
-    // OP_COMPRESSED messages that arrive before any compression negotiation has run; otherwise a
-    // pre-negotiation frame would fall back to the process-wide union registry and could use a
-    // replication-only compressor on an external connection.
+    // True once this connection has an explicit compressor-id permit list, established by
+    // serverNegotiate() or the clientBegin()/clientFinish() handshake. Used to reject compressed
+    // frames before negotiation completes.
     bool hasCompressorPermitListForThisSession() const {
         return _permittedCompressorIds.has_value();
     }
@@ -244,26 +218,13 @@ public:
     static MessageCompressorManager& forSession(const std::shared_ptr<transport::Session>& session);
 
 private:
-    // SERVER-130410: per-connection permit list of compressor ids that are allowed to appear on the
-    // wire for THIS connection. On the server it is engaged by serverNegotiate() from the
-    // connection's candidate set 'allowed' (net.compression.compressors for external clients,
-    // replication.networkCompression.compressors for replication connections) intersected with the
-    // process-wide registry. On the client it is initialized empty by clientBegin() and populated by
-    // clientFinish() from the compressors the client both advertised and accepted from the server.
-    //
-    // Rationale: the process-wide registry is the union net union replication, so it is larger than
-    // any single connection's candidate set. Before SERVER-130410 registry == the single candidate
-    // set, which made the negotiation-agnostic decompressMessage()/echo-back compressMessage()
-    // lookups (which consult the registry directly) safe. The union broke that invariant. This
-    // permit list re-establishes "registry-visible == this connection's candidate set" per connection.
-    // When boost::none (legacy/direct callers that have not negotiated) the check below returns true
-    // and the original full-registry semantics are preserved unchanged.
+    // Per-connection compressor-id permit list. Once engaged, only these ids may appear on the
+    // wire for this connection. This is needed because the process-wide registry may contain both
+    // net and replication compressors, while each connection must enforce its own candidate set.
+    // boost::none preserves legacy/direct-call behavior before negotiation.
     boost::optional<std::array<bool, std::numeric_limits<MessageCompressorId>::max() + 1>>
         _permittedCompressorIds;
 
-    // Returns true if 'id' may be used on the wire for this connection. Returns true unconditionally
-    // when the permit list has not been engaged, preserving pre-SERVER-130410 behavior only for
-    // legacy/direct callers that have not run compression negotiation.
     bool _isCompressorPermittedForThisSession(MessageCompressorId id) const {
         if (!_permittedCompressorIds) {
             return true;

--- a/src/mongo/transport/message_compressor_manager_test.cpp
+++ b/src/mongo/transport/message_compressor_manager_test.cpp
@@ -260,6 +260,85 @@ TEST(MessageCompressorManager, FullNormalCompression) {
     clientManager.clientFinish(serverObj);
 }
 
+// Non-replication traffic bumps only the process-wide network.compression counters; the
+// replication subset counters stay at zero.
+TEST(MessageCompressorManager, NonReplicationTrafficNotCountedInReplicationCompressionStats) {
+    auto registry = buildRegistry();
+    auto* compressor = registry.getCompressor("noop");
+    ASSERT(compressor);
+
+    MessageCompressorManager manager(&registry);
+    BSONObjBuilder negotiatorOut;
+    std::vector<std::string_view> negotiator({"noop"});
+    manager.serverNegotiate(negotiator, &negotiatorOut);
+    checkNegotiationResult(negotiatorOut.done(), {"noop"});
+
+    auto compressed = assertOk(manager.compressMessage(buildMessage()));
+    ASSERT_EQ(compressed.operation(), dbCompressed);
+    ASSERT_GT(compressor->getCompressorBytesIn(), 0);
+    ASSERT_EQ(compressor->getReplicationCompressorBytesIn(), 0);
+
+    assertOk(manager.decompressMessage(compressed));
+    ASSERT_GT(compressor->getDecompressorBytesIn(), 0);
+    ASSERT_EQ(compressor->getReplicationDecompressorBytesIn(), 0);
+}
+
+// Replication data-plane traffic is a subset view: it bumps the replication counters AND is still
+// included in the process-wide network.compression counters (repl.compression is a subset, not a
+// separate accounting).
+TEST(MessageCompressorManager, ReplicationTrafficCountedInBothNetworkAndReplicationStats) {
+    auto registry = buildRegistry();
+    auto* compressor = registry.getCompressor("noop");
+    ASSERT(compressor);
+
+    MessageCompressorManager manager(&registry);
+    manager.countAsReplicationCompressionTrafficForThisSession(true);
+    BSONObjBuilder negotiatorOut;
+    std::vector<std::string_view> negotiator({"noop"});
+    manager.serverNegotiate(negotiator, &negotiatorOut);
+    checkNegotiationResult(negotiatorOut.done(), {"noop"});
+
+    auto compressed = assertOk(manager.compressMessage(buildMessage()));
+    ASSERT_EQ(compressed.operation(), dbCompressed);
+    ASSERT_GT(compressor->getReplicationCompressorBytesIn(), 0);
+    // Subset semantics: the same bytes are also present in the process-wide net counters, and the
+    // replication portion never exceeds the process-wide total.
+    ASSERT_GTE(compressor->getCompressorBytesIn(), compressor->getReplicationCompressorBytesIn());
+
+    assertOk(manager.decompressMessage(compressed));
+    ASSERT_GT(compressor->getReplicationDecompressorBytesIn(), 0);
+    ASSERT_GTE(compressor->getDecompressorBytesIn(),
+               compressor->getReplicationDecompressorBytesIn());
+}
+
+// A replication connection's later hello without the replicationCompressionClient marker must NOT
+// clear the connection's replication accounting role: subsequent compression is still attributed to
+// repl.compression. This guards the sticky-flag fix in replication_info.cpp.
+TEST(MessageCompressorManager, ReplicationAccountingSurvivesLaterNonMarkerHello) {
+    auto registry = buildRegistry();
+    auto* compressor = registry.getCompressor("noop");
+    ASSERT(compressor);
+
+    MessageCompressorManager manager(&registry);
+    manager.countAsReplicationCompressionTrafficForThisSession(true);
+
+    std::vector<std::string_view> negotiator({"noop"});
+    BSONObjBuilder initialHelloOut;
+    manager.serverNegotiate(negotiator, &initialHelloOut);
+    checkNegotiationResult(initialHelloOut.done(), {"noop"});
+
+    // A later hello without replicationCompressionClient should not clear the connection's
+    // replication accounting role. replication_info.cpp enforces that by not writing false for
+    // non-marker hellos; this simulates that path by only re-reading the negotiated result.
+    BSONObjBuilder laterHelloOut;
+    manager.serverNegotiate(boost::none, &laterHelloOut);
+    checkNegotiationResult(laterHelloOut.done(), {"noop"});
+
+    auto compressed = assertOk(manager.compressMessage(buildMessage()));
+    ASSERT_EQ(compressed.operation(), dbCompressed);
+    ASSERT_GT(compressor->getReplicationCompressorBytesIn(), 0);
+}
+
 // When a client opts out via disableCompressionForThisSession(), clientBegin()
 // must not emit a "compression" field, the server responds without one, and clientFinish()
 // leaves the negotiated compressor list empty so subsequent compressMessage() calls become
@@ -444,6 +523,31 @@ TEST(MessageCompressorManager, ServerNegotiateInternalUsesReplicationCandidateSe
     std::vector<std::string> replCandidates{"snappy"};
     manager.serverNegotiate(clientList, &out, replCandidates);
     checkNegotiationResult(out.done(), {"snappy"});
+}
+
+// A replication connection's candidate set is sticky for the connection's lifetime. After the
+// initial marker-bearing hello negotiates the replication candidate set, a later hello that
+// re-advertises compression WITHOUT the replicationCompressionClient marker (so serverNegotiate()
+// is called with no allow-list) must NOT fall back to the empty net.compression set and silently
+// drop the replication compression. This guards the sticky-candidate-set fix in
+// MessageCompressorManager::serverNegotiate().
+TEST(MessageCompressorManager, ServerRenegotiateKeepsReplicationCandidateSetSticky) {
+    auto registry = buildNetDisabledReplSnappyRegistry();  // net disabled, repl = snappy
+    MessageCompressorManager manager(&registry);
+
+    std::vector<std::string_view> clientList{"snappy"};
+    std::vector<std::string> replCandidates{"snappy"};
+
+    // Initial hello with the replication allow-list negotiates snappy.
+    BSONObjBuilder initialOut;
+    manager.serverNegotiate(clientList, &initialOut, replCandidates);
+    checkNegotiationResult(initialOut.done(), {"snappy"});
+
+    // Later hello on the same connection re-advertises compression but supplies no allow-list
+    // (marker absent). Without stickiness this would use the empty net set and drop snappy.
+    BSONObjBuilder laterOut;
+    manager.serverNegotiate(clientList, &laterOut);
+    checkNegotiationResult(laterOut.done(), {"snappy"});
 }
 
 // An empty internal candidate set (replication.networkCompression.compressors: disabled) forces

--- a/src/mongo/transport/message_compressor_manager_test.cpp
+++ b/src/mongo/transport/message_compressor_manager_test.cpp
@@ -260,7 +260,7 @@ TEST(MessageCompressorManager, FullNormalCompression) {
     clientManager.clientFinish(serverObj);
 }
 
-// SERVER-130410: when a client opts out via disableCompressionForThisSession(), clientBegin()
+// When a client opts out via disableCompressionForThisSession(), clientBegin()
 // must not emit a "compression" field, the server responds without one, and clientFinish()
 // leaves the negotiated compressor list empty so subsequent compressMessage() calls become
 // no-ops. This is the mechanism that lets the oplog fetcher run uncompressed independently of
@@ -291,7 +291,7 @@ TEST(MessageCompressorManager, ClientCanSuppressCompressionOfferForThisSession) 
     ASSERT_TRUE(serverManager.getNegotiatedCompressors().empty());
 }
 
-// SERVER-130410: verify that re-enabling before the next clientBegin() restores normal
+// Verify that re-enabling before the next clientBegin() restores normal
 // advertisement. This models a replication client that first disabled compression on its
 // manager and then, on a later (re)connect, re-enabled it before the next handshake ran.
 TEST(MessageCompressorManager, ClientCanReenableCompressionOfferAfterSuppressing) {
@@ -323,7 +323,7 @@ TEST(MessageCompressorManager, ClientCanReenableCompressionOfferAfterSuppressing
     ASSERT_FALSE(clientManager.getNegotiatedCompressors().empty());
 }
 
-// SERVER-130410: an allow-list restricts advertisement to the intersection of the caller's
+// An allow-list restricts advertisement to the intersection of the caller's
 // list and the process-wide compressor list, preserving the caller's ordering so it becomes
 // the client's negotiation preference order.
 TEST(MessageCompressorManager, ClientAllowListNarrowsAdvertisedCompressors) {
@@ -363,7 +363,7 @@ TEST(MessageCompressorManager, ClientAllowListNarrowsAdvertisedCompressors) {
     ASSERT_FALSE(clientManager.getNegotiatedCompressors().empty());
 }
 
-// SERVER-130410: unknown names in the allow-list are silently dropped so an operator cannot
+// Unknown names in the allow-list are silently dropped so an operator cannot
 // use the per-session hook to widen the process-wide compressor list. If every name is
 // unknown, the connection is negotiated uncompressed rather than falling back to the full
 // process list, so the operator gets a predictable failure mode.
@@ -406,7 +406,7 @@ TEST(MessageCompressorManager, ClientAllowListDropsUnknownNamesAndCanCollapseToD
     }
 }
 
-// SERVER-130410: builds a registry that mimics `net.compression.compressors: disabled` combined
+// Builds a registry that mimics `net.compression.compressors: disabled` combined
 // with `replication.networkCompression.compressors: snappy`. The net set is empty, snappy is
 // folded into the process-wide capability set (union) via addReplicationCompressors(), and snappy
 // is registered so it can be negotiated for internal connections and decoded on any connection.
@@ -482,7 +482,7 @@ TEST(MessageCompressorManager, ClientBeginAllowListAdvertisesReplicationOnlyComp
     checkNegotiationResult(out.done(), {"snappy"});
 }
 
-// SERVER-130410: mimics `net.compression.compressors: snappy` combined with
+// Mimics `net.compression.compressors: snappy` combined with
 // `replication.networkCompression.compressors: zlib`. Both algorithms are registered process-wide,
 // so the union registry contains {snappy, zlib}, but the net candidate set is only {snappy} and the
 // replication candidate set is only {zlib}. This is the configuration where the union registry is
@@ -498,7 +498,7 @@ MessageCompressorRegistry buildNetSnappyReplZlibRegistry() {
 }
 
 // Produces an OP_COMPRESSED frame compressed with 'name' using a throwaway, un-negotiated manager.
-// Because that manager never ran serverNegotiate(), its whitelist is unengaged and it can emit any
+// Because that manager never ran serverNegotiate(), its permit list is unengaged and it can emit any
 // registered algorithm - exactly what a peer (or a hand-crafted malicious client) could put on the
 // wire.
 Message compressWith(MessageCompressorRegistry* registry, const Message& msg, std::string_view name) {
@@ -507,7 +507,7 @@ Message compressWith(MessageCompressorRegistry* registry, const Message& msg, st
     return assertOk(producer.compressMessage(msg, &id));
 }
 
-// SERVER-130410 (P1/P2): an external connection negotiates the net set (snappy) only. A frame
+// An external connection negotiates the net set (snappy) only. A frame
 // compressed with a replication-only algorithm (zlib) must be rejected at decompression even though
 // zlib is registered process-wide, so the union registry can no longer be used to smuggle an
 // out-of-domain algorithm onto an external connection.
@@ -526,7 +526,7 @@ TEST(MessageCompressorManager, ServerExternalRejectsDecompressOfReplicationOnlyF
     ASSERT_EQ(ErrorCodes::BadValue, sw.getStatus());
 }
 
-// SERVER-130410 (P1/P3): the server echo-back path must never emit a compressor outside this
+// The server echo-back path must never emit a compressor outside this
 // connection's candidate set. Forcing the zlib id on an external connection returns the message
 // uncompressed instead of producing an OP_COMPRESSED zlib frame.
 TEST(MessageCompressorManager, ServerExternalEchoBackOfReplicationOnlyCompressorFallsBackUncompressed) {
@@ -544,8 +544,8 @@ TEST(MessageCompressorManager, ServerExternalEchoBackOfReplicationOnlyCompressor
     ASSERT_EQ(sw.getValue().operation(), dbQuery);
 }
 
-// SERVER-130410: the same registry, but a replication connection (candidate set {zlib}) both
-// decompresses a zlib frame and echoes it back with zlib. This confirms the whitelist keeps
+// The same registry, but a replication connection (candidate set {zlib}) both
+// decompresses a zlib frame and echoes it back with zlib. This confirms the permit list keeps
 // in-domain behavior fully working and only blocks cross-domain use.
 TEST(MessageCompressorManager, ServerReplicationConnectionAcceptsReplicationCompressor) {
     auto registry = buildNetSnappyReplZlibRegistry();
@@ -565,8 +565,8 @@ TEST(MessageCompressorManager, ServerReplicationConnectionAcceptsReplicationComp
     ASSERT_EQ(echoed.operation(), dbCompressed);
 }
 
-// SERVER-130410 (P2): with net.compression.compressors: disabled the external candidate set is
-// empty, so the whitelist is empty and even a registered, replication-attributed algorithm (snappy)
+// With net.compression.compressors: disabled the external candidate set is
+// empty, so the permit list is empty and even a registered, replication-attributed algorithm (snappy)
 // cannot be decompressed on an external connection. This makes "disabled" truly mean uncompressed
 // for external clients despite the union registry containing snappy.
 TEST(MessageCompressorManager, ServerExternalWithNetDisabledRejectsAnyCompressedFrame) {
@@ -584,7 +584,7 @@ TEST(MessageCompressorManager, ServerExternalWithNetDisabledRejectsAnyCompressed
     ASSERT_EQ(ErrorCodes::BadValue, sw.getStatus());
 }
 
-// SERVER-130410: client-side inbound decompression is also constrained by the negotiated result.
+// Client-side inbound decompression is also constrained by the negotiated result.
 // A server response compressed with a replication-only algorithm that the client did not advertise
 // or negotiate must be rejected even though that algorithm is registered process-wide in the union.
 TEST(MessageCompressorManager, ClientSideDecompressionRejectsUnnegotiatedCompressor) {
@@ -620,7 +620,7 @@ TEST(MessageCompressorManager, ClientSideDisabledNegotiationRejectsCompressedRes
     ASSERT_EQ(ErrorCodes::BadValue, sw.getStatus());
 }
 
-// SERVER-130410: a manager NOT marked as a replication client must never emit the
+// A manager NOT marked as a replication client must never emit the
 // "replicationCompressionClient" hello marker, so the server treats it like any other internal or
 // external connection (heartbeats, shard RPC, external clients all keep using the net set). This
 // is the guard that scopes replication.networkCompression to actual sync-source connections.
@@ -634,7 +634,7 @@ TEST(MessageCompressorManager, ClientBeginDoesNotMarkReplicationByDefault) {
     ASSERT_FALSE(obj.hasField(MessageCompressorManager::kReplicationCompressionClientFieldName));
 }
 
-// SERVER-130410: once marked as a replication client, clientBegin() must emit
+// Once marked as a replication client, clientBegin() must emit
 // "replicationCompressionClient": true so the server routes this connection (and only this
 // connection) through the replication candidate set. The marker must be present in every state
 // (inherit / allow-list / suppressed) because the server needs to identify the connection type
@@ -686,7 +686,7 @@ TEST(MessageCompressorManager, ClientBeginMarksReplicationClientInEveryState) {
 // an unavailable net compressor. This keeps replication.networkCompression.compressors consistent
 // with net.compression.compressors: a configured-but-uncompiled algorithm can never be silently
 // ignored (which would leave the operator believing replication compression is active when it is
-// not). See SERVER-130410.
+// not).
 TEST(MessageCompressorRegistryTest, FinalizeRejectsUnavailableReplicationCompressor) {
     MessageCompressorRegistry registry;
     registry.setSupportedCompressors(std::vector<std::string>{});

--- a/src/mongo/transport/message_compressor_manager_test.cpp
+++ b/src/mongo/transport/message_compressor_manager_test.cpp
@@ -260,6 +260,468 @@ TEST(MessageCompressorManager, FullNormalCompression) {
     clientManager.clientFinish(serverObj);
 }
 
+// SERVER-130410: when a client opts out via disableCompressionForThisSession(), clientBegin()
+// must not emit a "compression" field, the server responds without one, and clientFinish()
+// leaves the negotiated compressor list empty so subsequent compressMessage() calls become
+// no-ops. This is the mechanism that lets the oplog fetcher run uncompressed independently of
+// net.compression.compressors.
+TEST(MessageCompressorManager, ClientCanSuppressCompressionOfferForThisSession) {
+    auto registry = buildRegistry();
+    MessageCompressorManager clientManager(&registry);
+    MessageCompressorManager serverManager(&registry);
+
+    ASSERT_TRUE(clientManager.isCompressionOfferedForThisSession());
+    clientManager.disableCompressionForThisSession();
+    ASSERT_FALSE(clientManager.isCompressionOfferedForThisSession());
+
+    BSONObjBuilder clientOutput;
+    clientManager.clientBegin(&clientOutput);
+    auto clientObj = clientOutput.done();
+    // No "compression" element should be emitted at all.
+    ASSERT_FALSE(clientObj.hasField("compression"));
+
+    BSONObjBuilder serverOutput;
+    serverManager.serverNegotiate(parseBSON(clientObj), &serverOutput);
+    auto serverObj = serverOutput.done();
+    // Server has nothing to negotiate against, so it must not echo a compression list.
+    ASSERT_FALSE(serverObj.hasField("compression"));
+
+    clientManager.clientFinish(serverObj);
+    ASSERT_TRUE(clientManager.getNegotiatedCompressors().empty());
+    ASSERT_TRUE(serverManager.getNegotiatedCompressors().empty());
+}
+
+// SERVER-130410: verify that re-enabling before the next clientBegin() restores normal
+// advertisement. This models a replication client that first disabled compression on its
+// manager and then, on a later (re)connect, re-enabled it before the next handshake ran.
+TEST(MessageCompressorManager, ClientCanReenableCompressionOfferAfterSuppressing) {
+    auto registry = buildRegistry();
+    MessageCompressorManager clientManager(&registry);
+    MessageCompressorManager serverManager(&registry);
+
+    clientManager.disableCompressionForThisSession();
+    {
+        BSONObjBuilder out;
+        clientManager.clientBegin(&out);
+        ASSERT_FALSE(out.done().hasField("compression"));
+    }
+
+    clientManager.enableCompressionForThisSession();
+    ASSERT_TRUE(clientManager.isCompressionOfferedForThisSession());
+
+    BSONObjBuilder clientOutput;
+    clientManager.clientBegin(&clientOutput);
+    auto clientObj = clientOutput.done();
+    checkNegotiationResult(clientObj, {"noop"});
+
+    BSONObjBuilder serverOutput;
+    serverManager.serverNegotiate(parseBSON(clientObj), &serverOutput);
+    auto serverObj = serverOutput.done();
+    checkNegotiationResult(serverObj, {"noop"});
+
+    clientManager.clientFinish(serverObj);
+    ASSERT_FALSE(clientManager.getNegotiatedCompressors().empty());
+}
+
+// SERVER-130410: an allow-list restricts advertisement to the intersection of the caller's
+// list and the process-wide compressor list, preserving the caller's ordering so it becomes
+// the client's negotiation preference order.
+TEST(MessageCompressorManager, ClientAllowListNarrowsAdvertisedCompressors) {
+    std::unique_ptr<MessageCompressorBase> zstdCompressor =
+        std::make_unique<ZstdMessageCompressor>();
+    std::unique_ptr<MessageCompressorBase> zlibCompressor =
+        std::make_unique<ZlibMessageCompressor>();
+    std::unique_ptr<MessageCompressorBase> snappyCompressor =
+        std::make_unique<SnappyMessageCompressor>();
+
+    MessageCompressorRegistry registry;
+    registry.setSupportedCompressors(
+        {snappyCompressor->getName(), zlibCompressor->getName(), zstdCompressor->getName()});
+    registry.registerImplementation(std::move(zlibCompressor));
+    registry.registerImplementation(std::move(zstdCompressor));
+    registry.registerImplementation(std::move(snappyCompressor));
+    ASSERT_OK(registry.finalizeSupportedCompressors());
+
+    MessageCompressorManager clientManager(&registry);
+    MessageCompressorManager serverManager(&registry);
+
+    // Allow-list is a strict subset; order given by the caller must be preserved verbatim.
+    clientManager.setCompressorAllowListForThisSession({"zstd", "snappy"});
+
+    BSONObjBuilder clientOutput;
+    clientManager.clientBegin(&clientOutput);
+    auto clientObj = clientOutput.done();
+    checkNegotiationResult(clientObj, {"zstd", "snappy"});
+
+    BSONObjBuilder serverOutput;
+    serverManager.serverNegotiate(parseBSON(clientObj), &serverOutput);
+    auto serverObj = serverOutput.done();
+    // Server echoes the mutually supported compressors in client preference order.
+    checkNegotiationResult(serverObj, {"zstd", "snappy"});
+
+    clientManager.clientFinish(serverObj);
+    ASSERT_FALSE(clientManager.getNegotiatedCompressors().empty());
+}
+
+// SERVER-130410: unknown names in the allow-list are silently dropped so an operator cannot
+// use the per-session hook to widen the process-wide compressor list. If every name is
+// unknown, the connection is negotiated uncompressed rather than falling back to the full
+// process list, so the operator gets a predictable failure mode.
+TEST(MessageCompressorManager, ClientAllowListDropsUnknownNamesAndCanCollapseToDisabled) {
+    auto registry = buildRegistry();  // registers only "noop"
+    MessageCompressorManager clientManager(&registry);
+    MessageCompressorManager serverManager(&registry);
+
+    // "zstd" is not in this registry; "noop" is. Only "noop" should be advertised.
+    clientManager.setCompressorAllowListForThisSession({"zstd", "noop"});
+    {
+        BSONObjBuilder out;
+        clientManager.clientBegin(&out);
+        checkNegotiationResult(out.done(), {"noop"});
+    }
+
+    // Every name unknown => nothing advertised, connection stays uncompressed.
+    clientManager.setCompressorAllowListForThisSession({"zstd", "brotli"});
+    {
+        BSONObjBuilder out;
+        clientManager.clientBegin(&out);
+        ASSERT_FALSE(out.done().hasField("compression"));
+    }
+
+    // Clearing the allow-list restores full advertisement of the process-wide list.
+    clientManager.setCompressorAllowListForThisSession({});
+    {
+        BSONObjBuilder out;
+        clientManager.clientBegin(&out);
+        checkNegotiationResult(out.done(), {"noop"});
+    }
+
+    // disableCompressionForThisSession() must still win over any allow-list state.
+    clientManager.setCompressorAllowListForThisSession({"noop"});
+    clientManager.disableCompressionForThisSession();
+    {
+        BSONObjBuilder out;
+        clientManager.clientBegin(&out);
+        ASSERT_FALSE(out.done().hasField("compression"));
+    }
+}
+
+// SERVER-130410: builds a registry that mimics `net.compression.compressors: disabled` combined
+// with `replication.networkCompression.compressors: snappy`. The net set is empty, snappy is
+// folded into the process-wide capability set (union) via addReplicationCompressors(), and snappy
+// is registered so it can be negotiated for internal connections and decoded on any connection.
+MessageCompressorRegistry buildNetDisabledReplSnappyRegistry() {
+    MessageCompressorRegistry registry;
+    registry.setSupportedCompressors(std::vector<std::string>{});  // net disabled
+    registry.addReplicationCompressors({"snappy"});                // replication-only
+    registry.registerImplementation(std::make_unique<SnappyMessageCompressor>());
+    ASSERT_OK(registry.finalizeSupportedCompressors());
+    return registry;
+}
+
+// An external (client-facing) negotiation uses the net set. With net disabled it is empty, so a
+// client advertising a replication-only compressor must be negotiated uncompressed. This is the
+// invariant that keeps net.compression.compressors: disabled meaningful for external clients even
+// though the union registry now contains snappy.
+TEST(MessageCompressorManager, ServerNegotiateExternalIgnoresReplicationOnlyCompressor) {
+    auto registry = buildNetDisabledReplSnappyRegistry();
+    MessageCompressorManager manager(&registry);
+
+    std::vector<std::string_view> clientList{"snappy"};
+    BSONObjBuilder out;
+    manager.serverNegotiate(clientList, &out);  // default => external / net set (empty)
+    checkNegotiationResult(out.done(), {});
+}
+
+// An internal replica-set negotiation passes the replication candidate set. Even with net
+// disabled, snappy is accepted because it is both in the candidate set and registered.
+TEST(MessageCompressorManager, ServerNegotiateInternalUsesReplicationCandidateSet) {
+    auto registry = buildNetDisabledReplSnappyRegistry();
+    MessageCompressorManager manager(&registry);
+
+    std::vector<std::string_view> clientList{"snappy"};
+    BSONObjBuilder out;
+    std::vector<std::string> replCandidates{"snappy"};
+    manager.serverNegotiate(clientList, &out, replCandidates);
+    checkNegotiationResult(out.done(), {"snappy"});
+}
+
+// An empty internal candidate set (replication.networkCompression.compressors: disabled) forces
+// internal connections uncompressed regardless of what the client advertises.
+TEST(MessageCompressorManager, ServerNegotiateInternalDisabledForcesUncompressed) {
+    auto registry = buildNetDisabledReplSnappyRegistry();
+    MessageCompressorManager manager(&registry);
+
+    std::vector<std::string_view> clientList{"snappy"};
+    BSONObjBuilder out;
+    std::vector<std::string> emptyCandidates{};
+    manager.serverNegotiate(clientList, &out, emptyCandidates);
+    checkNegotiationResult(out.done(), {});
+}
+
+// The client default path (no per-session allow-list) advertises only the net set, so a node with
+// net disabled offers nothing on ordinary outbound connections even though snappy is in the union.
+TEST(MessageCompressorManager, ClientBeginDefaultAdvertisesNetSetOnly) {
+    auto registry = buildNetDisabledReplSnappyRegistry();
+    MessageCompressorManager manager(&registry);
+
+    BSONObjBuilder out;
+    manager.clientBegin(&out);
+    ASSERT_FALSE(out.done().hasField("compression"));
+}
+
+// The oplog fetcher path (per-session allow-list) intersects against the union, so a
+// replication-only compressor can be advertised even when net.compression.compressors: disabled.
+TEST(MessageCompressorManager, ClientBeginAllowListAdvertisesReplicationOnlyCompressor) {
+    auto registry = buildNetDisabledReplSnappyRegistry();
+    MessageCompressorManager manager(&registry);
+
+    manager.setCompressorAllowListForThisSession({"snappy"});
+    BSONObjBuilder out;
+    manager.clientBegin(&out);
+    checkNegotiationResult(out.done(), {"snappy"});
+}
+
+// SERVER-130410: mimics `net.compression.compressors: snappy` combined with
+// `replication.networkCompression.compressors: zlib`. Both algorithms are registered process-wide,
+// so the union registry contains {snappy, zlib}, but the net candidate set is only {snappy} and the
+// replication candidate set is only {zlib}. This is the configuration where the union registry is
+// strictly larger than any single connection's candidate set.
+MessageCompressorRegistry buildNetSnappyReplZlibRegistry() {
+    MessageCompressorRegistry registry;
+    registry.setSupportedCompressors({"snappy"});  // net
+    registry.addReplicationCompressors({"zlib"});  // replication-only
+    registry.registerImplementation(std::make_unique<SnappyMessageCompressor>());
+    registry.registerImplementation(std::make_unique<ZlibMessageCompressor>());
+    ASSERT_OK(registry.finalizeSupportedCompressors());
+    return registry;
+}
+
+// Produces an OP_COMPRESSED frame compressed with 'name' using a throwaway, un-negotiated manager.
+// Because that manager never ran serverNegotiate(), its whitelist is unengaged and it can emit any
+// registered algorithm - exactly what a peer (or a hand-crafted malicious client) could put on the
+// wire.
+Message compressWith(MessageCompressorRegistry* registry, const Message& msg, std::string_view name) {
+    MessageCompressorManager producer(registry);
+    auto id = registry->getCompressor(name)->getId();
+    return assertOk(producer.compressMessage(msg, &id));
+}
+
+// SERVER-130410 (P1/P2): an external connection negotiates the net set (snappy) only. A frame
+// compressed with a replication-only algorithm (zlib) must be rejected at decompression even though
+// zlib is registered process-wide, so the union registry can no longer be used to smuggle an
+// out-of-domain algorithm onto an external connection.
+TEST(MessageCompressorManager, ServerExternalRejectsDecompressOfReplicationOnlyFrame) {
+    auto registry = buildNetSnappyReplZlibRegistry();
+    auto zlibFrame = compressWith(&registry, buildMessage(), "zlib");
+
+    MessageCompressorManager server(&registry);
+    BSONObjBuilder out;
+    std::vector<std::string_view> clientList{"snappy"};
+    server.serverNegotiate(clientList, &out);  // default => external / net set
+    checkNegotiationResult(out.done(), {"snappy"});
+
+    MessageCompressorId cid;
+    auto sw = server.decompressMessage(zlibFrame, &cid);
+    ASSERT_EQ(ErrorCodes::BadValue, sw.getStatus());
+}
+
+// SERVER-130410 (P1/P3): the server echo-back path must never emit a compressor outside this
+// connection's candidate set. Forcing the zlib id on an external connection returns the message
+// uncompressed instead of producing an OP_COMPRESSED zlib frame.
+TEST(MessageCompressorManager, ServerExternalEchoBackOfReplicationOnlyCompressorFallsBackUncompressed) {
+    auto registry = buildNetSnappyReplZlibRegistry();
+    MessageCompressorManager server(&registry);
+    BSONObjBuilder out;
+    std::vector<std::string_view> clientList{"snappy"};
+    server.serverNegotiate(clientList, &out);
+
+    auto zlibId = registry.getCompressor("zlib")->getId();
+    auto msg = buildMessage();
+    auto sw = server.compressMessage(msg, &zlibId);
+    ASSERT_OK(sw.getStatus());
+    // Not permitted for this connection => returned as-is, still the original opcode (not compressed).
+    ASSERT_EQ(sw.getValue().operation(), dbQuery);
+}
+
+// SERVER-130410: the same registry, but a replication connection (candidate set {zlib}) both
+// decompresses a zlib frame and echoes it back with zlib. This confirms the whitelist keeps
+// in-domain behavior fully working and only blocks cross-domain use.
+TEST(MessageCompressorManager, ServerReplicationConnectionAcceptsReplicationCompressor) {
+    auto registry = buildNetSnappyReplZlibRegistry();
+    auto zlibFrame = compressWith(&registry, buildMessage(), "zlib");
+
+    MessageCompressorManager server(&registry);
+    BSONObjBuilder out;
+    std::vector<std::string_view> clientList{"zlib"};
+    std::vector<std::string> replCandidates{"zlib"};
+    server.serverNegotiate(clientList, &out, replCandidates);
+    checkNegotiationResult(out.done(), {"zlib"});
+
+    MessageCompressorId cid;
+    auto recvd = assertOk(server.decompressMessage(zlibFrame, &cid));
+    ASSERT_EQ(cid, registry.getCompressor("zlib")->getId());
+    auto echoed = assertOk(server.compressMessage(recvd, &cid));
+    ASSERT_EQ(echoed.operation(), dbCompressed);
+}
+
+// SERVER-130410 (P2): with net.compression.compressors: disabled the external candidate set is
+// empty, so the whitelist is empty and even a registered, replication-attributed algorithm (snappy)
+// cannot be decompressed on an external connection. This makes "disabled" truly mean uncompressed
+// for external clients despite the union registry containing snappy.
+TEST(MessageCompressorManager, ServerExternalWithNetDisabledRejectsAnyCompressedFrame) {
+    auto registry = buildNetDisabledReplSnappyRegistry();  // net empty, repl = snappy
+    auto snappyFrame = compressWith(&registry, buildMessage(), "snappy");
+
+    MessageCompressorManager server(&registry);
+    BSONObjBuilder out;
+    std::vector<std::string_view> clientList{"snappy"};
+    server.serverNegotiate(clientList, &out);  // external, net set empty
+    checkNegotiationResult(out.done(), {});
+
+    MessageCompressorId cid;
+    auto sw = server.decompressMessage(snappyFrame, &cid);
+    ASSERT_EQ(ErrorCodes::BadValue, sw.getStatus());
+}
+
+// SERVER-130410: client-side inbound decompression is also constrained by the negotiated result.
+// A server response compressed with a replication-only algorithm that the client did not advertise
+// or negotiate must be rejected even though that algorithm is registered process-wide in the union.
+TEST(MessageCompressorManager, ClientSideDecompressionRejectsUnnegotiatedCompressor) {
+    auto registry = buildNetSnappyReplZlibRegistry();
+    auto zlibFrame = compressWith(&registry, buildMessage(), "zlib");
+
+    MessageCompressorManager client(&registry);
+    BSONObjBuilder clientOut;
+    client.clientBegin(&clientOut);  // advertises the net set (snappy)
+    // Server responds negotiating snappy only.
+    client.clientFinish(BSON("compression" << BSON_ARRAY("snappy")));
+
+    MessageCompressorId cid;
+    auto sw = client.decompressMessage(zlibFrame, &cid);
+    ASSERT_EQ(ErrorCodes::BadValue, sw.getStatus());
+}
+
+// A client connection that negotiated no compression (for example replicationNetworkCompression:
+// disabled) must reject any compressed response, including a registered replication-only algorithm.
+TEST(MessageCompressorManager, ClientSideDisabledNegotiationRejectsCompressedResponse) {
+    auto registry = buildNetDisabledReplSnappyRegistry();
+    auto snappyFrame = compressWith(&registry, buildMessage(), "snappy");
+
+    MessageCompressorManager client(&registry);
+    client.disableCompressionForThisSession();
+    BSONObjBuilder clientOut;
+    client.clientBegin(&clientOut);
+    ASSERT_FALSE(clientOut.done().hasField("compression"));
+    client.clientFinish(BSONObj{});
+
+    MessageCompressorId cid;
+    auto sw = client.decompressMessage(snappyFrame, &cid);
+    ASSERT_EQ(ErrorCodes::BadValue, sw.getStatus());
+}
+
+// SERVER-130410: a manager NOT marked as a replication client must never emit the
+// "replicationCompressionClient" hello marker, so the server treats it like any other internal or
+// external connection (heartbeats, shard RPC, external clients all keep using the net set). This
+// is the guard that scopes replication.networkCompression to actual sync-source connections.
+TEST(MessageCompressorManager, ClientBeginDoesNotMarkReplicationByDefault) {
+    auto registry = buildRegistry();  // registers "noop" in the net set
+    MessageCompressorManager manager(&registry);
+
+    BSONObjBuilder out;
+    manager.clientBegin(&out);
+    auto obj = out.done();
+    ASSERT_FALSE(obj.hasField(MessageCompressorManager::kReplicationCompressionClientFieldName));
+}
+
+// SERVER-130410: once marked as a replication client, clientBegin() must emit
+// "replicationCompressionClient": true so the server routes this connection (and only this
+// connection) through the replication candidate set. The marker must be present in every state
+// (inherit / allow-list / suppressed) because the server needs to identify the connection type
+// regardless of whether it ends up advertising compression.
+TEST(MessageCompressorManager, ClientBeginMarksReplicationClientInEveryState) {
+    auto registry = buildNetDisabledReplSnappyRegistry();
+    MessageCompressorManager manager(&registry);
+    manager.markReplicationClientForThisSession(true);
+
+    // (a) inherit (no allow-list, net disabled => advertises nothing) still carries the marker.
+    {
+        BSONObjBuilder out;
+        manager.clientBegin(&out);
+        auto obj = out.done();
+        ASSERT_TRUE(
+            obj.getField(MessageCompressorManager::kReplicationCompressionClientFieldName)
+                .booleanSafe());
+        // net disabled + inherit => nothing advertised.
+        ASSERT_FALSE(obj.hasField("compression"));
+    }
+
+    // (b) allow-list (advertises snappy from the union) carries the marker.
+    {
+        manager.setCompressorAllowListForThisSession({"snappy"});
+        BSONObjBuilder out;
+        manager.clientBegin(&out);
+        auto obj = out.done();
+        ASSERT_TRUE(
+            obj.getField(MessageCompressorManager::kReplicationCompressionClientFieldName)
+                .booleanSafe());
+        checkNegotiationResult(obj, {"snappy"});
+    }
+
+    // (c) suppressed (disabled) still carries the marker even though it advertises nothing.
+    {
+        manager.setCompressorAllowListForThisSession({});
+        manager.disableCompressionForThisSession();
+        BSONObjBuilder out;
+        manager.clientBegin(&out);
+        auto obj = out.done();
+        ASSERT_TRUE(
+            obj.getField(MessageCompressorManager::kReplicationCompressionClientFieldName)
+                .booleanSafe());
+        ASSERT_FALSE(obj.hasField("compression"));
+    }
+}
+
+// A replication compressor that this build does not provide is a hard startup error, exactly like
+// an unavailable net compressor. This keeps replication.networkCompression.compressors consistent
+// with net.compression.compressors: a configured-but-uncompiled algorithm can never be silently
+// ignored (which would leave the operator believing replication compression is active when it is
+// not). See SERVER-130410.
+TEST(MessageCompressorRegistryTest, FinalizeRejectsUnavailableReplicationCompressor) {
+    MessageCompressorRegistry registry;
+    registry.setSupportedCompressors(std::vector<std::string>{});
+    // "brotli" is not a real compressor in this build; naming it for replication must fail startup.
+    registry.addReplicationCompressors({"snappy", "brotli"});
+    registry.registerImplementation(std::make_unique<SnappyMessageCompressor>());
+    ASSERT_NOT_OK(registry.finalizeSupportedCompressors());
+}
+
+// A replication compressor that IS compiled in survives finalize and is reported in both the union
+// and the replication attribution set, while the net set stays empty (disabled).
+TEST(MessageCompressorRegistryTest, FinalizeKeepsAvailableReplicationOnlyCompressor) {
+    MessageCompressorRegistry registry;
+    registry.setSupportedCompressors(std::vector<std::string>{});
+    registry.addReplicationCompressors({"snappy"});
+    registry.registerImplementation(std::make_unique<SnappyMessageCompressor>());
+    ASSERT_OK(registry.finalizeSupportedCompressors());
+
+    const auto& unionNames = registry.getCompressorNames();
+    ASSERT_TRUE(std::find(unionNames.begin(), unionNames.end(), "snappy") != unionNames.end());
+
+    const auto& replNames = registry.getReplCompressorNames();
+    ASSERT_TRUE(std::find(replNames.begin(), replNames.end(), "snappy") != replNames.end());
+
+    // The net set stays empty (disabled).
+    ASSERT_TRUE(registry.getNetCompressorNames().empty());
+}
+
+TEST(MessageCompressorRegistryTest, FinalizeRejectsUnavailableNetCompressor) {
+    MessageCompressorRegistry registry;
+    // "brotli" as a net compressor is a hard error because no implementation registers it.
+    registry.setSupportedCompressors({"brotli"});
+    ASSERT_NOT_OK(registry.finalizeSupportedCompressors());
+}
+
 TEST(NoopMessageCompressor, Fidelity) {
     auto testMessage = buildMessage();
     checkFidelity(testMessage, std::make_unique<NoopMessageCompressor>());

--- a/src/mongo/transport/message_compressor_metrics.cpp
+++ b/src/mongo/transport/message_compressor_metrics.cpp
@@ -42,4 +42,35 @@ void appendMessageCompressionStats(BSONObjBuilder* b) {
     compressionSection.doneFast();
 }
 
+void appendReplicationMessageCompressionStats(BSONObjBuilder* b) {
+    // Replication-data-plane subset of appendMessageCompressionStats(). Same structure as
+    // serverStatus().network.compression, but the byte counts include ONLY traffic on connections
+    // attributed to replication data-plane traffic (oplog fetcher, initial-sync cloner, rollback
+    // remote oplog reader, and the sync source's responses to them). These bytes are also present
+    // in network.compression; this is an independent view, not a separate accounting.
+    auto& registry = MessageCompressorRegistry::get();
+    const auto& names = registry.getCompressorNames();
+    if (names.empty()) {
+        return;
+    }
+    BSONObjBuilder compressionSection(b->subobjStart("compression"));
+
+    for (auto&& name : names) {
+        auto&& compressor = registry.getCompressor(name);
+        BSONObjBuilder base(compressionSection.subobjStart(name));
+
+        BSONObjBuilder compressorSection(base.subobjStart("compressor"));
+        compressorSection << kBytesIn << compressor->getReplicationCompressorBytesIn() << kBytesOut
+                          << compressor->getReplicationCompressorBytesOut();
+        compressorSection.doneFast();
+
+        BSONObjBuilder decompressorSection(base.subobjStart("decompressor"));
+        decompressorSection << kBytesIn << compressor->getReplicationDecompressorBytesIn()
+                            << kBytesOut << compressor->getReplicationDecompressorBytesOut();
+        decompressorSection.doneFast();
+        base.doneFast();
+    }
+    compressionSection.doneFast();
+}
+
 }  // namespace mongo

--- a/src/mongo/transport/message_compressor_registry.cpp
+++ b/src/mongo/transport/message_compressor_registry.cpp
@@ -81,6 +81,14 @@ const std::vector<std::string>& MessageCompressorRegistry::getCompressorNames() 
     return _compressorNames;
 }
 
+const std::vector<std::string>& MessageCompressorRegistry::getNetCompressorNames() const {
+    return _netCompressorNames;
+}
+
+const std::vector<std::string>& MessageCompressorRegistry::getReplCompressorNames() const {
+    return _replCompressorNames;
+}
+
 MessageCompressorBase* MessageCompressorRegistry::getCompressor(MessageCompressorId id) const {
     return _compressorsByIds.at(id).get();
 }
@@ -93,7 +101,31 @@ MessageCompressorBase* MessageCompressorRegistry::getCompressor(std::string_view
 }
 
 void MessageCompressorRegistry::setSupportedCompressors(std::vector<std::string>&& names) {
+    // Seed the client-facing net set and the process-wide capability set (union) to the same
+    // names, and reset the replication attribution set. addReplicationCompressors() folds in any
+    // replication-only algorithms afterwards, deduplicating names already present from net.
+    //
+    // Call ordering contract: this must run BEFORE addReplicationCompressors() and only once during
+    // startup. It overwrites _compressorNames wholesale and clears _replCompressorNames, so calling
+    // it after addReplicationCompressors() would silently discard the replication-only algorithms
+    // that were folded into the union.
+    _netCompressorNames = names;
     _compressorNames = std::move(names);
+    _replCompressorNames.clear();
+}
+
+void MessageCompressorRegistry::addReplicationCompressors(
+    const std::vector<std::string>& replCompressorNames) {
+    for (const auto& name : replCompressorNames) {
+        if (std::find(_replCompressorNames.begin(), _replCompressorNames.end(), name) ==
+            _replCompressorNames.end()) {
+            _replCompressorNames.push_back(name);
+        }
+        if (std::find(_compressorNames.begin(), _compressorNames.end(), name) ==
+            _compressorNames.end()) {
+            _compressorNames.push_back(name);
+        }
+    }
 }
 
 Status storeMessageCompressionOptions(const std::string& compressors) {

--- a/src/mongo/transport/message_compressor_registry.h
+++ b/src/mongo/transport/message_compressor_registry.h
@@ -56,13 +56,36 @@ public:
     void registerImplementation(std::unique_ptr<MessageCompressorBase> impl);
 
     /*
-     * Returns the list of compressor names that have been registered and configured.
+     * Returns the process-wide capability set: the union of net.compression.compressors and
+     * replication.networkCompression.compressors startup lists. Compressor implementations are
+     * registered only if named here. Per-connection negotiation still restricts which registered
+     * compressors may appear on a given connection.
+     *
+     * Used as the intersection base for per-session allow-lists so a replication-configured
+     * compressor can be advertised even when net.compression.compressors is "disabled".
      *
      * Iterators and value in this vector may be invalidated by calls to:
      *   setSupportedCompressors
+     *   addReplicationCompressors
      *   finalizeSupportedCompressors
      */
     const std::vector<std::string>& getCompressorNames() const;
+
+    /*
+     * Returns the compressor names sourced from net.compression.compressors. This is the candidate
+     * set for external, client-facing connections. It is empty when net.compression.compressors is
+     * "disabled", which is what keeps external connections uncompressed independently of any
+     * replication.networkCompression.compressors setting (SERVER-130410).
+     */
+    const std::vector<std::string>& getNetCompressorNames() const;
+
+    /*
+     * Returns the compressor names sourced from replication.networkCompression.compressors. After
+     * startup finalization, any name here has been validated against the compressors compiled into
+     * this build. Provided for observability; server-side replication negotiation uses the
+     * per-handshake candidate list supplied by the caller rather than this snapshot.
+     */
+    const std::vector<std::string>& getReplCompressorNames() const;
 
     /*
      * Returns a compressor given an ID number. If no compressor exists with the ID number, it
@@ -76,15 +99,32 @@ public:
     MessageCompressorBase* getCompressor(std::string_view name) const;
 
     /*
-     * Sets the list of supported compressors for this registry. Should be called during
-     * option parsing and before calling registerImplementation for any compressors.
+     * Sets the compressor names sourced from net.compression.compressors. This seeds both the
+     * client-facing net candidate set and the process-wide capability union, and clears the
+     * replication attribution set. Should be called during option parsing and before calling
+     * registerImplementation for any compressors. Call addReplicationCompressors() afterwards to
+     * fold in replication-configured names.
      */
     void setSupportedCompressors(std::vector<std::string>&& compressorNames);
 
     /*
+     * Merges replication-configured compressor names into the process-wide capability union so
+     * their implementations get registered, without adding them to the client-facing net candidate
+     * set. Names already in the union are deduplicated. Must run after setSupportedCompressors()
+     * and before compressor implementations register. See SERVER-130410.
+     */
+    void addReplicationCompressors(const std::vector<std::string>& replCompressorNames);
+
+    /*
      * Finalizes the list of supported compressors for this registry. Should be called after all
-     * calls to registerImplementation. It will remove any compressor names that aren't keys in
-     * the _compressors map.
+     * calls to registerImplementation.
+     *
+     * Any name that was requested but is not provided by this build is a hard startup error
+     * (fail-fast), regardless of whether it came from net.compression.compressors or
+     * replication.networkCompression.compressors. The two sources are treated identically so a
+     * compressor named in the replication configuration can never be silently ignored, which would
+     * otherwise leave the operator believing replication compression is active when it is not.
+     * See SERVER-130410.
      */
     Status finalizeSupportedCompressors();
 
@@ -93,7 +133,16 @@ private:
     std::array<std::unique_ptr<MessageCompressorBase>,
                std::numeric_limits<MessageCompressorId>::max() + 1>
         _compressorsByIds;
+    // Union of the net and replication startup lists: the process-wide capability ceiling used for
+    // compressor registration and lookup. Per-connection policy still gates wire use.
     std::vector<std::string> _compressorNames;
+    // Names from net.compression.compressors. Candidate set for external client-facing
+    // connections; empty when net.compression.compressors: disabled.
+    std::vector<std::string> _netCompressorNames;
+    // Names from replication.networkCompression.compressors. Recorded for observability
+    // (getReplCompressorNames()); after startup finalization, these have been validated the same
+    // way as net.compression algorithms.
+    std::vector<std::string> _replCompressorNames;
 };
 
 Status storeMessageCompressionOptions(const std::string& compressors);

--- a/src/mongo/transport/message_compressor_registry.h
+++ b/src/mongo/transport/message_compressor_registry.h
@@ -72,10 +72,9 @@ public:
     const std::vector<std::string>& getCompressorNames() const;
 
     /*
-     * Returns the compressor names sourced from net.compression.compressors. This is the candidate
-     * set for external, client-facing connections. It is empty when net.compression.compressors is
-     * "disabled", which is what keeps external connections uncompressed independently of any
-     * replication.networkCompression.compressors setting (SERVER-130410).
+     * Returns compressor names from net.compression.compressors. This is the candidate set for
+     * external, client-facing connections and is empty when net.compression is disabled,
+     * independently of replication.networkCompression.compressors.
      */
     const std::vector<std::string>& getNetCompressorNames() const;
 
@@ -111,7 +110,7 @@ public:
      * Merges replication-configured compressor names into the process-wide capability union so
      * their implementations get registered, without adding them to the client-facing net candidate
      * set. Names already in the union are deduplicated. Must run after setSupportedCompressors()
-     * and before compressor implementations register. See SERVER-130410.
+     * and before compressor implementations register.
      */
     void addReplicationCompressors(const std::vector<std::string>& replCompressorNames);
 
@@ -119,12 +118,8 @@ public:
      * Finalizes the list of supported compressors for this registry. Should be called after all
      * calls to registerImplementation.
      *
-     * Any name that was requested but is not provided by this build is a hard startup error
-     * (fail-fast), regardless of whether it came from net.compression.compressors or
-     * replication.networkCompression.compressors. The two sources are treated identically so a
-     * compressor named in the replication configuration can never be silently ignored, which would
-     * otherwise leave the operator believing replication compression is active when it is not.
-     * See SERVER-130410.
+     * Any requested name that is not provided by this build is a hard startup error, regardless of
+     * whether it came from net.compression or replication.networkCompression.
      */
     Status finalizeSupportedCompressors();
 
@@ -139,12 +134,15 @@ private:
     // Names from net.compression.compressors. Candidate set for external client-facing
     // connections; empty when net.compression.compressors: disabled.
     std::vector<std::string> _netCompressorNames;
-    // Names from replication.networkCompression.compressors. Recorded for observability
-    // (getReplCompressorNames()); after startup finalization, these have been validated the same
-    // way as net.compression algorithms.
+    // Names from replication.networkCompression.compressors. Recorded for observability; after
+    // startup finalization, these have been validated the same way as net.compression algorithms.
     std::vector<std::string> _replCompressorNames;
 };
 
 Status storeMessageCompressionOptions(const std::string& compressors);
 void appendMessageCompressionStats(BSONObjBuilder* b);
+// Appends a "compression" subobject (same shape as appendMessageCompressionStats) containing the
+// replication-data-plane subset of the per-algorithm byte counters. Used by
+// serverStatus().repl.compression.
+void appendReplicationMessageCompressionStats(BSONObjBuilder* b);
 }  // namespace mongo

--- a/src/mongo/transport/session_workflow.cpp
+++ b/src/mongo/transport/session_workflow.cpp
@@ -582,11 +582,24 @@ public:
     void decompressRequest() {
         if (_in.operation() != dbCompressed)
             return;
+        auto& mgr = compressorMgr();
+        if (!mgr.hasCompressorPermitListForThisSession()) {
+            // SERVER-130410: reject OP_COMPRESSED before the server has processed a hello and
+            // established this connection's compressor permit list. Historically decompression was
+            // negotiation-agnostic because the registry was the single net.compression.compressors
+            // set. With the registry now being net union replication, allowing pre-negotiation
+            // compressed frames would let an external connection use a replication-only compressor
+            // before it has been routed through serverNegotiate(). Apply this before-negotiation
+            // guard in auth-disabled and mongoBridge modes as well; compression negotiation, not
+            // authentication state, is the boundary for accepting OP_COMPRESSED.
+            uasserted(ErrorCodes::BadValue,
+                      "Compressed messages are not accepted before compression negotiation");
+        }
         MessageCompressorId cid;
         _in = isPreAuth(_swf->client())
-            ? uassertStatusOK(compressorMgr().decompressMessage(
-                  _in, &cid, gPreAuthMaximumMessageSizeBytes.loadRelaxed()))
-            : uassertStatusOK(compressorMgr().decompressMessage(_in, &cid));
+            ? uassertStatusOK(
+                  mgr.decompressMessage(_in, &cid, gPreAuthMaximumMessageSizeBytes.loadRelaxed()))
+            : uassertStatusOK(mgr.decompressMessage(_in, &cid));
         _compressorId = cid;
         MessageHooks::onMessageReceived(*_swf->session(), _in);
     }

--- a/src/mongo/transport/session_workflow.cpp
+++ b/src/mongo/transport/session_workflow.cpp
@@ -584,14 +584,9 @@ public:
             return;
         auto& mgr = compressorMgr();
         if (!mgr.hasCompressorPermitListForThisSession()) {
-            // SERVER-130410: reject OP_COMPRESSED before the server has processed a hello and
-            // established this connection's compressor permit list. Historically decompression was
-            // negotiation-agnostic because the registry was the single net.compression.compressors
-            // set. With the registry now being net union replication, allowing pre-negotiation
-            // compressed frames would let an external connection use a replication-only compressor
-            // before it has been routed through serverNegotiate(). Apply this before-negotiation
-            // guard in auth-disabled and mongoBridge modes as well; compression negotiation, not
-            // authentication state, is the boundary for accepting OP_COMPRESSED.
+            // Reject OP_COMPRESSED before hello establishes this connection's compressor permit
+            // list. The process-wide registry may include replication-only compressors, so
+            // compression negotiation is the boundary for accepting compressed frames.
             uasserted(ErrorCodes::BadValue,
                       "Compressed messages are not accepted before compression negotiation");
         }

--- a/src/mongo/transport/session_workflow_test.cpp
+++ b/src/mongo/transport/session_workflow_test.cpp
@@ -88,6 +88,7 @@
 #include <tuple>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 #define MONGO_LOGV2_DEFAULT_COMPONENT ::mongo::logv2::LogComponent::kTest
 
@@ -288,6 +289,14 @@ public:
         _session->getTransportLayerCb = [this] {
             return _transportLayer;
         };
+    }
+
+    void permitSnappyCompressionForCurrentSession() {
+        BSONObjBuilder out;
+        std::vector<std::string_view> clientCompressors{"snappy"};
+        std::vector<std::string> serverCompressors{"snappy"};
+        MessageCompressorManager::forSession(_session)
+            .serverNegotiate(clientCompressors, &out, serverCompressors);
     }
 
     /** Waits for the current Session and SessionWorkflow to end. */
@@ -1050,6 +1059,7 @@ TEST_F(IngressRequestRateLimiterTest, FireAndForgetResponse) {
 TEST_F(IngressRequestRateLimiterTest, FireAndForgetResponseCompressed) {
     enableRateOverrideBehaviorWithSpecifiedBurstSize(1.0);
 
+    permitSnappyCompressionForCurrentSession();
     startSession();
     auto msg = makeOpMsg();
     setMoreToCome(msg);
@@ -1060,6 +1070,7 @@ TEST_F(IngressRequestRateLimiterTest, FireAndForgetResponseCompressed) {
     expect<Event::sepEndSession>();
 
     initializeNewSession();
+    permitSnappyCompressionForCurrentSession();
     startSession();
     expect<Event::sessionSourceMessage>(msg);
     expect<Event::sessionSourceMessage>(kClosedSessionError);
@@ -1714,6 +1725,7 @@ TEST_F(SessionWorkflowTest, OversizedDecompressedMessage) {
 
     unittest::ServerParameterGuard maxSizeController{"preAuthMaximumMessageSizeBytes", 1024};
 
+    permitSnappyCompressionForCurrentSession();
     startSession();
 
     const size_t bufferSize = MsgData::MsgDataHeaderSize + CompressionHeader::size();

--- a/src/mongo/transport/session_workflow_test.cpp
+++ b/src/mongo/transport/session_workflow_test.cpp
@@ -1747,6 +1747,37 @@ TEST_F(SessionWorkflowTest, OversizedDecompressedMessage) {
     joinSessions();
 }
 
+// A client that sends OP_COMPRESSED before the server has negotiated compression (no permit list
+// engaged for this session) must have the frame rejected and the connection ended - not crash the
+// server. This guards the pre-negotiation boundary: an unnegotiated connection must not fall back
+// to the process-wide registry (net union replication) to decompress arbitrary frames.
+TEST_F(SessionWorkflowTest, CompressedMessageBeforeNegotiationIsRejected) {
+    auto& registry = MessageCompressorRegistry::get();
+    const auto& compressorNames = registry.getCompressorNames();
+    if (std::ranges::find(compressorNames, "snappy") == compressorNames.end()) {
+        registry.setSupportedCompressors({"snappy"});
+        registry.registerImplementation(std::make_unique<SnappyMessageCompressor>());
+        uassertStatusOK(registry.finalizeSupportedCompressors());
+    }
+
+    // Deliberately do NOT call permitSnappyCompressionForCurrentSession(): this session never ran
+    // serverNegotiate(), so it has no compressor permit list.
+    startSession();
+
+    // Build a real snappy-compressed OP_COMPRESSED frame with a throwaway, un-negotiated manager
+    // (its permit list is unengaged, so it can produce any registered algorithm - exactly what an
+    // unnegotiated peer could put on the wire).
+    MessageCompressorManager producer{};
+    const auto snappyId = static_cast<MessageCompressorId>(MessageCompressor::kSnappy);
+    auto compressed = uassertStatusOK(producer.compressMessage(makeOpMsg(), &snappyId));
+
+    // The workflow sources the compressed frame, rejects it during decompression because no
+    // negotiation has occurred, and ends the session instead of crashing.
+    expect<Event::sessionSourceMessage>(StatusWith{compressed});
+    expect<Event::sepEndSession>();
+    joinSessions();
+}
+
 /** Builds a minimal opReply (OP_QUERY response) message using LegacyReplyBuilder. */
 Message makeOpReplyMsg() {
     rpc::LegacyReplyBuilder builder;


### PR DESCRIPTION
What: Adds a compression policy that applies only to the replication data plane — oplog fetcher, initial sync cloner, and rollback oplog reader — and negotiates independently from the client-facing net.compression.compressors.

Config option: replication.networkCompression.compressors
setParameter: replicationNetworkCompression
"" (default) = inherit net.compression.compressors (no behavior change)
"disabled" = negotiate replication data-plane connections uncompressed
"a,b,c" = use only these algorithms for replication, even when net.compression.compressors is disabled
Why: Replication traffic currently shares the single net.compression.compressors knob with ordinary client traffic. Operators cannot compress replication while keeping clients uncompressed, or use a different compressor for replication than for clients.

Implementation notes / review focus:

Union registry + per-connection candidate sets: MessageCompressorRegistry now distinguishes the net set, the replication set, and their union. The net set is used for ordinary client / non-replication connections; the replication set is used for replication data-plane connections; the union only determines which compressor implementations are registered in the process. This allows replication to use algorithms such as zstd / snappy even when net.compression.compressors is disabled.

Per-connection permit list (_permittedCompressorIds): since the registry is now the net∪repl union, “registered” no longer means “allowed on this connection”, so decompression can no longer rely on the registry alone. We also cannot simply reuse _negotiated[]: _negotiated represents the negotiated result and the default compression preference order, while existing behavior also supports echoing the request’s compression state back in the response (see MessageCompressorManager.SERVER_28008 / SERVER-28008). In that path, decompressMessage() returns the actual compressorId used by the request, and that id is then passed to compressMessage() to explicitly choose the response compressor. Therefore we need a per-connection set of allowed compressor ids, which is what _permittedCompressorIds provides. This makes external connections reject registered replication-only compressors according to the net policy, prevents algorithm smuggling through the union registry, and applies the same rule to explicit echo-back compression. Legacy/direct callers that never negotiated keep the existing permit-all behavior.

Routing via hello marker: replication clients call applyReplicationNetworkCompressionToManager(), which adds replicationCompressionClient: true to hello. The server routes only marked connections through the replication candidate set; heartbeats, shard RPC, and external clients continue to use the net set. This is applied to the three replication data-plane paths: oplog_fetcher.cpp, all_database_cloner.cpp, and bgsync.cpp.

repl.compression observability: adds serverStatus().repl.compression, which reports the replication subset of network.compression. The same bytes are still included in network.compression; replication-marked connections are additionally attributed to repl.compression so replication traffic can be observed separately.

Sticky state: the replicationCompressionClient marker is present only on the initial handshake. Later marker-less hello / awaitable hello commands on the same connection must not reset the connection back to the net policy. The server-side replication candidate set and repl.compression accounting flag are therefore sticky for the lifetime of the connection: they are set once and are not cleared by later marker-less hello commands.

Validation semantics: this option is startup-only; runtime setParameter is rejected. "" means inherit net.compression.compressors. Non-empty values containing only whitespace/separators, such as " " or ",", are rejected. "disabled" cannot be combined with compressor names. Unknown or unregistered compressors fail during startup finalization and do not silently downgrade. Supplying both the config option and the setParameter form is treated as a conflict and startup is rejected.

Compatibility and safety: the default inherits net.compression.compressors, so existing behavior is unchanged. Invalid configuration fails fast. Disjoint replication allow-lists safely fall back to uncompressed replication without breaking replication. Replication-only compressors are never exposed to external clients. MessageCompressorManager is per-session state and is only mutated within that session’s serial SessionWorkflow iteration, so no additional locking is required.