### PR TITLE
docs: remove duplicate 'the' in golden data test docs

### DIFF
--- a/docs/golden_data_test_framework.md
+++ b/docs/golden_data_test_framework.md
@@ -332,7 +332,7 @@ $> diff -ruN --unidirectional-new-file --color=always <expected_root> <actual_ro
 
 ## Find the outputs of tests that failed.
 
-Parse logs and find the the expected and actual outputs for each failed test.
+Parse logs and find the expected and actual outputs for each failed test.
 
 **Example: (linux/macOS)**
 


### PR DESCRIPTION
Tiny docs fix in `docs/golden_data_test_framework.md`: remove duplicate "the" in the failed-test output instructions.

Context-checked against the surrounding "Find the outputs of tests that failed" section.