### PR TITLE
docs: fix 'allows to the consumer' grammar in change streams

### DIFF
--- a/docs/change_streams.md
+++ b/docs/change_streams.md
@@ -39,7 +39,7 @@ Change Streams provide various guarantees:
 - Resumability: change stream consumption can be interrupted due to transient errors (e.g. network
   issues, node failures, application errors), but it can be resumed from the exact point where the
   consumption stopped. This is made possible by the resume token (`_id` field) that accompanies
-  every change event, which acts as a bookmark. This allows to the consumer to continue processing
+  every change event, which acts as a bookmark. This allows the consumer to continue processing
   changes from the last known position without missing events.
 
 ### Change Stream Namespace Scopes


### PR DESCRIPTION
Tiny docs fix in `docs/change_streams.md`: "This allows to the consumer" → "This allows the consumer".

Validated against the surrounding resumability paragraph; the resume-token bookmark wording is otherwise unchanged.