### PR TITLE
fix(resmoke): avoid mutable default for shell_options in CheckIdleCursors

### DIFF
--- a/buildscripts/resmokelib/testing/hooks/check_idle_cursors.py
+++ b/buildscripts/resmokelib/testing/hooks/check_idle_cursors.py
@@ -10,7 +10,9 @@ class CheckIdleCursors(jsfile.JSHook):
     # Tag you’ll set in the JS test files that are allowed to leak cursors.
     ALLOW_LEAK_TAG = "can_leak_idle_cursors"
 
-    def __init__(self, hook_logger, fixture, shell_options={}):
+    def __init__(self, hook_logger, fixture, shell_options=None):
+        if shell_options is None:
+            shell_options = {}
         description = "Checking for idle cursors in $currentOp"
         js_filename = os.path.join("jstests", "hooks", "jstest_infra", "run_check_idle_cursors.js")
         super().__init__(


### PR DESCRIPTION
`shell_options={}` at `check_idle_cursors.py:13` is declared as a default argument. It is shared across hook instances, so `after_test` mutating `global_vars` and `TestData` leaks `TestData` between them.

The default becomes `None`. No other files are touched.

Verified RED to GREEN: before the fix the default is an empty dict literal, after the fix it is `None` with a guard that creates a fresh dict. The file compiles with `py_compile` and the AST check passes.
